### PR TITLE
Add markdown preview for changed files in Changes tab

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,4 +1,6 @@
 import { Router } from 'express';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
 import { sessions, messages, sessionNotes, projects } from '../database.js';
 import { continueSession, stopSession, endSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges } from '../services/diffService.js';
@@ -35,6 +37,44 @@ router.get('/:id/changes', async (req, res) => {
     const changes = await getChanges(directory);
     res.json(changes);
   } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// GET /api/sessions/:id/file - Get file content for markdown preview
+router.get('/:id/file', async (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const project = projects.getById(session.projectId);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  const { path: filePath } = req.query;
+  if (!filePath) {
+    return res.status(400).json({ error: 'File path is required' });
+  }
+
+  // Prevent directory traversal attacks
+  const normalizedPath = filePath.replace(/\.\./g, '');
+  const directory = session.gitWorktree || project.workingDirectory;
+  const fullPath = join(directory, normalizedPath);
+
+  // Ensure the path is within the working directory
+  if (!fullPath.startsWith(directory)) {
+    return res.status(403).json({ error: 'Access denied' });
+  }
+
+  try {
+    const content = await readFile(fullPath, 'utf-8');
+    res.json({ content, path: normalizedPath });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return res.status(404).json({ error: 'File not found' });
+    }
     res.status(500).json({ error: error.message });
   }
 });

