### PR TITLE
Fix: Display 'Claude is working' message on follow-up without refresh

### DIFF
--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -72,6 +72,15 @@ export const useSessionsStore = defineStore('sessions', {
       this.error = null;
       try {
         await api.sendMessage(sessionId, content);
+        // Optimistically update status to 'running' immediately after send succeeds
+        // This ensures the UI shows "Claude is working..." without waiting for WebSocket
+        const session = this.sessions.find((s) => s.id === sessionId);
+        if (session) {
+          session.status = 'running';
+        }
+        if (this.currentSession?.id === sessionId) {
+          this.currentSession.status = 'running';
+        }
       } catch (err) {
         this.error = err.message;
         throw err;

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useCanvasStore } from '../stores/canvas.js';
@@ -122,6 +122,19 @@ function stopPolling() {
     pollIntervalId.value = null;
   }
 }
+
+// Watch for status changes from any source (optimistic updates, WebSocket, etc.)
+// This ensures polling starts even when status is updated directly in the store
+watch(
+  () => sessionsStore.currentSession?.status,
+  (newStatus, oldStatus) => {
+    if (newStatus === 'running' || newStatus === 'starting') {
+      startPolling();
+    } else if (oldStatus === 'running' || oldStatus === 'starting') {
+      stopPolling();
+    }
+  }
+);
 
 onMounted(async () => {
   // Subscribe to WebSocket first to minimize race condition window


### PR DESCRIPTION
## Summary

- Fixes issue where responding to Claude Code in a conversation required a page refresh to see the "Claude is working..." message
- Adds optimistic status update when sending a message - UI updates immediately without waiting for WebSocket
- Adds a Vue watcher to start/stop polling when session status changes from any source

## Root Cause

The HTTP POST to `/api/sessions/:id/message` returned immediately while the session status update was broadcast asynchronously via WebSocket. This race condition meant the UI often missed the status update and remained in the "waiting" state.

## Changes

| File | Change |
|------|--------|
| `packages/web/src/stores/sessions.js` | Optimistically set status to 'running' after sendMessage succeeds |
| `packages/web/src/views/SessionDetailView.vue` | Add watcher to start polling when status changes |

## Test plan

- [ ] Send a follow-up message in a conversation
- [ ] Verify "Claude is working..." appears immediately without refresh
- [ ] Verify UI updates correctly when Claude's response arrives
- [ ] Verify polling stops when session returns to "waiting" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)