### PR TITLE
Add active sessions view to see all running/waiting sessions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,104 +1,147 @@
-# Plan: Easy Git Worktree Creation for New Sessions
+# Plan: Active/Waiting Sessions List View
 
 ## Overview
 
-When creating a new session, users should be able to easily elect to create a new git worktree from the project's working path. Currently, the worktree option exists but is buried in a multi-step selection process. This plan improves the UX by making worktree creation more prominent and streamlined.
+Create a new view that shows all sessions across all projects that are currently "active" (running, waiting, or starting). This provides users with a quick way to see all sessions that need attention without having to navigate to each project individually.
 
-## Current State
+## Session Statuses Reference
 
-- **Session creation form** (`packages/web/src/views/NewSessionView.vue`) has:
-  - Git Mode dropdown: "None", "Switch Branch", "Create Worktree"
-  - Branch selection (existing or new) when git mode is selected
-- **Backend** (`packages/server/src/services/gitSessionSetup.js`) already supports:
-  - Automatic worktree creation at `.worktrees/{sessionId}`
-  - Branch creation if it doesn't exist
-- **UX Problem**: Users must select "Create Worktree" from dropdown, then manually enter a branch name - this is cumbersome for the common case of wanting quick isolation
+- `starting` - Initial creation (ACTIVE)
+- `running` - Claude is actively processing (ACTIVE)
+- `waiting` - Waiting for user input (ACTIVE)
+- `completed` - Session ended
+- `error` - An error occurred
 
-## Proposed Solution
+**Active sessions = `starting`, `running`, or `waiting` status**
 
-Add a "Quick Worktree" feature that:
-1. Shows a single checkbox: "Create isolated worktree"
-2. Auto-generates a sensible branch name based on session name or timestamp
-3. One-click worktree creation without needing to understand git modes
+---
 
-## Implementation Plan
+## Implementation Steps
 
-### 1. Frontend Changes (`packages/web/src/views/NewSessionView.vue`)
+### 1. Backend: Add Repository Method
 
-**Add quick worktree toggle:**
-- Add a checkbox labeled "Create isolated worktree" (checked by default when git is available)
-- When checked, auto-generate branch name: `vk/{shortId}-{sanitized-session-name}`
-- Show the auto-generated branch name with option to customize
-- Keep advanced git mode options available via "Advanced options" expandable section
+**File:** `packages/server/src/db/SessionRepository.js`
 
-**UI Layout:**
+Add a new method to fetch all active sessions across all projects:
+
+```javascript
+getActiveAndWaiting() {
+  const rows = this.db
+    .prepare(
+      `SELECT s.*, p.name as project_name, p.path as project_path
+       FROM sessions s
+       JOIN projects p ON s.project_id = p.id
+       WHERE s.status IN ('starting', 'running', 'waiting')
+       ORDER BY s.updated_at DESC`
+    )
+    .all();
+  return rows.map(row => ({
+    ...this.map(row),
+    projectName: row.project_name,
+    projectPath: row.project_path
+  }));
+}
 ```
-[x] Create isolated worktree
-    Branch: vk/4a52-implement-auth  [Edit]
 
-▸ Advanced git options (collapsed by default)
+### 2. Backend: Add API Endpoint
+
+**File:** `packages/server/src/api/sessions.js`
+
+Add a new route at the beginning of the router (before `/:id` routes):
+
+```javascript
+router.get('/', async (req, res) => {
+  const sessions = req.sessionRepository.getActiveAndWaiting();
+  res.json(sessions);
+});
 ```
 
-### 2. Branch Name Generation
+This will be accessible at `GET /api/sessions`.
 
-**Format:** `vk/{shortId}-{slug}`
-- `shortId`: First 4 characters of a new UUID
-- `slug`: Sanitized session name (lowercase, hyphens, max 30 chars)
-- If no session name: use first few words of prompt
+### 3. Frontend: Add API Client Method
 
-**Examples:**
-- Session "Implement auth" → `vk/a3f2-implement-auth`
-- Session "Fix bug #123" → `vk/b4c1-fix-bug-123`
-- No name, prompt "Add dark mode toggle..." → `vk/c5d2-add-dark-mode`
+**File:** `packages/web/src/api/ApiClient.js`
 
-### 3. API Changes
+Add method:
 
