### PR TITLE
Add start-server.sh script

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Stop any process listening on port 5000
+echo "Checking for processes on port 5000..."
+PID=$(lsof -t -i:5000 2>/dev/null)
+
+if [ -n "$PID" ]; then
+    echo "Stopping process $PID on port 5000..."
+    kill -9 $PID 2>/dev/null
+    sleep 1
+    echo "Process stopped."
+else
+    echo "No process found on port 5000."
+fi
+
+# Start the server
+echo "Starting server..."
+yarn dev


### PR DESCRIPTION
## Summary
- Adds a `scripts/start-server.sh` script that kills any process on port 5000 before starting the dev server
- Makes development workflow easier by handling port conflicts automatically

## Test plan
- [ ] Run `./scripts/start-server.sh` and verify it starts the server
- [ ] Start a process on port 5000, then run the script to verify it kills the existing process before starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)