### PR TITLE
Easy git worktree/branch creation for new sessions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,104 @@
+# Plan: Easy Git Worktree Creation for New Sessions
+
+## Overview
+
+When creating a new session, users should be able to easily elect to create a new git worktree from the project's working path. Currently, the worktree option exists but is buried in a multi-step selection process. This plan improves the UX by making worktree creation more prominent and streamlined.
+
+## Current State
+
+- **Session creation form** (`packages/web/src/views/NewSessionView.vue`) has:
+  - Git Mode dropdown: "None", "Switch Branch", "Create Worktree"
+  - Branch selection (existing or new) when git mode is selected
+- **Backend** (`packages/server/src/services/gitSessionSetup.js`) already supports:
+  - Automatic worktree creation at `.worktrees/{sessionId}`
+  - Branch creation if it doesn't exist
+- **UX Problem**: Users must select "Create Worktree" from dropdown, then manually enter a branch name - this is cumbersome for the common case of wanting quick isolation
+
+## Proposed Solution
+
+Add a "Quick Worktree" feature that:
+1. Shows a single checkbox: "Create isolated worktree"
+2. Auto-generates a sensible branch name based on session name or timestamp
+3. One-click worktree creation without needing to understand git modes
+
+## Implementation Plan
+
+### 1. Frontend Changes (`packages/web/src/views/NewSessionView.vue`)
+
+**Add quick worktree toggle:**
+- Add a checkbox labeled "Create isolated worktree" (checked by default when git is available)
+- When checked, auto-generate branch name: `vk/{shortId}-{sanitized-session-name}`
+- Show the auto-generated branch name with option to customize
+- Keep advanced git mode options available via "Advanced options" expandable section
+
+**UI Layout:**
+```
+[x] Create isolated worktree
+    Branch: vk/4a52-implement-auth  [Edit]
+
+▸ Advanced git options (collapsed by default)
+```
+
+### 2. Branch Name Generation
+
+**Format:** `vk/{shortId}-{slug}`
+- `shortId`: First 4 characters of a new UUID
+- `slug`: Sanitized session name (lowercase, hyphens, max 30 chars)
+- If no session name: use first few words of prompt
+
+**Examples:**
+- Session "Implement auth" → `vk/a3f2-implement-auth`
+- Session "Fix bug #123" → `vk/b4c1-fix-bug-123`
+- No name, prompt "Add dark mode toggle..." → `vk/c5d2-add-dark-mode`
+
+### 3. API Changes
+
+**No backend changes required** - the existing `gitMode: 'worktree'` and `gitBranch` parameters handle everything. The frontend will simply:
+- Set `gitMode: 'worktree'` when checkbox is checked
+- Set `gitBranch` to the auto-generated (or customized) branch name
+
+### 4. Shared Utilities (`packages/shared`)
+
+Add branch name generation utility:
+- `generateWorktreeBranch(sessionName, prompt)` → returns formatted branch name
+- Can be used by both frontend (preview) and potentially backend (validation)
+
+### 5. Files to Modify
+
+| File | Changes |
+|------|---------|
+| `packages/web/src/views/NewSessionView.vue` | Add quick worktree checkbox, branch name preview, collapsible advanced options |
+| `packages/shared/src/utils.js` (new) | Add `generateWorktreeBranch()` utility function |
+| `packages/shared/src/index.js` | Export new utility |
+
+### 6. UX Flow
+
+**Before (current):**
+1. Fill session name and prompt
+2. Select "Create Worktree" from Git Mode dropdown
+3. Type or select a branch name
+4. Click Start Session
+
+**After (proposed):**
+1. Fill session name and prompt
+2. Checkbox "Create isolated worktree" is pre-checked (git available)
+3. See auto-generated branch name (can edit if desired)
+4. Click Start Session
+
+### 7. Edge Cases
+
+- **Non-git project**: Hide worktree checkbox entirely
+- **Branch already exists**: Show warning, suggest different name
+- **Invalid characters in session name**: Sanitize automatically
+- **Empty session name**: Fall back to prompt-based or random name
+
+### 8. Testing
+
+- Unit test for `generateWorktreeBranch()` utility
+- E2E test for quick worktree creation flow
+- Verify worktree is created at correct path
+- Verify branch naming works with various inputs
+
+## Summary
+
+This change makes worktree creation a first-class, one-click experience while preserving the existing advanced options for users who need fine-grained control. The auto-generated branch names follow a consistent pattern that's easy to identify and manage.

