### PR TITLE
Add Tool Templates feature to architecture and wireframes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -917,7 +917,75 @@ claudetools.io/
     */
    ```
 
-4. **Define WebSocket protocol (`packages/shared/src/protocol.js`)**
+4. **Define tool template types**
+   ```javascript
+   /**
+    * Tool template scope - determines where the tool is available
+    * - 'global': Available across all sessions, executed as shell commands
+    * - 'project': Available within a specific project's sessions
+    * @typedef {'global' | 'project'} ToolTemplateScope
+    */
+
+   /**
+    * Payload type for project tool templates
+    * - 'command': Executes as a shell command in a background process
+    * - 'prompt': Populates the session message input with the payload
+    * @typedef {'command' | 'prompt'} ToolTemplatePayloadType
+    */
+
+   /**
+    * Base tool template properties shared by all template types
+    * @typedef {Object} ToolTemplateBase
+    * @property {string} id - Unique identifier
+    * @property {string} name - Display name for the tool
+    * @property {string} payload - The command or prompt text
+    * @property {number} createdAt - Unix timestamp
+    * @property {number} updatedAt - Unix timestamp
+    */
+
+   /**
+    * Global tool template - available across all sessions
+    * Global tools always have payloadType 'command' and execute shell commands
+    * @typedef {Object} GlobalToolTemplate
+    * @property {string} id
+    * @property {'global'} scope
+    * @property {string} name - Display name for the tool
+    * @property {string} payload - The shell command to execute
+    * @property {'command'} payloadType - Always 'command' for global tools
+    * @property {number} createdAt
+    * @property {number} updatedAt
+    */
+
+   /**
+    * Project tool template - available within a specific project
+    * @typedef {Object} ProjectToolTemplate
+    * @property {string} id
+    * @property {'project'} scope
+    * @property {string} projectId - The project this template belongs to
+    * @property {string} name - Display name for the tool
+    * @property {string} payload - The command or prompt text
+    * @property {ToolTemplatePayloadType} payloadType - 'command' or 'prompt'
+    * @property {number} createdAt
+    * @property {number} updatedAt
+    */
+
+   /**
+    * Union type for all tool templates
+    * @typedef {GlobalToolTemplate | ProjectToolTemplate} ToolTemplate
+    */
+
+   /**
+    * Tool templates JSON structure
+    * A JSON object with a single key 'tools' containing an array of tool templates
+    * @typedef {Object} ToolTemplatesConfig
+    * @property {ToolTemplate[]} tools - Array of tool templates
+    */
+
+   export const TOOL_TEMPLATE_SCOPES = ['global', 'project'];
+   export const TOOL_TEMPLATE_PAYLOAD_TYPES = ['command', 'prompt'];
+   ```
+
+5. **Define WebSocket protocol (`packages/shared/src/protocol.js`)**
    ```javascript
    // ============================================
    // Server -> Client Messages
@@ -4491,6 +4559,23 @@ claudetools.io/
 | GET | `/api/git/current-branch` | Get current branch |
 | POST | `/api/git/worktrees` | Create new worktree |
 
+### Tool Templates API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/tools` | List all global tool templates |
+| POST | `/api/tools` | Create new global tool template |
+| GET | `/api/tools/:id` | Get global tool template details |
+| PUT | `/api/tools/:id` | Update global tool template |
+| DELETE | `/api/tools/:id` | Delete global tool template |
+| POST | `/api/tools/:id/execute` | Execute a global tool template command |
+| GET | `/api/projects/:projectId/tools` | List project tool templates |
+| POST | `/api/projects/:projectId/tools` | Create project tool template |
+| GET | `/api/projects/:projectId/tools/:toolId` | Get project tool template details |
+| PUT | `/api/projects/:projectId/tools/:toolId` | Update project tool template |
+| DELETE | `/api/projects/:projectId/tools/:toolId` | Delete project tool template |
+| POST | `/api/projects/:projectId/tools/:toolId/execute` | Execute a project tool template |
+
 ---
 
 ## WebSocket Protocol
