### PR TITLE
Change git worktree branch prefix from 'vk' to 'claude-tools'

### DIFF
--- a/packages/shared/src/utils.js
+++ b/packages/shared/src/utils.js
@@ -44,7 +44,7 @@ export function extractSlugFromPrompt(prompt) {
  * Generate a git branch name for a worktree
  * @param {string} [sessionName] - Optional session name
  * @param {string} [prompt] - Optional prompt to extract slug from
- * @returns {string} Branch name in format: vk/{shortId}-{slug}
+ * @returns {string} Branch name in format: claude-tools/{shortId}-{slug}
  */
 export function generateWorktreeBranch(sessionName, prompt) {
   const shortId = generateShortId();
@@ -63,5 +63,5 @@ export function generateWorktreeBranch(sessionName, prompt) {
     slug = 'session';
   }
 
-  return `vk/${shortId}-${slug}`;
+  return `claude-tools/${shortId}-${slug}`;
 }

--- a/packages/shared/src/utils.test.js
+++ b/packages/shared/src/utils.test.js
@@ -81,38 +81,38 @@ describe('extractSlugFromPrompt', () => {
 });
 
 describe('generateWorktreeBranch', () => {
-  it('generates branch with format vk/{shortId}-{slug}', () => {
+  it('generates branch with format claude-tools/{shortId}-{slug}', () => {
     const branch = generateWorktreeBranch('Implement auth', '');
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-implement-auth$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-implement-auth$/);
   });
 
   it('uses session name when provided', () => {
     const branch = generateWorktreeBranch('Fix login bug', 'Some prompt text');
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-fix-login-bug$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-fix-login-bug$/);
   });
 
   it('falls back to prompt when no session name', () => {
     const branch = generateWorktreeBranch('', 'Add dark mode toggle to settings');
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-add-dark-mode-toggle$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-add-dark-mode-toggle$/);
   });
 
   it('uses session as default when no name or prompt', () => {
     const branch = generateWorktreeBranch('', '');
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-session$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-session$/);
   });
 
   it('handles undefined parameters', () => {
     const branch = generateWorktreeBranch(undefined, undefined);
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-session$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-session$/);
   });
 
   it('handles whitespace-only input', () => {
     const branch = generateWorktreeBranch('   ', '   ');
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-session$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-session$/);
   });
 
   it('sanitizes special characters in session name', () => {
     const branch = generateWorktreeBranch('Fix bug #123!', '');
-    expect(branch).toMatch(/^vk\/[0-9a-f]{4}-fix-bug-123$/);
+    expect(branch).toMatch(/^claude-tools\/[0-9a-f]{4}-fix-bug-123$/);
   });
 });


### PR DESCRIPTION
## Summary
- Changed the auto-generated git worktree branch prefix from `vk/` to `claude-tools/`
- The previous `vk` prefix had no documented meaning
- The new prefix matches the application name and makes branches more identifiable

## Test plan
- [x] All 21 tests in `packages/shared` pass
- [ ] Verify new sessions create branches with `claude-tools/` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)