### PR TITLE
Improve E2E test coverage and strengthen assertions

### DIFF
--- a/playwright.config.docker.ts
+++ b/playwright.config.docker.ts
@@ -12,8 +12,9 @@ export default defineConfig({
     // Test directory
     testDir: '/tests',
 
-    // Run tests in files in parallel
-    fullyParallel: true,
+    // Run tests serially within describe blocks (configured per-file),
+    // but allow different test files to run in parallel
+    fullyParallel: false,
 
     // Fail the build on CI if you accidentally left test.only in the source code
     forbidOnly: !!process.env.CI,

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -29,9 +29,21 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    // Verify item label and type are visible
-    await expect(page.getByText('Test Label')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('markdown')).toBeVisible();
+    // Verify canvas item card structure
+    const canvasItem = page.locator('.canvas-item').filter({ hasText: 'Test Label' });
+    await expect(canvasItem).toBeVisible();
+
+    // Verify item label is within the canvas item
+    await expect(canvasItem.locator('.canvas-item-label, [class*="label"]')).toHaveText('Test Label');
+
+    // Verify item type badge shows correct type
+    await expect(canvasItem.locator('.canvas-item-type')).toHaveText('markdown');
+
+    // Verify delete button is present
+    await expect(canvasItem.locator('button[title="Delete"]')).toBeVisible();
+
+    // Verify empty state is NOT visible
+    await expect(page.getByText('No canvas items yet')).not.toBeVisible();
 
     // Verify via API that the item exists with correct data
     const items = await getCanvasItems(session.id);
@@ -55,17 +67,25 @@ test.describe('Canvas Management', () => {
     expect(items[0].id).toBe(item.id);
 
     await page.goto(`/sessions/${session.id}/canvas`);
-    await expect(page.getByText('To Delete')).toBeVisible();
+
+    // Find the specific canvas item
+    const canvasItem = page.locator('.canvas-item').filter({ hasText: 'To Delete' });
+    await expect(canvasItem).toBeVisible();
 
     // Handle confirmation dialog
     page.on('dialog', (dialog) => dialog.accept());
-    await page.click('button[title="Delete"]');
+
+    // Click delete button within the specific canvas item
+    await canvasItem.locator('button[title="Delete"]').click();
 
     // Verify not visible in UI
     await expect(page.getByText('To Delete')).not.toBeVisible();
 
     // Verify empty state is shown
     await expect(page.getByText('No canvas items yet')).toBeVisible();
+
+    // Verify toast notification for success
+    await expect(page.locator('.toast-success, .toast')).toBeVisible({ timeout: 3000 });
 
     // Verify via API that the item was actually deleted
     items = await getCanvasItems(session.id);
@@ -87,11 +107,22 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    // Verify both items are visible with correct labels and types
-    await expect(page.getByText('Text Item')).toBeVisible();
-    await expect(page.getByText('JSON Item')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('text')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('json')).toBeVisible();
+    // Verify correct number of canvas items
+    const canvasItems = page.locator('.canvas-item');
+    await expect(canvasItems).toHaveCount(2);
+
+    // Verify Text Item card structure
+    const textItemCard = page.locator('.canvas-item').filter({ hasText: 'Text Item' });
+    await expect(textItemCard).toBeVisible();
+    await expect(textItemCard.locator('.canvas-item-type')).toHaveText('text');
+    await expect(textItemCard.locator('.canvas-item-content, [class*="content"]')).toContainText(
+      'Plain text content'
+    );
+
+    // Verify JSON Item card structure
+    const jsonItemCard = page.locator('.canvas-item').filter({ hasText: 'JSON Item' });
+    await expect(jsonItemCard).toBeVisible();
+    await expect(jsonItemCard.locator('.canvas-item-type')).toHaveText('json');
 
     // Verify via API that both items exist with correct types
     const items = await getCanvasItems(session.id);
@@ -107,5 +138,60 @@ test.describe('Canvas Management', () => {
     expect(apiJsonItem).toBeTruthy();
     expect(apiJsonItem.type).toBe('json');
     expect(JSON.parse(apiJsonItem.content)).toEqual({ key: 'value' });
+  });
+
+  test('can cancel canvas item deletion', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Keep this item',
+      label: 'Keep Me',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Handle confirmation dialog - dismiss it
+    page.on('dialog', (dialog) => dialog.dismiss());
+
+    // Click delete button
+    await page.click('button[title="Delete"]');
+
+    // Item should still be visible
+    await expect(page.getByText('Keep Me')).toBeVisible();
+
+    // Empty state should not be visible
+    await expect(page.getByText('No canvas items yet')).not.toBeVisible();
+
+    // Verify via API that item still exists
+    const items = await getCanvasItems(session.id);
+    expect(items.length).toBe(1);
+    expect(items[0].label).toBe('Keep Me');
+  });
+
+  test('displays loading state while fetching canvas items', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Loading state should resolve quickly
+    await expect(page.locator('.loading-state')).not.toBeVisible({ timeout: 5000 });
+
+    // Should show empty state since no items
+    await expect(page.getByText('No canvas items yet')).toBeVisible();
+  });
+
+  test('canvas items display in grid layout', async ({ page }) => {
+    // Add multiple items
+    await seedCanvasItem(session.id, { type: 'text', content: 'Item 1', label: 'First' });
+    await seedCanvasItem(session.id, { type: 'text', content: 'Item 2', label: 'Second' });
+    await seedCanvasItem(session.id, { type: 'text', content: 'Item 3', label: 'Third' });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Verify all items are visible
+    await expect(page.locator('.canvas-item')).toHaveCount(3);
+    await expect(page.getByText('First')).toBeVisible();
+    await expect(page.getByText('Second')).toBeVisible();
+    await expect(page.getByText('Third')).toBeVisible();
+
+    // Verify canvas grid container exists
+    await expect(page.locator('.canvas-grid, .canvas-items')).toBeVisible();
   });
 });

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 import { seedProject, seedSession, seedCanvasItem, cleanupAll, getCanvasItems } from './helpers';
 
 test.describe('Canvas Management', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   let project: any;
   let session: any;
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -36,6 +36,18 @@ export async function getCanvasItems(sessionId: string) {
   return response.json();
 }
 
+export async function getNotes(sessionId: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}/notes`);
+  if (!response.ok) return [];
+  return response.json();
+}
+
+export async function getNote(sessionId: string, noteId: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}/notes/${noteId}`);
+  if (!response.ok) return null;
+  return response.json();
+}
+
 // ============================================================
 // Seeding Helpers
 // ============================================================