--- a/packages/server/src/api/canvas.js
+++ b/packages/server/src/api/canvas.js
@@ -72,7 +72,7 @@ router.delete('/:id/canvas/:itemId', (req, res) => {
   canvasItems.delete(req.params.itemId);
 
   // Broadcast to session subscribers
-  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { itemId: req.params.itemId });
+  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId: req.params.id, itemId: req.params.itemId });
 
   res.status(204).send();
 });

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -71,8 +71,11 @@ router.post('/:id/message', async (req, res) => {
   }
 
   try {
+    // Use gitWorktree if set, otherwise use the project's working directory
+    const workingDirectory = session.gitWorktree || project.workingDirectory;
+
     // Start continuation (non-blocking)
-    continueSession(session.id, content, project.workingDirectory).catch((error) => {
+    continueSession(session.id, content, workingDirectory).catch((error) => {
       console.error('Continue session error:', error);
     });
     res.json({ success: true });

--- a/packages/server/src/services/canvasStore.js
+++ b/packages/server/src/services/canvasStore.js
@@ -35,5 +35,5 @@ export function removeItem(sessionId, itemId) {
   }
 
   canvasItems.delete(itemId);
-  broadcastToSession(sessionId, WS_MESSAGE_TYPES.CANVAS_REMOVE, { itemId });
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId, itemId });
 }

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -115,7 +115,7 @@ export async function runSession(sessionId, prompt, workingDirectory) {
     console.error('Error stack:', error.stack);
     if (!controller.signal.aborted) {
       sessions.update(sessionId, { status: 'error', error: error.message });
-      broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { error: error.message });
+      broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
     }
     throw error;
   } finally {
@@ -196,7 +196,7 @@ export async function continueSession(sessionId, content, workingDirectory) {
     console.error('Error stack:', error.stack);
     if (!controller.signal.aborted) {
       sessions.update(sessionId, { status: 'error', error: error.message });
-      broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { error: error.message });
+      broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
     }
     throw error;
   } finally {
@@ -285,7 +285,7 @@ async function handleStreamEvent(sessionId, event) {
     case 'result': {
       if (event.subtype === 'error') {
         sessions.update(sessionId, { status: 'error', error: event.error });
-        broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { error: event.error });
+        broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: event.error });
       } else {
         // Store cost info
         if (event.total_cost_usd !== undefined) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,9 +8,17 @@
     "./types": "./src/types.js",
     "./protocol": "./src/protocol.js",
     "./constants": "./src/constants.js",
-    "./contracts/*": "./src/contracts/*.js"
+    "./contracts/*": "./src/contracts/*.js",
+    "./utils": "./src/utils.js"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "vitest": "^1.2.2"
   }
 }

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -1,3 +1,4 @@
 export * from './types.js';
 export * from './protocol.js';
 export * from './constants.js';
+export * from './utils.js';

--- a/packages/shared/src/utils.js
+++ b/packages/shared/src/utils.js
@@ -1,0 +1,67 @@
+/**
+ * Generate a short random ID (4 hex characters)
+ * @returns {string}
+ */
+export function generateShortId() {
+  return Math.random().toString(16).substring(2, 6);
+}
+
+/**
+ * Sanitize a string for use in a git branch name
+ * @param {string} text - The text to sanitize
+ * @param {number} [maxLength=30] - Maximum length of the result
+ * @returns {string}
+ */
+export function sanitizeBranchName(text, maxLength = 30) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-') // Collapse multiple hyphens
+    .replace(/^-|-$/g, '') // Trim leading/trailing hyphens
+    .substring(0, maxLength);
+}
+
+/**
+ * Extract a slug from a prompt (first few meaningful words)
+ * @param {string} prompt - The prompt text
+ * @returns {string}
+ */
+export function extractSlugFromPrompt(prompt) {
+  // Take first 5 words, filter out common stop words
+  const stopWords = ['a', 'an', 'the', 'to', 'and', 'or', 'for', 'in', 'on', 'at', 'of', 'with', 'is', 'it', 'this', 'that', 'i', 'me', 'my', 'we', 'our', 'you', 'your', 'can', 'please', 'help'];
+  const words = prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .split(/\s+/)
+    .filter((word) => word.length > 1 && !stopWords.includes(word))
+    .slice(0, 4);
+
+  return words.join('-') || 'session';
+}
+
+/**
+ * Generate a git branch name for a worktree
+ * @param {string} [sessionName] - Optional session name
+ * @param {string} [prompt] - Optional prompt to extract slug from
+ * @returns {string} Branch name in format: vk/{shortId}-{slug}
+ */
+export function generateWorktreeBranch(sessionName, prompt) {
+  const shortId = generateShortId();
+
+  let slug;
+  if (sessionName && sessionName.trim()) {
+    slug = sanitizeBranchName(sessionName.trim());
+  } else if (prompt && prompt.trim()) {
+    slug = sanitizeBranchName(extractSlugFromPrompt(prompt.trim()));
+  } else {
+    slug = 'session';
+  }
+
+  // Ensure slug is not empty
+  if (!slug) {
+    slug = 'session';
+  }
+
+  return `vk/${shortId}-${slug}`;
+}

