### PR TITLE
Address user safety and protocol issues (#34, #35, #36)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1309,6 +1309,7 @@ claudetools.io/
     * Canvas item added
     * @typedef {Object} WsCanvasAddMessage
     * @property {'canvas:add'} type
+    * @property {string} sessionId - Session the item was added to
     * @property {CanvasItem} item
     */
 
@@ -1316,12 +1317,14 @@ claudetools.io/
     * Canvas cleared
     * @typedef {Object} WsCanvasClearMessage
     * @property {'canvas:clear'} type
+    * @property {string} sessionId - Session that was cleared
     */
 
    /**
     * Canvas item removed
     * @typedef {Object} WsCanvasRemoveMessage
     * @property {'canvas:remove'} type
+    * @property {string} sessionId - Session the item was removed from
     * @property {string} itemId
     */
 
@@ -5010,13 +5013,13 @@ Connect to `ws://localhost:3000/ws`
 { type: 'session:pr-url:updated', sessionId: 'string', prUrl: 'string | null' }
 
 // Canvas item added
-{ type: 'canvas:add', item: CanvasItem }
+{ type: 'canvas:add', sessionId: 'string', item: CanvasItem }
 
 // Canvas item removed
-{ type: 'canvas:remove', itemId: 'string' }
+{ type: 'canvas:remove', sessionId: 'string', itemId: 'string' }
 
 // Canvas cleared
-{ type: 'canvas:clear' }
+{ type: 'canvas:clear', sessionId: 'string' }
 ```
 
 ### Client → Server Messages

--- a/wireframes/ProjectListView.md
+++ b/wireframes/ProjectListView.md
@@ -152,8 +152,7 @@ Dropdown options:
    - Opens ProjectEditView for editing (/projects/:id/edit)
 
 5. **Delete Button (on hover)**
-   - Shows confirmation dialog
-   - Warns about deleting all associated sessions
+   - Shows confirmation dialog with detailed data loss warning
    - On confirm, deletes project and all sessions
 
 6. **Project Actions (on hover)**
@@ -162,11 +161,36 @@ Dropdown options:
    |  Project Card                            [+ Session] [Edit] [X]  |
    |  ...                                                              |
    +------------------------------------------------------------------+
-
-   [X] reveals confirmation:
-   "Delete this project and all 3 sessions?"
-   [Cancel] [Delete]
    ```
+
+## Delete Project Confirmation Dialog
+
+When user clicks the delete [X] button on a project card:
+
+```
++--------------------------------------------------------------+
+|                     Delete Project?                           |
+|                                                              |
+|  Are you sure you want to delete "My Web App"?               |
+|                                                              |
+|  This will permanently delete:                               |
+|  - 5 sessions and their conversation history                 |
+|  - 12 canvas items (screenshots, documents, data)            |
+|  - 3 session notes                                           |
+|  - 2 project tool templates                                  |
+|                                                              |
+|  This action cannot be undone.                               |
+|                                                              |
+|                        [Cancel]  [Delete Project]            |
++--------------------------------------------------------------+
+```
+
+### Dialog Behavior
+- Counts are dynamically populated based on actual project data
+- If a count is zero, that line is omitted (e.g., no "0 session notes" line)
+- "Delete Project" button uses destructive styling (red background)
+- Cancel dismisses dialog without action
+- Dialog is modal (blocks interaction with page behind)
 
 ## Real-time Updates
 

--- a/wireframes/SessionDetailView.md
+++ b/wireframes/SessionDetailView.md
@@ -725,6 +725,60 @@ Line numbers:   Gray, non-selectable
     - Stop Session: Stops running session (shows confirmation)
     - Delete Session: Deletes session (shows confirmation with warning)
 
+## Delete Session Confirmation Dialog
+
+When user clicks "Delete Session" from the actions menu:
+
+### Standard Confirmation (session completed or idle)
+
+```
++--------------------------------------------------------------+
+|                     Delete Session?                           |
+|                                                              |
+|  Are you sure you want to delete "Fix authentication bug"?   |
+|                                                              |
+|  This will permanently delete:                               |
+|  - 24 conversation messages                                  |
+|  - 3 canvas items (screenshots, documents)                   |
+|  - 1 session note                                            |
+|                                                              |
+|  This action cannot be undone.                               |
+|                                                              |
+|                        [Cancel]  [Delete Session]            |
++--------------------------------------------------------------+
+```
+
+### Active Session Warning (session running or waiting for input)
+
+```
++--------------------------------------------------------------+
+|                   Delete Active Session?                      |
+|                                                              |
+|  Are you sure you want to delete "Fix authentication bug"?   |
+|                                                              |
+|  This session is currently running.                          |
+|  Deleting it will stop Claude and discard all work in        |
+|  progress.                                                   |
+|                                                              |
+|  This will permanently delete:                               |
+|  - 24 conversation messages                                  |
+|  - 3 canvas items (screenshots, documents)                   |
+|  - 1 session note                                            |
+|                                                              |
+|  This action cannot be undone.                               |
+|                                                              |
+|                        [Cancel]  [Delete Session]            |
++--------------------------------------------------------------+
+```
+
+### Dialog Behavior
+- Counts are dynamically populated based on actual session data
+- If a count is zero, that line is omitted (e.g., no "0 canvas items" line)
+- Active session warning appears when session status is "running" or "waiting"
+- "Delete Session" button uses destructive styling (red background)
+- Cancel dismisses dialog without action
+- Dialog is modal (blocks interaction with page behind)
+
 ## Responsive Behavior
 
 ### Mobile (<768px)

--- a/wireframes/SessionListView.md
+++ b/wireframes/SessionListView.md
@@ -197,6 +197,9 @@ Dropdown options:
    - View in Terminal (future)
    ```
 
+   Delete Session action shows the same confirmation dialog as in SessionDetailView
+   (see SessionDetailView.md for full dialog specification).
+
 ## Real-time Updates
 
 - New sessions appear at top of list (if sorted by newest)


### PR DESCRIPTION
## Summary

- **Issue #34**: Added missing `sessionId` property to WebSocket canvas message type definitions (`canvas:add`, `canvas:remove`, `canvas:clear`) in ARCHITECTURE.md to match actual broadcast implementation
- **Issue #35**: Added detailed delete confirmation dialog to ProjectListView wireframe showing itemized data loss (sessions, canvas items, notes, tool templates)
- **Issue #36**: Added delete confirmation dialogs to SessionDetailView wireframe with standard and active-session variants, plus cross-reference in SessionListView

Also closed issue #37 as not needed.

## Test plan

- [ ] Review ARCHITECTURE.md WebSocket type definitions match broadcast calls
- [ ] Review ProjectListView.md delete confirmation dialog wireframe
- [ ] Review SessionDetailView.md delete confirmation dialogs (standard and active session variants)
- [ ] Review SessionListView.md cross-reference to SessionDetailView

🤖 Generated with [Claude Code](https://claude.com/claude-code)