### PR TITLE
Remove all references to port 5173

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -877,7 +877,7 @@ claudetools.io/
 
 **Deliverables**:
 - All three packages exist and build without errors
-- `yarn dev` starts both server (port 5000) and frontend (port 5173)
+- `yarn dev` starts the server (port 5000) which serves both API and frontend
 - Frontend dev server proxies `/api/*` and `/ws` to server
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ yarn dev
 ```
 
 This starts:
-- **Frontend**: http://localhost:5173
+- **Frontend**: http://localhost:5000
 - **Backend API**: http://localhost:5000
 - **WebSocket**: ws://localhost:5000/ws
 
@@ -98,7 +98,7 @@ yarn workspace @claudetools/web test         # Web tests only
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BASE_URL` | `http://localhost:5173` | Frontend URL |
+| `BASE_URL` | `http://localhost:5000` | Frontend URL |
 | `API_URL` | `http://localhost:5000` | Backend URL |
 | `BROWSER` | `chromium` | Browser to use |
 | `HEADLESS` | `true` | Run headless |

--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -9,8 +9,8 @@
 #
 # Examples:
 #   docker compose -f docker-compose.playwright.yml run --rm playwright test
-#   docker compose -f docker-compose.playwright.yml run --rm playwright screenshot http://localhost:5173 home.png
-#   docker compose -f docker-compose.playwright.yml run --rm -e DEVICE="iPhone 14" playwright screenshot http://localhost:5173 mobile.png
+#   docker compose -f docker-compose.playwright.yml run --rm playwright screenshot http://localhost:5000 home.png
+#   docker compose -f docker-compose.playwright.yml run --rm -e DEVICE="iPhone 14" playwright screenshot http://localhost:5000 mobile.png
 
 services:
   playwright:
@@ -32,7 +32,7 @@ services:
     # Environment configuration
     environment:
       # Base URL for tests (frontend dev server)