--- a/packages/shared/src/utils.test.js
+++ b/packages/shared/src/utils.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateShortId,
+  sanitizeBranchName,
+  extractSlugFromPrompt,
+  generateWorktreeBranch,
+} from './utils.js';
+
+describe('generateShortId', () => {
+  it('generates a 4-character hex string', () => {
+    const id = generateShortId();
+    expect(id).toHaveLength(4);
+    expect(id).toMatch(/^[0-9a-f]{4}$/);
+  });
+
+  it('generates unique IDs', () => {
+    const ids = new Set();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateShortId());
+    }
+    // Should have mostly unique IDs (allowing for rare collisions)
+    expect(ids.size).toBeGreaterThan(90);
+  });
+});
+
+describe('sanitizeBranchName', () => {
+  it('converts to lowercase', () => {
+    expect(sanitizeBranchName('Hello World')).toBe('hello-world');
+  });
+
+  it('replaces spaces with hyphens', () => {
+    expect(sanitizeBranchName('my new feature')).toBe('my-new-feature');
+  });
+
+  it('removes special characters', () => {
+    expect(sanitizeBranchName("fix bug #123!")).toBe('fix-bug-123');
+  });
+
+  it('collapses multiple hyphens', () => {
+    expect(sanitizeBranchName('hello---world')).toBe('hello-world');
+  });
+
+  it('trims leading and trailing hyphens', () => {
+    expect(sanitizeBranchName('--hello--')).toBe('hello');
+  });
+
+  it('respects maxLength parameter', () => {
+    const result = sanitizeBranchName('this is a very long session name that should be truncated', 20);
+    expect(result.length).toBeLessThanOrEqual(20);
+  });
+
+  it('uses default maxLength of 30', () => {
+    const result = sanitizeBranchName('this is a very very very long session name');
+    expect(result.length).toBeLessThanOrEqual(30);
+  });
+});
+
+describe('extractSlugFromPrompt', () => {
+  it('extracts meaningful words from prompt', () => {
+    expect(extractSlugFromPrompt('Add a dark mode toggle')).toBe('add-dark-mode-toggle');
+  });
+
+  it('filters out stop words', () => {
+    expect(extractSlugFromPrompt('Please help me to fix the bug')).toBe('fix-bug');
+  });
+
+  it('limits to 4 words', () => {
+    const result = extractSlugFromPrompt('implement user authentication with oauth and jwt tokens');
+    const words = result.split('-');
+    expect(words.length).toBeLessThanOrEqual(4);
+  });
+
+  it('returns session for empty/meaningless prompts', () => {
+    expect(extractSlugFromPrompt('the a an')).toBe('session');
+    expect(extractSlugFromPrompt('')).toBe('session');
+  });
+
+  it('removes special characters', () => {
+    expect(extractSlugFromPrompt("Fix bug #123 in user's profile!")).toBe('fix-bug-123-users');
+  });
+});
+
+describe('generateWorktreeBranch', () => {
+  it('generates branch with format vk/{shortId}-{slug}', () => {
+    const branch = generateWorktreeBranch('Implement auth', '');
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-implement-auth$/);
+  });
+
+  it('uses session name when provided', () => {
+    const branch = generateWorktreeBranch('Fix login bug', 'Some prompt text');
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-fix-login-bug$/);
+  });
+
+  it('falls back to prompt when no session name', () => {
+    const branch = generateWorktreeBranch('', 'Add dark mode toggle to settings');
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-add-dark-mode-toggle$/);
+  });
+
+  it('uses session as default when no name or prompt', () => {
+    const branch = generateWorktreeBranch('', '');
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-session$/);
+  });
+
+  it('handles undefined parameters', () => {
+    const branch = generateWorktreeBranch(undefined, undefined);
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-session$/);
+  });
+
+  it('handles whitespace-only input', () => {
+    const branch = generateWorktreeBranch('   ', '   ');
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-session$/);
+  });
+
+  it('sanitizes special characters in session name', () => {
+    const branch = generateWorktreeBranch('Fix bug #123!', '');
+    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-fix-bug-123$/);
+  });
+});

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -130,25 +130,42 @@ export function useSessionSubscription(sessionId) {
   };
 
   const onMessage = (callback) => {
-    const handler = (msg) => callback(msg.message);
+    const handler = (msg) => {
+      // Filter by sessionId to avoid cross-session interference
+      if (msg.message?.sessionId === sessionId) {
+        callback(msg.message);
+      }
+    };
     on(WS_MESSAGE_TYPES.SESSION_MESSAGE, handler);
     return () => off(WS_MESSAGE_TYPES.SESSION_MESSAGE, handler);
   };
 
   const onError = (callback) => {
-    const handler = (msg) => callback(msg.error);
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.error);
+      }
+    };
     on(WS_MESSAGE_TYPES.SESSION_ERROR, handler);
     return () => off(WS_MESSAGE_TYPES.SESSION_ERROR, handler);
   };
 
   const onCanvasAdd = (callback) => {
-    const handler = (msg) => callback(msg.item);
+    const handler = (msg) => {
+      if (msg.item?.sessionId === sessionId) {
+        callback(msg.item);
+      }
+    };
     on(WS_MESSAGE_TYPES.CANVAS_ADD, handler);
     return () => off(WS_MESSAGE_TYPES.CANVAS_ADD, handler);
   };
 
   const onCanvasRemove = (callback) => {
-    const handler = (msg) => callback(msg.itemId);
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.itemId);
+      }
+    };
     on(WS_MESSAGE_TYPES.CANVAS_REMOVE, handler);
     return () => off(WS_MESSAGE_TYPES.CANVAS_REMOVE, handler);
   };

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -38,8 +38,67 @@
         </select>
       </div>
 