-**No backend changes required** - the existing `gitMode: 'worktree'` and `gitBranch` parameters handle everything. The frontend will simply:
-- Set `gitMode: 'worktree'` when checkbox is checked
-- Set `gitBranch` to the auto-generated (or customized) branch name
+```javascript
+async getActiveSessions() {
+  return this.get('/sessions');
+}
+```
 
-### 4. Shared Utilities (`packages/shared`)
+### 4. Frontend: Update Sessions Store
 
-Add branch name generation utility:
-- `generateWorktreeBranch(sessionName, prompt)` → returns formatted branch name
-- Can be used by both frontend (preview) and potentially backend (validation)
+**File:** `packages/web/src/stores/sessions.js`
 
-### 5. Files to Modify
+Add new state and action:
 
-| File | Changes |
-|------|---------|
-| `packages/web/src/views/NewSessionView.vue` | Add quick worktree checkbox, branch name preview, collapsible advanced options |
-| `packages/shared/src/utils.js` (new) | Add `generateWorktreeBranch()` utility function |
-| `packages/shared/src/index.js` | Export new utility |
+```javascript
+// In state
+activeSessions: []
 
-### 6. UX Flow
+// New action
+async fetchActiveSessions() {
+  this.loading = true;
+  this.error = null;
+  try {
+    this.activeSessions = await apiClient.getActiveSessions();
+  } catch (error) {
+    this.error = error.message;
+  } finally {
+    this.loading = false;
+  }
+}
+```
 
-**Before (current):**
-1. Fill session name and prompt
-2. Select "Create Worktree" from Git Mode dropdown
-3. Type or select a branch name
-4. Click Start Session
+### 5. Frontend: Create New View Component
 
-**After (proposed):**
-1. Fill session name and prompt
-2. Checkbox "Create isolated worktree" is pre-checked (git available)
-3. See auto-generated branch name (can edit if desired)
-4. Click Start Session
+**File:** `packages/web/src/views/ActiveSessionsView.vue` (new file)
 
-### 7. Edge Cases
+Create a view that:
+- Fetches and displays all active/waiting sessions on mount
+- Shows session name, project name, status, mode, and last updated time
+- Links to the session detail view
+- Highlights "waiting" sessions as needing user attention
+- Shows empty state when no active sessions exist
+- Auto-refreshes periodically (every 10 seconds) to keep status current
 
-- **Non-git project**: Hide worktree checkbox entirely
-- **Branch already exists**: Show warning, suggest different name
-- **Invalid characters in session name**: Sanitize automatically
-- **Empty session name**: Fall back to prompt-based or random name
+### 6. Frontend: Add Route
 
-### 8. Testing
+**File:** `packages/web/src/router.js`
 
-- Unit test for `generateWorktreeBranch()` utility
-- E2E test for quick worktree creation flow
-- Verify worktree is created at correct path
-- Verify branch naming works with various inputs
+Add new route BEFORE the `/sessions/:id/:tab?` route to avoid conflict:
 
-## Summary
+```javascript
+{
+  path: '/sessions/active',
+  name: 'ActiveSessions',
+  component: () => import('./views/ActiveSessionsView.vue'),
+}
+```
 
-This change makes worktree creation a first-class, one-click experience while preserving the existing advanced options for users who need fine-grained control. The auto-generated branch names follow a consistent pattern that's easy to identify and manage.
+### 7. Frontend: Add Navigation Link
+
+**File:** `packages/web/src/App.vue`
+
+Add a link to the active sessions view in the main navigation.
+
+### 8. Tests
+
+**Files to update:**
+- `packages/server/src/db/SessionRepository.test.js` - Test `getActiveAndWaiting()` method
+
+---
+
+## Files to Modify/Create Summary
+
+| File | Action |
+|------|--------|
+| `packages/server/src/db/SessionRepository.js` | Add `getActiveAndWaiting()` method |
+| `packages/server/src/api/sessions.js` | Add `GET /api/sessions` route |
+| `packages/web/src/api/ApiClient.js` | Add `getActiveSessions()` method |
+| `packages/web/src/stores/sessions.js` | Add `activeSessions` state and fetch action |
+| `packages/web/src/views/ActiveSessionsView.vue` | **Create new file** |
+| `packages/web/src/router.js` | Add route for active sessions |
+| `packages/web/src/App.vue` | Add navigation link |
+| `packages/server/src/db/SessionRepository.test.js` | Add tests for new method |

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -5,6 +5,12 @@ import { getChanges } from '../services/diffService.js';
 
 const router = Router();
 
