### PR TITLE
Enable full chat conversations in sessions

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { sessions, messages, sessionNotes } from '../database.js';
-import { sendMessage, stopSession } from '../services/sessionManager.js';
+import { sessions, messages, sessionNotes, projects } from '../database.js';
+import { continueSession, stopSession, endSession } from '../services/sessionManager.js';
 
 const router = Router();
 
@@ -40,8 +40,17 @@ router.post('/:id/message', async (req, res) => {
     return res.status(400).json({ error: 'Session is not waiting for input' });
   }
 
+  // Get the project for the working directory
+  const project = projects.getById(session.projectId);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
   try {
-    await sendMessage(session.id, content);
+    // Start continuation (non-blocking)
+    continueSession(session.id, content, project.workingDirectory).catch((error) => {
+      console.error('Continue session error:', error);
+    });
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -61,6 +70,25 @@ router.post('/:id/stop', async (req, res) => {
 
   try {
     await stopSession(session.id);
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// POST /api/sessions/:id/end - End session (mark as completed)
+router.post('/:id/end', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  if (session.status === 'completed') {
+    return res.status(400).json({ error: 'Session is already completed' });
+  }
+
+  try {
+    endSession(session.id);
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -3,7 +3,7 @@ import { sessions, messages } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT } from '@claudetools/shared';
 
-/** @type {Map<string, { controller: AbortController, inputResolve: Function | null }>} */
+/** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
 
 /**
@@ -28,7 +28,7 @@ For images, use base64 encoding in the content field.`;
  */
 export async function runSession(sessionId, prompt, workingDirectory) {
   const controller = new AbortController();
-  activeSessions.set(sessionId, { controller, inputResolve: null });
+  activeSessions.set(sessionId, { controller });
 
   try {
     // Update status to running
@@ -45,7 +45,11 @@ export async function runSession(sessionId, prompt, workingDirectory) {
         abortController: controller,
         includePartialMessages: true,
         permissionMode: 'bypassPermissions',
-        appendSystemPrompt: buildCanvasSystemPrompt(sessionId),
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+          append: buildCanvasSystemPrompt(sessionId),
+        },
       },
     })) {
       if (controller.signal.aborted) break;
@@ -53,11 +57,11 @@ export async function runSession(sessionId, prompt, workingDirectory) {
       await handleStreamEvent(sessionId, event);
     }
 
-    // Session completed
+    // Session ready for follow-up - set to waiting instead of completed
     const session = activeSessions.get(sessionId);
     if (session && !controller.signal.aborted) {
-      sessions.update(sessionId, { status: 'completed' });
-      broadcastSessionStatus(sessionId, 'completed');
+      sessions.update(sessionId, { status: 'waiting' });
+      broadcastSessionStatus(sessionId, 'waiting');
     }
   } catch (error) {
     console.error('Session error:', error);
@@ -73,31 +77,77 @@ export async function runSession(sessionId, prompt, workingDirectory) {
 }
 
 /**
- * Send a follow-up message to a session
+ * Continue a session with a follow-up message
  * @param {string} sessionId
  * @param {string} content
+ * @param {string} workingDirectory
  */
-export async function sendMessage(sessionId, content) {
-  const sessionData = activeSessions.get(sessionId);
-  if (!sessionData) {
-    throw new Error('Session is not active');
+export async function continueSession(sessionId, content, workingDirectory) {
+  // Check if session is already running
+  if (activeSessions.has(sessionId)) {
+    throw new Error('Session is already processing');
   }
 
-  if (!sessionData.inputResolve) {
-    throw new Error('Session is not waiting for input');
+  // Get the session to retrieve the Claude session ID
+  const session = sessions.getById(sessionId);
+  if (!session) {
+    throw new Error('Session not found');
   }
 
-  // Store the message
-  const message = messages.create(sessionId, 'user', content);
-  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, { message });
+  if (!session.claudeSessionId) {
+    throw new Error('Session has no Claude session ID - cannot resume');
+  }
 
-  // Update status
-  sessions.update(sessionId, { status: 'running' });
-  broadcastSessionStatus(sessionId, 'running');
+  const controller = new AbortController();
+  activeSessions.set(sessionId, { controller });
 
-  // Resolve the waiting input generator
-  sessionData.inputResolve(content);
-  sessionData.inputResolve = null;
+  try {
+    // Store the user message
+    const message = messages.create(sessionId, 'user', content);
+    broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, { message });
+
+    // Update status to running
+    sessions.update(sessionId, { status: 'running' });
+    broadcastSessionStatus(sessionId, 'running');
+
+    // Resume the session with the new message
+    for await (const event of query({
+      prompt: content,
+      options: {
+        cwd: workingDirectory,
+        abortController: controller,
+        includePartialMessages: true,
+        permissionMode: 'bypassPermissions',
+        resume: session.claudeSessionId,
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+          append: buildCanvasSystemPrompt(sessionId),
+        },
+      },
+    })) {
+      if (controller.signal.aborted) break;
+
+      await handleStreamEvent(sessionId, event);
+    }
+
+    // Session ready for more follow-ups
+    const activeSession = activeSessions.get(sessionId);
+    if (activeSession && !controller.signal.aborted) {
+      sessions.update(sessionId, { status: 'waiting' });
+      broadcastSessionStatus(sessionId, 'waiting');
+    }
+  } catch (error) {
+    console.error('Continue session error:', error);
+    console.error('Error stack:', error.stack);
+    if (!controller.signal.aborted) {
+      sessions.update(sessionId, { status: 'error', error: error.message });
+      broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { error: error.message });
+    }
+    throw error;
+  } finally {
+    activeSessions.delete(sessionId);
+  }
 }
 
 /**
@@ -111,6 +161,22 @@ export async function stopSession(sessionId) {
   }
 
   sessionData.controller.abort();
+  sessions.update(sessionId, { status: 'completed' });
+  broadcastSessionStatus(sessionId, 'completed');
+}
+
+/**
+ * End a session (mark as completed)
+ * @param {string} sessionId
+ */
+export function endSession(sessionId) {
+  // If actively running, abort first
+  const sessionData = activeSessions.get(sessionId);
+  if (sessionData) {
+    sessionData.controller.abort();
+    activeSessions.delete(sessionId);
+  }
+
   sessions.update(sessionId, { status: 'completed' });
   broadcastSessionStatus(sessionId, 'completed');
 }

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -158,6 +158,15 @@ export class ApiClient {
     return this.#request('POST', `/sessions/${id}/stop`);
   }
 
+  /**
+   * End a session (mark as completed)
+   * @param {string} id - Session ID
+   * @returns {Promise<Object>}
+   */
+  async endSession(id) {
+    return this.#request('POST', `/sessions/${id}/end`);
+  }
+
   // Canvas
 
   /**

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -41,15 +41,24 @@
         rows="3"
         @keydown.enter.ctrl="handleSend"
       ></textarea>
-      <button type="submit" class="btn btn-primary" :disabled="!input.trim() || sending">
-        <span v-if="sending" class="loading-spinner"></span>
-        Send
-      </button>
+      <div class="input-actions">
+        <button type="submit" class="btn btn-primary" :disabled="!input.trim() || sending">
+          <span v-if="sending" class="loading-spinner"></span>
+          Send
+        </button>
+        <button type="button" class="btn btn-secondary" @click="handleEndSession" :disabled="ending">
+          End Session
+        </button>
+      </div>
     </form>
 
     <div v-else-if="sessionsStore.currentSession?.status === 'running'" class="status-message">
       <span class="loading-spinner"></span>
       Claude is working...
+    </div>
+
+    <div v-else-if="sessionsStore.currentSession?.status === 'completed'" class="status-message status-completed">
+      Session completed
     </div>
   </div>
 </template>
@@ -69,6 +78,7 @@ const uiStore = useUiStore();
 
 const input = ref('');
 const sending = ref(false);
+const ending = ref(false);
 const messagesContainer = ref(null);
 const partialText = ref('');
 
@@ -128,6 +138,19 @@ async function handleSend() {
     uiStore.error(err.message);
   } finally {
     sending.value = false;
+  }
+}
+
+async function handleEndSession() {
+  if (ending.value) return;
+
+  ending.value = true;
+  try {
+    await sessionsStore.endSession(props.sessionId);
+  } catch (err) {
+    uiStore.error(err.message);
+  } finally {
+    ending.value = false;
   }
 }
 </script>
@@ -226,6 +249,22 @@ async function handleSend() {
   flex: 1;
 }
 
+.input-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.btn-secondary {
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-soft);
+}
+
+.btn-secondary:hover {
+  background-color: var(--color-background-mute);
+}
+
 .status-message {
   display: flex;
   align-items: center;
@@ -233,6 +272,10 @@ async function handleSend() {
   padding: 1rem;
   color: var(--color-text-soft);
   border-top: 1px solid var(--color-border);
+}
+
+.status-completed {
+  color: var(--color-success, #10b981);
 }
 
 /* Streaming indicator animation */

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -91,6 +91,23 @@ export const useSessionsStore = defineStore('sessions', {
       }
     },
 
+    async endSession(id) {
+      this.error = null;
+      try {
+        await api.endSession(id);
+        if (this.currentSession?.id === id) {
+          this.currentSession.status = 'completed';
+        }
+        const session = this.sessions.find((s) => s.id === id);
+        if (session) {
+          session.status = 'completed';
+        }
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
     addMessage(message) {
       this.messages.push(message);
     },

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -99,16 +99,17 @@ const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCan
 let cleanups = [];
 const pollIntervalId = ref(null);
 
-// Poll for updates while session is active (fallback for race conditions)
+// Poll for updates while session is actively processing (fallback for race conditions)
 function startPolling() {
   if (pollIntervalId.value) return;
   pollIntervalId.value = setInterval(async () => {
     const status = sessionsStore.currentSession?.status;
-    if (status === 'running' || status === 'starting' || status === 'waiting') {
+    // Only poll while actively processing, not while waiting for user input
+    if (status === 'running' || status === 'starting') {
       await sessionsStore.fetchSession(route.params.id);
       await sessionsStore.fetchMessages(route.params.id);
     } else {
-      // Session no longer active, stop polling
+      // Session no longer actively processing, stop polling
       stopPolling();
     }
   }, 2000);
@@ -130,18 +131,20 @@ onMounted(async () => {
   await sessionsStore.fetchMessages(route.params.id);
   canvasStore.fetchItems(route.params.id);
 
-  // Start polling if session is active (handles race condition where session
+  // Start polling if session is actively processing (handles race condition where session
   // completes before WebSocket subscription is established)
   const status = sessionsStore.currentSession?.status;
-  if (status === 'running' || status === 'starting' || status === 'waiting') {
+  if (status === 'running' || status === 'starting') {
     startPolling();
   }
 
   cleanups.push(
     onStatus((status) => {
       sessionsStore.updateSessionStatus(route.params.id, status);
-      // Stop polling when session becomes inactive
-      if (status !== 'running' && status !== 'starting' && status !== 'waiting') {
+      // Start polling when session starts processing, stop when done
+      if (status === 'running' || status === 'starting') {
+        startPolling();
+      } else {
         stopPolling();
       }
     })


### PR DESCRIPTION
## Summary

- Enable multi-turn chat conversations with Claude Code sessions instead of ending after one interaction
- Sessions now transition to `waiting` status after Claude responds, allowing follow-up messages
- Added "End Session" button to explicitly mark sessions as completed
- Fixed polling loop that caused page to reload every 2 seconds

## Changes

**Backend (`packages/server`):**
- `sessionManager.js`: Changed `runSession()` to set status to `waiting` after processing; added `continueSession()` using SDK's `resume` option; added `endSession()` function
- `sessions.js` API: Updated message endpoint to call `continueSession()`; added `POST /api/sessions/:id/end` endpoint

**Frontend (`packages/web`):**
- `ConversationTab.vue`: Added "End Session" button; show "Session completed" status
- `sessions.js` store: Added `endSession()` action
- `ApiClient.js`: Added `endSession()` API method
- `SessionDetailView.vue`: Fixed polling to only run during `running`/`starting` status, not `waiting`

## Test plan

- [ ] Create a new session and verify initial message gets a response
- [ ] After response, verify session shows "waiting" status with input form visible
- [ ] Send follow-up message and verify conversation continues with context
- [ ] Click "End Session" and verify session transitions to "completed"
- [ ] Verify page no longer reloads repeatedly when viewing a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)