-      <div v-if="gitStatus" class="form-group">
-        <label class="form-label" for="gitMode">Git Mode</label>
+      <!-- Quick Git Options -->
+      <div v-if="gitStatus?.isGitRepo && !showAdvancedGit" class="form-group">
+        <label class="form-label">Git Options</label>
+        <div class="quick-git-options">
+          <label class="radio-option">
+            <input type="radio" v-model="quickGitMode" value="" />
+            <span class="radio-label">Use current branch</span>
+            <span class="radio-help">{{ gitStatus.currentBranch }}</span>
+          </label>
+          <label class="radio-option">
+            <input type="radio" v-model="quickGitMode" value="branch" />
+            <span class="radio-label">Create new branch</span>
+            <span class="radio-help">Work in the project directory</span>
+          </label>
+          <label class="radio-option">
+            <input type="radio" v-model="quickGitMode" value="worktree" />
+            <span class="radio-label">Create isolated worktree</span>
+            <span class="radio-help">Separate working directory for this session</span>
+          </label>
+        </div>
+
+        <!-- Branch name input (shown for branch or worktree) -->
+        <div v-if="quickGitMode" class="quick-branch-section">
+          <label class="form-label form-label-small">Branch Name</label>
+          <div class="quick-branch-input">
+            <input
+              v-model="quickWorktreeBranch"
+              type="text"
+              class="form-input"
+              :placeholder="autoBranchName"
+              @focus="handleBranchEdit"
+            />
+            <button
+              v-if="editingBranch"
+              type="button"
+              class="btn btn-small"
+              @click="resetBranchName"
+            >
+              Reset
+            </button>
+          </div>
+          <p class="form-help">Auto-generated from session name/prompt</p>
+        </div>
+
+        <button
+          type="button"
+          class="link-button"
+          @click="showAdvancedGit = true"
+        >
+          Advanced git options...
+        </button>
+      </div>
+
+      <!-- Advanced Git Options (legacy UI) -->
+      <div v-if="gitStatus?.isGitRepo && showAdvancedGit" class="form-group">
+        <div class="advanced-header">
+          <label class="form-label">Git Mode (Advanced)</label>
+          <button type="button" class="link-button" @click="showAdvancedGit = false">
+            Simple options
+          </button>
+        </div>
         <select id="gitMode" v-model="gitMode" class="form-input">
           <option value="">None (use current branch)</option>
           <option value="branch">Switch Branch</option>