@@ -4580,12 +4665,18 @@ Visual wireframes for each view in the application are available in the [`wirefr
 
 | View | Description | Wireframe |
 |------|-------------|-----------|
-| **AppLayout** | Mobile-friendly layout with top navigation bar | [AppLayout.md](wireframes/AppLayout.md) |
+| **AppLayout** | Mobile-friendly layout with top navigation bar (Projects, Tools, Settings) | [AppLayout.md](wireframes/AppLayout.md) |
 | **ProjectListView** | List of all projects with session counts (default route `/`) | [ProjectListView.md](wireframes/ProjectListView.md) |
-| **ProjectEditView** | Form for creating/editing projects with working directory | [ProjectEditView.md](wireframes/ProjectEditView.md) |
+| **ProjectEditView** | Form for creating/editing projects with working directory and project tools | [ProjectEditView.md](wireframes/ProjectEditView.md) |
 | **SessionListView** | List of sessions within a project | [SessionListView.md](wireframes/SessionListView.md) |
-| **SessionDetailView** | Session view with tabbed sub-navigation (Conversation, Changes, Canvas) and mode toggle | [SessionDetailView.md](wireframes/SessionDetailView.md) |
+| **SessionDetailView** | Session view with tabbed sub-navigation (Conversation, Changes, Canvas, Tools) and mode toggle | [SessionDetailView.md](wireframes/SessionDetailView.md) |
 | **NewSessionView** | Form for creating new sessions within a project (git configuration) | [NewSessionView.md](wireframes/NewSessionView.md) |
+| **SettingsView** | Application settings showing global and project tool templates | [SettingsView.md](wireframes/SettingsView.md) |
+| **ToolsGlobalView** | List of global tool templates with create button | [ToolsGlobalView.md](wireframes/ToolsGlobalView.md) |
+| **NewGlobalToolTemplateView** | Form for creating a new global tool template | [NewGlobalToolTemplateView.md](wireframes/NewGlobalToolTemplateView.md) |
+| **EditGlobalToolTemplateView** | Form for editing/deleting a global tool template | [EditGlobalToolTemplateView.md](wireframes/EditGlobalToolTemplateView.md) |
+| **NewProjectToolTemplateView** | Form for creating a new project tool template | [NewProjectToolTemplateView.md](wireframes/NewProjectToolTemplateView.md) |
+| **EditProjectToolTemplateView** | Form for editing/deleting a project tool template | [EditProjectToolTemplateView.md](wireframes/EditProjectToolTemplateView.md) |
 
 ### Wireframe Contents
 

--- a/wireframes/AppLayout.md
+++ b/wireframes/AppLayout.md
@@ -9,7 +9,7 @@ This layout is defined in `App.vue` and wraps all views.
 +------------------------------------------------------------------+
 |  HEADER / TOP NAV                                                 |
 |  +--------------------------------------------------------------+ |
-|  |  [logo] claudetools.io    [Projects]  [+ New]    [Connected] | |
+|  |  [logo] claudetools.io  [Projects] [Tools] [+ New] [*] [Cog] | |
 |  +--------------------------------------------------------------+ |
 +------------------------------------------------------------------+
 |                                                                    |
@@ -26,6 +26,12 @@ This layout is defined in `App.vue` and wraps all views.
 |  |  - SessionListView (/projects/:projectId/sessions)           | |
 |  |  - SessionDetailView (/sessions/:id)                         | |
 |  |  - NewSessionView (/projects/:projectId/sessions/new)        | |
+|  |  - ToolsGlobalView (/tools)                                  | |
+|  |  - NewGlobalToolTemplateView (/tools/new)                    | |
+|  |  - EditGlobalToolTemplateView (/tools/:id/edit)              | |
+|  |  - SettingsView (/settings)                                  | |
+|  |  - NewProjectToolTemplateView (/projects/:id/tools/new)      | |
+|  |  - EditProjectToolTemplateView (/projects/:id/tools/:toolId) | |
 |  |                                                              | |
 |  +--------------------------------------------------------------+ |
 |                                                                    |
@@ -39,7 +45,7 @@ This layout is defined in `App.vue` and wraps all views.
 |                                                                    |
 |  [Claude Icon]  claudetools.io                                    |
 |                                                                    |
-|                           [Projects]  [+ New Project]  [*] Connected|
+|            [Projects] [Tools] [+ New Project]  [*] Connected [Cog]|
 |                                                                    |
 +------------------------------------------------------------------+
 
@@ -47,17 +53,19 @@ Legend:
 - [Claude Icon]: Application logo/branding
 - "claudetools.io": Application name
 - [Projects]: Navigate to project list (active when on /)
+- [Tools]: Navigate to global tools list (/tools)
 - [+ New Project]: Primary action, routes to /projects/new
 - [*] Connected: WebSocket connection status indicator
   - Green dot = Connected
   - Red dot = Disconnected (with reconnect attempt info)
+- [Cog]: Settings icon, routes to /settings
 ```
 
 ## Mobile Layout (<768px)
 
 ```
 +--------------------------------+
-|  [=]  claudetools.io    [*]    |
+|  [=]  claudetools.io  [*] [Cog]|
 +--------------------------------+
 |                                |
 |  MAIN CONTENT AREA             |
@@ -75,6 +83,7 @@ Legend:
 [=] Hamburger menu reveals:
 +--------------------------------+
 |  Projects                      |
+|  Tools                         |
 |  + New Project                 |
 +--------------------------------+
 ```
@@ -83,7 +92,7 @@ Legend:
 
 ```
 +------------------------------------------------------------------+
-|  [logo] claudetools.io          [Projects] [+ New]    [Connected] |
+|  [logo] claudetools.io    [Projects] [Tools] [+ New] [*] [Cog]    |
 +------------------------------------------------------------------+
 |                                                                    |
 |  MAIN CONTENT AREA (full width)                                    |
@@ -95,7 +104,7 @@ Legend:
 
 ```
 +------------------------------------------------------------------+
-|  [logo] claudetools.io          [Projects] [+ New]    [Connected] |
+|  [logo] claudetools.io    [Projects] [Tools] [+ New] [*] [Cog]    |
 +------------------------------------------------------------------+
 |                                                                    |
 |  MAIN CONTENT AREA (max-width container, centered)                 |
@@ -121,15 +130,23 @@ Reconnecting: [Yellow Dot] Reconnecting (3)...
    - Routes to ProjectListView (/)
    - Active state when on any project route
 
-3. **New Project Button**
+3. **Tools Nav**
+   - Routes to ToolsGlobalView (/tools)
+   - Active state when on /tools or /tools/*
+
+4. **New Project Button**
    - Primary action button (accent color)
    - Routes to ProjectEditView (/projects/new)
 
-4. **Connection Status**
+5. **Connection Status**
    - Click to see connection details (optional)
    - Shows reconnect attempt count when disconnected
 
-5. **Mobile Hamburger Menu**
+6. **Settings Cog**
+   - Routes to SettingsView (/settings)
+   - Active state when on /settings
+
+7. **Mobile Hamburger Menu**
    - Slides in from left or drops down
-   - Contains navigation items
+   - Contains navigation items (Projects, Tools, + New Project)
    - Closes on route change or outside click

--- a/wireframes/EditGlobalToolTemplateView.md
+++ b/wireframes/EditGlobalToolTemplateView.md
@@ -1,0 +1,196 @@
+# EditGlobalToolTemplateView Wireframe
+
+The EditGlobalToolTemplateView provides a form for editing or deleting an existing
+global tool template. Global tool templates always execute shell commands.
+
+## Full View
+
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [<- Back]  Edit Global Tool Template                              |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  NAME *                                                            |
+|  +--------------------------------------------------------------+ |
+|  | [Run Tests                                                  ] | |
+|  +--------------------------------------------------------------+ |
+|  A short, descriptive name for this tool                          |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  COMMAND *                                                         |
+|  +--------------------------------------------------------------+ |
+|  | [npm test                                                   ] | |
+|  +--------------------------------------------------------------+ |
+|  The shell command to execute. Arguments entered at runtime        |
+|  will be appended to this command.                                 |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  [Delete Tool]                         [Cancel]  [Save Changes]    |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Form Fields Detail
+
+### Name Field
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | [Current tool name                                          ] | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Pre-filled with existing value                                     |
+| Validation: Required, max 50 characters                            |
++------------------------------------------------------------------+
+```
+
+### Command Field (Payload)
+```
++------------------------------------------------------------------+
+| COMMAND *                                                Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | [Current command                                            ] | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Pre-filled with existing value                                     |
+| Validation: Required, max 500 characters                           |
++------------------------------------------------------------------+
+```
+
+## States
+
+### Loading State (fetching tool data)
+```
++------------------------------------------------------------------+
+| [<- Back]  Edit Global Tool Template                               |
++------------------------------------------------------------------+
+|                                                                    |
+|  [Spinner] Loading tool template...                                |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+### Validation Errors
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+| [!] This field is required                              (red text)|
++------------------------------------------------------------------+
+```
+
+### Submitting State (Save)
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [Delete Tool]                         [Cancel]  [Saving...] (disabled)|
+|                                                    [Spinner]       |
++------------------------------------------------------------------+
+```
+
+### Delete Confirmation Modal
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |                    Delete Tool Template?                      | |
+|  |                                                              | |
+|  |  Are you sure you want to delete "Run Tests"?                | |
+|  |  This action cannot be undone.                               | |
+|  |                                                              | |
+|  |                              [Cancel]  [Delete]              | |
+|  |                                                              | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+### Deleting State
+```
++------------------------------------------------------------------+
+|  |                                                              | |
+|  |                              [Cancel]  [Deleting...] (disabled)| |
+|  |                                         [Spinner]            | |
+|  +--------------------------------------------------------------+ |
++------------------------------------------------------------------+
+```
+
+### Error State (API failure)
+```
++------------------------------------------------------------------+
+|  [!] Failed to save changes. Please try again.                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  [Delete Tool]                         [Cancel]  [Save Changes]    |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Interactions
+
+1. **Back Button**
+   - Returns to ToolsGlobalView
+   - Confirms if form has unsaved changes
+
+2. **Name Input**
+   - Pre-filled with existing value
+   - Validates on blur
+
+3. **Command Input**
+   - Pre-filled with existing value
+   - Validates on blur
+
+4. **Cancel Button**
+   - Returns to ToolsGlobalView
+   - Confirms if form has unsaved changes
+
+5. **Save Changes Button**
+   - Validates all required fields
+   - Shows loading state while saving
+   - On success: Navigates to ToolsGlobalView with success toast
+   - On failure: Shows error message, form remains editable
+
+6. **Delete Tool Button**
+   - Opens confirmation modal
+   - Modal has Cancel and Delete buttons
+   - Delete shows loading state while deleting
+   - On success: Navigates to ToolsGlobalView with deletion toast
+   - On failure: Shows error message in modal
+
+## API Requests
+
+### Update Tool
+```
+PUT /api/tools/:id
+{
+  "name": "Run Tests",
+  "payload": "npm test"
+}
+```
+
+### Delete Tool
+```
+DELETE /api/tools/:id
+```
+
+## Responsive Behavior
+
+### Mobile (<768px)
+- Full-width form fields
+- Delete button stacks above Cancel/Save
+- Modal is full-width with padding
+
+### Tablet/Desktop (>768px)
+- Centered form with max-width container
+- Delete button aligned left, Cancel/Save aligned right
+- Modal centered with max-width

--- a/wireframes/EditProjectToolTemplateView.md
+++ b/wireframes/EditProjectToolTemplateView.md
@@ -1,0 +1,231 @@
+# EditProjectToolTemplateView Wireframe
+
+The EditProjectToolTemplateView provides a form for editing or deleting an existing
+project tool template. Project tool templates can be either "command" type (execute
+shell commands) or "prompt" type (populate the session message input).
+
+## Full View
+
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [<- Back]  Edit Project Tool Template                             |
+|             Project: My Web App                                    |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  NAME *                                                            |
+|  +--------------------------------------------------------------+ |
+|  | [Run Tests                                                  ] | |
+|  +--------------------------------------------------------------+ |
+|  A short, descriptive name for this tool                          |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  TYPE *                                                            |
+|  +--------------------------------------------------------------+ |
+|  | (o) Command - Executes a shell command in the background      | |
+|  | ( ) Prompt  - Populates the session message input             | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  PAYLOAD *                                                         |
+|  +--------------------------------------------------------------+ |
+|  | [npm test                                                   ] | |
+|  +--------------------------------------------------------------+ |
+|  The command to execute or prompt text to insert.                  |
+|  Runtime arguments will be appended.                               |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  [Delete Tool]                         [Cancel]  [Save Changes]    |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Form Fields Detail
+
+### Name Field
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | [Current tool name                                          ] | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Pre-filled with existing value                                     |
+| Validation: Required, max 50 characters                            |
++------------------------------------------------------------------+
+```
+
+### Type Field
+```
++------------------------------------------------------------------+
+| TYPE *                                                   Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | (o) Command - Executes a shell command in the background      | |
+| | ( ) Prompt  - Populates the session message input             | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Pre-selected based on existing payloadType                         |
+| Changing type will update help text for payload field              |
++------------------------------------------------------------------+
+```
+
+### Payload Field
+```
++------------------------------------------------------------------+
+| PAYLOAD *                                                Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | [Current payload                                            ] | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Pre-filled with existing value                                     |
+| Validation: Required, max 1000 characters                          |
+| For prompt type, consider multiline textarea                       |
++------------------------------------------------------------------+
+```
+
+## States
+
+### Loading State (fetching tool data)
+```
++------------------------------------------------------------------+
+| [<- Back]  Edit Project Tool Template                              |
+|            Project: My Web App                                     |
++------------------------------------------------------------------+
+|                                                                    |
+|  [Spinner] Loading tool template...                                |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+### Validation Errors
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+| [!] This field is required                              (red text)|
++------------------------------------------------------------------+
+```
+
+### Submitting State (Save)
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [Delete Tool]                         [Cancel]  [Saving...] (disabled)|
+|                                                    [Spinner]       |
++------------------------------------------------------------------+
+```
+
+### Delete Confirmation Modal
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |                    Delete Tool Template?                      | |
+|  |                                                              | |
+|  |  Are you sure you want to delete "Run Tests"?                | |
+|  |  This action cannot be undone.                               | |
+|  |                                                              | |
+|  |                              [Cancel]  [Delete]              | |
+|  |                                                              | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+### Deleting State
+```
++------------------------------------------------------------------+
+|  |                                                              | |
+|  |                              [Cancel]  [Deleting...] (disabled)| |
+|  |                                         [Spinner]            | |
+|  +--------------------------------------------------------------+ |
++------------------------------------------------------------------+
+```
+
+### Error State (API failure)
+```
++------------------------------------------------------------------+
+|  [!] Failed to save changes. Please try again.                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  [Delete Tool]                         [Cancel]  [Save Changes]    |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Interactions
+
+1. **Back Button**
+   - Returns to ProjectEditView with tools section
+   - Confirms if form has unsaved changes
+
+2. **Name Input**
+   - Pre-filled with existing value
+   - Validates on blur
+
+3. **Type Radio Buttons**
+   - Pre-selected based on existing payloadType
+   - Changing updates help text for payload field
+   - May prompt user if changing type with existing payload
+
+4. **Payload Input**
+   - Pre-filled with existing value
+   - Input type may change between single line and textarea based on type
+
+5. **Cancel Button**
+   - Returns to ProjectEditView with tools section
+   - Confirms if form has unsaved changes
+
+6. **Save Changes Button**
+   - Validates all required fields
+   - Shows loading state while saving
+   - On success: Navigates to ProjectEditView with success toast
+   - On failure: Shows error message, form remains editable
+
+7. **Delete Tool Button**
+   - Opens confirmation modal
+   - Modal has Cancel and Delete buttons
+   - Delete shows loading state while deleting
+   - On success: Navigates to ProjectEditView with deletion toast
+   - On failure: Shows error message in modal
+
+## API Requests
+
+### Update Tool
+```
+PUT /api/projects/:projectId/tools/:toolId
+{
+  "name": "Run Tests",
+  "payload": "npm test",
+  "payloadType": "command"
+}
+```
+
+### Delete Tool
+```
+DELETE /api/projects/:projectId/tools/:toolId
+```
+
+## Responsive Behavior
+
+### Mobile (<768px)
+- Full-width form fields
+- Radio buttons stack vertically
+- Delete button stacks above Cancel/Save
+- Modal is full-width with padding
+
+### Tablet/Desktop (>768px)
+- Centered form with max-width container
+- Radio buttons in single row
+- Delete button aligned left, Cancel/Save aligned right
+- Modal centered with max-width

--- a/wireframes/NewGlobalToolTemplateView.md
+++ b/wireframes/NewGlobalToolTemplateView.md
@@ -1,0 +1,161 @@
+# NewGlobalToolTemplateView Wireframe
+
+The NewGlobalToolTemplateView provides a form for creating a new global tool template.
+Global tool templates always execute shell commands (payloadType is always "command").
+
+## Full View
+
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [<- Back]  New Global Tool Template                               |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  Create a tool template to run shell commands from any session.    |
+|  Commands run in background processes and won't block the UI.      |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  NAME *                                                            |
+|  +--------------------------------------------------------------+ |
+|  | [e.g., Run Tests                                            ] | |
+|  +--------------------------------------------------------------+ |
+|  A short, descriptive name for this tool                          |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  COMMAND *                                                         |
+|  +--------------------------------------------------------------+ |
+|  | [e.g., npm test                                             ] | |
+|  +--------------------------------------------------------------+ |
+|  The shell command to execute. Arguments entered at runtime        |
+|  will be appended to this command.                                 |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|                                              [Cancel]  [Create Tool]|
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Form Fields Detail
+
+### Name Field
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Placeholder: "e.g., Run Tests"                                    |
+| Help text: "A short, descriptive name for this tool"              |
+| Validation: Required, max 50 characters                            |
++------------------------------------------------------------------+
+```
+
+### Command Field (Payload)
+```
++------------------------------------------------------------------+
+| COMMAND *                                                Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Placeholder: "e.g., npm test"                                     |
+| Help text: "The shell command to execute. Arguments entered at     |
+|             runtime will be appended to this command."             |
+| Validation: Required, max 500 characters                           |
++------------------------------------------------------------------+
+```
+
+## States
+
+### Validation Errors
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+| [!] This field is required                              (red text)|
++------------------------------------------------------------------+
+
++------------------------------------------------------------------+
+| COMMAND *                                                Required  |
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+| [!] This field is required                              (red text)|
++------------------------------------------------------------------+
+```
+
+### Submitting State
+```
++------------------------------------------------------------------+
+|                                                                    |
+|                              [Cancel]  [Creating...] (disabled)    |
+|                                        [Spinner]                   |
++------------------------------------------------------------------+
+```
+
+### Error State (API failure)
+```
++------------------------------------------------------------------+
+|  [!] Failed to create tool template. Please try again.            |
++------------------------------------------------------------------+
+|                                                                    |
+|                                              [Cancel]  [Create Tool]|
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Interactions
+
+1. **Back Button**
+   - Returns to ToolsGlobalView
+   - Confirms if form has unsaved changes
+
+2. **Name Input**
+   - Required text input
+   - Focus on page load
+   - Validates on blur
+
+3. **Command Input**
+   - Required text input
+   - Single line for simple commands
+   - Validates on blur
+
+4. **Cancel Button**
+   - Returns to ToolsGlobalView
+   - Confirms if form has unsaved changes
+
+5. **Create Tool Button**
+   - Validates all required fields
+   - Shows loading state while creating
+   - On success: Navigates to ToolsGlobalView
+   - On failure: Shows error message, form remains editable
+
+## API Request
+
+```
+POST /api/tools
+{
+  "name": "Run Tests",
+  "payload": "npm test",
+  "payloadType": "command"  // Always "command" for global tools
+}
+```
+
+## Responsive Behavior
+
+### Mobile (<768px)
+- Full-width form fields
+- Buttons stack vertically on narrow screens
+
+### Tablet/Desktop (>768px)
+- Centered form with max-width container
+- Buttons aligned to right

--- a/wireframes/NewProjectToolTemplateView.md
+++ b/wireframes/NewProjectToolTemplateView.md
@@ -1,0 +1,198 @@
+# NewProjectToolTemplateView Wireframe
+
+The NewProjectToolTemplateView provides a form for creating a new project tool template.
+Project tool templates can be either "command" type (execute shell commands) or "prompt"
+type (populate the session message input).
+
+## Full View
+
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [<- Back]  New Project Tool Template                              |
+|             Project: My Web App                                    |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  Create a tool template for sessions in this project.              |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  NAME *                                                            |
+|  +--------------------------------------------------------------+ |
+|  | [e.g., Run Tests                                            ] | |
+|  +--------------------------------------------------------------+ |
+|  A short, descriptive name for this tool                          |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  TYPE *                                                            |
+|  +--------------------------------------------------------------+ |
+|  | ( ) Command - Executes a shell command in the background      | |
+|  | (o) Prompt  - Populates the session message input             | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  PAYLOAD *                                                         |
+|  +--------------------------------------------------------------+ |
+|  | [e.g., npm test                                             ] | |
+|  +--------------------------------------------------------------+ |
+|  The command to execute or prompt text to insert.                  |
+|  Runtime arguments will be appended.                               |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|                                              [Cancel]  [Create Tool]|
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Form Fields Detail
+
+### Name Field
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Placeholder: "e.g., Run Tests"                                    |
+| Help text: "A short, descriptive name for this tool"              |
+| Validation: Required, max 50 characters                            |
++------------------------------------------------------------------+
+```
+
+### Type Field
+```
++------------------------------------------------------------------+
+| TYPE *                                                   Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| | ( ) Command - Executes a shell command in the background      | |
+| | (o) Prompt  - Populates the session message input             | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Radio button group, default: "prompt"                              |
+| Help text changes based on selection:                              |
+| - Command: "Runs in background, won't block UI"                   |
+| - Prompt: "Puts text in message input, switches to Conversation"  |
++------------------------------------------------------------------+
+```
+
+### Payload Field
+```
++------------------------------------------------------------------+
+| PAYLOAD *                                                Required  |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Placeholder changes based on type:                                 |
+| - Command: "e.g., npm test"                                       |
+| - Prompt: "e.g., Review this code for security issues"            |
+|                                                                    |
+| Help text: "The command to execute or prompt text to insert.       |
+|             Runtime arguments will be appended."                   |
+| Validation: Required, max 1000 characters                          |
+| For prompt type, consider multiline textarea                       |
++------------------------------------------------------------------+
+```
+
+## States
+
+### Validation Errors
+```
++------------------------------------------------------------------+
+| NAME *                                                   Required  |
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+| [!] This field is required                              (red text)|
++------------------------------------------------------------------+
+
++------------------------------------------------------------------+
+| PAYLOAD *                                                Required  |
+| +--------------------------------------------------------------+ |
+| |                                                              | |
+| +--------------------------------------------------------------+ |
+| [!] This field is required                              (red text)|
++------------------------------------------------------------------+
+```
+
+### Submitting State
+```
++------------------------------------------------------------------+
+|                                                                    |
+|                              [Cancel]  [Creating...] (disabled)    |
+|                                        [Spinner]                   |
++------------------------------------------------------------------+
+```
+
+### Error State (API failure)
+```
++------------------------------------------------------------------+
+|  [!] Failed to create tool template. Please try again.            |
++------------------------------------------------------------------+
+|                                                                    |
+|                                              [Cancel]  [Create Tool]|
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Interactions
+
+1. **Back Button**
+   - Returns to ProjectEditView
+   - Confirms if form has unsaved changes
+
+2. **Name Input**
+   - Required text input
+   - Focus on page load
+   - Validates on blur
+
+3. **Type Radio Buttons**
+   - Select between "command" and "prompt"
+   - Changes placeholder and help text for payload field
+   - Default: "prompt"
+
+4. **Payload Input**
+   - Required text input (or textarea for prompt type)
+   - Placeholder changes based on type selection
+   - Validates on blur
+
+5. **Cancel Button**
+   - Returns to ProjectEditView
+   - Confirms if form has unsaved changes
+
+6. **Create Tool Button**
+   - Validates all required fields
+   - Shows loading state while creating
+   - On success: Navigates to ProjectEditView with tools section
+   - On failure: Shows error message, form remains editable
+
+## API Request
+
+```
+POST /api/projects/:projectId/tools
+{
+  "name": "Run Tests",
+  "payload": "npm test",
+  "payloadType": "command"  // or "prompt"
+}
+```
+
+## Responsive Behavior
+
+### Mobile (<768px)
+- Full-width form fields
+- Radio buttons stack vertically
+- Buttons stack vertically on narrow screens
+
+### Tablet/Desktop (>768px)
+- Centered form with max-width container
+- Radio buttons in single row
+- Buttons aligned to right

--- a/wireframes/ProjectEditView.md
+++ b/wireframes/ProjectEditView.md
@@ -1,7 +1,8 @@
 # ProjectEditView Wireframe
 
 The ProjectEditView provides a form for creating a new project or editing an existing one.
-A project defines a working directory where all its sessions will run.
+A project defines a working directory where all its sessions will run. When editing,
+additional sections for project tool templates are displayed.
 
 ## Create New Project View
 
@@ -72,6 +73,25 @@ A project defines a working directory where all its sessions will run.
 |                                                                    |
 +------------------------------------------------------------------+
 |                                                                    |
+|  PROJECT TOOL TEMPLATES                               (id="tools") |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |  Tool templates for sessions in this project. Prompt tools    | |
+|  |  populate the message input; command tools run shell commands.| |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Run Tests          command    npm test             |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Code Review        prompt     Review this code...  |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Deploy Staging     command    ./deploy.sh staging  |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  |                       [+ New Project Tool Template]          | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
 |                                           [Cancel]  [Save Changes] |
 |                                                                    |
 +------------------------------------------------------------------+
@@ -113,6 +133,44 @@ Recent directories (shown below input):
 | Recent:                                                            |
 | [/Users/dev/project-a] [/Users/dev/project-b] [/Users/dev/work]   |
 +------------------------------------------------------------------+
+```
+
+### Project Tool Templates (Edit view only)
+```
++------------------------------------------------------------------+
+| PROJECT TOOL TEMPLATES                                             |
++------------------------------------------------------------------+
+| +--------------------------------------------------------------+ |
+| |  Tool templates for sessions in this project. Prompt tools    | |
+| |  populate the message input; command tools run shell commands.| |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| Tool list item:                                                    |
+| +--------------------------------------------------------------+ |
+| | [>] Tool Name       type (command/prompt)    payload...       | |
+| +--------------------------------------------------------------+ |
+|                                                                    |
+| - Click row to navigate to EditProjectToolTemplateView            |
+| - Type badge shows "command" or "prompt"                          |
+| - Payload shown truncated with ellipsis                           |
+|                                                                    |
+| [+ New Project Tool Template] button navigates to                  |
+| NewProjectToolTemplateView                                         |
++------------------------------------------------------------------+
+
+Empty state (no tools configured):
++--------------------------------------------------------------+
+|                                                              |
+|                    [Tools Icon]                              |
+|                                                              |
+|        No project tool templates configured                   |
+|                                                              |
+|  Create tool templates to run commands or send prompts        |
+|  from sessions in this project.                              |
+|                                                              |
+|          [+ Create Project Tool Template]                     |
+|                                                              |
++--------------------------------------------------------------+
 ```
 
 ## States
@@ -170,12 +228,17 @@ Recent directories (shown below input):
    - Recent directories shown as quick-select chips
    - Pre-filled with existing value when editing
 
-3. **Cancel Button**
+3. **Project Tool Templates** (Edit view only)
+   - Click tool row to navigate to EditProjectToolTemplateView
+   - Click "New Project Tool Template" to navigate to NewProjectToolTemplateView
+   - Section scrollable if many tools configured
+
+4. **Cancel Button**
    - Returns to ProjectListView (if creating)
    - Returns to SessionListView for this project (if editing)
    - Confirms if form has unsaved changes
 
-4. **Create Project / Save Changes Button**
+5. **Create Project / Save Changes Button**
    - Validates all required fields
    - Shows loading state while creating/saving
    - On success:

--- a/wireframes/SessionDetailView.md
+++ b/wireframes/SessionDetailView.md
@@ -1,7 +1,7 @@
 # SessionDetailView Wireframe
 
 The SessionDetailView shows the full conversation for a single Claude Code session,
-with a tabbed sub-navigation for Conversation, Changes (diffs), and Canvas.
+with a tabbed sub-navigation for Conversation, Changes (diffs), Canvas, and Tools.
 
 ## Full View with Tab Navigation
 
@@ -13,9 +13,9 @@ with a tabbed sub-navigation for Conversation, Changes (diffs), and Canvas.
 |                                                                    |
 +------------------------------------------------------------------+
 |  TAB NAVIGATION                                                    |
-|  +------------+------------+------------+                          |
-|  | Conversation| Changes(3)| Canvas(2) |                          |
-|  +------------+------------+------------+--------------------------+
+|  +------------+------------+------------+------------+             |
+|  | Conversation| Changes(3)| Canvas(2) |   Tools   |             |
+|  +------------+------------+------------+------------+-------------+
 |                                                                    |
 |  TAB CONTENT (varies by selected tab)                              |
 |                                                                    |
@@ -164,6 +164,70 @@ Empty state:
 |                                                              |
 |      Claude will add screenshots, documents, and data        |
 |      here as it works on this session.                       |
+|                                                              |
++--------------------------------------------------------------+
+```
+
+## Tools Tab
+
+The Tools tab displays project tool templates that can be executed within the session context.
+
+```
++------------------------------------------------------------------+
+|  [<- Back]  Fix authentication bug                [Running *]      |
+|             /path/to/project  |  Branch: feature/auth-fix          |
++------------------------------------------------------------------+
+|  +------------+------------+------------+------------+             |
+|  | Conversation| Changes(3)| Canvas(2) |[*]Tools   |             |
+|  +------------+------------+------------+------------+-------------+
+|                                                                    |
+|  PROJECT TOOLS                                                     |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [Run Tests]  [________________________] (input field)  |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [Deploy]     [________________________] (input field)  |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [Lint]       [________________________] (input field)  |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+
+Tool Item Detail:
++--------------------------------------------------------------+
+| [Button: Tool Name]  [Input field for arguments]              |
++--------------------------------------------------------------+
+
+Button states:
+- Default: Clickable, accent color
+- Running: Disabled, shows spinner, muted color
+- After click (command type): Button disabled until command completes
+
+Behavior:
+- Command type tools: Clicking runs the command with input appended
+  in a background process. Button is disabled during execution.
+- Prompt type tools: Clicking puts the payload + input into the
+  Message input on Conversation tab and switches to that tab with
+  focus on the message input control.
+
+Empty state:
++--------------------------------------------------------------+
+|                                                              |
+|                    [Tools Icon]                              |
+|                                                              |
+|              No project tools configured                      |
+|                                                              |
+|      Configure tools in the project settings to run           |
+|      commands or send prompts from this session.              |
+|                                                              |
+|              [Configure Project Tools]                        |
 |                                                              |
 +--------------------------------------------------------------+
 ```
@@ -377,9 +441,9 @@ Line numbers:   Gray, non-selectable
    - Returns to SessionListView for the project
 
 2. **Tab Switching**
-   - Click tab to switch between Conversation, Changes, Canvas
+   - Click tab to switch between Conversation, Changes, Canvas, Tools
    - Badge on tabs shows counts (file changes, canvas items)
-   - URL updates to reflect current tab (e.g., /sessions/:id/changes)
+   - URL updates to reflect current tab (e.g., /sessions/:id/changes, /sessions/:id/tools)
 
 3. **Mode Selector** (Conversation tab)
    - Dropdown above message input to select execution mode
@@ -409,6 +473,17 @@ Line numbers:   Gray, non-selectable
    - [X] button to delete item
    - Filter/sort controls
    - Grid/list view toggle
+
+8. **Tools** (Tools tab)
+   - Each tool displays as a button with an adjacent input field
+   - Command type tools:
+     - Click button to run command with input value appended
+     - Command runs in background process (non-blocking)
+     - Button disabled while command is running
+   - Prompt type tools:
+     - Click button to populate Message input with payload + input value
+     - Switches to Conversation tab with focus on message input
+   - "Configure Project Tools" button navigates to project settings
 
 ## Responsive Behavior
 

--- a/wireframes/SettingsView.md
+++ b/wireframes/SettingsView.md
@@ -1,0 +1,153 @@
+# SettingsView Wireframe
+
+The SettingsView provides access to application-wide settings, including management
+of global tool templates and links to project tool templates.
+
+## Full View
+
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [<- Back]  Settings                                               |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  GLOBAL TOOL TEMPLATES                                             |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |  Tool templates that run shell commands across all sessions  | |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Run Tests              npm test                    |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Deploy Staging         ./deploy.sh staging         |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Generate Docs          npm run docs                |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  |                          [+ New Global Tool Template]        | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  PROJECT TOOL TEMPLATES                                            |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |  Tool templates are configured per-project. Select a project | |
+|  |  to manage its tool templates.                               | |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] My Web App           3 tools configured            |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] API Server           1 tool configured             |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [>] Mobile App           0 tools configured            |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Global Tool Template List Item
+
+```
++--------------------------------------------------------------+
+| [>] Tool Name                    Payload preview...           |
++--------------------------------------------------------------+
+
+- Click anywhere on row to navigate to EditGlobalToolTemplateView
+- [>] indicates clickable/navigable item
+- Payload shown truncated with ellipsis if too long
+```
+
+## Project Tool Template List Item
+
+```
++--------------------------------------------------------------+
+| [>] Project Name                 N tools configured           |
++--------------------------------------------------------------+
+
+- Click anywhere on row to navigate to ProjectEditView with tools section focused
+- Shows count of tools configured for that project
+```
+
+## Empty States
+
+### No Global Tool Templates
+```
++--------------------------------------------------------------+
+|                                                              |
+|                    [Tools Icon]                              |
+|                                                              |
+|           No global tool templates configured                 |
+|                                                              |
+|    Global tools run shell commands across all sessions.       |
+|    Create one to automate common tasks like running tests     |
+|    or deployments.                                           |
+|                                                              |
+|              [+ Create Global Tool Template]                  |
+|                                                              |
++--------------------------------------------------------------+
+```
+
+### No Projects
+```
++--------------------------------------------------------------+
+|                                                              |
+|                    [Folder Icon]                             |
+|                                                              |
+|                    No projects yet                            |
+|                                                              |
+|    Create a project to configure project-specific tools.      |
+|                                                              |
+|                    [+ New Project]                            |
+|                                                              |
++--------------------------------------------------------------+
+```
+
+## Loading State
+
+```
++------------------------------------------------------------------+
+|  [<- Back]  Settings                                               |
++------------------------------------------------------------------+
+|                                                                    |
+|  GLOBAL TOOL TEMPLATES                                             |
+|  +--------------------------------------------------------------+ |
+|  |  [Spinner] Loading tool templates...                         | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
+|  PROJECT TOOL TEMPLATES                                            |
+|  +--------------------------------------------------------------+ |
+|  |  [Spinner] Loading projects...                               | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Interactions
+
+1. **Back Button**
+   - Returns to previous view (typically ProjectListView)
+
+2. **Global Tool Template Row Click**
+   - Navigates to EditGlobalToolTemplateView (/tools/:id/edit)
+
+3. **New Global Tool Template Button**
+   - Navigates to NewGlobalToolTemplateView (/tools/new)
+
+4. **Project Row Click**
+   - Navigates to ProjectEditView with tools section (/projects/:id/edit#tools)
+
+## Responsive Behavior
+
+### Mobile (<768px)
+- Full-width sections
+- Stacked list items
+- Payload preview may be hidden on narrow screens
+
+### Tablet/Desktop (>768px)
+- Centered content with max-width container
+- Full payload preview visible
+- Hover states on list items

--- a/wireframes/ToolsGlobalView.md
+++ b/wireframes/ToolsGlobalView.md
@@ -1,0 +1,169 @@
+# ToolsGlobalView Wireframe
+
+The ToolsGlobalView displays all global tool templates and allows users to execute
+them or navigate to create/edit views. Global tools execute shell commands that
+run in background processes.
+
+## Full View
+
+```
++------------------------------------------------------------------+
+|                                                                    |
+|  [<- Back]  Global Tools                     [+ New Tool Template] |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  Execute shell commands across all sessions. Each tool runs in     |
+|  a background process and won't block the UI.                      |
+|                                                                    |
++------------------------------------------------------------------+
+|                                                                    |
+|  TOOL TEMPLATES                                                    |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [Run Tests]    [________________________] [Edit]       |  | |
+|  |  | npm test                                                |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [Deploy]       [________________________] [Edit]       |  | |
+|  |  | ./deploy.sh staging                                     |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  |  +--------------------------------------------------------+  | |
+|  |  | [Generate Docs][________________________] [Edit]       |  | |
+|  |  | npm run docs                                            |  | |
+|  |  +--------------------------------------------------------+  | |
+|  |                                                              | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Tool Template Item Detail
+
+```
++--------------------------------------------------------------+
+| [Button: Name]    [Input field for args]         [Edit]       |
+| payload command shown below                                   |
++--------------------------------------------------------------+
+
+Components:
+- [Button]: Primary action button with tool name
+  - Clicking executes the command with input value appended
+  - Disabled while command is running
+- [Input field]: Optional arguments to append to command
+- [Edit]: Secondary button, navigates to EditGlobalToolTemplateView
+- Payload: Command text shown in muted color below
+```
+
+## Button States
+
+```
+Default state:
++--------------------------------------------------------------+
+| [Run Tests]      [test/*.spec.js      ]          [Edit]       |
+| npm test                                                      |
++--------------------------------------------------------------+
+
+Running state:
++--------------------------------------------------------------+
+| [Running...] (disabled, spinner)  [        ]     [Edit]       |
+| npm test test/*.spec.js                                       |
++--------------------------------------------------------------+
+
+After completion (success):
++--------------------------------------------------------------+
+| [Run Tests]      [                    ]          [Edit]       |
+| npm test                                          [v] Done    |
++--------------------------------------------------------------+
+
+After completion (error):
++--------------------------------------------------------------+
+| [Run Tests]      [                    ]          [Edit]       |
+| npm test                                          [!] Failed  |
++--------------------------------------------------------------+
+```
+
+## Empty State
+
+```
++------------------------------------------------------------------+
+|  [<- Back]  Global Tools                     [+ New Tool Template] |
++------------------------------------------------------------------+
+|                                                                    |
+|  +--------------------------------------------------------------+ |
+|  |                                                              | |
+|  |                    [Tools Icon]                              | |
+|  |                                                              | |
+|  |           No global tool templates configured                 | |
+|  |                                                              | |
+|  |    Create tool templates to run shell commands like           | |
+|  |    tests, builds, or deployments from any session.            | |
+|  |                                                              | |
+|  |              [+ Create Tool Template]                         | |
+|  |                                                              | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Loading State
+
+```
++------------------------------------------------------------------+
+|  [<- Back]  Global Tools                     [+ New Tool Template] |
++------------------------------------------------------------------+
+|                                                                    |
+|  +--------------------------------------------------------------+ |
+|  |  [Spinner] Loading tool templates...                         | |
+|  +--------------------------------------------------------------+ |
+|                                                                    |
++------------------------------------------------------------------+
+```
+
+## Interactions
+
+1. **Back Button**
+   - Returns to previous view (typically ProjectListView or SettingsView)
+
+2. **New Tool Template Button**
+   - Navigates to NewGlobalToolTemplateView (/tools/new)
+
+3. **Tool Button Click**
+   - Executes the command with input value appended
+   - Command runs in background process (non-blocking)
+   - Button shows "Running..." state with spinner
+   - Button is disabled while running
+   - Shows success/error indicator when complete
+
+4. **Input Field**
+   - Optional arguments to append to the command
+   - Pressing Enter while focused triggers the tool button
+   - Cleared after successful execution (optional behavior)
+
+5. **Edit Button**
+   - Navigates to EditGlobalToolTemplateView (/tools/:id/edit)
+
+## Command Execution Flow
+
+1. User enters optional arguments in input field
+2. User clicks tool button
+3. Button enters "Running..." state (disabled)
+4. API call: `POST /api/tools/:id/execute` with `{ arguments: "input value" }`
+5. Server spawns background process: `<payload> <arguments>`
+6. Button re-enables when process completes
+7. Success/error indicator shown briefly
+
+## Responsive Behavior
+
+### Mobile (<768px)
+- Full-width tool items
+- Input field and edit button may stack below button
+- Payload text wraps
+
+### Tablet/Desktop (>768px)
+- Centered content with max-width container
+- Horizontal layout: button, input, edit in one row
+- Hover states on buttons


### PR DESCRIPTION
## Summary

- Added "Tools" feature to the architecture documentation and wireframes
- Tool templates allow users to define reusable commands and prompts
- Global tool templates execute shell commands across all sessions
- Project tool templates can be either "command" (shell) or "prompt" (message input) type

## Changes

### Architecture Document (ARCHITECTURE.md)
- Added Tool Template data models (`GlobalToolTemplate`, `ProjectToolTemplate`, `ToolTemplateScope`, `ToolTemplatePayloadType`)
- Added Tool Templates API endpoints for CRUD operations and execution
- Updated wireframes table with new views

### Updated Wireframes
- **AppLayout.md** - Added Tools nav item and Settings cog icon
- **SessionDetailView.md** - Added Tools tab to sub-navigation
- **ProjectEditView.md** - Added Project Tool Templates section

### New Wireframes Created
- **SettingsView.md** - Lists global and project tool templates
- **ToolsGlobalView.md** - Global tools list with execute functionality
- **NewGlobalToolTemplateView.md** - Create global tool template form
- **EditGlobalToolTemplateView.md** - Edit/delete global tool template form
- **NewProjectToolTemplateView.md** - Create project tool template form
- **EditProjectToolTemplateView.md** - Edit/delete project tool template form

## Test plan

- [ ] Review architecture data model changes
- [ ] Review API endpoint definitions
- [ ] Verify wireframe consistency across views
- [ ] Ensure tool execution flow is clearly documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)