@@ -73,6 +85,26 @@ export async function seedCanvasItem(
     body: JSON.stringify(data),
   });
   if (!response.ok) throw new Error('Failed to seed canvas item');
+  return response.json();
+}
+
+export async function seedNote(sessionId: string, content: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}/notes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!response.ok) throw new Error('Failed to seed note');
+  return response.json();
+}
+
+export async function updateSessionStatus(sessionId: string, status: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+  if (!response.ok) throw new Error('Failed to update session status');
   return response.json();
 }
 

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 import { seedProject, seedSession, seedNote, cleanupAll, getNotes } from './helpers';
 
 test.describe('Notes Management', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   let project: any;
   let session: any;
 

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -1,0 +1,278 @@
+import { test, expect } from '@playwright/test';
+import { seedProject, seedSession, seedNote, cleanupAll, getNotes } from './helpers';
+
+test.describe('Notes Management', () => {
+  let project: any;
+  let session: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+    session = await seedSession(project.id, { prompt: 'Test', name: 'Notes Test Session' });
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('displays empty state when no notes exist', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Verify empty state message
+    await expect(page.locator('.empty-state')).toBeVisible();
+    await expect(page.getByText('No notes yet')).toBeVisible();
+
+    // Verify add note form is still visible even when empty
+    await expect(page.locator('.add-note-form')).toBeVisible();
+    await expect(page.locator('.add-note-form textarea')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add Note' })).toBeVisible();
+
+    // Verify via API that no notes exist
+    const notes = await getNotes(session.id);
+    expect(notes.length).toBe(0);
+  });
+
+  test('can add a new note', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    const noteContent = 'This is my first test note';
+
+    // Fill in the note content
+    await page.fill('.add-note-form textarea', noteContent);
+
+    // Verify Add Note button is enabled
+    const addButton = page.getByRole('button', { name: 'Add Note' });
+    await expect(addButton).toBeEnabled();
+
+    // Submit the note
+    await addButton.click();
+
+    // Verify note appears in the list
+    await expect(page.locator('.note .note-content')).toBeVisible();
+    await expect(page.locator('.note .note-content')).toHaveText(noteContent);
+
+    // Verify textarea is cleared after submission
+    await expect(page.locator('.add-note-form textarea')).toHaveValue('');
+
+    // Verify empty state is no longer visible
+    await expect(page.locator('.empty-state')).not.toBeVisible();
+
+    // Verify toast notification appears
+    await expect(page.locator('.toast-success')).toBeVisible();
+    await expect(page.getByText('Note added')).toBeVisible();
+
+    // Verify via API that note was persisted
+    const notes = await getNotes(session.id);
+    expect(notes.length).toBe(1);
+    expect(notes[0].content).toBe(noteContent);
+  });
+
+  test('Add Note button is disabled when textarea is empty', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Verify button is disabled initially
+    const addButton = page.getByRole('button', { name: 'Add Note' });
+    await expect(addButton).toBeDisabled();
+
+    // Type something
+    await page.fill('.add-note-form textarea', 'Some content');
+    await expect(addButton).toBeEnabled();
+
+    // Clear it
+    await page.fill('.add-note-form textarea', '');
+    await expect(addButton).toBeDisabled();
+
+    // Type only whitespace
+    await page.fill('.add-note-form textarea', '   ');
+    await expect(addButton).toBeDisabled();
+  });
+
+  test('displays multiple notes in reverse chronological order', async ({ page }) => {
+    // Seed notes with slight delay to ensure different timestamps
+    const note1 = await seedNote(session.id, 'First note');
+    const note2 = await seedNote(session.id, 'Second note');
+    const note3 = await seedNote(session.id, 'Third note');
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Verify all notes are visible
+    const noteElements = page.locator('.note');
+    await expect(noteElements).toHaveCount(3);
+
+    // Verify notes appear in reverse chronological order (newest first)
+    const noteContents = page.locator('.note .note-content');
+    await expect(noteContents.nth(0)).toHaveText('Third note');
+    await expect(noteContents.nth(1)).toHaveText('Second note');
+    await expect(noteContents.nth(2)).toHaveText('First note');
+
+    // Verify each note has date displayed
+    const noteDates = page.locator('.note .note-date');
+    await expect(noteDates).toHaveCount(3);
+
+    // Verify via API
+    const notes = await getNotes(session.id);
+    expect(notes.length).toBe(3);
+  });
+
+  test('can edit an existing note', async ({ page }) => {
+    const note = await seedNote(session.id, 'Original content');
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Verify original content is visible
+    await expect(page.locator('.note .note-content')).toHaveText('Original content');
+
+    // Click Edit button
+    await page.click('.note .btn-link:has-text("Edit")');
+
+    // Verify edit mode is active (textarea appears)
+    await expect(page.locator('.note-edit')).toBeVisible();
+    await expect(page.locator('.note-edit textarea')).toBeVisible();
+    await expect(page.locator('.note-edit textarea')).toHaveValue('Original content');
+
+    // Verify Save and Cancel buttons are visible
+    await expect(page.locator('.note-edit-actions button:has-text("Save")')).toBeVisible();
+    await expect(page.locator('.note-edit-actions button:has-text("Cancel")')).toBeVisible();
+
+    // Edit the content
+    await page.fill('.note-edit textarea', 'Updated content');
+
+    // Save the changes
+    await page.click('.note-edit-actions button:has-text("Save")');
+
+    // Verify edit mode is closed
+    await expect(page.locator('.note-edit')).not.toBeVisible();
+
+    // Verify updated content is displayed
+    await expect(page.locator('.note .note-content')).toHaveText('Updated content');
+
+    // Verify toast notification
+    await expect(page.locator('.toast-success')).toBeVisible();
+    await expect(page.getByText('Note updated')).toBeVisible();
+
+    // Verify via API that change was persisted
+    const notes = await getNotes(session.id);
+    expect(notes.length).toBe(1);
+    expect(notes[0].content).toBe('Updated content');
+  });
+
+  test('can cancel editing a note', async ({ page }) => {
+    await seedNote(session.id, 'Original content');
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Click Edit
+    await page.click('.note .btn-link:has-text("Edit")');
+
+    // Modify content
+    await page.fill('.note-edit textarea', 'Modified but not saved');
+
+    // Click Cancel
+    await page.click('.note-edit-actions button:has-text("Cancel")');
+
+    // Verify edit mode is closed
+    await expect(page.locator('.note-edit')).not.toBeVisible();
+
+    // Verify original content is still displayed
+    await expect(page.locator('.note .note-content')).toHaveText('Original content');
+
+    // Verify via API that content was not changed
+    const notes = await getNotes(session.id);
+    expect(notes[0].content).toBe('Original content');
+  });
+
+  test('can delete a note', async ({ page }) => {
+    const note = await seedNote(session.id, 'Note to delete');
+
+    // Verify note exists via API
+    let notes = await getNotes(session.id);
+    expect(notes.length).toBe(1);
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Verify note is visible
+    await expect(page.getByText('Note to delete')).toBeVisible();
+
+    // Handle confirmation dialog
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Click Delete button
+    await page.click('.note .btn-link-danger:has-text("Delete")');
+
+    // Verify note is no longer visible
+    await expect(page.getByText('Note to delete')).not.toBeVisible();
+
+    // Verify empty state is shown
+    await expect(page.locator('.empty-state')).toBeVisible();
+
+    // Verify toast notification
+    await expect(page.locator('.toast-success')).toBeVisible();
+    await expect(page.getByText('Note deleted')).toBeVisible();
+
+    // Verify via API that note was deleted
+    notes = await getNotes(session.id);
+    expect(notes.length).toBe(0);
+  });
+
+  test('can cancel note deletion', async ({ page }) => {
+    await seedNote(session.id, 'Note to keep');
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Handle confirmation dialog - reject
+    page.on('dialog', (dialog) => dialog.dismiss());
+
+    // Click Delete button
+    await page.click('.note .btn-link-danger:has-text("Delete")');
+
+    // Verify note is still visible
+    await expect(page.getByText('Note to keep')).toBeVisible();
+
+    // Verify empty state is NOT shown
+    await expect(page.locator('.empty-state')).not.toBeVisible();
+
+    // Verify via API that note still exists
+    const notes = await getNotes(session.id);
+    expect(notes.length).toBe(1);
+  });
+
+  test('displays loading state while fetching notes', async ({ page }) => {
+    // Navigate to notes tab
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Loading state should disappear quickly and show empty state
+    await expect(page.locator('.loading-state')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.empty-state')).toBeVisible();
+  });
+
+  test('note actions (Edit/Delete) are visible for each note', async ({ page }) => {
+    await seedNote(session.id, 'Note with actions');
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Verify note card has both action buttons
+    const note = page.locator('.note');
+    await expect(note.locator('.note-actions')).toBeVisible();
+    await expect(note.locator('.btn-link:has-text("Edit")')).toBeVisible();
+    await expect(note.locator('.btn-link-danger:has-text("Delete")')).toBeVisible();
+  });
+
+  test('newly added note appears at the top of the list', async ({ page }) => {
+    // Seed an existing note
+    await seedNote(session.id, 'Existing note');
+
+    await page.goto(`/sessions/${session.id}/notes`);
+
+    // Add a new note via UI
+    await page.fill('.add-note-form textarea', 'New note added via UI');
+    await page.click('button:has-text("Add Note")');
+
+    // Wait for note to appear
+    await expect(page.locator('.note')).toHaveCount(2);
+
+    // Verify new note is at the top
+    const noteContents = page.locator('.note .note-content');
+    await expect(noteContents.nth(0)).toHaveText('New note added via UI');
+    await expect(noteContents.nth(1)).toHaveText('Existing note');
+  });
+});

