### PR TITLE
Fix Changes view to show git diff and untracked files

### DIFF
--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { projects, sessions } from '../database.js';
 import { CreateProjectRequest, UpdateProjectRequest } from '@claudetools/shared/contracts/projects';
+import { setupGitForSession } from '../services/gitSessionSetup.js';
 
 const router = Router();
 
@@ -76,7 +77,7 @@ router.post('/:id/sessions', async (req, res) => {
     return res.status(404).json({ error: 'Project not found' });
   }
 
-  const { prompt, name, mode, gitBranch } = req.body;
+  const { prompt, name, mode, gitBranch, gitMode } = req.body;
   if (!prompt) {
     return res.status(400).json({ error: 'Prompt is required' });
   }
@@ -84,14 +85,35 @@ router.post('/:id/sessions', async (req, res) => {
   const sessionName = name || `Session ${Date.now()}`;
   const session = sessions.create(req.params.id, sessionName, prompt, mode, gitBranch);
 
-  // Start session manager (non-blocking)
-  const { runSession } = await import('../services/sessionManager.js');
-  runSession(session.id, prompt, project.workingDirectory).catch((error) => {
-    console.error('Session error:', error);
-    sessions.update(session.id, { status: 'error', error: error.message });
-  });
+  // Setup git environment (branch checkout or worktree creation)
+  try {
+    const { workingDirectory, gitWorktree } = await setupGitForSession({
+      projectDir: project.workingDirectory,
+      gitMode: gitMode || null,
+      gitBranch: gitBranch || null,
+      sessionId: session.id,
+    });
 
-  res.status(201).json(session);
+    // Update session with worktree path if created
+    if (gitWorktree) {
+      sessions.update(session.id, { gitWorktree });
+    }
+
+    // Start session manager (non-blocking)
+    const { runSession } = await import('../services/sessionManager.js');
+    runSession(session.id, prompt, workingDirectory).catch((error) => {
+      console.error('Session error:', error);
+      sessions.update(session.id, { status: 'error', error: error.message });
+    });
+
+    // Return updated session with gitWorktree if set
+    const updatedSession = sessions.getById(session.id);
+    res.status(201).json(updatedSession);
+  } catch (error) {
+    console.error('Git setup error:', error);
+    sessions.update(session.id, { status: 'error', error: error.message });
+    res.status(500).json({ error: `Git setup failed: ${error.message}` });
+  }
 });
 
 export default router;

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
-import { sessions, messages, sessionNotes } from '../database.js';
+import { sessions, messages, sessionNotes, projects } from '../database.js';
 import { sendMessage, stopSession } from '../services/sessionManager.js';
+import { getChanges } from '../services/diffService.js';
 
 const router = Router();
 
@@ -11,6 +12,29 @@ router.get('/:id', (req, res) => {
     return res.status(404).json({ error: 'Session not found' });
   }
   res.json(session);
+});
+
+// GET /api/sessions/:id/changes - Get git changes for session
+router.get('/:id/changes', async (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const project = projects.getById(session.projectId);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  // Use gitWorktree if set, otherwise use the project's working directory
+  const directory = session.gitWorktree || project.workingDirectory;
+
+  try {
+    const changes = await getChanges(directory);
+    res.json(changes);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
 // GET /api/sessions/:id/messages - Get session messages

--- a/packages/server/src/services/diffService.js
+++ b/packages/server/src/services/diffService.js
@@ -1,15 +1,16 @@
 import * as gitService from './gitService.js';
 
 /**
- * Get the combined diff (staged + unstaged) for a directory
+ * Get the combined diff (staged + unstaged + untracked) for a directory
  * @param {string} directory
- * @returns {Promise<{staged: string, unstaged: string}>}
+ * @returns {Promise<{staged: string, unstaged: string, untracked: string[]}>}
  */
 export async function getChanges(directory) {
-  const [staged, unstaged] = await Promise.all([
+  const [staged, unstaged, untracked] = await Promise.all([
     gitService.getStagedDiff(directory),
     gitService.getDiff(directory),
+    gitService.getUntrackedFiles(directory),
   ]);
 
-  return { staged, unstaged };
+  return { staged, unstaged, untracked };
 }

--- a/packages/server/src/services/diffService.test.js
+++ b/packages/server/src/services/diffService.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getChanges } from './diffService.js';
+import * as gitService from './gitService.js';
+
+vi.mock('./gitService.js');
+
+describe('diffService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getChanges', () => {
+    it('returns staged and unstaged diffs', async () => {
+      gitService.getStagedDiff.mockResolvedValue('staged diff content');
+      gitService.getDiff.mockResolvedValue('unstaged diff content');
+
+      const result = await getChanges('/test/dir');
+
+      expect(result).toEqual({
+        staged: 'staged diff content',
+        unstaged: 'unstaged diff content',
+      });
+    });
+
+    it('calls git service with correct directory', async () => {
+      gitService.getStagedDiff.mockResolvedValue('');
+      gitService.getDiff.mockResolvedValue('');
+
+      await getChanges('/my/project/path');
+
+      expect(gitService.getStagedDiff).toHaveBeenCalledWith('/my/project/path');
+      expect(gitService.getDiff).toHaveBeenCalledWith('/my/project/path');
+    });
+
+    it('returns empty strings when no changes', async () => {
+      gitService.getStagedDiff.mockResolvedValue('');
+      gitService.getDiff.mockResolvedValue('');
+
+      const result = await getChanges('/test/dir');
+
+      expect(result).toEqual({ staged: '', unstaged: '' });
+    });
+
+    it('fetches staged and unstaged diffs in parallel', async () => {
+      let stagedResolve;
+      let unstagedResolve;
+
+      gitService.getStagedDiff.mockReturnValue(
+        new Promise((resolve) => {
+          stagedResolve = resolve;
+        })
+      );
+      gitService.getDiff.mockReturnValue(
+        new Promise((resolve) => {
+          unstagedResolve = resolve;
+        })
+      );
+
+      const promise = getChanges('/test/dir');
+
+      // Both should be called immediately (in parallel)
+      expect(gitService.getStagedDiff).toHaveBeenCalled();
+      expect(gitService.getDiff).toHaveBeenCalled();
+
+      // Resolve them
+      stagedResolve('staged');
+      unstagedResolve('unstaged');
+
+      const result = await promise;
+      expect(result).toEqual({ staged: 'staged', unstaged: 'unstaged' });
+    });
+
+    it('propagates errors from getStagedDiff', async () => {
+      gitService.getStagedDiff.mockRejectedValue(new Error('Git error'));
+      gitService.getDiff.mockResolvedValue('');
+
+      await expect(getChanges('/test/dir')).rejects.toThrow('Git error');
+    });
+
+    it('propagates errors from getDiff', async () => {
+      gitService.getStagedDiff.mockResolvedValue('');
+      gitService.getDiff.mockRejectedValue(new Error('Diff error'));
+
+      await expect(getChanges('/test/dir')).rejects.toThrow('Diff error');
+    });
+
+    it('handles multi-line diff output', async () => {
+      const stagedDiff = `diff --git a/file.js b/file.js
+index 1234567..abcdefg 100644
+--- a/file.js
++++ b/file.js
+@@ -1,3 +1,4 @@
+ line 1
++new line
+ line 2
+ line 3`;
+
+      const unstagedDiff = `diff --git a/other.js b/other.js
+index 9876543..fedcba9 100644
+--- a/other.js
++++ b/other.js
+@@ -10,5 +10,6 @@
+ existing
+-removed
++modified
+ end`;
+
+      gitService.getStagedDiff.mockResolvedValue(stagedDiff);
+      gitService.getDiff.mockResolvedValue(unstagedDiff);
+
+      const result = await getChanges('/test/dir');
+
+      expect(result.staged).toBe(stagedDiff);
+      expect(result.unstaged).toBe(unstagedDiff);
+    });
+  });
+});

--- a/packages/server/src/services/diffService.test.js
+++ b/packages/server/src/services/diffService.test.js
@@ -14,40 +14,46 @@ describe('diffService', () => {
   });
 
   describe('getChanges', () => {
-    it('returns staged and unstaged diffs', async () => {
+    it('returns staged, unstaged diffs, and untracked files', async () => {
       gitService.getStagedDiff.mockResolvedValue('staged diff content');
       gitService.getDiff.mockResolvedValue('unstaged diff content');
+      gitService.getUntrackedFiles.mockResolvedValue(['new-file.txt', 'another.js']);
 
       const result = await getChanges('/test/dir');
 
       expect(result).toEqual({
         staged: 'staged diff content',
         unstaged: 'unstaged diff content',
+        untracked: ['new-file.txt', 'another.js'],
       });
     });
 
     it('calls git service with correct directory', async () => {
       gitService.getStagedDiff.mockResolvedValue('');
       gitService.getDiff.mockResolvedValue('');
+      gitService.getUntrackedFiles.mockResolvedValue([]);
 
       await getChanges('/my/project/path');
 
       expect(gitService.getStagedDiff).toHaveBeenCalledWith('/my/project/path');
       expect(gitService.getDiff).toHaveBeenCalledWith('/my/project/path');
+      expect(gitService.getUntrackedFiles).toHaveBeenCalledWith('/my/project/path');
     });
 
-    it('returns empty strings when no changes', async () => {
+    it('returns empty values when no changes', async () => {
       gitService.getStagedDiff.mockResolvedValue('');
       gitService.getDiff.mockResolvedValue('');
+      gitService.getUntrackedFiles.mockResolvedValue([]);
 
       const result = await getChanges('/test/dir');
 
-      expect(result).toEqual({ staged: '', unstaged: '' });
+      expect(result).toEqual({ staged: '', unstaged: '', untracked: [] });
     });
 
-    it('fetches staged and unstaged diffs in parallel', async () => {
+    it('fetches all git info in parallel', async () => {
       let stagedResolve;
       let unstagedResolve;
+      let untrackedResolve;
 
       gitService.getStagedDiff.mockReturnValue(
         new Promise((resolve) => {
@@ -59,24 +65,32 @@ describe('diffService', () => {
           unstagedResolve = resolve;
         })
       );
+      gitService.getUntrackedFiles.mockReturnValue(
+        new Promise((resolve) => {
+          untrackedResolve = resolve;
+        })
+      );
 
       const promise = getChanges('/test/dir');
 
-      // Both should be called immediately (in parallel)
+      // All should be called immediately (in parallel)
       expect(gitService.getStagedDiff).toHaveBeenCalled();
       expect(gitService.getDiff).toHaveBeenCalled();
+      expect(gitService.getUntrackedFiles).toHaveBeenCalled();
 
       // Resolve them
       stagedResolve('staged');
       unstagedResolve('unstaged');
+      untrackedResolve(['file.txt']);
 
       const result = await promise;
-      expect(result).toEqual({ staged: 'staged', unstaged: 'unstaged' });
+      expect(result).toEqual({ staged: 'staged', unstaged: 'unstaged', untracked: ['file.txt'] });
     });
 
     it('propagates errors from getStagedDiff', async () => {
       gitService.getStagedDiff.mockRejectedValue(new Error('Git error'));
       gitService.getDiff.mockResolvedValue('');
+      gitService.getUntrackedFiles.mockResolvedValue([]);
 
       await expect(getChanges('/test/dir')).rejects.toThrow('Git error');
     });
@@ -84,6 +98,7 @@ describe('diffService', () => {
     it('propagates errors from getDiff', async () => {
       gitService.getStagedDiff.mockResolvedValue('');
       gitService.getDiff.mockRejectedValue(new Error('Diff error'));
+      gitService.getUntrackedFiles.mockResolvedValue([]);
 
       await expect(getChanges('/test/dir')).rejects.toThrow('Diff error');
     });
@@ -111,6 +126,7 @@ index 9876543..fedcba9 100644
 
       gitService.getStagedDiff.mockResolvedValue(stagedDiff);
       gitService.getDiff.mockResolvedValue(unstagedDiff);
+      gitService.getUntrackedFiles.mockResolvedValue([]);
 
       const result = await getChanges('/test/dir');
 

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -130,3 +130,50 @@ export async function getStagedDiff(directory) {
     return '';
   }
 }
+
+/**
+ * Check if a branch exists
+ * @param {string} directory
+ * @param {string} branch
+ * @returns {Promise<boolean>}
+ */
+export async function branchExists(directory, branch) {
+  try {
+    await git(directory, `rev-parse --verify refs/heads/${branch}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checkout a branch, creating it if it doesn't exist
+ * @param {string} directory
+ * @param {string} branch
+ * @returns {Promise<void>}
+ */
+export async function checkoutBranch(directory, branch) {
+  const exists = await branchExists(directory, branch);
+  if (exists) {
+    await git(directory, `checkout "${branch}"`);
+  } else {
+    await git(directory, `checkout -b "${branch}"`);
+  }
+}
+
+/**
+ * Create a worktree for a branch (creates branch if it doesn't exist)
+ * @param {string} directory - Main repo directory
+ * @param {string} branch - Branch name
+ * @param {string} worktreePath - Path for the new worktree
+ * @returns {Promise<{path: string, branch: string}>}
+ */
+export async function createWorktreeForBranch(directory, branch, worktreePath) {
+  const exists = await branchExists(directory, branch);
+  if (exists) {
+    await git(directory, `worktree add "${worktreePath}" "${branch}"`);
+  } else {
+    await git(directory, `worktree add -b "${branch}" "${worktreePath}"`);
+  }
+  return { path: worktreePath, branch };
+}

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -177,3 +177,18 @@ export async function createWorktreeForBranch(directory, branch, worktreePath) {
   }
   return { path: worktreePath, branch };
 }
+
+/**
+ * Get list of untracked files
+ * @param {string} directory
+ * @returns {Promise<string[]>}
+ */
+export async function getUntrackedFiles(directory) {
+  try {
+    const output = await git(directory, 'ls-files --others --exclude-standard');
+    if (!output) return [];
+    return output.split('\n').filter((line) => line.trim());
+  } catch {
+    return [];
+  }
+}

--- a/packages/server/src/services/gitService.test.js
+++ b/packages/server/src/services/gitService.test.js
@@ -8,6 +8,7 @@ import {
   checkoutBranch,
   createWorktreeForBranch,
   getCurrentBranch,
+  getUntrackedFiles,
   isGitRepo,
 } from './gitService.js';
 
@@ -132,6 +133,38 @@ describe('gitService', () => {
       await expect(
         createWorktreeForBranch(testDir, 'branch-2', worktreePath)
       ).rejects.toThrow();
+    });
+  });
+
+  describe('getUntrackedFiles', () => {
+    it('returns empty array when no untracked files', async () => {
+      const files = await getUntrackedFiles(testDir);
+      expect(files).toEqual([]);
+    });
+
+    it('returns list of untracked files', async () => {
+      await writeFile(join(testDir, 'new-file.txt'), 'content');
+      await writeFile(join(testDir, 'another-file.js'), 'code');
+
+      const files = await getUntrackedFiles(testDir);
+
+      expect(files).toContain('new-file.txt');
+      expect(files).toContain('another-file.js');
+      expect(files).toHaveLength(2);
+    });
+
+    it('does not include tracked files', async () => {
+      // README.md is tracked
+      const files = await getUntrackedFiles(testDir);
+      expect(files).not.toContain('README.md');
+    });
+
+    it('does not include staged files', async () => {
+      await writeFile(join(testDir, 'staged-file.txt'), 'content');
+      execSync('git add staged-file.txt', { cwd: testDir });
+
+      const files = await getUntrackedFiles(testDir);
+      expect(files).not.toContain('staged-file.txt');
     });
   });
 });

--- a/packages/server/src/services/gitService.test.js
+++ b/packages/server/src/services/gitService.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import {
+  branchExists,
+  checkoutBranch,
+  createWorktreeForBranch,
+  getCurrentBranch,
+  isGitRepo,
+} from './gitService.js';
+
+describe('gitService', () => {
+  let testDir;
+
+  beforeEach(async () => {
+    // Create a temporary directory with a git repo
+    testDir = await mkdtemp(join(tmpdir(), 'git-test-'));
+    execSync('git init', { cwd: testDir });
+    execSync('git config user.email "test@test.com"', { cwd: testDir });
+    execSync('git config user.name "Test"', { cwd: testDir });
+    // Create initial commit so we have a valid repo state
+    await writeFile(join(testDir, 'README.md'), '# Test');
+    execSync('git add .', { cwd: testDir });
+    execSync('git commit -m "Initial commit"', { cwd: testDir });
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('branchExists', () => {
+    it('returns true for existing branch', async () => {
+      // 'main' or 'master' should exist after init
+      const currentBranch = await getCurrentBranch(testDir);
+      const exists = await branchExists(testDir, currentBranch);
+      expect(exists).toBe(true);
+    });
+
+    it('returns false for non-existent branch', async () => {
+      const exists = await branchExists(testDir, 'non-existent-branch');
+      expect(exists).toBe(false);
+    });
+
+    it('returns true for branch created with git branch', async () => {
+      execSync('git branch feature-test', { cwd: testDir });
+      const exists = await branchExists(testDir, 'feature-test');
+      expect(exists).toBe(true);
+    });
+  });
+
+  describe('checkoutBranch', () => {
+    it('checks out an existing branch', async () => {
+      execSync('git branch existing-branch', { cwd: testDir });
+
+      await checkoutBranch(testDir, 'existing-branch');
+
+      const current = await getCurrentBranch(testDir);
+      expect(current).toBe('existing-branch');
+    });
+
+    it('creates and checks out a new branch when it does not exist', async () => {
+      await checkoutBranch(testDir, 'new-branch');
+
+      const current = await getCurrentBranch(testDir);
+      expect(current).toBe('new-branch');
+    });
+
+    it('throws error when checkout fails for other reasons', async () => {
+      // Try to checkout with uncommitted changes that would conflict
+      await writeFile(join(testDir, 'README.md'), 'Modified content');
+      execSync('git add README.md', { cwd: testDir });
+
+      // Create a branch with different content
+      execSync('git stash', { cwd: testDir });
+      execSync('git checkout -b conflict-branch', { cwd: testDir });
+      await writeFile(join(testDir, 'README.md'), 'Conflict content');
+      execSync('git add README.md', { cwd: testDir });
+      execSync('git commit -m "Conflict"', { cwd: testDir });
+
+      // Go back and unstash
+      const originalBranch = 'master';
+      execSync(`git checkout ${originalBranch} 2>/dev/null || git checkout main`, { cwd: testDir });
+      execSync('git stash pop', { cwd: testDir });
+
+      // This should handle the checkout gracefully
+      // (behavior depends on implementation)
+    });
+  });
+
+  describe('createWorktreeForBranch', () => {
+    it('creates worktree with new branch', async () => {
+      const worktreePath = join(testDir, '.worktrees', 'session-123');
+
+      const result = await createWorktreeForBranch(testDir, 'new-feature', worktreePath);
+
+      expect(result.path).toBe(worktreePath);
+      expect(result.branch).toBe('new-feature');
+
+      // Verify worktree exists and is on correct branch
+      const isRepo = await isGitRepo(worktreePath);
+      expect(isRepo).toBe(true);
+
+      const branch = await getCurrentBranch(worktreePath);
+      expect(branch).toBe('new-feature');
+    });
+
+    it('creates worktree with existing branch', async () => {
+      // Create branch first
+      execSync('git branch existing-feature', { cwd: testDir });
+
+      const worktreePath = join(testDir, '.worktrees', 'session-456');
+
+      const result = await createWorktreeForBranch(testDir, 'existing-feature', worktreePath);
+
+      expect(result.path).toBe(worktreePath);
+      expect(result.branch).toBe('existing-feature');
+
+      const branch = await getCurrentBranch(worktreePath);
+      expect(branch).toBe('existing-feature');
+    });
+
+    it('throws error if worktree path already exists', async () => {
+      const worktreePath = join(testDir, '.worktrees', 'session-789');
+
+      // Create first worktree
+      await createWorktreeForBranch(testDir, 'branch-1', worktreePath);
+
+      // Try to create another at same path
+      await expect(
+        createWorktreeForBranch(testDir, 'branch-2', worktreePath)
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/server/src/services/gitSessionSetup.js
+++ b/packages/server/src/services/gitSessionSetup.js
@@ -1,0 +1,46 @@
+import { join } from 'path';
+import * as gitService from './gitService.js';
+
+/**
+ * Setup git environment for a session based on git mode
+ * @param {Object} options
+ * @param {string} options.projectDir - Project working directory
+ * @param {string|null} options.gitMode - 'branch', 'worktree', or null
+ * @param {string|null} options.gitBranch - Branch name
+ * @param {string} options.sessionId - Session ID
+ * @returns {Promise<{workingDirectory: string, gitWorktree: string|null}>}
+ */
+export async function setupGitForSession({ projectDir, gitMode, gitBranch, sessionId }) {
+  // No git operations if gitMode is not specified
+  if (!gitMode || !gitBranch) {
+    return {
+      workingDirectory: projectDir,
+      gitWorktree: null,
+    };
+  }
+
+  if (gitMode === 'branch') {
+    // Checkout (or create) the branch in the project directory
+    await gitService.checkoutBranch(projectDir, gitBranch);
+    return {
+      workingDirectory: projectDir,
+      gitWorktree: null,
+    };
+  }
+
+  if (gitMode === 'worktree') {
+    // Create a worktree in .worktrees/{sessionId}
+    const worktreePath = join(projectDir, '.worktrees', sessionId);
+    await gitService.createWorktreeForBranch(projectDir, gitBranch, worktreePath);
+    return {
+      workingDirectory: worktreePath,
+      gitWorktree: worktreePath,
+    };
+  }
+
+  // Unknown git mode, fallback to project directory
+  return {
+    workingDirectory: projectDir,
+    gitWorktree: null,
+  };
+}

--- a/packages/server/test/session-git-modes.test.js
+++ b/packages/server/test/session-git-modes.test.js
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { projects, sessions } from '../src/database.js';
+import * as gitService from '../src/services/gitService.js';
+import * as sessionManager from '../src/services/sessionManager.js';
+
+vi.mock('../src/services/gitService.js');
+vi.mock('../src/services/sessionManager.js');
+
+describe('Session Creation with Git Modes', () => {
+  let project;
+
+  beforeEach(() => {
+    project = projects.create('Test Project', '/test/project/path');
+    vi.resetAllMocks();
+    // Default mock for runSession
+    sessionManager.runSession = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('gitMode: branch', () => {
+    it('checks out existing branch when gitMode is branch', async () => {
+      gitService.branchExists.mockResolvedValue(true);
+      gitService.checkoutBranch.mockResolvedValue(undefined);
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      const result = await setupGitForSession({
+        projectDir: '/test/project/path',
+        gitMode: 'branch',
+        gitBranch: 'feature-x',
+        sessionId: 'session-123',
+      });
+
+      expect(gitService.checkoutBranch).toHaveBeenCalledWith('/test/project/path', 'feature-x');
+      expect(result.workingDirectory).toBe('/test/project/path');
+      expect(result.gitWorktree).toBeNull();
+    });
+
+    it('creates new branch when it does not exist', async () => {
+      gitService.branchExists.mockResolvedValue(false);
+      gitService.checkoutBranch.mockResolvedValue(undefined);
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      const result = await setupGitForSession({
+        projectDir: '/test/project/path',
+        gitMode: 'branch',
+        gitBranch: 'new-feature',
+        sessionId: 'session-123',
+      });
+
+      expect(gitService.checkoutBranch).toHaveBeenCalledWith('/test/project/path', 'new-feature');
+      expect(result.workingDirectory).toBe('/test/project/path');
+    });
+
+    it('returns project directory as working directory for branch mode', async () => {
+      gitService.checkoutBranch.mockResolvedValue(undefined);
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      const result = await setupGitForSession({
+        projectDir: '/my/project',
+        gitMode: 'branch',
+        gitBranch: 'develop',
+        sessionId: 'session-456',
+      });
+
+      expect(result.workingDirectory).toBe('/my/project');
+      expect(result.gitWorktree).toBeNull();
+    });
+  });
+
+  describe('gitMode: worktree', () => {
+    it('creates worktree when gitMode is worktree', async () => {
+      gitService.createWorktreeForBranch.mockResolvedValue({
+        path: '/test/project/path/.worktrees/session-123',
+        branch: 'feature-y',
+      });
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      const result = await setupGitForSession({
+        projectDir: '/test/project/path',
+        gitMode: 'worktree',
+        gitBranch: 'feature-y',
+        sessionId: 'session-123',
+      });
+
+      expect(gitService.createWorktreeForBranch).toHaveBeenCalledWith(
+        '/test/project/path',
+        'feature-y',
+        '/test/project/path/.worktrees/session-123'
+      );
+      expect(result.workingDirectory).toBe('/test/project/path/.worktrees/session-123');
+      expect(result.gitWorktree).toBe('/test/project/path/.worktrees/session-123');
+    });
+
+    it('generates worktree path based on session ID', async () => {
+      gitService.createWorktreeForBranch.mockResolvedValue({
+        path: '/project/.worktrees/my-session-id',
+        branch: 'test-branch',
+      });
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      await setupGitForSession({
+        projectDir: '/project',
+        gitMode: 'worktree',
+        gitBranch: 'test-branch',
+        sessionId: 'my-session-id',
+      });
+
+      expect(gitService.createWorktreeForBranch).toHaveBeenCalledWith(
+        '/project',
+        'test-branch',
+        '/project/.worktrees/my-session-id'
+      );
+    });
+  });
+
+  describe('gitMode: null (no git operations)', () => {
+    it('does not perform git operations when gitMode is null', async () => {
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      const result = await setupGitForSession({
+        projectDir: '/test/project/path',
+        gitMode: null,
+        gitBranch: null,
+        sessionId: 'session-123',
+      });
+
+      expect(gitService.checkoutBranch).not.toHaveBeenCalled();
+      expect(gitService.createWorktreeForBranch).not.toHaveBeenCalled();
+      expect(result.workingDirectory).toBe('/test/project/path');
+      expect(result.gitWorktree).toBeNull();
+    });
+
+    it('uses project directory when no git mode specified', async () => {
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      const result = await setupGitForSession({
+        projectDir: '/my/project',
+        gitMode: undefined,
+        gitBranch: undefined,
+        sessionId: 'session-789',
+      });
+
+      expect(result.workingDirectory).toBe('/my/project');
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws error when branch checkout fails', async () => {
+      gitService.checkoutBranch.mockRejectedValue(new Error('Checkout failed'));
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      await expect(
+        setupGitForSession({
+          projectDir: '/test/project',
+          gitMode: 'branch',
+          gitBranch: 'bad-branch',
+          sessionId: 'session-123',
+        })
+      ).rejects.toThrow('Checkout failed');
+    });
+
+    it('throws error when worktree creation fails', async () => {
+      gitService.createWorktreeForBranch.mockRejectedValue(new Error('Worktree creation failed'));
+
+      const { setupGitForSession } = await import('../src/services/gitSessionSetup.js');
+
+      await expect(
+        setupGitForSession({
+          projectDir: '/test/project',
+          gitMode: 'worktree',
+          gitBranch: 'feature-z',
+          sessionId: 'session-123',
+        })
+      ).rejects.toThrow('Worktree creation failed');
+    });
+  });
+});

--- a/packages/server/test/sessions-changes.test.js
+++ b/packages/server/test/sessions-changes.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { projects, sessions } from '../src/database.js';
+import * as diffService from '../src/services/diffService.js';
+
+vi.mock('../src/services/diffService.js');
+
+describe('Session Changes API Logic', () => {
+  let project;
+  let session;
+
+  beforeEach(() => {
+    project = projects.create('Test Project', '/test/project/path');
+    session = sessions.create(project.id, 'Test Session', 'Test prompt');
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getting changes directory', () => {
+    it('uses project working directory by default', async () => {
+      diffService.getChanges.mockResolvedValue({ staged: '', unstaged: '' });
+
+      // Simulate what the API endpoint does
+      const targetSession = sessions.getById(session.id);
+      const targetProject = projects.getById(targetSession.projectId);
+      const directory = targetSession.gitWorktree || targetProject.workingDirectory;
+
+      await diffService.getChanges(directory);
+
+      expect(diffService.getChanges).toHaveBeenCalledWith('/test/project/path');
+    });
+
+    it('prefers gitWorktree when set', async () => {
+      sessions.update(session.id, { gitWorktree: '/custom/worktree/path' });
+      diffService.getChanges.mockResolvedValue({ staged: '', unstaged: '' });
+
+      const targetSession = sessions.getById(session.id);
+      const targetProject = projects.getById(targetSession.projectId);
+      const directory = targetSession.gitWorktree || targetProject.workingDirectory;
+
+      await diffService.getChanges(directory);
+
+      expect(diffService.getChanges).toHaveBeenCalledWith('/custom/worktree/path');
+    });
+  });
+
+  describe('session lookup', () => {
+    it('finds session by id', () => {
+      const found = sessions.getById(session.id);
+      expect(found).not.toBeNull();
+      expect(found.id).toBe(session.id);
+    });
+
+    it('returns null for non-existent session', () => {
+      const found = sessions.getById('nonexistent-id');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('project lookup from session', () => {
+    it('finds project via session.projectId', () => {
+      const targetSession = sessions.getById(session.id);
+      const targetProject = projects.getById(targetSession.projectId);
+      expect(targetProject).not.toBeNull();
+      expect(targetProject.workingDirectory).toBe('/test/project/path');
+    });
+
+    it('handles deleted project (cascade deletes session)', () => {
+      projects.delete(project.id);
+      // Session cascade deleted too due to foreign key
+      const targetSession = sessions.getById(session.id);
+      expect(targetSession).toBeNull();
+    });
+  });
+
+  describe('diffService integration', () => {
+    it('returns staged and unstaged diffs', async () => {
+      diffService.getChanges.mockResolvedValue({
+        staged: 'staged diff content',
+        unstaged: 'unstaged diff content',
+      });
+
+      const result = await diffService.getChanges('/test/project/path');
+
+      expect(result).toEqual({
+        staged: 'staged diff content',
+        unstaged: 'unstaged diff content',
+      });
+    });
+
+    it('propagates errors', async () => {
+      diffService.getChanges.mockRejectedValue(new Error('Git command failed'));
+
+      await expect(diffService.getChanges('/test')).rejects.toThrow('Git command failed');
+    });
+
+    it('returns empty strings when no changes', async () => {
+      diffService.getChanges.mockResolvedValue({ staged: '', unstaged: '' });
+
+      const result = await diffService.getChanges('/test');
+
+      expect(result).toEqual({ staged: '', unstaged: '' });
+    });
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.3",
+    "@vue/test-utils": "^2.4.4",
     "jsdom": "^24.0.0",
     "vite": "^5.0.12",
     "vitest": "^1.2.2"

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -158,6 +158,15 @@ export class ApiClient {
     return this.#request('POST', `/sessions/${id}/stop`);
   }
 
+  /**
+   * Get git changes for a session
+   * @param {string} sessionId - Session ID
+   * @returns {Promise<{staged: string, unstaged: string}>}
+   */
+  async getSessionChanges(sessionId) {
+    return this.#request('GET', `/sessions/${sessionId}/changes`);
+  }
+
   // Canvas
 
   /**

--- a/packages/web/src/api/ApiClient.test.js
+++ b/packages/web/src/api/ApiClient.test.js
@@ -182,6 +182,26 @@ describe('ApiClient', () => {
         }));
       });
     });
+
+    describe('getSessionChanges', () => {
+      it('fetches changes for session', async () => {
+        const mockData = { staged: 'staged diff', unstaged: 'unstaged diff' };
+        mockFetch.mockReturnValue(mockResponse(mockData));
+
+        const result = await client.getSessionChanges('sess-123');
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/sessions/sess-123/changes', expect.any(Object));
+        expect(result).toEqual(mockData);
+      });
+
+      it('returns empty strings when no changes', async () => {
+        mockFetch.mockReturnValue(mockResponse({ staged: '', unstaged: '' }));
+
+        const result = await client.getSessionChanges('sess-123');
+
+        expect(result).toEqual({ staged: '', unstaged: '' });
+      });
+    });
   });
 
   describe('canvas', () => {

--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -37,12 +37,12 @@ describe('ChangesTab', () => {
     expect(wrapper.text()).toContain('Loading changes...');
 
     // Clean up by resolving the promise
-    resolvePromise({ staged: '', unstaged: '' });
+    resolvePromise({ staged: '', unstaged: '', untracked: [] });
     await flushPromises();
   });
 
   it('fetches changes on mount', async () => {
-    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '' });
+    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: [] });
 
     mount(ChangesTab, {
       props: { sessionId: 'test-session' },
@@ -55,6 +55,7 @@ describe('ChangesTab', () => {
     api.getSessionChanges.mockResolvedValue({
       staged: 'diff --git a/file.js\n+new line',
       unstaged: '',
+      untracked: [],
     });
 
     const wrapper = mount(ChangesTab, {
@@ -72,6 +73,7 @@ describe('ChangesTab', () => {
     api.getSessionChanges.mockResolvedValue({
       staged: '',
       unstaged: 'diff --git b/other.js\n-removed line',
+      untracked: [],
     });
 
     const wrapper = mount(ChangesTab, {
@@ -89,6 +91,7 @@ describe('ChangesTab', () => {
     api.getSessionChanges.mockResolvedValue({
       staged: 'staged content',
       unstaged: 'unstaged content',
+      untracked: [],
     });
 
     const wrapper = mount(ChangesTab, {
@@ -104,7 +107,7 @@ describe('ChangesTab', () => {
   });
 
   it('displays empty state when no changes', async () => {
-    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '' });
+    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: [] });
 
     const wrapper = mount(ChangesTab, {
       props: { sessionId: 'test-session' },
@@ -113,6 +116,24 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('No git changes to show');
+  });
+
+  it('displays untracked files when present', async () => {
+    api.getSessionChanges.mockResolvedValue({
+      staged: '',
+      unstaged: '',
+      untracked: ['new-file.txt', 'another-file.js'],
+    });
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Untracked Files');
+    expect(wrapper.text()).toContain('new-file.txt');
+    expect(wrapper.text()).toContain('another-file.js');
   });
 
   it('displays error message on failure', async () => {
@@ -128,7 +149,7 @@ describe('ChangesTab', () => {
   });
 
   it('uses sessionId prop for API call', async () => {
-    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '' });
+    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: [] });
 
     mount(ChangesTab, {
       props: { sessionId: 'custom-session-id' },
@@ -140,7 +161,7 @@ describe('ChangesTab', () => {
   });
 
   it('handles null staged/unstaged values', async () => {
-    api.getSessionChanges.mockResolvedValue({ staged: null, unstaged: null });
+    api.getSessionChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
 
     const wrapper = mount(ChangesTab, {
       props: { sessionId: 'test-session' },

--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import ChangesTab from './ChangesTab.vue';
+import { api } from '../api/ApiClient.js';
+
+vi.mock('../api/ApiClient.js', () => ({
+  api: {
+    getSessionChanges: vi.fn(),
+  },
+}));
+
+describe('ChangesTab', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state while fetching', async () => {
+    let resolvePromise;
+    api.getSessionChanges.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePromise = resolve;
+      })
+    );
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    // Wait for component to update after onMounted sets loading = true
+    await nextTick();
+
+    expect(wrapper.text()).toContain('Loading changes...');
+
+    // Clean up by resolving the promise
+    resolvePromise({ staged: '', unstaged: '' });
+    await flushPromises();
+  });
+
+  it('fetches changes on mount', async () => {
+    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '' });
+
+    mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    expect(api.getSessionChanges).toHaveBeenCalledWith('test-session');
+  });
+
+  it('displays staged changes when present', async () => {
+    api.getSessionChanges.mockResolvedValue({
+      staged: 'diff --git a/file.js\n+new line',
+      unstaged: '',
+    });
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Staged Changes');
+    expect(wrapper.text()).toContain('diff --git a/file.js');
+    expect(wrapper.text()).toContain('+new line');
+  });
+
+  it('displays unstaged changes when present', async () => {
+    api.getSessionChanges.mockResolvedValue({
+      staged: '',
+      unstaged: 'diff --git b/other.js\n-removed line',
+    });
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Unstaged Changes');
+    expect(wrapper.text()).toContain('diff --git b/other.js');
+    expect(wrapper.text()).toContain('-removed line');
+  });
+
+  it('displays both staged and unstaged changes', async () => {
+    api.getSessionChanges.mockResolvedValue({
+      staged: 'staged content',
+      unstaged: 'unstaged content',
+    });
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Staged Changes');
+    expect(wrapper.text()).toContain('staged content');
+    expect(wrapper.text()).toContain('Unstaged Changes');
+    expect(wrapper.text()).toContain('unstaged content');
+  });
+
+  it('displays empty state when no changes', async () => {
+    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '' });
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('No git changes to show');
+  });
+
+  it('displays error message on failure', async () => {
+    api.getSessionChanges.mockRejectedValue(new Error('Network error'));
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Network error');
+  });
+
+  it('uses sessionId prop for API call', async () => {
+    api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '' });
+
+    mount(ChangesTab, {
+      props: { sessionId: 'custom-session-id' },
+    });
+
+    await flushPromises();
+
+    expect(api.getSessionChanges).toHaveBeenCalledWith('custom-session-id');
+  });
+
+  it('handles null staged/unstaged values', async () => {
+    api.getSessionChanges.mockResolvedValue({ staged: null, unstaged: null });
+
+    const wrapper = mount(ChangesTab, {
+      props: { sessionId: 'test-session' },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('No git changes to show');
+  });
+});

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -23,6 +23,15 @@
         <h3>Unstaged Changes</h3>
         <pre class="diff-content">{{ unstaged }}</pre>
       </div>
+
+      <div v-if="untracked.length > 0" class="diff-section">
+        <h3>Untracked Files</h3>
+        <ul class="untracked-list">
+          <li v-for="file in untracked" :key="file" class="untracked-file">
+            {{ file }}
+          </li>
+        </ul>
+      </div>
     </template>
   </div>
 </template>
@@ -37,10 +46,11 @@ const props = defineProps({
 
 const staged = ref('');
 const unstaged = ref('');
+const untracked = ref([]);
 const loading = ref(false);
 const error = ref(null);
 
-const hasChanges = computed(() => staged.value || unstaged.value);
+const hasChanges = computed(() => staged.value || unstaged.value || untracked.value.length > 0);
 
 async function fetchChanges() {
   loading.value = true;
@@ -49,6 +59,7 @@ async function fetchChanges() {
     const changes = await api.getSessionChanges(props.sessionId);
     staged.value = changes.staged || '';
     unstaged.value = changes.unstaged || '';
+    untracked.value = changes.untracked || [];
   } catch (err) {
     error.value = err.message;
   } finally {
@@ -101,5 +112,23 @@ onMounted(() => {
   font-size: 0.75rem;
   max-height: 300px;
   overflow: auto;
+}
+
+.untracked-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: monospace;
+  font-size: 0.75rem;
+}
+
+.untracked-file {
+  padding: 0.25rem 0.5rem;
+  color: var(--color-success, #22c55e);
+}
+
+.untracked-file::before {
+  content: '+ ';
+  color: var(--color-success, #22c55e);
 }
 </style>

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -29,13 +29,11 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { api } from '../api/ApiClient.js';
 
-const _props = defineProps({
+const props = defineProps({
   sessionId: { type: String, required: true },
 });
-
-const sessionsStore = useSessionsStore();
 
 const staged = ref('');
 const unstaged = ref('');
@@ -44,22 +42,22 @@ const error = ref(null);
 
 const hasChanges = computed(() => staged.value || unstaged.value);
 
-onMounted(async () => {
-  if (!sessionsStore.currentSession?.gitWorktree) {
-    return;
-  }
-
+async function fetchChanges() {
   loading.value = true;
+  error.value = null;
   try {
-    // In a real implementation, this would call the diff service
-    // For now, we'll just show a placeholder
-    staged.value = '';
-    unstaged.value = '';
+    const changes = await api.getSessionChanges(props.sessionId);
+    staged.value = changes.staged || '';
+    unstaged.value = changes.unstaged || '';
   } catch (err) {
     error.value = err.message;
   } finally {
     loading.value = false;
   }
+}
+
+onMounted(() => {
+  fetchChanges();
 });
 </script>
 

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -39,13 +39,39 @@
       </div>
 
       <div v-if="gitStatus" class="form-group">
-        <label class="form-label" for="gitBranch">Git Branch (optional)</label>
-        <select id="gitBranch" v-model="gitBranch" class="form-input">
-          <option value="">Use current branch</option>
-          <option v-for="branch in gitStatus.branches" :key="branch.name" :value="branch.name">
-            {{ branch.name }}
-          </option>
+        <label class="form-label" for="gitMode">Git Mode</label>
+        <select id="gitMode" v-model="gitMode" class="form-input">
+          <option value="">None (use current branch)</option>
+          <option value="branch">Switch Branch</option>
+          <option value="worktree">Create Worktree</option>
         </select>
+        <p class="form-help">
+          <template v-if="gitMode === ''">Session runs in the current branch</template>
+          <template v-else-if="gitMode === 'branch'">Checkout/create a branch in the project directory</template>
+          <template v-else-if="gitMode === 'worktree'">Create an isolated worktree for this session</template>
+        </p>
+      </div>
+
+      <div v-if="gitStatus && gitMode" class="form-group">
+        <label class="form-label" for="gitBranch">
+          {{ gitMode === 'branch' ? 'Branch Name' : 'Worktree Branch' }}
+        </label>
+        <div class="branch-input-group">
+          <select id="gitBranch" v-model="gitBranch" class="form-input">
+            <option value="">-- Select existing or type new --</option>
+            <option v-for="branch in gitStatus.branches" :key="branch.name" :value="branch.name">
+              {{ branch.name }}
+            </option>
+          </select>
+          <span class="or-text">or</span>
+          <input
+            v-model="newBranchName"
+            type="text"
+            class="form-input"
+            placeholder="New branch name"
+            @input="gitBranch = newBranchName"
+          />
+        </div>
         <p v-if="gitStatus.currentBranch" class="form-help">
           Current branch: {{ gitStatus.currentBranch }}
         </p>
@@ -84,7 +110,9 @@ const uiStore = useUiStore();
 const name = ref('');
 const prompt = ref('');
 const mode = ref('standard');
+const gitMode = ref('');
 const gitBranch = ref('');
+const newBranchName = ref('');
 const gitStatus = ref(null);
 const loading = ref(false);
 const loadingGit = ref(false);
@@ -110,6 +138,7 @@ async function handleSubmit() {
       name: name.value || undefined,
       prompt: prompt.value,
       mode: mode.value,
+      gitMode: gitMode.value || undefined,
       gitBranch: gitBranch.value || undefined,
     });
     uiStore.success('Session started');
@@ -162,5 +191,24 @@ h1 {
 .error-message {
   color: var(--color-error);
   margin-bottom: 1rem;
+}
+
+.branch-input-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.branch-input-group select {
+  flex: 1;
+}
+
+.branch-input-group input {
+  flex: 1;
+}
+
+.or-text {
+  color: var(--color-text-soft);
+  font-size: 0.875rem;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,6 +340,18 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
   integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz"
@@ -372,6 +384,16 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@one-ini/wasm@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@one-ini/wasm/-/wasm-0.1.1.tgz#6013659736c9dbfccc96e8a9c2b3de317df39323"
+  integrity sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@playwright/test@^1.57.0":
   version "1.57.0"
@@ -653,6 +675,19 @@
   resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz"
   integrity sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==
 
+"@vue/test-utils@^2.4.4":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.4.6.tgz#7d534e70c4319d2a587d6a3b45a39e9695ade03c"
+  integrity sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==
+  dependencies:
+    js-beautify "^1.14.9"
+    vue-component-type-helpers "^2.0.0"
+
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
@@ -698,6 +733,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
@@ -709,6 +749,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -799,6 +844,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -919,6 +971,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
@@ -953,6 +1010,14 @@ confbox@^0.1.8:
   version "0.1.8"
   resolved "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz"
   integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
+
+config-chain@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
+  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 content-disposition@~0.5.4:
   version "0.5.4"
@@ -989,7 +1054,7 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1115,6 +1180,21 @@ dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+editorconfig@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-1.0.4.tgz#040c9a8e9a6c5288388b87c2db07028aa89f53a3"
+  integrity sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==
+  dependencies:
+    "@one-ini/wasm" "0.1.1"
+    commander "^10.0.0"
+    minimatch "9.0.1"
+    semver "^7.5.3"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
@@ -1124,6 +1204,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -1487,6 +1572,14 @@ follow-redirects@^1.0.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 form-data@^4.0.0:
   version "4.0.5"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
@@ -1583,6 +1676,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@^10.4.2:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^7.1.3:
   version "7.2.3"
@@ -1758,7 +1863,7 @@ inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, i
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -1819,6 +1924,31 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+js-beautify@^1.14.9:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.15.4.tgz#f579f977ed4c930cef73af8f98f3f0a608acd51e"
+  integrity sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==
+  dependencies:
+    config-chain "^1.1.13"
+    editorconfig "^1.0.4"
+    glob "^10.4.2"
+    js-cookie "^3.0.5"
+    nopt "^7.2.1"
+
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
 js-tokens@^9.0.1:
   version "9.0.1"
@@ -1921,7 +2051,7 @@ loupe@^2.3.6, loupe@^2.3.7:
   dependencies:
     get-func-name "^2.0.1"
 
-lru-cache@^10.4.3:
+lru-cache@^10.2.0, lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -1993,6 +2123,13 @@ mimic-response@^3.1.0:
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
+minimatch@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
+  integrity sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -2000,10 +2137,22 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
@@ -2076,6 +2225,13 @@ node-abi@^3.3.0:
   integrity sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==
   dependencies:
     semver "^7.3.5"
+
+nopt@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
+  dependencies:
+    abbrev "^2.0.0"
 
 npm-run-path@^5.1.0:
   version "5.3.0"
@@ -2160,6 +2316,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -2198,6 +2359,14 @@ path-key@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz"
   integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-to-regexp@~0.1.12:
   version "0.1.12"
@@ -2318,6 +2487,11 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -2520,7 +2694,7 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-semver@^7.3.5, semver@^7.3.6, semver@^7.6.3:
+semver@^7.3.5, semver@^7.3.6, semver@^7.5.3, semver@^7.6.3:
   version "7.7.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
@@ -2640,7 +2814,7 @@ siginfo@^2.0.0:
   resolved "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^4.1.0:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -2694,6 +2868,15 @@ streamsearch@^1.1.0:
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -2703,6 +2886,15 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
@@ -2710,12 +2902,26 @@ string_decoder@^1.1.1, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
+  integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-final-newline@^3.0.0:
   version "3.0.0"
@@ -2973,6 +3179,11 @@ vitest@^1.2.2:
     vite-node "1.6.1"
     why-is-node-running "^2.2.2"
 
+vue-component-type-helpers@^2.0.0:
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz#5014787aad185a22f460ad469cc51f14524308bc"
+  integrity sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==
+
 vue-demi@^0.14.10:
   version "0.14.10"
   resolved "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz"
@@ -3061,6 +3272,15 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
@@ -3069,6 +3289,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
## Summary

- **Fixed Changes view** - The ChangesTab component was previously a placeholder that never called the backend. Now it properly fetches and displays git changes.
- **Added untracked files support** - The Changes view now shows untracked files (new files not yet added to git) in addition to staged and unstaged changes.
- **Added git branch/worktree support for sessions** - When creating a session, users can now select a git mode:
  - **Use current branch** - Operates in the project's current branch
  - **Branch mode** - Switches to (or creates) the specified branch
  - **Worktree mode** - Creates an isolated git worktree for the session

## Changes

### Backend
- Added `GET /api/sessions/:id/changes` endpoint to fetch git diff data
- Added `getUntrackedFiles()` to gitService for listing untracked files
- Updated diffService to return `{ staged, unstaged, untracked }`
- Added `gitSessionSetup.js` service for handling branch/worktree setup
- Added branch checkout and worktree creation functions to gitService

### Frontend
- Updated `ChangesTab.vue` to fetch and display:
  - Staged changes (from `git diff --cached`)
  - Unstaged changes (from `git diff`)
  - Untracked files (with green `+` prefix)
- Added `getSessionChanges()` to ApiClient
- Updated `NewSessionView.vue` with Git Mode selection UI

### Tests
- Added comprehensive tests for all new functionality
- All 216 tests passing (172 server + 44 web)

## Test plan

- [ ] Create a new session and verify the Changes tab shows untracked files
- [ ] Make changes to tracked files and verify staged/unstaged diffs appear
- [ ] Test branch mode: create session with new branch, verify Claude operates in that branch
- [ ] Test worktree mode: create session with worktree, verify isolated directory is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)