### PR TITLE
CI: Only run tests when PR is ready for review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +15,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +34,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
 
@@ -52,6 +55,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Skip CI tests for draft PRs to save CI resources
- Added `ready_for_review` event type to trigger tests when a draft is marked ready
- Added `if: github.event.pull_request.draft == false` condition to all jobs

## Test plan
- [ ] Create a draft PR and verify tests don't run
- [ ] Mark draft PR as ready for review and verify tests run
- [ ] Push to main and verify tests still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)