@@ -50,31 +109,31 @@
           <template v-else-if="gitMode === 'branch'">Checkout/create a branch in the project directory</template>
           <template v-else-if="gitMode === 'worktree'">Create an isolated worktree for this session</template>
         </p>
-      </div>
 
-      <div v-if="gitStatus && gitMode" class="form-group">
-        <label class="form-label" for="gitBranch">
-          {{ gitMode === 'branch' ? 'Branch Name' : 'Worktree Branch' }}
-        </label>
-        <div class="branch-input-group">
-          <select id="gitBranch" v-model="gitBranch" class="form-input">
-            <option value="">-- Select existing or type new --</option>
-            <option v-for="branch in gitStatus.branches" :key="branch.name" :value="branch.name">
-              {{ branch.name }}
-            </option>
-          </select>
-          <span class="or-text">or</span>
-          <input
-            v-model="newBranchName"
-            type="text"
-            class="form-input"
-            placeholder="New branch name"
-            @input="gitBranch = newBranchName"
-          />
+        <div v-if="gitMode" class="form-group nested-group">
+          <label class="form-label" for="gitBranch">
+            {{ gitMode === 'branch' ? 'Branch Name' : 'Worktree Branch' }}
+          </label>
+          <div class="branch-input-group">
+            <select id="gitBranch" v-model="gitBranch" class="form-input">
+              <option value="">-- Select existing or type new --</option>
+              <option v-for="branch in gitStatus.branches" :key="branch.name" :value="branch.name">
+                {{ branch.name }}
+              </option>
+            </select>
+            <span class="or-text">or</span>
+            <input
+              v-model="newBranchName"
+              type="text"
+              class="form-input"
+              placeholder="New branch name"
+              @input="gitBranch = newBranchName"
+            />
+          </div>
+          <p v-if="gitStatus.currentBranch" class="form-help">
+            Current branch: {{ gitStatus.currentBranch }}
+          </p>
         </div>
-        <p v-if="gitStatus.currentBranch" class="form-help">
-          Current branch: {{ gitStatus.currentBranch }}
-        </p>
       </div>
 
       <div v-if="loadingGit" class="git-loading">
@@ -96,11 +155,12 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, computed, watch, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { api } from '../composables/useApi.js';
+import { generateWorktreeBranch } from '@claudetools/shared';
 
 const route = useRoute();
 const router = useRouter();
@@ -118,6 +178,35 @@ const loading = ref(false);
 const loadingGit = ref(false);
 const error = ref(null);
 
