### PR TITLE
Fix Type Definition issues in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1066,8 +1066,13 @@ claudetools.io/
     * @property {string} name - User-provided or auto-generated
     * @property {SessionStatus} status
     * @property {ClaudeMode} mode - Execution mode (plan, standard, yolo)
+    * @property {string} [model] - Claude model ID (e.g., 'claude-sonnet-4-5')
     * @property {string} [gitBranch] - Current branch if in git repo
-    * @property {string} [gitWorktree] - Worktree name if applicable
+    * @property {string} [gitWorktree] - Worktree path if applicable
+    * @property {string} [prUrl] - Linked pull request URL
+    * @property {number} [inputTokens] - Input tokens used
+    * @property {number} [outputTokens] - Output tokens used
+    * @property {number} [estimatedCost] - Estimated cost in USD
     * @property {number} createdAt - Unix timestamp
     * @property {number} updatedAt - Last activity timestamp
     * @property {ConversationMessage[]} messages - Full conversation history
@@ -1359,9 +1364,9 @@ claudetools.io/
    /**
     * POST /api/sessions - Create new session
     * @typedef {Object} CreateSessionRequest
+    * @property {string} projectId - The project to create the session in (inherits workingDirectory from project)
     * @property {string} prompt - Initial prompt for Claude
     * @property {string} [name] - Optional session name
-    * @property {string} workingDirectory - Where to run Claude
     * @property {string} [gitBranch] - Optional branch to checkout
     * @property {ClaudeMode} [mode] - Claude Code execution mode (plan, standard, yolo). Defaults to 'standard'
     */


### PR DESCRIPTION
## Summary

- Resolves #21: Added `model` field to Session type
- Resolves #22: Added token/cost tracking fields (`inputTokens`, `outputTokens`, `estimatedCost`) to Session type
- Resolves #23: Fixed workingDirectory redundancy - CreateSessionRequest now uses `projectId` instead of `workingDirectory` (sessions inherit from parent Project)
- Resolves #32: Added `prUrl` field to Session type
- Resolves #33: Verified `projectId` was already present in SessionSummary type

## Test plan

- [ ] Verify JSDoc type definitions are valid syntax
- [ ] Confirm Session type now includes all required fields
- [ ] Confirm CreateSessionRequest uses projectId instead of workingDirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)