### PR TITLE
Replace pnpm with yarn in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,7 +195,7 @@ Used for:
 
 | Technology | Purpose |
 |------------|---------|
-| **pnpm** | Package manager with workspace support |
+| **yarn** | Package manager with workspace support |
 | **ESLint** | Linting |
 | **Prettier** | Code formatting |
 | **concurrently** | Run server and frontend in parallel |
@@ -733,7 +733,7 @@ function useKeyboardShortcuts() {
 claudetools.io/
 │
 ├── package.json                    # Root package.json for workspaces
-├── pnpm-workspace.yaml             # pnpm workspace configuration
+├── yarn.lock                       # yarn lockfile
 ├── .gitignore                      # Git ignore rules
 ├── .prettierrc                     # Prettier configuration
 ├── .eslintrc.cjs                   # ESLint configuration
@@ -842,17 +842,18 @@ claudetools.io/
      "name": "claudetools",
      "private": true,
      "scripts": {
-       "dev": "concurrently \"pnpm --filter server dev\" \"pnpm --filter web dev\"",
-       "build": "pnpm -r build",
-       "start": "pnpm --filter server start"
+       "dev": "concurrently \"yarn workspace server dev\" \"yarn workspace web dev\"",
+       "build": "yarn workspaces run build",
+       "start": "yarn workspace server start"
      }
    }
    ```
 
-2. **Create pnpm-workspace.yaml**
-   ```yaml
-   packages:
-     - 'packages/*'
+2. **Configure yarn workspaces in root package.json**
+   ```json
+   {
+     "workspaces": ["packages/*"]
+   }
    ```
 
 3. **Initialize packages/shared**
@@ -870,13 +871,13 @@ claudetools.io/
    - Configure Vite to proxy API requests to server in dev mode
 
 6. **Verify setup**
-   - Run `pnpm install` from root
-   - Run `pnpm dev` and verify both server and frontend start
+   - Run `yarn install` from root
+   - Run `yarn dev` and verify both server and frontend start
    - Verify frontend can reach server API
 
 **Deliverables**:
 - All three packages exist and build without errors
-- `pnpm dev` starts both server (port 3000) and frontend (port 5173)
+- `yarn dev` starts both server (port 3000) and frontend (port 5173)
 - Frontend dev server proxies `/api/*` and `/ws` to server
 
 ---
@@ -1419,7 +1420,7 @@ claudetools.io/
 1. **Install Claude Agent SDK**
    ```bash
    cd packages/server
-   pnpm add @anthropic-ai/claude-agent-sdk
+   yarn add @anthropic-ai/claude-agent-sdk
    ```
 
 2. **Create SessionManager class (`src/services/sessionManager.js`)**
@@ -3319,7 +3320,7 @@ claudetools.io/
 1. **Install chokidar for file watching**
    ```bash
    cd packages/server
-   pnpm add chokidar
+   yarn add chokidar
    ```
 
 2. **Create DiffService class (`src/services/diffService.js`)**
@@ -3572,7 +3573,7 @@ claudetools.io/
    **Installation:**
    ```bash
    cd packages/web
-   pnpm add diff2html
+   yarn add diff2html
    ```
 
    **Component Implementation (`src/components/DiffViewer.vue`):**
@@ -3660,7 +3661,7 @@ claudetools.io/
 1. **Install gray-matter for frontmatter parsing**
    ```bash
    cd packages/server
-   pnpm add gray-matter
+   yarn add gray-matter
    ```
 
 2. **Create SlashCommandService class (`src/services/slashCommandService.js`)**


### PR DESCRIPTION
## Summary
- Updated all package manager references from `pnpm` to `yarn` throughout ARCHITECTURE.md
- Changed workspace configuration from `pnpm-workspace.yaml` to yarn's `"workspaces"` field in package.json
- Updated all scripts to use yarn workspace syntax (e.g., `yarn workspace server dev`)

## Test plan
- [ ] Verify ARCHITECTURE.md renders correctly
- [ ] Confirm no remaining pnpm references exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)