### PR TITLE
Add delete session feature

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,7 +1,9 @@
 import { Router } from 'express';
 import { sessions, messages, sessionNotes, projects } from '../database.js';
-import { continueSession, stopSession, endSession } from '../services/sessionManager.js';
+import { continueSession, stopSession, endSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges } from '../services/diffService.js';
+import { broadcastToSession } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 
 const router = Router();
 
@@ -173,6 +175,25 @@ router.delete('/:id/notes/:noteId', (req, res) => {
   }
 
   sessionNotes.delete(req.params.noteId);
+  res.status(204).send();
+});
+
+// DELETE /api/sessions/:id - Delete session
+router.delete('/:id', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  // Clean up active session if running
+  cleanupActiveSession(req.params.id);
+
+  // Broadcast deletion to close any open WebSocket subscriptions
+  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.SESSION_DELETED, { sessionId: req.params.id });
+
+  // Delete session (cascade will handle messages, canvas items, notes)
+  sessions.delete(req.params.id);
+
   res.status(204).send();
 });
 

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -236,6 +236,21 @@ export function endSession(sessionId) {
 }
 
 /**
+ * Clean up an active session before deletion
+ * @param {string} sessionId
+ * @returns {boolean} true if session was active and cleaned up
+ */
+export function cleanupActiveSession(sessionId) {
+  const sessionData = activeSessions.get(sessionId);
+  if (sessionData) {
+    sessionData.controller.abort();
+    activeSessions.delete(sessionId);
+    return true;
+  }
+  return false;
+}
+
+/**
  * Handle a stream event from Claude SDK
  * @param {string} sessionId
  * @param {Object} event

--- a/packages/server/test/session-git-modes.test.js
+++ b/packages/server/test/session-git-modes.test.js
@@ -1,19 +1,13 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { projects, sessions } from '../src/database.js';
+import { projects } from '../src/database.js';
 import * as gitService from '../src/services/gitService.js';
-import * as sessionManager from '../src/services/sessionManager.js';
 
 vi.mock('../src/services/gitService.js');
-vi.mock('../src/services/sessionManager.js');
 
 describe('Session Creation with Git Modes', () => {
-  let project;
-
   beforeEach(() => {
-    project = projects.create('Test Project', '/test/project/path');
+    projects.create('Test Project', '/test/project/path');
     vi.resetAllMocks();
-    // Default mock for runSession
-    sessionManager.runSession = vi.fn().mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/packages/shared/src/protocol.js
+++ b/packages/shared/src/protocol.js
@@ -12,6 +12,7 @@ export const WS_MESSAGE_TYPES = {
   SESSION_MESSAGE: 'session:message',
   SESSION_PARTIAL: 'session:partial',
   SESSION_ERROR: 'session:error',
+  SESSION_DELETED: 'session:deleted',
   CANVAS_ADD: 'canvas:add',
   CANVAS_REMOVE: 'canvas:remove',
 };

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -176,6 +176,15 @@ export class ApiClient {
     return this.#request('POST', `/sessions/${id}/end`);
   }
 
+  /**
+   * Delete a session
+   * @param {string} id - Session ID
+   * @returns {Promise<void>}
+   */
+  async deleteSession(id) {
+    return this.#request('DELETE', `/sessions/${id}`);
+  }
+
   // Canvas
 
   /**

--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -10,6 +10,7 @@
   --color-success: #3fb950;
   --color-warning: #d29922;
   --color-error: #f85149;
+  --color-danger: #f85149;
   --color-info: #58a6ff;
   --border-radius: 6px;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
@@ -93,6 +94,32 @@ input, textarea, select {
 
 .btn-danger:hover {
   opacity: 0.9;
+}
+
+.btn-outline-danger {
+  background-color: transparent;
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.btn-outline-danger:hover {
+  background-color: var(--color-error);
+  color: #fff;
+}
+
+.btn-secondary {
+  background-color: var(--color-background-mute);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.btn-secondary:hover {
+  background-color: var(--color-border);
+}
+
+.btn-sm {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
 }
 
 /* Cards */

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -108,6 +108,22 @@ export const useSessionsStore = defineStore('sessions', {
       }
     },
 
+    async deleteSession(id) {
+      this.error = null;
+      try {
+        await api.deleteSession(id);
+        // Remove session from list
+        this.sessions = this.sessions.filter((s) => s.id !== id);
+        // Clear current session if it's the deleted one
+        if (this.currentSession?.id === id) {
+          this.currentSession = null;
+        }
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
     addMessage(message) {
       this.messages.push(message);
     },

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -30,6 +30,28 @@
           >
             Stop Session
           </button>
+          <button
+            v-if="!showDeleteConfirm"
+            class="btn btn-outline-danger"
+            @click="showDeleteConfirm = true"
+          >
+            Delete Session
+          </button>
+          <div v-else class="delete-confirm">
+            <span class="delete-confirm-text">Delete this session?</span>
+            <button
+              class="btn btn-danger btn-sm"
+              @click="handleDelete"
+            >
+              Confirm
+            </button>
+            <button
+              class="btn btn-secondary btn-sm"
+              @click="showDeleteConfirm = false"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </div>
 
@@ -72,7 +94,7 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useCanvasStore } from '../stores/canvas.js';
 import { useUiStore } from '../stores/ui.js';
@@ -83,9 +105,11 @@ import CanvasTab from '../components/CanvasTab.vue';
 import NotesTab from '../components/NotesTab.vue';
 
 const route = useRoute();
+const router = useRouter();
 const sessionsStore = useSessionsStore();
 const canvasStore = useCanvasStore();
 const uiStore = useUiStore();
+const showDeleteConfirm = ref(false);
 
 const activeTab = computed(() => route.params.tab || 'conversation');
 const isActive = computed(() => {
@@ -190,6 +214,23 @@ async function handleStop() {
     uiStore.error(err.message);
   }
 }
+
+async function handleDelete() {
+  try {
+    const projectId = sessionsStore.currentSession?.projectId;
+    await sessionsStore.deleteSession(route.params.id);
+    uiStore.success('Session deleted');
+    // Navigate to project sessions list
+    if (projectId) {
+      router.push(`/projects/${projectId}/sessions`);
+    } else {
+      router.push('/');
+    }
+  } catch (err) {
+    uiStore.error(err.message);
+    showDeleteConfirm.value = false;
+  }
+}
 </script>
 
 <style scoped>
@@ -239,5 +280,22 @@ async function handleStop() {
 
 .tab-content {
   min-height: 400px;
+}
+
+.session-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.delete-confirm {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.delete-confirm-text {
+  font-size: 0.875rem;
+  color: var(--color-danger);
 }
 </style>


### PR DESCRIPTION
## Summary

- Add DELETE `/api/sessions/:id` endpoint with active session cleanup
- Add `cleanupActiveSession()` function to abort running sessions before deletion
- Add `SESSION_DELETED` WebSocket message type for client notification
- Add `deleteSession()` method to ApiClient and sessions store
- Add delete button with confirmation dialog in SessionDetailView
- Add button styles (`btn-outline-danger`, `btn-secondary`, `btn-sm`)

## Test plan

- [ ] Navigate to a session detail view
- [ ] Click "Delete Session" button
- [ ] Verify confirmation dialog appears
- [ ] Click "Cancel" and verify session is not deleted
- [ ] Click "Delete Session" again, then "Confirm"
- [ ] Verify success toast appears
- [ ] Verify redirect to project sessions list
- [ ] Verify session is removed from the list
- [ ] Test deleting an active/running session to verify it stops first

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)