+// GET /api/sessions - Get all active/waiting sessions across all projects
+router.get('/', (req, res) => {
+  const activeSessions = sessions.getActiveAndWaiting();
+  res.json(activeSessions);
+});
+
 // GET /api/sessions/:id - Get session details
 router.get('/:id', (req, res) => {
   const session = sessions.getById(req.params.id);

--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -58,6 +58,23 @@ export class SessionRepository extends BaseRepository {
     return this.mapAll(rows);
   }
 
+  getActiveAndWaiting() {
+    const rows = this.db
+      .prepare(
+        `SELECT s.*, p.name as project_name, p.path as project_path
+         FROM sessions s
+         JOIN projects p ON s.project_id = p.id
+         WHERE s.status IN ('starting', 'running', 'waiting')
+         ORDER BY s.updated_at DESC`
+      )
+      .all();
+    return rows.map(row => ({
+      ...SessionRepository.#mapSession(row),
+      projectName: row.project_name,
+      projectPath: row.project_path,
+    }));
+  }
+
   update(id, data) {
     const updates = [];
     const values = [];

--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -61,7 +61,7 @@ export class SessionRepository extends BaseRepository {
   getActiveAndWaiting() {
     const rows = this.db
       .prepare(
-        `SELECT s.*, p.name as project_name, p.path as project_path
+        `SELECT s.*, p.name as project_name, p.working_directory as project_working_directory
          FROM sessions s
          JOIN projects p ON s.project_id = p.id
          WHERE s.status IN ('starting', 'running', 'waiting')
@@ -71,7 +71,7 @@ export class SessionRepository extends BaseRepository {
     return rows.map(row => ({
       ...SessionRepository.#mapSession(row),
       projectName: row.project_name,
-      projectPath: row.project_path,
+      projectWorkingDirectory: row.project_working_directory,
     }));
   }
 

--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -203,7 +203,7 @@ describe('SessionRepository', () => {
     });
 
     it('returns sessions with starting, running, or waiting status', () => {
-      const starting = repo.create(projectId, 'Starting Session', 'Prompt');
+      repo.create(projectId, 'Starting Session', 'Prompt');
       // starting is the default status
 
       const running = repo.create(projectId, 'Running Session', 'Prompt');
@@ -215,8 +215,8 @@ describe('SessionRepository', () => {
       const completed = repo.create(projectId, 'Completed Session', 'Prompt');
       repo.update(completed.id, { status: 'completed' });
 
-      const error = repo.create(projectId, 'Error Session', 'Prompt');
-      repo.update(error.id, { status: 'error' });
+      const errorSession = repo.create(projectId, 'Error Session', 'Prompt');
+      repo.update(errorSession.id, { status: 'error' });
 
       const sessions = repo.getActiveAndWaiting();
 
@@ -229,7 +229,7 @@ describe('SessionRepository', () => {
       expect(statuses).not.toContain('error');
     });
 
-    it('includes project name and path in results', () => {
+    it('includes project name and working directory in results', () => {
       const session = repo.create(projectId, 'Test Session', 'Prompt');
       repo.update(session.id, { status: 'running' });
 
@@ -237,7 +237,7 @@ describe('SessionRepository', () => {
 
       expect(sessions).toHaveLength(1);
       expect(sessions[0].projectName).toBe('Test Project');
-      expect(sessions[0].projectPath).toBe('/tmp/test');
+      expect(sessions[0].projectWorkingDirectory).toBe('/tmp/test');
     });
 
     it('returns sessions from multiple projects', () => {

--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -196,6 +196,81 @@ describe('SessionRepository', () => {
     });
   });
 
+  describe('getActiveAndWaiting', () => {
+    it('returns empty array when no sessions exist', () => {
+      const sessions = repo.getActiveAndWaiting();
+      expect(sessions).toEqual([]);
+    });
+
+    it('returns sessions with starting, running, or waiting status', () => {
+      const starting = repo.create(projectId, 'Starting Session', 'Prompt');
+      // starting is the default status
+
+      const running = repo.create(projectId, 'Running Session', 'Prompt');
+      repo.update(running.id, { status: 'running' });
+
+      const waiting = repo.create(projectId, 'Waiting Session', 'Prompt');
+      repo.update(waiting.id, { status: 'waiting' });
+
+      const completed = repo.create(projectId, 'Completed Session', 'Prompt');
+      repo.update(completed.id, { status: 'completed' });
+
+      const error = repo.create(projectId, 'Error Session', 'Prompt');
+      repo.update(error.id, { status: 'error' });
+
+      const sessions = repo.getActiveAndWaiting();
+
+      expect(sessions).toHaveLength(3);
+      const statuses = sessions.map((s) => s.status);
+      expect(statuses).toContain('starting');
+      expect(statuses).toContain('running');
+      expect(statuses).toContain('waiting');
+      expect(statuses).not.toContain('completed');
+      expect(statuses).not.toContain('error');
+    });
+
+    it('includes project name and path in results', () => {
+      const session = repo.create(projectId, 'Test Session', 'Prompt');
+      repo.update(session.id, { status: 'running' });
+
+      const sessions = repo.getActiveAndWaiting();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].projectName).toBe('Test Project');
+      expect(sessions[0].projectPath).toBe('/tmp/test');
+    });
+
+    it('returns sessions from multiple projects', () => {
+      const otherProject = projectRepo.create('Other Project', '/tmp/other');
+
+      const session1 = repo.create(projectId, 'Session 1', 'Prompt');
+      repo.update(session1.id, { status: 'running' });
+
+      const session2 = repo.create(otherProject.id, 'Session 2', 'Prompt');
+      repo.update(session2.id, { status: 'waiting' });
+
+      const sessions = repo.getActiveAndWaiting();
+
+      expect(sessions).toHaveLength(2);
+      const projectNames = sessions.map((s) => s.projectName);
+      expect(projectNames).toContain('Test Project');
+      expect(projectNames).toContain('Other Project');
+    });
+
+    it('orders sessions by updatedAt descending', () => {
+      const older = repo.create(projectId, 'Older Session', 'Prompt');
+      repo.update(older.id, { status: 'running' });
+
+      const newer = repo.create(projectId, 'Newer Session', 'Prompt');
+      repo.update(newer.id, { status: 'waiting' });
+
+      const sessions = repo.getActiveAndWaiting();
+
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0].updatedAt).toBeGreaterThanOrEqual(sessions[1].updatedAt);
+    });
+  });
+
   describe('update', () => {
     it('updates session status', () => {
       const session = repo.create(projectId, 'Test', 'Prompt');

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -5,6 +5,7 @@
         <router-link to="/" class="logo">ClaudeTools.io</router-link>
         <nav class="nav">
           <router-link to="/" class="nav-link">Projects</router-link>
+          <router-link to="/sessions/active" class="nav-link">Active Sessions</router-link>
         </nav>
       </div>
     </header>

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -103,6 +103,14 @@ export class ApiClient {
   // Sessions
 
   /**
+   * Get all active/waiting sessions across all projects
+   * @returns {Promise<Array>}
+   */
+  async getActiveSessions() {
+    return this.#request('GET', '/sessions');
+  }
+
+  /**
    * Get all sessions for a project
    * @param {string} projectId - Project ID
    * @returns {Promise<Array>}

--- a/packages/web/src/router.js
+++ b/packages/web/src/router.js
@@ -27,6 +27,11 @@ const routes = [
     component: () => import('./views/NewSessionView.vue'),
   },
   {
+    path: '/sessions/active',
+    name: 'ActiveSessions',
+    component: () => import('./views/ActiveSessionsView.vue'),
+  },
+  {
     path: '/sessions/:id/:tab?',
     name: 'SessionDetail',
     component: () => import('./views/SessionDetailView.vue'),

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -4,6 +4,7 @@ import { api } from '../composables/useApi.js';
 export const useSessionsStore = defineStore('sessions', {
   state: () => ({
     sessions: [],
+    activeSessions: [],
     currentSession: null,
     messages: [],
     loading: false,
@@ -17,6 +18,18 @@ export const useSessionsStore = defineStore('sessions', {
   },
 
   actions: {
+    async fetchActiveSessions(showLoading = true) {
+      if (showLoading) this.loading = true;
+      this.error = null;
+      try {
+        this.activeSessions = await api.getActiveSessions();
+      } catch (err) {
+        this.error = err.message;
+      } finally {
+        if (showLoading) this.loading = false;
+      }
+    },
+
     async fetchSessions(projectId) {
       this.loading = true;
       this.error = null;

--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="container">
+    <div class="page-header">
+      <div>
+        <router-link to="/" class="back-link">&larr; Projects</router-link>
+        <h1>Active Sessions</h1>
+        <p class="page-description">Sessions that are running or waiting for input</p>
+      </div>
+    </div>
+
+    <div v-if="sessionsStore.loading" class="skeleton-list">
+      <div v-for="i in 3" :key="i" class="skeleton card" style="height: 80px"></div>
+    </div>
+
+    <div v-else-if="sessionsStore.error" class="error-message">
+      {{ sessionsStore.error }}
+    </div>
+
+    <div v-else-if="sessionsStore.activeSessions.length === 0" class="empty-state">
+      <p>No active sessions. All sessions are completed or there are no sessions yet.</p>
+      <router-link to="/" class="btn btn-primary">View Projects</router-link>
+    </div>
+
+    <div v-else class="session-list">
+      <router-link
+        v-for="session in sessionsStore.activeSessions"
+        :key="session.id"
+        :to="`/sessions/${session.id}`"
+        class="session-card card"
+      >
+        <div class="session-info">
+          <h3 class="session-name">{{ session.name }}</h3>
+          <p class="session-meta">
+            <span :class="['status-badge', `status-${session.status}`]">{{ session.status }}</span>
+            <span class="session-mode">{{ session.mode }}</span>
+            <span v-if="session.gitBranch" class="session-branch">{{ session.gitBranch }}</span>
+          </p>
+          <p class="session-project">
+            <span class="project-name">{{ session.projectName }}</span>
+          </p>
+        </div>
+        <div class="session-date">
+          {{ formatDate(session.updatedAt) }}
+        </div>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onUnmounted } from 'vue';
+import { useSessionsStore } from '../stores/sessions.js';
+
+const sessionsStore = useSessionsStore();
+
+let refreshInterval = null;
+
+onMounted(() => {
+  sessionsStore.fetchActiveSessions();
+
+  // Auto-refresh every 10 seconds
+  refreshInterval = setInterval(() => {
+    sessionsStore.fetchActiveSessions(false);
+  }, 10000);
+});
+
+onUnmounted(() => {
+  if (refreshInterval) {
+    clearInterval(refreshInterval);
+  }
+});
+
+function formatDate(timestamp) {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+<style scoped>
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+}
+
+.back-link {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+  display: inline-block;
+  margin-bottom: 0.5rem;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
+.page-description {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+}
+
+.skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.error-message {
+  color: var(--color-error);
+  padding: 1rem;
+  background-color: rgba(248, 81, 73, 0.1);
+  border-radius: var(--border-radius);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: var(--color-text-soft);
+}
+
+.empty-state p {
+  margin-bottom: 1rem;
+}
+
+.session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.session-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--color-text);
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+
+.session-card:hover {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.session-name {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.session-meta {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.session-mode {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  text-transform: capitalize;
+}
+
+.session-branch {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  font-family: var(--font-mono);
+}
+
+.session-project {
+  margin: 0.5rem 0 0;
+}
+
+.project-name {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.session-date {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds a new **Active Sessions** view at `/sessions/active` that shows all sessions across all projects with status `starting`, `running`, or `waiting`
- Allows users to quickly see sessions that need attention without navigating to each project individually
- View auto-refreshes every 10 seconds to keep status current

## Changes

- **Backend**: Add `getActiveAndWaiting()` method to `SessionRepository` with project JOIN for project name/path
- **Backend**: Add `GET /api/sessions` endpoint
- **Frontend**: Add `getActiveSessions()` to API client
- **Frontend**: Add `activeSessions` state and `fetchActiveSessions()` action to sessions store
- **Frontend**: Create `ActiveSessionsView.vue` component
- **Frontend**: Add `/sessions/active` route (placed before dynamic `:id` route to avoid conflict)
- **Frontend**: Add "Active Sessions" link in main navigation header

## Test plan

- [ ] Verify active sessions view loads at `/sessions/active`
- [ ] Verify sessions with status `starting`, `running`, or `waiting` appear in the list
- [ ] Verify completed and error sessions do NOT appear
- [ ] Verify project name is displayed for each session
- [ ] Verify clicking a session navigates to its detail view
- [ ] Verify empty state shows when no active sessions exist
- [ ] Verify auto-refresh updates the list every 10 seconds
- [ ] Run all tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)