### PR TITLE
Fix new session button off viewport on iPhone SE

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -174,4 +174,20 @@ function formatDate(timestamp) {
   font-size: 0.875rem;
   color: var(--color-text-soft);
 }
+
+@media (max-width: 480px) {
+  .page-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .page-header .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .project-path {
+    word-break: break-all;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary
- Add mobile responsive styles to SessionListView header for screens ≤480px
- Stack the title/path and "New Session" button vertically on small screens
- Make button full-width for easier tapping on mobile
- Fix long project paths overflowing by adding word-break

## Test plan
- [ ] Test on iPhone SE (375px width) - button should be visible and full-width
- [ ] Test on larger screens - layout should remain unchanged (horizontal)
- [ ] Verify long project paths wrap correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)