--- a/tests/e2e/path-chooser.spec.ts
+++ b/tests/e2e/path-chooser.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 import { seedProject, cleanupAll } from './helpers';
 
 test.describe('Path Chooser', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async () => {
     await cleanupAll();
   });
@@ -72,6 +75,9 @@ test.describe('Path Chooser', () => {
 });
 
 test.describe('Path Chooser Navigation', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async () => {
     await cleanupAll();
   });
@@ -166,6 +172,9 @@ test.describe('Path Chooser Navigation', () => {
 });
 
 test.describe('Path Chooser Selection', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async () => {
     await cleanupAll();
   });
@@ -230,6 +239,9 @@ test.describe('Path Chooser Selection', () => {
 });
 
 test.describe('Path Chooser in Edit View', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async () => {
     await cleanupAll();
   });
@@ -275,6 +287,9 @@ test.describe('Path Chooser in Edit View', () => {
 });
 
 test.describe('Path Chooser Error Handling', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async () => {
     await cleanupAll();
   });

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 import { seedProject, cleanupAll, getProject, getProjects } from './helpers';
 
 test.describe('Project Management', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   test.beforeEach(async () => {
     await cleanupAll();
   });

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -22,6 +22,11 @@ test.describe('Project Management', () => {
 
     await expect(page).toHaveURL('/projects/new');
 
+    // Verify form elements are present
+    await expect(page.locator('input[id="name"]')).toBeVisible();
+    await expect(page.locator('.path-chooser input')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create Project' })).toBeVisible();
+
     await page.fill('input[id="name"]', 'Test Project');
     await page.fill('.path-chooser input', '/tmp/test-project');
     await page.click('button:has-text("Create Project")');
@@ -41,18 +46,49 @@ test.describe('Project Management', () => {
 
     // Verify project name is visible on the sessions page header
     await expect(page.getByText('Test Project')).toBeVisible();
+
+    // Verify toast notification for success
+    await expect(page.locator('.toast-success, .toast')).toBeVisible({ timeout: 3000 });
   });
 
   test('displays project list', async ({ page }) => {
     // Seed some projects
-    await seedProject('Project Alpha', '/path/to/alpha');
-    await seedProject('Project Beta', '/path/to/beta');
+    const projectAlpha = await seedProject('Project Alpha', '/path/to/alpha');
+    const projectBeta = await seedProject('Project Beta', '/path/to/beta');
 
     await page.goto('/');
 
-    await expect(page.getByText('Project Alpha')).toBeVisible();
-    await expect(page.getByText('Project Beta')).toBeVisible();
-    await expect(page.getByText('/path/to/alpha')).toBeVisible();
+    // Verify project cards exist with correct structure
+    const projectCards = page.locator('.card, .project-card');
+    await expect(projectCards).toHaveCount(2);
+
+    // Verify Project Alpha card content
+    const alphaCard = page.locator('.card, .project-card').filter({ hasText: 'Project Alpha' });
+    await expect(alphaCard).toBeVisible();
+    await expect(alphaCard.getByText('/path/to/alpha')).toBeVisible();
+    await expect(alphaCard.getByRole('link', { name: 'Sessions' })).toBeVisible();
+    await expect(alphaCard.getByRole('link', { name: 'Edit' })).toBeVisible();
+
+    // Verify Project Beta card content
+    const betaCard = page.locator('.card, .project-card').filter({ hasText: 'Project Beta' });
+    await expect(betaCard).toBeVisible();
+    await expect(betaCard.getByText('/path/to/beta')).toBeVisible();
+
+    // Verify Sessions links have correct hrefs
+    await expect(alphaCard.getByRole('link', { name: 'Sessions' })).toHaveAttribute(
+      'href',
+      `/projects/${projectAlpha.id}/sessions`
+    );
+    await expect(betaCard.getByRole('link', { name: 'Sessions' })).toHaveAttribute(
+      'href',
+      `/projects/${projectBeta.id}/sessions`
+    );
+
+    // Verify via API that projects exist
+    const projects = await getProjects();
+    expect(projects.length).toBe(2);
+    expect(projects.find((p: any) => p.name === 'Project Alpha')).toBeTruthy();
+    expect(projects.find((p: any) => p.name === 'Project Beta')).toBeTruthy();
   });
 
   test('can navigate to project sessions', async ({ page }) => {
@@ -78,6 +114,10 @@ test.describe('Project Management', () => {
 
     await expect(page).toHaveURL(`/projects/${project.id}/edit`);
 
+    // Verify form is pre-filled with current values
+    await expect(page.locator('input[id="name"]')).toHaveValue('Original Name');
+    await expect(page.locator('.path-chooser input')).toHaveValue('/original/path');
+
     await page.fill('input[id="name"]', 'Updated Name');
     await page.click('button:has-text("Save")');
 
@@ -85,6 +125,9 @@ test.describe('Project Management', () => {
 
     // Verify updated name is visible on page
     await expect(page.getByText('Updated Name')).toBeVisible();
+
+    // Verify toast notification for success
+    await expect(page.locator('.toast-success, .toast')).toBeVisible({ timeout: 3000 });
 
     // Verify via API that the change persisted
     const updated = await getProject(project.id);
@@ -108,12 +151,70 @@ test.describe('Project Management', () => {
     await expect(page).toHaveURL('/');
     await expect(page.getByText('To Delete')).not.toBeVisible();
 
+    // Verify toast notification for success
+    await expect(page.locator('.toast-success, .toast')).toBeVisible({ timeout: 3000 });
+
     // Verify via API that the project was actually deleted
     const deleted = await getProject(project.id);
     expect(deleted).toBeNull();
 
-    // Verify project list is empty
+    // Verify project list is empty (shows empty state)
     const projects = await getProjects();
     expect(projects.length).toBe(0);
+    await expect(page.getByText('No projects yet')).toBeVisible();
+  });
+
+  test('can cancel project deletion', async ({ page }) => {
+    const project = await seedProject('Keep Me', '/tmp/keep');
+
+    await page.goto('/');
+    await page.click('text=Edit');
+
+    // Handle confirmation dialog - dismiss it
+    page.on('dialog', (dialog) => dialog.dismiss());
+    await page.click('button:has-text("Delete")');
+
+    // Should still be on edit page
+    await expect(page).toHaveURL(`/projects/${project.id}/edit`);
+
+    // Verify via API that project still exists
+    const existing = await getProject(project.id);
+    expect(existing).not.toBeNull();
+    expect(existing.name).toBe('Keep Me');
+  });
+
+  test('cancel button on new project form navigates back', async ({ page }) => {
+    await page.goto('/projects/new');
+
+    // Click cancel
+    await page.click('button:has-text("Cancel"), a:has-text("Cancel")');
+
+    // Should navigate back to projects list
+    await expect(page).toHaveURL('/');
+  });
+
+  test('cancel button on edit project form navigates back', async ({ page }) => {
+    const project = await seedProject('Edit Cancel Test', '/tmp/cancel');
+
+    await page.goto(`/projects/${project.id}/edit`);
+
+    // Click cancel
+    await page.click('button:has-text("Cancel"), a:has-text("Cancel")');
+
+    // Should navigate back to sessions list
+    await expect(page).toHaveURL(`/projects/${project.id}/sessions`);
+  });
+
+  test('displays loading state while fetching projects', async ({ page }) => {
+    // Navigate to page
+    await page.goto('/');
+
+    // Loading state should resolve quickly
+    await expect(page.locator('.loading-skeleton, .loading-state')).not.toBeVisible({
+      timeout: 5000,
+    });
+
+    // Should show empty state since no projects
+    await expect(page.getByText('No projects yet')).toBeVisible();
   });
 });

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -12,6 +12,9 @@ import {
 } from './helpers';
 
 test.describe('Session Management', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   let project: any;
 
   test.beforeEach(async () => {

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -6,6 +6,7 @@ import {
   waitForSessionStatus,
   getSession,
   getProjectSessions,
+  updateSessionStatus,
 } from './helpers';
 
 test.describe('Session Management', () => {
@@ -147,5 +148,248 @@ test.describe('Session Management', () => {
     const apiSession = await getSession(session.id);
     expect(apiSession).not.toBeNull();
     expect(apiSession.mode).toBe('plan');
+  });
+
+  test('displays Stop Session button for active sessions', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test active session',
+      name: 'Active Session',
+    });
+
+    // Update session to running state
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify Stop Session button is visible for running session
+    const stopButton = page.getByRole('button', { name: 'Stop Session' });
+    await expect(stopButton).toBeVisible();
+    await expect(stopButton).toHaveClass(/btn-danger/);
+
+    // Verify status badge shows running
+    await expect(page.locator('.status-badge.status-running')).toBeVisible();
+  });
+
+  test('Stop Session button is hidden for completed sessions', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test completed session',
+      name: 'Completed Session',
+    });
+
+    // Update session to completed state
+    await updateSessionStatus(session.id, 'completed');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify Stop Session button is NOT visible for completed session
+    const stopButton = page.getByRole('button', { name: 'Stop Session' });
+    await expect(stopButton).not.toBeVisible();
+
+    // Verify status badge shows completed
+    await expect(page.locator('.status-badge.status-completed')).toBeVisible();
+  });
+
+  test('displays message input form when session is waiting', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test waiting session',
+      name: 'Waiting Session',
+    });
+
+    // Update session to waiting state
+    await updateSessionStatus(session.id, 'waiting');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify status badge shows waiting
+    await expect(page.locator('.status-badge.status-waiting')).toBeVisible();
+
+    // Verify message input form is visible
+    await expect(page.locator('.input-form')).toBeVisible();
+    await expect(page.locator('.input-form textarea')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
+
+    // Verify placeholder text
+    await expect(page.locator('.input-form textarea')).toHaveAttribute(
+      'placeholder',
+      'Send a follow-up message...'
+    );
+  });
+
+  test('message input is hidden when session is running', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test running session',
+      name: 'Running Session',
+    });
+
+    // Update session to running state
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify status badge shows running
+    await expect(page.locator('.status-badge.status-running')).toBeVisible();
+
+    // Verify message input form is NOT visible
+    await expect(page.locator('.input-form')).not.toBeVisible();
+
+    // Verify "Claude is working..." status message is visible
+    await expect(page.locator('.status-message')).toBeVisible();
+    await expect(page.getByText('Claude is working...')).toBeVisible();
+  });
+
+  test('Send button is disabled when message is empty', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Send Test',
+    });
+
+    // Update to waiting state to show input form
+    await updateSessionStatus(session.id, 'waiting');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Wait for form to be visible
+    await expect(page.locator('.input-form')).toBeVisible();
+
+    // Verify Send button is disabled when textarea is empty
+    const sendButton = page.getByRole('button', { name: 'Send' });
+    await expect(sendButton).toBeDisabled();
+
+    // Type something
+    await page.fill('.input-form textarea', 'Hello');
+    await expect(sendButton).toBeEnabled();
+
+    // Clear it
+    await page.fill('.input-form textarea', '');
+    await expect(sendButton).toBeDisabled();
+
+    // Type only whitespace
+    await page.fill('.input-form textarea', '   ');
+    await expect(sendButton).toBeDisabled();
+  });
+
+  test('displays all session modes correctly', async ({ page }) => {
+    // Test standard mode
+    const standardSession = await seedSession(project.id, {
+      prompt: 'Standard test',
+      name: 'Standard Mode',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${standardSession.id}`);
+    await expect(page.locator('.session-mode')).toHaveText('standard');
+
+    // Test yolo mode
+    const yoloSession = await seedSession(project.id, {
+      prompt: 'Yolo test',
+      name: 'Yolo Mode',
+      mode: 'yolo',
+    });
+
+    await page.goto(`/sessions/${yoloSession.id}`);
+    await expect(page.locator('.session-mode')).toHaveText('yolo');
+
+    // Verify via API
+    const apiYoloSession = await getSession(yoloSession.id);
+    expect(apiYoloSession.mode).toBe('yolo');
+  });
+
+  test('displays session status badge with correct colors', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Status test',
+      name: 'Status Test',
+    });
+
+    // Test running status
+    await updateSessionStatus(session.id, 'running');
+    await page.goto(`/sessions/${session.id}`);
+    await expect(page.locator('.status-badge.status-running')).toBeVisible();
+    await expect(page.locator('.status-badge')).toHaveText('running');
+
+    // Test waiting status
+    await updateSessionStatus(session.id, 'waiting');
+    await page.reload();
+    await expect(page.locator('.status-badge.status-waiting')).toBeVisible();
+    await expect(page.locator('.status-badge')).toHaveText('waiting');
+
+    // Test completed status
+    await updateSessionStatus(session.id, 'completed');
+    await page.reload();
+    await expect(page.locator('.status-badge.status-completed')).toBeVisible();
+    await expect(page.locator('.status-badge')).toHaveText('completed');
+
+    // Test error status
+    await updateSessionStatus(session.id, 'error');
+    await page.reload();
+    await expect(page.locator('.status-badge.status-error')).toBeVisible();
+    await expect(page.locator('.status-badge')).toHaveText('error');
+  });
+
+  test('session list shows clickable session cards that navigate to details', async ({ page }) => {
+    const session1 = await seedSession(project.id, { prompt: 'Task 1', name: 'Session One' });
+    const session2 = await seedSession(project.id, { prompt: 'Task 2', name: 'Session Two' });
+
+    await page.goto(`/projects/${project.id}/sessions`);
+
+    // Find session cards and verify they're clickable links
+    const sessionCards = page.locator('.session-card, .card');
+    await expect(sessionCards).toHaveCount(2);
+
+    // Click on first session and verify navigation
+    await page.click('text=Session One');
+    await expect(page).toHaveURL(`/sessions/${session1.id}`);
+    await expect(page.locator('h1')).toHaveText('Session One');
+
+    // Go back and click second session
+    await page.goBack();
+    await page.click('text=Session Two');
+    await expect(page).toHaveURL(`/sessions/${session2.id}`);
+    await expect(page.locator('h1')).toHaveText('Session Two');
+  });
+
+  test('back link navigates to sessions list', async ({ page }) => {
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Navigation Test' });
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify back link is visible and has correct text
+    const backLink = page.locator('.back-link');
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveText(/Sessions/);
+
+    // Click back link and verify navigation
+    await backLink.click();
+    await expect(page).toHaveURL(`/projects/${project.id}/sessions`);
+  });
+
+  test('tab URLs are correct and maintain session context', async ({ page }) => {
+    const session = await seedSession(project.id, { prompt: 'Tab test', name: 'Tab URL Test' });
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Default tab should be conversation
+    await expect(page).toHaveURL(`/sessions/${session.id}`);
+
+    // Each tab link should have correct href
+    await expect(page.locator('a.tab[href*="conversation"]')).toHaveAttribute(
+      'href',
+      `/sessions/${session.id}/conversation`
+    );
+    await expect(page.locator('a.tab[href*="changes"]')).toHaveAttribute(
+      'href',
+      `/sessions/${session.id}/changes`
+    );
+    await expect(page.locator('a.tab[href*="canvas"]')).toHaveAttribute(
+      'href',
+      `/sessions/${session.id}/canvas`
+    );
+    await expect(page.locator('a.tab[href*="notes"]')).toHaveAttribute(
+      'href',
+      `/sessions/${session.id}/notes`
+    );
+
+    // Session name should remain visible after tab switches
+    await page.click('a.tab[href*="canvas"]');
+    await expect(page.locator('h1')).toHaveText('Tab URL Test');
   });
 });

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -11,6 +11,9 @@ import {
 } from './helpers';
 
 test.describe('Session Management', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   let project: any;
 
   test.beforeEach(async () => {

--- a/tests/e2e/websocket.spec.ts
+++ b/tests/e2e/websocket.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  seedCanvasItem,
+  cleanupAll,
+  updateSessionStatus,
+  getSession,
+} from './helpers';
+
+const API_URL = process.env.API_URL || 'http://localhost:5000';
+
+test.describe('WebSocket Real-time Updates', () => {
+  let project: any;
+  let session: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+    session = await seedSession(project.id, { prompt: 'WebSocket test', name: 'WS Test Session' });
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('session status updates are reflected in UI without page reload', async ({ page }) => {
+    // Set initial status to running
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify initial status
+    await expect(page.locator('.status-badge.status-running')).toBeVisible();
+    await expect(page.locator('.status-badge')).toHaveText('running');
+
+    // Update status via API (simulating backend update)
+    await updateSessionStatus(session.id, 'waiting');
+
+    // Wait for UI to reflect the change (via polling or WebSocket)
+    await expect(page.locator('.status-badge.status-waiting')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.status-badge')).toHaveText('waiting');
+
+    // Verify input form appears when status changes to waiting
+    await expect(page.locator('.input-form')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('session status change to completed hides Stop button', async ({ page }) => {
+    // Start with running session
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify Stop button is visible
+    await expect(page.getByRole('button', { name: 'Stop Session' })).toBeVisible();
+
+    // Update status to completed
+    await updateSessionStatus(session.id, 'completed');
+
+    // Wait for UI to reflect the change
+    await expect(page.locator('.status-badge.status-completed')).toBeVisible({ timeout: 5000 });
+
+    // Stop button should disappear
+    await expect(page.getByRole('button', { name: 'Stop Session' })).not.toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('canvas items added via API appear in UI without page reload', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Verify empty state initially
+    await expect(page.getByText('No canvas items yet')).toBeVisible();
+
+    // Add canvas item via API
+    await seedCanvasItem(session.id, {
+      type: 'markdown',
+      content: '# Real-time Canvas Item',
+      label: 'WS Canvas Test',
+    });
+
+    // Wait for item to appear in UI (via polling or WebSocket)
+    await expect(page.getByText('WS Canvas Test')).toBeVisible({ timeout: 5000 });
+
+    // Verify empty state is gone
+    await expect(page.getByText('No canvas items yet')).not.toBeVisible();
+  });
+
+  test('multiple canvas items added appear in correct order', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Add multiple canvas items
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'First item content',
+      label: 'First Item',
+    });
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Second item content',
+      label: 'Second Item',
+    });
+
+    // Wait for items to appear
+    await expect(page.getByText('First Item')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Second Item')).toBeVisible({ timeout: 5000 });
+
+    // Verify both items are present
+    const canvasItems = page.locator('.canvas-item');
+    await expect(canvasItems).toHaveCount(2);
+  });
+
+  test('session transitions from running to waiting shows input form', async ({ page }) => {
+    // Start with running session
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify "Claude is working..." message
+    await expect(page.getByText('Claude is working...')).toBeVisible();
+    await expect(page.locator('.input-form')).not.toBeVisible();
+
+    // Update to waiting
+    await updateSessionStatus(session.id, 'waiting');
+
+    // Wait for input form to appear
+    await expect(page.locator('.input-form')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Claude is working...')).not.toBeVisible();
+  });
+
+  test('session error status is reflected in UI', async ({ page }) => {
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+    await expect(page.locator('.status-badge.status-running')).toBeVisible();
+
+    // Simulate error
+    await updateSessionStatus(session.id, 'error');
+
+    // Wait for error status to appear
+    await expect(page.locator('.status-badge.status-error')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.status-badge')).toHaveText('error');
+
+    // Stop button should disappear for error state
+    await expect(page.getByRole('button', { name: 'Stop Session' })).not.toBeVisible();
+  });
+});
+
+test.describe('Session Polling Fallback', () => {
+  let project: any;
+  let session: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+    session = await seedSession(project.id, { prompt: 'Polling test', name: 'Polling Test' });
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('active session polls for updates', async ({ page }) => {
+    // Set session to running (active state that triggers polling)
+    await updateSessionStatus(session.id, 'running');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify initial state
+    await expect(page.locator('.status-badge.status-running')).toBeVisible();
+
+    // Change status - should be picked up by polling within 2-3 seconds
+    await updateSessionStatus(session.id, 'waiting');
+
+    // Polling interval is 2 seconds, so within 5 seconds we should see the update
+    await expect(page.locator('.status-badge.status-waiting')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('completed session does not continue polling', async ({ page }) => {
+    // Start with completed session
+    await updateSessionStatus(session.id, 'completed');
+
+    await page.goto(`/sessions/${session.id}`);
+
+    // Verify completed status
+    await expect(page.locator('.status-badge.status-completed')).toBeVisible();
+
+    // This test verifies that the page loads correctly for completed sessions
+    // and doesn't cause unnecessary polling (though we can't easily verify no polling occurs)
+    await expect(page.locator('h1')).toHaveText('Polling Test');
+  });
+});

--- a/tests/e2e/websocket.spec.ts
+++ b/tests/e2e/websocket.spec.ts
@@ -11,6 +11,9 @@ import {
 const API_URL = process.env.API_URL || 'http://localhost:5000';
 
 test.describe('WebSocket Real-time Updates', () => {
+  // Run tests serially to avoid race conditions with shared database
+  test.describe.configure({ mode: 'serial' });
+
   let project: any;
   let session: any;
 


### PR DESCRIPTION
- Add notes.spec.ts with full CRUD coverage for Notes tab
- Add websocket.spec.ts for real-time update tests
- Add session tests for: stop session, message input state, all modes, status badges
- Add helper functions: seedNote, getNotes, getNote, updateSessionStatus
- Strengthen project assertions: verify card structure, links, toast notifications
- Strengthen canvas assertions: verify item structure, add cancel deletion test
- Strengthen session assertions: verify navigation, tab URLs, clickable cards
- Add toast notification assertions across all test files
- Add form validation and cancel button tests