-      - BASE_URL=${BASE_URL:-http://localhost:5173}
+      - BASE_URL=${BASE_URL:-http://localhost:5000}
       # Browser selection: chromium, firefox, webkit
       - BROWSER=${BROWSER:-chromium}
       # Run in headless mode

--- a/docker/playwright/Dockerfile
+++ b/docker/playwright/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/playwright:v1.40.0-jammy
 
 # Set environment defaults
 ENV NODE_ENV=production \
-    BASE_URL=http://localhost:5173 \
+    BASE_URL=http://localhost:5000 \
     BROWSER=chromium \
     HEADLESS=true \
     VIEWPORT_WIDTH=1280 \

--- a/docker/playwright/README.md
+++ b/docker/playwright/README.md
@@ -9,7 +9,7 @@ A Docker container for browser automation, testing, and screenshots. Supports hi
 ./scripts/pw.sh build
 
 # Take a screenshot
-./scripts/pw.sh screenshot http://localhost:5173 homepage.png
+./scripts/pw.sh screenshot http://localhost:5000 homepage.png
 
 # Run tests
 ./scripts/pw.sh test
@@ -31,19 +31,19 @@ A Docker container for browser automation, testing, and screenshots. Supports hi
 
 ```bash
 # Basic screenshot
-./scripts/pw.sh screenshot http://localhost:5173 home.png
+./scripts/pw.sh screenshot http://localhost:5000 home.png
 
 # Full page capture
-FULL_PAGE=true ./scripts/pw.sh screenshot http://localhost:5173 full.png
+FULL_PAGE=true ./scripts/pw.sh screenshot http://localhost:5000 full.png
 
 # Mobile device emulation
-DEVICE="iPhone 14" ./scripts/pw.sh screenshot http://localhost:5173 mobile.png
+DEVICE="iPhone 14" ./scripts/pw.sh screenshot http://localhost:5000 mobile.png
 
 # Custom viewport
-VIEWPORT_WIDTH=1920 VIEWPORT_HEIGHT=1080 ./scripts/pw.sh screenshot http://localhost:5173 wide.png
+VIEWPORT_WIDTH=1920 VIEWPORT_HEIGHT=1080 ./scripts/pw.sh screenshot http://localhost:5000 wide.png
 
 # Use Firefox
-BROWSER=firefox ./scripts/pw.sh screenshot http://localhost:5173 firefox.png
+BROWSER=firefox ./scripts/pw.sh screenshot http://localhost:5000 firefox.png
 ```
 
 Screenshots are saved to the `screenshots/` directory.
@@ -70,7 +70,7 @@ Test reports are saved to `playwright-report/`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BASE_URL` | `http://localhost:5173` | Base URL for tests |
+| `BASE_URL` | `http://localhost:5000` | Base URL for tests |
 | `BROWSER` | `chromium` | Browser: `chromium`, `firefox`, `webkit` |
 | `HEADLESS` | `true` | Run headless mode |
 | `FULL_PAGE` | `false` | Capture full page screenshots |
@@ -85,7 +85,7 @@ The container uses `network_mode: host` to access services on your machine:
 
 | Service | URL |
 |---------|-----|
-| Frontend (Vite) | `http://localhost:5173` |
+| Frontend (Vite) | `http://localhost:5000` |
 | Backend (Express) | `http://localhost:5000` |
 
 **macOS/Windows**: The entrypoint auto-detects Docker Desktop and uses `host.docker.internal`.
@@ -118,7 +118,7 @@ If you prefer using Docker directly:
 docker compose -f docker-compose.playwright.yml build
 
 # Screenshot
-docker compose -f docker-compose.playwright.yml run --rm playwright screenshot http://localhost:5173 home.png
+docker compose -f docker-compose.playwright.yml run --rm playwright screenshot http://localhost:5000 home.png
 
 # Tests
 docker compose -f docker-compose.playwright.yml run --rm playwright test

--- a/docker/playwright/entrypoint.sh
+++ b/docker/playwright/entrypoint.sh
@@ -74,18 +74,18 @@ Commands:
                            Example: test tests/home.spec.ts
 
   screenshot <url> [file]  Capture screenshot of URL
-                           Example: screenshot http://localhost:5173 home.png
+                           Example: screenshot http://localhost:5000 home.png
                            Example: screenshot http://localhost:5000/api/health api.png
 
   codegen [url]            Launch Playwright codegen (requires X11)
-                           Example: codegen http://localhost:5173
+                           Example: codegen http://localhost:5000
 
   shell                    Start interactive bash shell
 
   help                     Show this help message
 
 Environment Variables:
-  BASE_URL          Base URL for tests (default: http://localhost:5173)
+  BASE_URL          Base URL for tests (default: http://localhost:5000)
   BROWSER           Browser to use: chromium, firefox, webkit (default: chromium)
   HEADLESS          Run headless: true/false (default: true)
   FULL_PAGE         Capture full page screenshots: true/false (default: false)
@@ -102,13 +102,13 @@ Examples:
   docker compose run --rm playwright test tests/auth.spec.ts
 
   # Capture screenshot
-  docker compose run --rm playwright screenshot http://localhost:5173 homepage.png
+  docker compose run --rm playwright screenshot http://localhost:5000 homepage.png
 
   # Capture full-page screenshot
-  docker compose run --rm -e FULL_PAGE=true playwright screenshot http://localhost:5173 full.png
+  docker compose run --rm -e FULL_PAGE=true playwright screenshot http://localhost:5000 full.png
 
   # Use mobile viewport
-  docker compose run --rm -e DEVICE="iPhone 14" playwright screenshot http://localhost:5173 mobile.png
+  docker compose run --rm -e DEVICE="iPhone 14" playwright screenshot http://localhost:5000 mobile.png
 EOF
 }
 

--- a/docker/playwright/tools/screenshot.js
+++ b/docker/playwright/tools/screenshot.js
@@ -115,9 +115,9 @@ async function main() {
         console.error('Usage: node screenshot.js <url> [output]');
         console.error('');
         console.error('Example:');
-        console.error('  node screenshot.js http://localhost:5173 homepage.png');
-        console.error('  FULL_PAGE=true node screenshot.js http://localhost:5173 full-page.png');
-        console.error('  DEVICE="iPhone 14" node screenshot.js http://localhost:5173 mobile.png');
+        console.error('  node screenshot.js http://localhost:5000 homepage.png');
+        console.error('  FULL_PAGE=true node screenshot.js http://localhost:5000 full-page.png');
+        console.error('  DEVICE="iPhone 14" node screenshot.js http://localhost:5000 mobile.png');
         process.exit(1);
     }
 

--- a/playwright.config.docker.ts
+++ b/playwright.config.docker.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     // Shared settings for all projects
     use: {
         // Base URL from environment
-        baseURL: process.env.BASE_URL || 'http://localhost:5173',
+        baseURL: process.env.BASE_URL || 'http://localhost:5000',
 
         // Collect trace when retrying the failed test
         trace: 'on-first-retry',
@@ -117,7 +117,7 @@ export default defineConfig({
     // Uncomment if you want the container to start the dev server
     // webServer: {
     //     command: 'pnpm dev',
-    //     url: 'http://localhost:5173',
+    //     url: 'http://localhost:5000',
     //     reuseExistingServer: !process.env.CI,
     //     timeout: 120 * 1000,
     // },

--- a/scripts/pw.sh
+++ b/scripts/pw.sh
@@ -74,7 +74,7 @@ cmd_screenshot() {
     if [ -z "$1" ]; then
         print_error "URL is required"
         echo "Usage: $0 screenshot <url> [filename]"
-        echo "Example: $0 screenshot http://localhost:5173 homepage.png"
+        echo "Example: $0 screenshot http://localhost:5000 homepage.png"
         exit 1
     fi
 
@@ -88,7 +88,7 @@ cmd_screenshot() {
 
 # Run codegen
 cmd_codegen() {
-    local url="${1:-http://localhost:5173}"
+    local url="${1:-http://localhost:5000}"
 
     # Check if X11 is available
     if [ -z "$DISPLAY" ]; then
@@ -134,11 +134,11 @@ Commands:
                            Example: $(basename "$0") test tests/home.spec.ts
 
   screenshot <url> [file]  Capture screenshot of URL
-                           Example: $(basename "$0") screenshot http://localhost:5173
-                           Example: $(basename "$0") screenshot http://localhost:5173 home.png
+                           Example: $(basename "$0") screenshot http://localhost:5000
+                           Example: $(basename "$0") screenshot http://localhost:5000 home.png
 
   codegen [url]            Launch Playwright test generator (requires X11)
-                           Example: $(basename "$0") codegen http://localhost:5173
+                           Example: $(basename "$0") codegen http://localhost:5000
 
   debug [args]             Run tests with headed browser (requires X11)
                            Example: $(basename "$0") debug tests/login.spec.ts
@@ -150,7 +150,7 @@ Commands:
   help                     Show this help message
 
 Environment Variables:
-  BASE_URL          Base URL for tests (default: http://localhost:5173)
+  BASE_URL          Base URL for tests (default: http://localhost:5000)
   BROWSER           Browser: chromium, firefox, webkit (default: chromium)
   HEADLESS          Run headless: true/false (default: true)
   FULL_PAGE         Full page screenshots: true/false (default: false)
@@ -167,13 +167,13 @@ Examples:
   $(basename "$0") test tests/auth.spec.ts
 
   # Screenshot with custom viewport
-  VIEWPORT_WIDTH=1920 VIEWPORT_HEIGHT=1080 $(basename "$0") screenshot http://localhost:5173 wide.png
+  VIEWPORT_WIDTH=1920 VIEWPORT_HEIGHT=1080 $(basename "$0") screenshot http://localhost:5000 wide.png
 
   # Mobile screenshot
-  DEVICE="iPhone 14" $(basename "$0") screenshot http://localhost:5173 mobile.png
+  DEVICE="iPhone 14" $(basename "$0") screenshot http://localhost:5000 mobile.png
 
   # Full page screenshot
-  FULL_PAGE=true $(basename "$0") screenshot http://localhost:5173 full.png
+  FULL_PAGE=true $(basename "$0") screenshot http://localhost:5000 full.png
 
   # Use Firefox
   BROWSER=firefox $(basename "$0") test


### PR DESCRIPTION
## Summary
- Replaced all 32 instances of port 5173 with port 5000 across 9 files
- The application serves both frontend and API from port 5000, so references to Vite's default port 5173 were incorrect

### Files Updated
- `README.md` - Updated frontend URL and BASE_URL default
- `ARCHITECTURE.md` - Updated dev server description  
- `docker-compose.playwright.yml` - Updated BASE_URL default and examples
- `playwright.config.docker.ts` - Updated baseURL defaults
- `docker/playwright/README.md` - Updated all examples and documentation
- `docker/playwright/entrypoint.sh` - Updated help text and examples
- `docker/playwright/Dockerfile` - Updated BASE_URL env default
- `docker/playwright/tools/screenshot.js` - Updated usage examples
- `scripts/pw.sh` - Updated help text and examples

## Test plan
- [ ] Verify `yarn dev` starts correctly on port 5000
- [ ] Verify Playwright tests run against correct port
- [ ] Verify screenshot tool works with port 5000

🤖 Generated with [Claude Code](https://claude.com/claude-code)