+// Quick git feature
+const quickGitMode = ref(''); // '', 'branch', or 'worktree'
+const quickWorktreeBranch = ref('');
+const editingBranch = ref(false);
+const showAdvancedGit = ref(false);
+
+// Generate branch name when session name or prompt changes
+const autoBranchName = computed(() => {
+  return generateWorktreeBranch(name.value, prompt.value);
+});
+
+// Update quick worktree branch when auto-generated name changes
+watch(autoBranchName, (newBranch) => {
+  if (!editingBranch.value) {
+    quickWorktreeBranch.value = newBranch;
+  }
+});
+
+// Initialize quick worktree branch
+watch(
+  () => gitStatus.value,
+  (status) => {
+    if (status?.isGitRepo) {
+      quickWorktreeBranch.value = autoBranchName.value;
+    }
+  },
+  { immediate: true }
+);
+
 onMounted(async () => {
   loadingGit.value = true;
   try {
@@ -129,17 +218,40 @@ onMounted(async () => {
   }
 });
 
+function handleBranchEdit() {
+  editingBranch.value = true;
+}
+
+function resetBranchName() {
+  editingBranch.value = false;
+  quickWorktreeBranch.value = autoBranchName.value;
+}
+
 async function handleSubmit() {
   loading.value = true;
   error.value = null;
 
   try {
+    // Determine git settings based on quick or advanced options
+    let submitGitMode;
+    let submitGitBranch;
+
+    if (showAdvancedGit.value) {
+      // Use advanced options
+      submitGitMode = gitMode.value || undefined;
+      submitGitBranch = gitBranch.value || undefined;
+    } else if (quickGitMode.value && gitStatus.value?.isGitRepo) {
+      // Use quick options
+      submitGitMode = quickGitMode.value;
+      submitGitBranch = quickWorktreeBranch.value;
+    }
+
     const session = await sessionsStore.createSession(route.params.id, {
       name: name.value || undefined,
       prompt: prompt.value,
       mode: mode.value,
-      gitMode: gitMode.value || undefined,
-      gitBranch: gitBranch.value || undefined,
+      gitMode: submitGitMode,
+      gitBranch: submitGitBranch,
     });
     uiStore.success('Session started');
     router.push(`/sessions/${session.id}`);
@@ -210,5 +322,105 @@ h1 {
 .or-text {
   color: var(--color-text-soft);
   font-size: 0.875rem;
+}
+
+/* Quick git options */
+.quick-git-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.radio-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.radio-option:hover {
+  border-color: var(--color-border-hover);
+  background-color: var(--color-bg-hover);
+}
+
+.radio-option:has(input:checked) {
+  border-color: var(--color-accent);
+  background-color: var(--color-accent-bg);
+}
+
+.radio-option input[type="radio"] {
+  margin-top: 0.125rem;
+}
+
+.radio-label {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.radio-help {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.quick-branch-section {
+  margin-top: 1rem;
+  padding: 1rem;
+  background-color: var(--color-bg-soft);
+  border-radius: 0.375rem;
+}
+
+.form-label-small {
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.quick-branch-input {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.quick-branch-input input {
+  flex: 1;
+}
+
+.btn-small {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--color-accent);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 0.5rem;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+.advanced-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.advanced-header .form-label {
+  margin-bottom: 0;
+}
+
+.nested-group {
+  margin-top: 1rem;
 }
 </style>


### PR DESCRIPTION
## Summary

- Added easy git worktree/branch creation when creating new sessions
- Users can now quickly select "Create new branch" or "Create isolated worktree" with auto-generated branch names
- Fixed critical bug where session continuation used wrong working directory for worktree sessions
- Fixed WebSocket handlers to properly filter messages by sessionId

## Changes

### New Features
- **Quick git options UI**: Radio buttons for "Use current branch", "Create new branch", "Create isolated worktree"
- **Auto-generated branch names**: Format `vk/{shortId}-{slug}` based on session name or prompt
- **Branch name preview**: Shows auto-generated name with edit/reset capability
- **Advanced options toggle**: Legacy dropdown UI still available for power users

### Bug Fixes
- **Worktree working directory fix**: Session continuation now correctly uses `session.gitWorktree` path instead of always using `project.workingDirectory`
- **WebSocket sessionId filtering**: Added sessionId filtering to `onMessage`, `onError`, `onCanvasAdd`, `onCanvasRemove` handlers to prevent cross-session interference
- **Server WebSocket payloads**: Added `sessionId` to error and canvas remove payloads

## Files Changed
- `packages/shared/src/utils.js` (new) - Branch name generation utilities
- `packages/shared/src/utils.test.js` (new) - 21 unit tests
- `packages/web/src/views/NewSessionView.vue` - Redesigned git options UI
- `packages/web/src/composables/useWebSocket.js` - Added sessionId filtering
- `packages/server/src/api/sessions.js` - Fixed worktree working directory
- `packages/server/src/services/sessionManager.js` - Added sessionId to error payloads
- `packages/server/src/services/canvasStore.js` - Added sessionId to canvas remove payload
- `packages/server/src/api/canvas.js` - Added sessionId to canvas remove payload

## Test plan
- [x] Unit tests pass for branch name generation utilities
- [x] All existing server tests pass
- [x] All existing web tests pass
- [x] Linting passes
- [ ] Manual test: Create session with worktree mode, verify Claude works in worktree
- [ ] Manual test: Send follow-up message, verify still in worktree directory
- [ ] Manual test: Verify UI updates correctly after second message

🤖 Generated with [Claude Code](https://claude.com/claude-code)