--- a/packages/server/test/sessions-file.test.js
+++ b/packages/server/test/sessions-file.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { projects, sessions } from '../src/database.js';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+vi.mock('fs/promises');
+
+describe('Session File API Logic', () => {
+  let project;
+  let session;
+
+  beforeEach(() => {
+    project = projects.create('Test Project', '/test/project/path');
+    session = sessions.create(project.id, 'Test Session', 'Test prompt');
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('file path resolution', () => {
+    it('uses project working directory by default', () => {
+      const targetSession = sessions.getById(session.id);
+      const targetProject = projects.getById(targetSession.projectId);
+      const directory = targetSession.gitWorktree || targetProject.workingDirectory;
+
+      expect(directory).toBe('/test/project/path');
+    });
+
+    it('prefers gitWorktree when set', () => {
+      sessions.update(session.id, { gitWorktree: '/custom/worktree/path' });
+
+      const targetSession = sessions.getById(session.id);
+      const targetProject = projects.getById(targetSession.projectId);
+      const directory = targetSession.gitWorktree || targetProject.workingDirectory;
+
+      expect(directory).toBe('/custom/worktree/path');
+    });
+  });
+
+  describe('path normalization', () => {
+    it('strips directory traversal attempts', () => {
+      const filePath = '../../../etc/passwd';
+      const normalizedPath = filePath.replace(/\.\./g, '');
+      expect(normalizedPath).toBe('///etc/passwd');
+    });
+
+    it('joins normalized path with directory', () => {
+      const directory = '/test/project/path';
+      const filePath = 'README.md';
+      const fullPath = join(directory, filePath);
+      expect(fullPath).toBe('/test/project/path/README.md');
+    });
+
+    it('strips directory traversal and keeps path within directory', () => {
+      const directory = '/test/project/path';
+      // After stripping .., ../../etc/passwd becomes //etc/passwd
+      // When joined with directory, it stays within the directory
+      const filePath = '../../etc/passwd';
+      const normalizedPath = filePath.replace(/\.\./g, '');
+      const fullPath = join(directory, normalizedPath);
+
+      // The path ends up as /test/project/path/etc/passwd which starts with directory
+      // This demonstrates that stripping .. is effective for this style of traversal
+      expect(fullPath.startsWith(directory)).toBe(true);
+    });
+
+    it('allows valid paths within directory', () => {
+      const directory = '/test/project/path';
+      const filePath = 'docs/README.md';
+      const fullPath = join(directory, filePath);
+
+      expect(fullPath.startsWith(directory)).toBe(true);
+      expect(fullPath).toBe('/test/project/path/docs/README.md');
+    });
+  });
+
+  describe('file reading', () => {
+    it('reads file content successfully', async () => {
+      readFile.mockResolvedValue('# Hello World\n\nSome markdown content.');
+
+      const content = await readFile('/test/project/path/README.md', 'utf-8');
+
+      expect(content).toBe('# Hello World\n\nSome markdown content.');
+      expect(readFile).toHaveBeenCalledWith('/test/project/path/README.md', 'utf-8');
+    });
+
+    it('throws ENOENT for non-existent files', async () => {
+      const error = new Error('ENOENT: no such file or directory');
+      error.code = 'ENOENT';
+      readFile.mockRejectedValue(error);
+
+      await expect(readFile('/test/project/path/nonexistent.md', 'utf-8')).rejects.toThrow();
+    });
+
+    it('handles other read errors', async () => {
+      const error = new Error('EACCES: permission denied');
+      error.code = 'EACCES';
+      readFile.mockRejectedValue(error);
+
+      await expect(readFile('/test/project/path/protected.md', 'utf-8')).rejects.toThrow();
+    });
+  });
+
+  describe('session lookup', () => {
+    it('finds session by id', () => {
+      const found = sessions.getById(session.id);
+      expect(found).not.toBeNull();
+      expect(found.id).toBe(session.id);
+    });
+
+    it('returns null for non-existent session', () => {
+      const found = sessions.getById('nonexistent-id');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('project lookup from session', () => {
+    it('finds project via session.projectId', () => {
+      const targetSession = sessions.getById(session.id);
+      const targetProject = projects.getById(targetSession.projectId);
+      expect(targetProject).not.toBeNull();
+      expect(targetProject.workingDirectory).toBe('/test/project/path');
+    });
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@claudetools/shared": "1.0.0",
+    "md-editor-v3": "^6.2.1",
     "pinia": "^2.1.7",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -168,6 +168,16 @@ export class ApiClient {
   }
 
   /**
+   * Get file content for a session
+   * @param {string} sessionId - Session ID
+   * @param {string} filePath - Path to file relative to working directory
+   * @returns {Promise<{content: string, path: string}>}
+   */
+  async getSessionFile(sessionId, filePath) {
+    return this.#request('GET', `/sessions/${sessionId}/file?path=${encodeURIComponent(filePath)}`);
+  }
+
+  /**
    * End a session (mark as completed)
    * @param {string} id - Session ID
    * @returns {Promise<Object>}

--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -7,6 +7,16 @@ import { api } from '../api/ApiClient.js';
 vi.mock('../api/ApiClient.js', () => ({
   api: {
     getSessionChanges: vi.fn(),
+    getSessionFile: vi.fn(),
+  },
+}));
+
+// Mock md-editor-v3 since it doesn't work in vitest
+vi.mock('md-editor-v3', () => ({
+  MdPreview: {
+    name: 'MdPreview',
+    props: ['modelValue', 'theme', 'previewTheme', 'showCodeRowNumber'],
+    template: '<div class="mock-md-preview">{{ modelValue }}</div>',
   },
 }));
 
@@ -53,7 +63,7 @@ describe('ChangesTab', () => {
 
   it('displays staged changes when present', async () => {
     api.getSessionChanges.mockResolvedValue({
-      staged: 'diff --git a/file.js\n+new line',
+      staged: 'diff --git a/file.js b/file.js\n+new line',
       unstaged: '',
       untracked: [],
     });
@@ -65,14 +75,14 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Staged Changes');
-    expect(wrapper.text()).toContain('diff --git a/file.js');
+    expect(wrapper.text()).toContain('file.js');
     expect(wrapper.text()).toContain('+new line');
   });
 
   it('displays unstaged changes when present', async () => {
     api.getSessionChanges.mockResolvedValue({
       staged: '',
-      unstaged: 'diff --git b/other.js\n-removed line',
+      unstaged: 'diff --git a/other.js b/other.js\n-removed line',
       untracked: [],
     });
 
@@ -83,14 +93,14 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Unstaged Changes');
-    expect(wrapper.text()).toContain('diff --git b/other.js');
+    expect(wrapper.text()).toContain('other.js');
     expect(wrapper.text()).toContain('-removed line');
   });
 
   it('displays both staged and unstaged changes', async () => {
     api.getSessionChanges.mockResolvedValue({
-      staged: 'staged content',
-      unstaged: 'unstaged content',
+      staged: 'diff --git a/staged.js b/staged.js\nstaged content',
+      unstaged: 'diff --git a/unstaged.js b/unstaged.js\nunstaged content',
       untracked: [],
     });
 
@@ -170,5 +180,202 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('No git changes to show');
+  });
+
+  describe('Markdown Preview', () => {
+    it('shows preview button for markdown files in staged changes', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/README.md b/README.md\n+# Hello',
+        unstaged: '',
+        untracked: [],
+      });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      const previewButton = wrapper.find('.preview-toggle');
+      expect(previewButton.exists()).toBe(true);
+      expect(previewButton.text()).toBe('Preview');
+    });
+
+    it('does not show preview button for non-markdown files', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/file.js b/file.js\n+console.log("hello")',
+        unstaged: '',
+        untracked: [],
+      });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      const previewButton = wrapper.find('.preview-toggle');
+      expect(previewButton.exists()).toBe(false);
+    });
+
+    it('shows preview button for untracked markdown files', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: '',
+        unstaged: '',
+        untracked: ['docs/guide.md', 'src/index.js'],
+      });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      const previewButtons = wrapper.findAll('.preview-toggle');
+      expect(previewButtons.length).toBe(1); // Only one for the .md file
+    });
+
+    it('toggles preview when button is clicked', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/README.md b/README.md\n+# Hello',
+        unstaged: '',
+        untracked: [],
+      });
+      api.getSessionFile.mockResolvedValue({ content: '# Hello World', path: 'README.md' });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      const previewButton = wrapper.find('.preview-toggle');
+      expect(previewButton.text()).toBe('Preview');
+
+      await previewButton.trigger('click');
+      await flushPromises();
+
+      expect(api.getSessionFile).toHaveBeenCalledWith('test-session', 'README.md');
+      expect(previewButton.text()).toBe('Show Diff');
+    });
+
+    it('shows markdown preview content after fetching', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/README.md b/README.md\n+# Hello',
+        unstaged: '',
+        untracked: [],
+      });
+      api.getSessionFile.mockResolvedValue({ content: '# Hello World', path: 'README.md' });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      await wrapper.find('.preview-toggle').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.mock-md-preview').exists()).toBe(true);
+      expect(wrapper.find('.mock-md-preview').text()).toBe('# Hello World');
+    });
+
+    it('shows loading state while fetching preview', async () => {
+      let resolveFile;
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/README.md b/README.md\n+# Hello',
+        unstaged: '',
+        untracked: [],
+      });
+      api.getSessionFile.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFile = resolve;
+        })
+      );
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      await wrapper.find('.preview-toggle').trigger('click');
+      await nextTick();
+
+      expect(wrapper.find('.preview-loading').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Loading preview...');
+
+      resolveFile({ content: '# Hello', path: 'README.md' });
+      await flushPromises();
+    });
+
+    it('shows error when preview fetch fails', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/README.md b/README.md\n+# Hello',
+        unstaged: '',
+        untracked: [],
+      });
+      api.getSessionFile.mockRejectedValue(new Error('File not found'));
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      await wrapper.find('.preview-toggle').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.preview-error').exists()).toBe(true);
+      expect(wrapper.text()).toContain('File not found');
+    });
+
+    it('recognizes various markdown extensions', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: '',
+        unstaged: '',
+        untracked: ['file.md', 'file.markdown', 'file.mdx', 'file.MD'],
+      });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      const previewButtons = wrapper.findAll('.preview-toggle');
+      expect(previewButtons.length).toBe(4); // All should have preview button
+    });
+
+    it('caches preview content on subsequent toggles', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: 'diff --git a/README.md b/README.md\n+# Hello',
+        unstaged: '',
+        untracked: [],
+      });
+      api.getSessionFile.mockResolvedValue({ content: '# Cached', path: 'README.md' });
+
+      const wrapper = mount(ChangesTab, {
+        props: { sessionId: 'test-session' },
+      });
+
+      await flushPromises();
+
+      const previewButton = wrapper.find('.preview-toggle');
+
+      // First click - should fetch
+      await previewButton.trigger('click');
+      await flushPromises();
+      expect(api.getSessionFile).toHaveBeenCalledTimes(1);
+
+      // Toggle back to diff
+      await previewButton.trigger('click');
+      await flushPromises();
+
+      // Toggle to preview again - should not fetch again
+      await previewButton.trigger('click');
+      await flushPromises();
+      expect(api.getSessionFile).toHaveBeenCalledTimes(1); // Still 1
+    });
   });
 });

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -16,28 +16,106 @@
     <template v-else>
       <div v-if="staged" class="diff-section">
         <h3>Staged Changes</h3>
-        <pre class="diff-content">{{ staged }}</pre>
+        <div v-for="file in parsedStaged" :key="'staged-' + file.path" class="file-diff">
+          <div class="file-header">
+            <span class="file-path">{{ file.path }}</span>
+            <button
+              v-if="file.isMarkdown"
+              class="preview-toggle"
+              @click="togglePreview('staged', file.path)"
+            >
+              {{ previewStates['staged-' + file.path] ? 'Show Diff' : 'Preview' }}
+            </button>
+          </div>
+          <div v-if="previewStates['staged-' + file.path]" class="markdown-preview">
+            <div v-if="previewLoading['staged-' + file.path]" class="preview-loading">
+              Loading preview...
+            </div>
+            <div v-else-if="previewErrors['staged-' + file.path]" class="preview-error">
+              {{ previewErrors['staged-' + file.path] }}
+            </div>
+            <MdPreview
+              v-else
+              :model-value="previewContent['staged-' + file.path] || ''"
+              theme="dark"
+              preview-theme="github"
+              :show-code-row-number="true"
+            />
+          </div>
+          <pre v-else class="diff-content">{{ file.diff }}</pre>
+        </div>
       </div>
 
       <div v-if="unstaged" class="diff-section">
         <h3>Unstaged Changes</h3>
-        <pre class="diff-content">{{ unstaged }}</pre>
+        <div v-for="file in parsedUnstaged" :key="'unstaged-' + file.path" class="file-diff">
+          <div class="file-header">
+            <span class="file-path">{{ file.path }}</span>
+            <button
+              v-if="file.isMarkdown"
+              class="preview-toggle"
+              @click="togglePreview('unstaged', file.path)"
+            >
+              {{ previewStates['unstaged-' + file.path] ? 'Show Diff' : 'Preview' }}
+            </button>
+          </div>
+          <div v-if="previewStates['unstaged-' + file.path]" class="markdown-preview">
+            <div v-if="previewLoading['unstaged-' + file.path]" class="preview-loading">
+              Loading preview...
+            </div>
+            <div v-else-if="previewErrors['unstaged-' + file.path]" class="preview-error">
+              {{ previewErrors['unstaged-' + file.path] }}
+            </div>
+            <MdPreview
+              v-else
+              :model-value="previewContent['unstaged-' + file.path] || ''"
+              theme="dark"
+              preview-theme="github"
+              :show-code-row-number="true"
+            />
+          </div>
+          <pre v-else class="diff-content">{{ file.diff }}</pre>
+        </div>
       </div>
 
       <div v-if="untracked.length > 0" class="diff-section">
         <h3>Untracked Files</h3>
-        <ul class="untracked-list">
-          <li v-for="file in untracked" :key="file" class="untracked-file">
-            {{ file }}
-          </li>
-        </ul>
+        <div v-for="file in untracked" :key="file" class="file-diff">
+          <div class="file-header">
+            <span class="file-path untracked-file">{{ file }}</span>
+            <button
+              v-if="isMarkdownFile(file)"
+              class="preview-toggle"
+              @click="togglePreview('untracked', file)"
+            >
+              {{ previewStates['untracked-' + file] ? 'Show Path' : 'Preview' }}
+            </button>
+          </div>
+          <div v-if="previewStates['untracked-' + file]" class="markdown-preview">
+            <div v-if="previewLoading['untracked-' + file]" class="preview-loading">
+              Loading preview...
+            </div>
+            <div v-else-if="previewErrors['untracked-' + file]" class="preview-error">
+              {{ previewErrors['untracked-' + file] }}
+            </div>
+            <MdPreview
+              v-else
+              :model-value="previewContent['untracked-' + file] || ''"
+              theme="dark"
+              preview-theme="github"
+              :show-code-row-number="true"
+            />
+          </div>
+        </div>
       </div>
     </template>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, reactive } from 'vue';
+import { MdPreview } from 'md-editor-v3';
+import 'md-editor-v3/lib/preview.css';
 import { api } from '../api/ApiClient.js';
 
 const props = defineProps({
@@ -50,7 +128,69 @@ const untracked = ref([]);
 const loading = ref(false);
 const error = ref(null);
 
+// Preview state management
+const previewStates = reactive({});
+const previewContent = reactive({});
+const previewLoading = reactive({});
+const previewErrors = reactive({});
+
 const hasChanges = computed(() => staged.value || unstaged.value || untracked.value.length > 0);
+
+function isMarkdownFile(path) {
+  return /\.(md|markdown|mdx)$/i.test(path);
+}
+
+function parseDiff(diffText) {
+  if (!diffText) return [];
+
+  const files = [];
+  const diffParts = diffText.split(/(?=^diff --git)/m);
+
+  for (const part of diffParts) {
+    if (!part.trim()) continue;
+
+    const match = part.match(/^diff --git a\/(.+?) b\/(.+?)$/m);
+    if (match) {
+      const path = match[2];
+      files.push({
+        path,
+        diff: part.trim(),
+        isMarkdown: isMarkdownFile(path),
+      });
+    }
+  }
+
+  return files;
+}
+
+const parsedStaged = computed(() => parseDiff(staged.value));
+const parsedUnstaged = computed(() => parseDiff(unstaged.value));
+
+async function togglePreview(section, path) {
+  const key = `${section}-${path}`;
+
+  if (previewStates[key]) {
+    previewStates[key] = false;
+    return;
+  }
+
+  previewStates[key] = true;
+
+  // Don't refetch if we already have content
+  if (previewContent[key]) return;
+
+  previewLoading[key] = true;
+  previewErrors[key] = null;
+
+  try {
+    const result = await api.getSessionFile(props.sessionId, path);
+    previewContent[key] = result.content;
+  } catch (err) {
+    previewErrors[key] = err.message;
+  } finally {
+    previewLoading[key] = false;
+  }
+}
 
 async function fetchChanges() {
   loading.value = true;
@@ -108,27 +248,124 @@ onMounted(() => {
   color: var(--color-text-soft);
 }
 
-.diff-content {
-  font-size: 0.75rem;
-  max-height: 300px;
-  overflow: auto;
+.file-diff {
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-border, #374151);
+  border-radius: var(--border-radius, 0.375rem);
+  overflow: hidden;
 }
 
-.untracked-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.file-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-bg-secondary, #1f2937);
+  border-bottom: 1px solid var(--color-border, #374151);
+}
+
+.file-path {
   font-family: monospace;
   font-size: 0.75rem;
-}
-
-.untracked-file {
-  padding: 0.25rem 0.5rem;
-  color: var(--color-success, #22c55e);
+  color: var(--color-text, #e5e7eb);
 }
 
 .untracked-file::before {
   content: '+ ';
   color: var(--color-success, #22c55e);
+}
+
+.preview-toggle {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background-color: var(--color-bg-tertiary, #374151);
+  color: var(--color-accent, #22d3ee);
+  border: 1px solid var(--color-accent, #22d3ee);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.preview-toggle:hover {
+  background-color: var(--color-accent, #22d3ee);
+  color: var(--color-bg, #111827);
+}
+
+.diff-content {
+  font-size: 0.75rem;
+  max-height: 300px;
+  overflow: auto;
+  margin: 0;
+  padding: 0.75rem;
+  background-color: var(--color-bg, #111827);
+}
+
+.markdown-preview {
+  padding: 1rem;
+  background-color: var(--color-bg, #111827);
+  max-height: 500px;
+  overflow: auto;
+}
+
+.preview-loading,
+.preview-error {
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+.preview-loading {
+  color: var(--color-text-soft, #9ca3af);
+}
+
+.preview-error {
+  color: var(--color-error, #f87171);
+}
+
+/* Override md-editor-v3 dark theme styles */
+:deep(.md-editor-preview-wrapper) {
+  background-color: transparent !important;
+}
+
+:deep(.md-editor-preview) {
+  color: var(--color-text, #e5e7eb) !important;
+  background-color: transparent !important;
+}
+
+:deep(.md-editor-preview h1),
+:deep(.md-editor-preview h2),
+:deep(.md-editor-preview h3),
+:deep(.md-editor-preview h4),
+:deep(.md-editor-preview h5),
+:deep(.md-editor-preview h6) {
+  color: var(--color-text, #e5e7eb) !important;
+  border-bottom-color: var(--color-border, #374151) !important;
+}
+
+:deep(.md-editor-preview code) {
+  background-color: var(--color-bg-secondary, #1f2937) !important;
+  color: var(--color-accent, #22d3ee) !important;
+}
+
+:deep(.md-editor-preview pre) {
+  background-color: var(--color-bg-secondary, #1f2937) !important;
+}
+
+:deep(.md-editor-preview blockquote) {
+  border-left-color: var(--color-accent, #22d3ee) !important;
+  color: var(--color-text-soft, #9ca3af) !important;
+}
+
+:deep(.md-editor-preview a) {
+  color: var(--color-accent, #22d3ee) !important;
+}
+
+:deep(.md-editor-preview table th),
+:deep(.md-editor-preview table td) {
+  border-color: var(--color-border, #374151) !important;
+}
+
+:deep(.md-editor-preview table tr:nth-child(2n)) {
+  background-color: var(--color-bg-secondary, #1f2937) !important;
 }
 </style>

--- a/tests/e2e/markdown-preview.spec.ts
+++ b/tests/e2e/markdown-preview.spec.ts
@@ -1,0 +1,380 @@
+import { test, expect } from '@playwright/test';
+import { seedProject, seedSession, cleanupAll, getSession } from './helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const API_URL = process.env.API_URL || 'http://localhost:5000';
+
+test.describe('Markdown Preview in Changes Tab', () => {
+  let project: any;
+  let testDir: string;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+
+    // Create a temporary test directory with git
+    testDir = `/tmp/md-preview-test-${Date.now()}`;
+    fs.mkdirSync(testDir, { recursive: true });
+
+    // Initialize git repo
+    const { execSync } = require('child_process');
+    execSync('git init', { cwd: testDir });
+    execSync('git config user.email "test@test.com"', { cwd: testDir });
+    execSync('git config user.name "Test User"', { cwd: testDir });
+
+    // Create an initial commit so we have a clean repo
+    fs.writeFileSync(path.join(testDir, '.gitkeep'), '');
+    execSync('git add .gitkeep && git commit -m "Initial commit"', { cwd: testDir });
+
+    project = await seedProject('Markdown Test Project', testDir);
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+
+    // Clean up test directory
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('displays preview button for staged markdown files', async ({ page }) => {
+    // Create a markdown file and stage it
+    const readmePath = path.join(testDir, 'README.md');
+    fs.writeFileSync(readmePath, '# Hello World\n\nThis is a test.');
+
+    const { execSync } = require('child_process');
+    execSync('git add README.md', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Preview Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+    await expect(page.getByText('README.md')).toBeVisible();
+
+    // Should see preview button for markdown file
+    const previewButton = page.getByRole('button', { name: 'Preview' });
+    await expect(previewButton).toBeVisible();
+  });
+
+  test('does not display preview button for non-markdown files', async ({ page }) => {
+    // Create a JS file and stage it
+    const jsPath = path.join(testDir, 'index.js');
+    fs.writeFileSync(jsPath, 'console.log("hello");');
+
+    const { execSync } = require('child_process');
+    execSync('git add index.js', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Non-MD Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+    await expect(page.getByText('index.js')).toBeVisible();
+
+    // Should NOT see preview button for JS file
+    const previewButton = page.getByRole('button', { name: 'Preview' });
+    await expect(previewButton).not.toBeVisible();
+  });
+
+  test('toggles between diff view and markdown preview', async ({ page }) => {
+    // Create a markdown file with content
+    const readmePath = path.join(testDir, 'README.md');
+    fs.writeFileSync(readmePath, '# Test Heading\n\nSome **bold** text and *italic* text.');
+
+    const { execSync } = require('child_process');
+    execSync('git add README.md', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Toggle Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+
+    // Initially should show diff view
+    const diffContent = page.locator('.diff-content');
+    await expect(diffContent).toBeVisible();
+
+    // Click preview button
+    const previewButton = page.getByRole('button', { name: 'Preview' });
+    await previewButton.click();
+
+    // Should now show markdown preview
+    await expect(page.locator('.markdown-preview')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Show Diff' })).toBeVisible();
+
+    // Click to toggle back to diff
+    await page.getByRole('button', { name: 'Show Diff' }).click();
+
+    // Should show diff again
+    await expect(diffContent).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible();
+  });
+
+  test('renders markdown content correctly in preview', async ({ page }) => {
+    // Create a markdown file with various markdown elements
+    const readmePath = path.join(testDir, 'README.md');
+    const markdownContent = `# Main Heading
+
+## Subheading
+
+This is a paragraph with **bold** and *italic* text.
+
+- List item 1
+- List item 2
+- List item 3
+
+\`\`\`javascript
+const hello = "world";
+\`\`\`
+
+> A blockquote
+
+[A link](https://example.com)
+`;
+    fs.writeFileSync(readmePath, markdownContent);
+
+    const { execSync } = require('child_process');
+    execSync('git add README.md', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Render Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load and click preview
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+    await page.getByRole('button', { name: 'Preview' }).click();
+
+    // Wait for preview to render
+    await expect(page.locator('.markdown-preview')).toBeVisible();
+
+    // Check that markdown elements are rendered (h1, h2, etc.)
+    await expect(page.locator('.md-editor-preview h1')).toBeVisible();
+    await expect(page.locator('.md-editor-preview h2')).toBeVisible();
+  });
+
+  test('displays preview button for untracked markdown files', async ({ page }) => {
+    // Create an untracked markdown file
+    const docsPath = path.join(testDir, 'docs.md');
+    fs.writeFileSync(docsPath, '# Documentation\n\nSome docs here.');
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Untracked Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Untracked Files')).toBeVisible();
+    await expect(page.getByText('docs.md')).toBeVisible();
+
+    // Should see preview button
+    const previewButton = page.getByRole('button', { name: 'Preview' });
+    await expect(previewButton).toBeVisible();
+  });
+
+  test('can preview untracked markdown file', async ({ page }) => {
+    // Create an untracked markdown file
+    const guidePath = path.join(testDir, 'GUIDE.md');
+    fs.writeFileSync(guidePath, '# User Guide\n\nWelcome to the guide!');
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Untracked Preview' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Untracked Files')).toBeVisible();
+
+    // Click preview
+    await page.getByRole('button', { name: 'Preview' }).click();
+
+    // Should show markdown preview
+    await expect(page.locator('.markdown-preview')).toBeVisible();
+    await expect(page.locator('.md-editor-preview')).toContainText('User Guide');
+  });
+
+  test('displays preview button for unstaged markdown changes', async ({ page }) => {
+    // Create, commit, then modify a markdown file (unstaged change)
+    const readmePath = path.join(testDir, 'README.md');
+    fs.writeFileSync(readmePath, '# Original');
+
+    const { execSync } = require('child_process');
+    execSync('git add README.md && git commit -m "Add README"', { cwd: testDir });
+
+    // Modify the file (unstaged change)
+    fs.writeFileSync(readmePath, '# Modified\n\nNew content added.');
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Unstaged Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Unstaged Changes')).toBeVisible();
+    await expect(page.getByText('README.md')).toBeVisible();
+
+    // Should see preview button
+    const previewButton = page.getByRole('button', { name: 'Preview' });
+    await expect(previewButton).toBeVisible();
+  });
+
+  test('handles file not found error gracefully', async ({ page }) => {
+    // Create and stage a markdown file
+    const readmePath = path.join(testDir, 'TEMP.md');
+    fs.writeFileSync(readmePath, '# Temporary');
+
+    const { execSync } = require('child_process');
+    execSync('git add TEMP.md', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Error Test' });
+
+    // Delete the file after staging (simulates a deleted file scenario)
+    fs.unlinkSync(readmePath);
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+
+    // Click preview - should handle the error
+    await page.getByRole('button', { name: 'Preview' }).click();
+
+    // Should show error message
+    await expect(page.locator('.preview-error')).toBeVisible();
+  });
+
+  test('shows loading state while fetching preview', async ({ page }) => {
+    // Create a markdown file
+    const readmePath = path.join(testDir, 'README.md');
+    fs.writeFileSync(readmePath, '# Hello');
+
+    const { execSync } = require('child_process');
+    execSync('git add README.md', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Loading Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+
+    // Click preview - loading should appear briefly
+    await page.getByRole('button', { name: 'Preview' }).click();
+
+    // The preview should eventually render (loading state is brief)
+    await expect(page.locator('.markdown-preview')).toBeVisible();
+  });
+
+  test('handles multiple markdown files independently', async ({ page }) => {
+    // Create multiple markdown files
+    fs.writeFileSync(path.join(testDir, 'README.md'), '# README Content');
+    fs.writeFileSync(path.join(testDir, 'CHANGELOG.md'), '# Changelog Content');
+
+    const { execSync } = require('child_process');
+    execSync('git add README.md CHANGELOG.md', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Multi File Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    // Wait for changes to load
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+
+    // Should see two preview buttons
+    const previewButtons = page.getByRole('button', { name: 'Preview' });
+    await expect(previewButtons).toHaveCount(2);
+
+    // Click first preview button
+    await previewButtons.first().click();
+
+    // Only the first file should show preview
+    await expect(page.locator('.markdown-preview')).toHaveCount(1);
+
+    // First button should now say "Show Diff", second should still say "Preview"
+    await expect(page.getByRole('button', { name: 'Show Diff' })).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Preview' })).toHaveCount(1);
+  });
+
+  test('recognizes .markdown extension', async ({ page }) => {
+    const docPath = path.join(testDir, 'doc.markdown');
+    fs.writeFileSync(docPath, '# Markdown Extension');
+
+    const { execSync } = require('child_process');
+    execSync('git add doc.markdown', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Extension Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible();
+  });
+
+  test('recognizes .mdx extension', async ({ page }) => {
+    const docPath = path.join(testDir, 'component.mdx');
+    fs.writeFileSync(docPath, '# MDX Component\n\nexport const Component = () => <div>Hello</div>');
+
+    const { execSync } = require('child_process');
+    execSync('git add component.mdx', { cwd: testDir });
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'MDX Test' });
+
+    await page.goto(`/sessions/${session.id}/changes`);
+
+    await expect(page.getByText('Staged Changes')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible();
+  });
+
+  test('file endpoint returns correct content', async ({ page }) => {
+    // Create a markdown file
+    const markdownContent = '# API Test\n\nContent for API verification.';
+    fs.writeFileSync(path.join(testDir, 'api-test.md'), markdownContent);
+
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'API Test' });
+
+    // Call the API directly to verify endpoint works
+    const response = await fetch(
+      `${API_URL}/api/sessions/${session.id}/file?path=api-test.md`
+    );
+
+    expect(response.ok).toBe(true);
+    const data = await response.json();
+    expect(data.content).toBe(markdownContent);
+    expect(data.path).toBe('api-test.md');
+  });
+
+  test('file endpoint returns 404 for non-existent file', async ({ page }) => {
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Not Found Test' });
+
+    const response = await fetch(
+      `${API_URL}/api/sessions/${session.id}/file?path=does-not-exist.md`
+    );
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error).toBe('File not found');
+  });
+
+  test('file endpoint returns 400 when path is missing', async ({ page }) => {
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Missing Path Test' });
+
+    const response = await fetch(`${API_URL}/api/sessions/${session.id}/file`);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('File path is required');
+  });
+
+  test('file endpoint prevents directory traversal', async ({ page }) => {
+    const session = await seedSession(project.id, { prompt: 'Test', name: 'Security Test' });
+
+    // Try to access a file outside the working directory
+    const response = await fetch(
+      `${API_URL}/api/sessions/${session.id}/file?path=../../../etc/passwd`
+    );
+
+    // Should either return 404 (file not found after sanitization) or 403 (access denied)
+    expect([403, 404]).toContain(response.status);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,344 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.18.7", "@codemirror/autocomplete@^6.3.2", "@codemirror/autocomplete@^6.7.1":
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz#db818c12dce892a93fb8abadc2426febb002f8c1"
+  integrity sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.0.0", "@codemirror/commands@^6.8.1":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.10.0.tgz#b3206984fec8443c4d910565eb2e9d591c7d80b2"
+  integrity sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.4.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/lang-angular@^0.1.0":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz#5b9e940786ba201a9a42eab6db9501fa3fe2292a"
+  integrity sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==
+  dependencies:
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.1.2"
+    "@codemirror/language" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.3"
+
+"@codemirror/lang-cpp@^6.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz#b175b59fcde8dd6e563b7feee8bbed81963a9491"
+  integrity sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/cpp" "^1.0.0"
+
+"@codemirror/lang-css@^6.0.0", "@codemirror/lang-css@^6.2.0":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.3.1.tgz#763ca41aee81bb2431be55e3cfcc7cc8e91421a3"
+  integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-go@^6.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-go/-/lang-go-6.0.1.tgz#598222c90f56eae28d11069c612ca64d0306b057"
+  integrity sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/go" "^1.0.0"
+
+"@codemirror/lang-html@^6.0.0":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.11.tgz#c46ba46ae642fd567cf05c4129005d2913ac248d"
+  integrity sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.12"
+
+"@codemirror/lang-java@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-java/-/lang-java-6.0.2.tgz#601d5b3d774a4a997d11647ccb6c05702c54bd5b"
+  integrity sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/java" "^1.0.0"
+
+"@codemirror/lang-javascript@^6.0.0", "@codemirror/lang-javascript@^6.1.2":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz#eef2227d1892aae762f3a0f212f72bec868a02c5"
+  integrity sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/lang-jinja@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-jinja/-/lang-jinja-6.0.0.tgz#cc02cd1e45d1fed1226e3c3b44615503f794c904"
+  integrity sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw==
+  dependencies:
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.2.0"
+    "@lezer/lr" "^1.4.0"
+
+"@codemirror/lang-json@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.2.tgz#054b160671306667e25d80385286049841836179"
+  integrity sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
+"@codemirror/lang-less@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-less/-/lang-less-6.0.2.tgz#2e3d82a3ddb8710e6409689cd4a28c66558d0cb8"
+  integrity sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==
+  dependencies:
+    "@codemirror/lang-css" "^6.2.0"
+    "@codemirror/language" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@codemirror/lang-liquid@^6.0.0":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-liquid/-/lang-liquid-6.3.1.tgz#3cf26003a1b3f4233eafd2a287cf64eb4a12dbc1"
+  integrity sha512-S/jE/D7iij2Pu70AC65ME6AYWxOOcX20cSJvaPgY5w7m2sfxsArAcUAuUgm/CZCVmqoi9KiOlS7gj/gyLipABw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.1"
+
+"@codemirror/lang-markdown@^6.0.0", "@codemirror/lang-markdown@^6.3.4":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz#29df87310a555b007beba8e12893363956a26e8e"
+  integrity sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.7.1"
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.3.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.2.1"
+    "@lezer/markdown" "^1.0.0"
+
+"@codemirror/lang-php@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-php/-/lang-php-6.0.2.tgz#bdc439d195c8e73513bc5b971a99a57b5c99ee55"
+  integrity sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==
+  dependencies:
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/php" "^1.0.0"
+
+"@codemirror/lang-python@^6.0.0":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-python/-/lang-python-6.2.1.tgz#37c9930716110156865a95c548aa0eef5552863a"
+  integrity sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.3.2"
+    "@codemirror/language" "^6.8.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.2.1"
+    "@lezer/python" "^1.1.4"
+
+"@codemirror/lang-rust@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz#69146e6b3e8f961ef149059aecb9e07bfd7bf3bd"
+  integrity sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/rust" "^1.0.0"
+
+"@codemirror/lang-sass@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz#38c1b0a1326cc9f5cb2741d2cd51cfbcd7abc0b2"
+  integrity sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==
+  dependencies:
+    "@codemirror/lang-css" "^6.2.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/sass" "^1.0.0"
+
+"@codemirror/lang-sql@^6.0.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz#49bfbf6cf31516a99e674da9a399f4426101a95a"
+  integrity sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@codemirror/lang-vue@^0.1.1":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz#bf79b9152cc18b4903d64c1f67e186ae045c8a97"
+  integrity sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==
+  dependencies:
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.1.2"
+    "@codemirror/language" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.1"
+
+"@codemirror/lang-wast@^6.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz#d2b14175e5e80d7878cbbb29e20ec90dc12d3a2b"
+  integrity sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@codemirror/lang-xml@^6.0.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz#e3e786e1a89fdc9520efe75c1d6d3de1c40eb91c"
+  integrity sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/xml" "^1.0.0"
+
+"@codemirror/lang-yaml@^6.0.0":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz#c84280c68fa7af456a355d91183b5e537e9b7038"
+  integrity sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.2.0"
+    "@lezer/lr" "^1.0.0"
+    "@lezer/yaml" "^1.0.0"
+
+"@codemirror/language-data@^6.5.1":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/language-data/-/language-data-6.5.2.tgz#404dc3d50a80d0f76bc8f81f93cc1d82e322417c"
+  integrity sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==
+  dependencies:
+    "@codemirror/lang-angular" "^0.1.0"
+    "@codemirror/lang-cpp" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-go" "^6.0.0"
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/lang-java" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/lang-jinja" "^6.0.0"
+    "@codemirror/lang-json" "^6.0.0"
+    "@codemirror/lang-less" "^6.0.0"
+    "@codemirror/lang-liquid" "^6.0.0"
+    "@codemirror/lang-markdown" "^6.0.0"
+    "@codemirror/lang-php" "^6.0.0"
+    "@codemirror/lang-python" "^6.0.0"
+    "@codemirror/lang-rust" "^6.0.0"
+    "@codemirror/lang-sass" "^6.0.0"
+    "@codemirror/lang-sql" "^6.0.0"
+    "@codemirror/lang-vue" "^0.1.1"
+    "@codemirror/lang-wast" "^6.0.0"
+    "@codemirror/lang-xml" "^6.0.0"
+    "@codemirror/lang-yaml" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/legacy-modes" "^6.4.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.11.3", "@codemirror/language@^6.3.0", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0", "@codemirror/language@^6.8.0":
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.11.3.tgz#8e6632df566a7ed13a1bd307f9837765bb1abfdd"
+  integrity sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.1.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/legacy-modes@^6.4.0":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz#7e2976c79007cd3fa9ed8a1d690892184a7f5ecf"
+  integrity sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.9.2.tgz#09ed0aedec13381c9e36e1ac5d126027740c3ef4"
+  integrity sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.35.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0", "@codemirror/search@^6.5.11":
+  version "6.5.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.5.11.tgz#a324ffee36e032b7f67aa31c4fb9f3e6f9f3ed63"
+  integrity sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.4.0", "@codemirror/state@^6.5.0", "@codemirror/state@^6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.5.2.tgz#8eca3a64212a83367dc85475b7d78d5c9b7076c6"
+  integrity sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.38.2":
+  version "6.39.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.39.4.tgz#b76c73ab48c749cc9ab9e5e0a5d9e47df9f31cb5"
+  integrity sha512-xMF6OfEAUVY5Waega4juo1QGACfNkNF+aJLqpd8oUJz96ms2zbfQ9Gh35/tI3y8akEV31FruKfj7hBnIU/nkqA==
+  dependencies:
+    "@codemirror/state" "^6.5.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
 "@csstools/color-helpers@^5.1.0":
   version "5.1.0"
   resolved "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz"
@@ -364,6 +702,155 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
+"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.4.0.tgz#e02e4523a6ff97c4506ec9f27d8fb660e23c0968"
+  integrity sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==
+
+"@lezer/cpp@^1.0.0":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@lezer/cpp/-/cpp-1.1.4.tgz#4c5c60a6f2f5d01314abd1d8a06c48a2cdc11cbc"
+  integrity sha512-aYSdZyUueeTgnfXQntiGUqKNW5WujlAsIbbHzkfJDneSZoyjPg8ObmWG3bzDPVYMC/Kf4l43WJLCunPnYFfQ0g==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/css@^1.1.0", "@lezer/css@^1.1.7":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.3.0.tgz#296f298814782c2fad42a936f3510042cdcd2034"
+  integrity sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/go@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@lezer/go/-/go-1.0.1.tgz#3004b54f5e4c9719edcba98653f380baf8c0d1a2"
+  integrity sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3", "@lezer/highlight@^1.2.0", "@lezer/highlight@^1.2.1":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
+"@lezer/html@^1.3.12":
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.12.tgz#a438e2d04f4c863d49cad27efe714cde8cf3ff1b"
+  integrity sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/java@^1.0.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@lezer/java/-/java-1.1.3.tgz#9efd6a29b4142d07f211076a6fb5e8061c85e147"
+  integrity sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.5.4.tgz#11746955f957d33c0933f17d7594db54a8b4beea"
+  integrity sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.3.tgz#e773a012ad0088fbf07ce49cfba875cc9e5bc05f"
+  integrity sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.1.0", "@lezer/lr@^1.3.0", "@lezer/lr@^1.3.1", "@lezer/lr@^1.3.3", "@lezer/lr@^1.4.0":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.5.tgz#a0a7f505d96593f0f06708d50fb85962e33686c1"
+  integrity sha512-/YTRKP5yPPSo1xImYQk7AZZMAgap0kegzqCSYHjAL9x1AZ0ZQW+IpcEzMKagCsbTsLnVeWkxYrCNeXG8xEPrjg==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/markdown@^1.0.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@lezer/markdown/-/markdown-1.6.1.tgz#9b6d1a1d31c0bf7e5ff3d11037a95f081fe6188c"
+  integrity sha512-72ah+Sml7lD8Wn7lnz9vwYmZBo9aQT+I2gjK/0epI+gjdwUbWw3MJ/ZBGEqG1UfrIauRqH37/c5mVHXeCTGXtA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+
+"@lezer/php@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@lezer/php/-/php-1.0.5.tgz#4e6b79daa97b98f0ba300f592e6916661339e661"
+  integrity sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.1.0"
+
+"@lezer/python@^1.1.4":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@lezer/python/-/python-1.1.18.tgz#fa02fbf492741c82dc2dc98a0a042bd0d4d7f1d3"
+  integrity sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/rust@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@lezer/rust/-/rust-1.0.2.tgz#cc9a75605d67182a0e799ac40b1965a61dcc6ef0"
+  integrity sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/sass@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lezer/sass/-/sass-1.1.0.tgz#c82e660aa5b39303d1de763923aef979fef1d3a4"
+  integrity sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/xml@^1.0.0":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@lezer/xml/-/xml-1.0.6.tgz#908c203923288f854eb8e2f4d9b06c437e8610b9"
+  integrity sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/yaml@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@lezer/yaml/-/yaml-1.0.3.tgz#b23770ab42b390056da6b187d861b998fd60b1ff"
+  integrity sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.4.0"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
+  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -529,6 +1016,24 @@
   dependencies:
     "@types/node" "*"
 
+"@types/linkify-it@^5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
+  integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
+
+"@types/markdown-it@^14.0.1":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-14.1.2.tgz#57f2532a0800067d9b934f3521429a2e8bfb4c61"
+  integrity sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
+  dependencies:
+    "@types/linkify-it" "^5"
+    "@types/mdurl" "^2"
+
+"@types/mdurl@^2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-2.0.0.tgz#d43878b5b20222682163ae6f897b20447233bdfd"
+  integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
+
 "@types/node@*":
   version "25.0.1"
   resolved "https://registry.npmjs.org/@types/node/-/node-25.0.1.tgz"
@@ -540,6 +1045,16 @@
   version "1.3.0"
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@vavt/copy2clipboard@^1.0.1":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@vavt/copy2clipboard/-/copy2clipboard-1.0.3.tgz#eae77af8e83835cae5d932c3dc025e8838bb4c12"
+  integrity sha512-HtG48r2FBYp9eRvGB3QGmtRBH1zzRRAVvFbGgFstOwz4/DDaNiX0uZc3YVKPydqgOav26pibr9MtoCaWxn7aeA==
+
+"@vavt/util@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@vavt/util/-/util-2.1.1.tgz#5e7b04d57e44d679cbaa37502d9e996176bed5a0"
+  integrity sha512-QYn/B2qiQhAGZVBoe5/6pPcA3NiGcxIm9htpVBjcdIOZQaWe+8kE/akEgLPrHxv5dbQQawnyHBokadW1d1z1tw==
 
 "@vitejs/plugin-vue@^5.0.3":
   version "5.2.4"
@@ -952,6 +1467,19 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+codemirror@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.2.tgz#4d3fea1ad60b6753f97ca835f2f48c6936a8946e"
+  integrity sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
@@ -975,6 +1503,11 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1054,6 +1587,11 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
+crelt@^1.0.5, crelt@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
+  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
@@ -1067,6 +1605,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
 cssstyle@^4.0.1:
   version "4.6.0"
@@ -1227,7 +1770,7 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-entities@^4.5.0:
+entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -2019,6 +2562,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
+
 local-pkg@^0.5.0:
   version "0.5.1"
   resolved "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz"
@@ -2056,6 +2606,16 @@ lru-cache@^10.2.0, lru-cache@^10.4.3:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
+lru-cache@^11.2.1:
+  version "11.2.4"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.4.tgz#ecb523ebb0e6f4d837c807ad1abaea8e0619770d"
+  integrity sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==
+
+lucide-vue-next@^0.543.0:
+  version "0.543.0"
+  resolved "https://registry.yarnpkg.com/lucide-vue-next/-/lucide-vue-next-0.543.0.tgz#3ac7f63ec60ed485730372513c7fe41e95250d4f"
+  integrity sha512-Az5kpNm/koKAwSNIKjsZ4uHV2tVfmlQlcHwFBygQ8gc5/jFg7An9OrxgDy/aE5m+HLx7VfLYqDxLr8gWecZbQA==
+
 magic-string@^0.30.21, magic-string@^0.30.5:
   version "0.30.21"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz"
@@ -2063,15 +2623,79 @@ magic-string@^0.30.21, magic-string@^0.30.5:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
+markdown-it-image-figures@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-image-figures/-/markdown-it-image-figures-2.1.1.tgz#fd32a2d0cec60ed8c3916d74fea70d5f9b56e4c7"
+  integrity sha512-mwXSQ2nPeVUzCMIE3HlLvjRioopiqyJLNph0pyx38yf9mpqFDhNGnMpAXF9/A2Xv0oiF2cVyg9xwfF0HNAz05g==
+
+markdown-it-sub@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-sub/-/markdown-it-sub-2.0.0.tgz#10f6c7bbf2faacf71ae1a64c75009c40ef9b2c94"
+  integrity sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==
+
+markdown-it-sup@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-sup/-/markdown-it-sup-2.0.0.tgz#683b9390929f3024fcd5291799c466ce3d367f44"
+  integrity sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==
+
+markdown-it@^14.0.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
+  integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+md-editor-v3@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/md-editor-v3/-/md-editor-v3-6.2.1.tgz#d4c4fd614de8b73b7fa8a9179aaba1f965b89b40"
+  integrity sha512-/9pmLG9qJ1/NmxE5e4aNmGSxWJh4vLVAd0zQ9w52YXe8I7b+xjXAQj7GRZVMxRhB9tXTjY7THiqwrNUy+9r0hQ==
+  dependencies:
+    "@codemirror/autocomplete" "^6.18.7"
+    "@codemirror/commands" "^6.8.1"
+    "@codemirror/lang-markdown" "^6.3.4"
+    "@codemirror/language" "^6.11.3"
+    "@codemirror/language-data" "^6.5.1"
+    "@codemirror/search" "^6.5.11"
+    "@codemirror/state" "^6.5.2"
+    "@codemirror/view" "^6.38.2"
+    "@lezer/highlight" "^1.2.1"
+    "@types/markdown-it" "^14.0.1"
+    "@vavt/copy2clipboard" "^1.0.1"
+    "@vavt/util" "^2.1.0"
+    codemirror "^6.0.2"
+    lru-cache "^11.2.1"
+    lucide-vue-next "^0.543.0"
+    markdown-it "^14.0.0"
+    markdown-it-image-figures "^2.1.1"
+    markdown-it-sub "^2.0.0"
+    markdown-it-sup "^2.0.0"
+    medium-zoom "^1.1.0"
+    xss "^1.0.15"
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
+
+medium-zoom@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.1.0.tgz#6efb6bbda861a02064ee71a2617a8dc4381ecc71"
+  integrity sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==
 
 merge-descriptors@1.0.3:
   version "1.0.3"
@@ -2516,6 +3140,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
+
 punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
@@ -2945,6 +3574,11 @@ strip-literal@^2.0.0:
   dependencies:
     js-tokens "^9.0.1"
 
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
@@ -3080,6 +3714,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 ufo@^1.6.1:
   version "1.6.1"
@@ -3220,6 +3859,11 @@ vue@^3.4.15:
     "@vue/server-renderer" "3.5.25"
     "@vue/shared" "3.5.25"
 
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
+
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz"
@@ -3323,6 +3967,14 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xss@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.15.tgz#96a0e13886f0661063028b410ed1b18670f4e59a"
+  integrity sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
- Install md-editor-v3 for Vue 3 markdown rendering
- Add GET /api/sessions/:id/file endpoint to fetch file content
- Update ChangesTab to parse diffs by file and show Preview button for .md/.markdown/.mdx files
- Toggle between raw diff view and rendered markdown preview
- Add comprehensive unit tests for markdown preview functionality
- Add Playwright E2E tests for markdown preview feature