### PR TITLE
Make entire project row clickable in project list

### DIFF
--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -19,14 +19,18 @@
     </div>
 
     <div v-else class="project-list">
-      <div v-for="project in projectsStore.projects" :key="project.id" class="project-card card">
+      <div
+        v-for="project in projectsStore.projects"
+        :key="project.id"
+        class="project-card card"
+        @click="goToSessions(project.id)"
+      >
         <div class="project-info">
           <h3 class="project-name">{{ project.name }}</h3>
           <p class="project-path">{{ project.workingDirectory }}</p>
         </div>
         <div class="project-actions">
-          <router-link :to="`/projects/${project.id}/sessions`" class="btn">Sessions</router-link>
-          <router-link :to="`/projects/${project.id}/edit`" class="btn">Edit</router-link>
+          <router-link :to="`/projects/${project.id}/edit`" class="btn" @click.stop>Edit</router-link>
         </div>
       </div>
     </div>
@@ -35,9 +39,15 @@
 
 <script setup>
 import { onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 
+const router = useRouter();
 const projectsStore = useProjectsStore();
+
+function goToSessions(projectId) {
+  router.push(`/projects/${projectId}/sessions`);
+}
 
 onMounted(() => {
   projectsStore.fetchProjects();
@@ -89,6 +99,12 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.project-card:hover {
+  background-color: var(--color-background-soft);
 }
 
 .project-name {

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -59,7 +59,8 @@ test.describe('Project Management', () => {
     const project = await seedProject('Test Project', '/tmp/test');
 
     await page.goto('/');
-    await page.click('text=Sessions');
+    // Click on the project row (which is now fully clickable)
+    await page.click('.project-card');
 
     await expect(page).toHaveURL(`/projects/${project.id}/sessions`);
 


### PR DESCRIPTION
## Summary
- Made the entire project card row clickable to navigate to sessions
- Removed the separate "Sessions" button (now redundant since row click navigates there)
- Added hover styling to indicate the row is interactive
- Edit button still works independently with click event propagation stopped

## Test plan
- [ ] Navigate to the project list
- [ ] Verify clicking anywhere on a project row navigates to the sessions view
- [ ] Verify the Edit button still works and doesn't navigate to sessions
- [ ] Verify hover state shows visual feedback on the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)