### PR TITLE
Remove TypeScript file extensions from Tailwind config in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -370,7 +370,7 @@ module.exports = {
 module.exports = {
   content: [
     './index.html',
-    './src/**/*.{vue,js,ts,jsx,tsx}',
+    './src/**/*.{vue,js}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- Removed TypeScript file extensions (`.ts`, `.tsx`, `.jsx`) from the Tailwind CSS content glob pattern in the architecture document
- The project uses plain JavaScript with JSDoc type annotations, not TypeScript

## Test plan
- [ ] Review the updated Tailwind config example in ARCHITECTURE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)