### PR TITLE
Add GitHub-style diff viewer to Changes tab

### DIFF
--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -53,7 +53,14 @@ describe('ChangesTab', () => {
 
   it('displays staged changes when present', async () => {
     api.getSessionChanges.mockResolvedValue({
-      staged: 'diff --git a/file.js\n+new line',
+      staged: `diff --git a/file.js b/file.js
+index 1234567..abcdefg 100644
+--- a/file.js
++++ b/file.js
+@@ -1,3 +1,4 @@
+ const x = 1;
++const newLine = 2;
+ const y = 3;`,
       unstaged: '',
       untracked: [],
     });
@@ -65,14 +72,21 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Staged Changes');
-    expect(wrapper.text()).toContain('diff --git a/file.js');
-    expect(wrapper.text()).toContain('+new line');
+    expect(wrapper.text()).toContain('file.js');
+    expect(wrapper.text()).toContain('const newLine = 2;');
   });
 
   it('displays unstaged changes when present', async () => {
     api.getSessionChanges.mockResolvedValue({
       staged: '',
-      unstaged: 'diff --git b/other.js\n-removed line',
+      unstaged: `diff --git a/other.js b/other.js
+index 1234567..abcdefg 100644
+--- a/other.js
++++ b/other.js
+@@ -1,4 +1,3 @@
+ const a = 1;
+-const removedLine = 2;
+ const b = 3;`,
       untracked: [],
     });
 
@@ -83,14 +97,26 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Unstaged Changes');
-    expect(wrapper.text()).toContain('diff --git b/other.js');
-    expect(wrapper.text()).toContain('-removed line');
+    expect(wrapper.text()).toContain('other.js');
+    expect(wrapper.text()).toContain('const removedLine = 2;');
   });
 
   it('displays both staged and unstaged changes', async () => {
     api.getSessionChanges.mockResolvedValue({
-      staged: 'staged content',
-      unstaged: 'unstaged content',
+      staged: `diff --git a/staged.js b/staged.js
+index 1234567..abcdefg 100644
+--- a/staged.js
++++ b/staged.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const stagedLine = 2;`,
+      unstaged: `diff --git a/unstaged.js b/unstaged.js
+index 1234567..abcdefg 100644
+--- a/unstaged.js
++++ b/unstaged.js
+@@ -1,2 +1,3 @@
+ const a = 1;
++const unstagedLine = 2;`,
       untracked: [],
     });
 
@@ -101,9 +127,9 @@ describe('ChangesTab', () => {
     await flushPromises();
 
     expect(wrapper.text()).toContain('Staged Changes');
-    expect(wrapper.text()).toContain('staged content');
+    expect(wrapper.text()).toContain('staged.js');
     expect(wrapper.text()).toContain('Unstaged Changes');
-    expect(wrapper.text()).toContain('unstaged content');
+    expect(wrapper.text()).toContain('unstaged.js');
   });
 
   it('displays empty state when no changes', async () => {

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -14,14 +14,14 @@
     </div>
 
     <template v-else>
-      <div v-if="staged" class="diff-section">
+      <div v-if="stagedFiles.length > 0" class="diff-section">
         <h3>Staged Changes</h3>
-        <pre class="diff-content">{{ staged }}</pre>
+        <DiffViewer :files="stagedFiles" />
       </div>
 
-      <div v-if="unstaged" class="diff-section">
+      <div v-if="unstagedFiles.length > 0" class="diff-section">
         <h3>Unstaged Changes</h3>
-        <pre class="diff-content">{{ unstaged }}</pre>
+        <DiffViewer :files="unstagedFiles" />
       </div>
 
       <div v-if="untracked.length > 0" class="diff-section">
@@ -39,6 +39,8 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import { api } from '../api/ApiClient.js';
+import { parseDiff } from '../utils/diffParser.js';
+import DiffViewer from './DiffViewer.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -50,6 +52,8 @@ const untracked = ref([]);
 const loading = ref(false);
 const error = ref(null);
 
+const stagedFiles = computed(() => parseDiff(staged.value));
+const unstagedFiles = computed(() => parseDiff(unstaged.value));
 const hasChanges = computed(() => staged.value || unstaged.value || untracked.value.length > 0);
 
 async function fetchChanges() {
@@ -106,12 +110,6 @@ onMounted(() => {
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
   color: var(--color-text-soft);
-}
-
-.diff-content {
-  font-size: 0.75rem;
-  max-height: 300px;
-  overflow: auto;
 }
 
 .untracked-list {

--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -1,0 +1,269 @@
+<template>
+  <div class="diff-viewer">
+    <div v-if="files.length === 0" class="diff-empty">
+      No changes to display
+    </div>
+
+    <div v-for="(file, fileIndex) in files" :key="fileIndex" class="diff-file">
+      <div class="diff-file-header" @click="toggleFile(fileIndex)">
+        <span class="diff-file-toggle">{{ expandedFiles[fileIndex] ? '▼' : '▶' }}</span>
+        <span class="diff-file-icon">
+          <span v-if="file.isNew" class="file-badge file-badge-new">A</span>
+          <span v-else-if="file.isDeleted" class="file-badge file-badge-deleted">D</span>
+          <span v-else-if="file.isRenamed" class="file-badge file-badge-renamed">R</span>
+          <span v-else class="file-badge file-badge-modified">M</span>
+        </span>
+        <span class="diff-file-path">{{ file.displayPath }}</span>
+        <span class="diff-file-stats">
+          <span v-if="file.additions" class="stat-additions">+{{ file.additions }}</span>
+          <span v-if="file.deletions" class="stat-deletions">-{{ file.deletions }}</span>
+        </span>
+      </div>
+
+      <div v-if="expandedFiles[fileIndex]" class="diff-file-content">
+        <div v-for="(hunk, hunkIndex) in file.hunks" :key="hunkIndex" class="diff-hunk">
+          <div class="diff-hunk-header">{{ hunk.header }}</div>
+          <table class="diff-table">
+            <tbody>
+              <tr
+                v-for="(line, lineIndex) in hunk.lines"
+                :key="lineIndex"
+                :class="['diff-line', `diff-line-${line.type}`]"
+              >
+                <td class="diff-line-num diff-line-num-old">{{ line.oldLineNumber ?? '' }}</td>
+                <td class="diff-line-num diff-line-num-new">{{ line.newLineNumber ?? '' }}</td>
+                <td class="diff-line-prefix">{{ getLinePrefix(line.type) }}</td>
+                <td class="diff-line-content">{{ line.content }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+  files: {
+    type: Array,
+    required: true,
+    default: () => [],
+  },
+  expandAll: {
+    type: Boolean,
+    default: true,
+  },
+});
+
+const expandedFiles = ref({});
+
+// Initialize expanded state
+watch(
+  () => props.files,
+  (newFiles) => {
+    newFiles.forEach((_, index) => {
+      if (expandedFiles.value[index] === undefined) {
+        expandedFiles.value[index] = props.expandAll;
+      }
+    });
+  },
+  { immediate: true }
+);
+
+function toggleFile(index) {
+  expandedFiles.value[index] = !expandedFiles.value[index];
+}
+
+function getLinePrefix(type) {
+  switch (type) {
+    case 'addition':
+      return '+';
+    case 'deletion':
+      return '-';
+    default:
+      return ' ';
+  }
+}
+</script>
+
+<style scoped>
+.diff-viewer {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.diff-empty {
+  color: var(--color-text-soft);
+  padding: 1rem;
+  text-align: center;
+}
+
+.diff-file {
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.diff-file-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-background-mute);
+  cursor: pointer;
+  user-select: none;
+}
+
+.diff-file-header:hover {
+  background-color: var(--color-border);
+}
+
+.diff-file-toggle {
+  color: var(--color-text-soft);
+  font-size: 0.625rem;
+  width: 1rem;
+}
+
+.diff-file-icon {
+  display: flex;
+  align-items: center;
+}
+
+.file-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 3px;
+  font-size: 0.625rem;
+  font-weight: 600;
+}
+
+.file-badge-new {
+  background-color: rgba(63, 185, 80, 0.2);
+  color: var(--color-success);
+}
+
+.file-badge-deleted {
+  background-color: rgba(248, 81, 73, 0.2);
+  color: var(--color-error);
+}
+
+.file-badge-renamed {
+  background-color: rgba(210, 153, 34, 0.2);
+  color: var(--color-warning);
+}
+
+.file-badge-modified {
+  background-color: rgba(88, 166, 255, 0.2);
+  color: var(--color-primary);
+}
+
+.diff-file-path {
+  flex: 1;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diff-file-stats {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.stat-additions {
+  color: var(--color-success);
+}
+
+.stat-deletions {
+  color: var(--color-error);
+}
+
+.diff-file-content {
+  background-color: var(--color-background);
+}
+
+.diff-hunk {
+  border-top: 1px solid var(--color-border);
+}
+
+.diff-hunk-header {
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(88, 166, 255, 0.1);
+  color: var(--color-text-soft);
+  font-size: 0.75rem;
+}
+
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.diff-line {
+  height: 1.5rem;
+}
+
+.diff-line-context {
+  background-color: var(--color-background);
+}
+
+.diff-line-addition {
+  background-color: rgba(63, 185, 80, 0.15);
+}
+
+.diff-line-deletion {
+  background-color: rgba(248, 81, 73, 0.15);
+}
+
+.diff-line-num {
+  width: 3rem;
+  min-width: 3rem;
+  padding: 0 0.5rem;
+  text-align: right;
+  color: var(--color-text-soft);
+  background-color: var(--color-background-soft);
+  border-right: 1px solid var(--color-border);
+  user-select: none;
+  vertical-align: top;
+}
+
+.diff-line-addition .diff-line-num {
+  background-color: rgba(63, 185, 80, 0.2);
+}
+
+.diff-line-deletion .diff-line-num {
+  background-color: rgba(248, 81, 73, 0.2);
+}
+
+.diff-line-prefix {
+  width: 1.5rem;
+  min-width: 1.5rem;
+  text-align: center;
+  user-select: none;
+  vertical-align: top;
+}
+
+.diff-line-addition .diff-line-prefix {
+  color: var(--color-success);
+}
+
+.diff-line-deletion .diff-line-prefix {
+  color: var(--color-error);
+}
+
+.diff-line-content {
+  padding: 0 0.5rem;
+  white-space: pre;
+  overflow-x: auto;
+  vertical-align: top;
+}
+</style>

--- a/packages/web/src/utils/diffParser.js
+++ b/packages/web/src/utils/diffParser.js
@@ -1,0 +1,190 @@
+/**
+ * Parse git unified diff format into structured data for rendering
+ */
+
+/**
+ * @typedef {Object} DiffLine
+ * @property {'addition'|'deletion'|'context'|'hunk-header'} type
+ * @property {string} content - The line content (without +/- prefix)
+ * @property {number|null} oldLineNumber
+ * @property {number|null} newLineNumber
+ */
+
+/**
+ * @typedef {Object} DiffHunk
+ * @property {string} header - The @@ header line
+ * @property {number} oldStart
+ * @property {number} oldCount
+ * @property {number} newStart
+ * @property {number} newCount
+ * @property {DiffLine[]} lines
+ */
+
+/**
+ * @typedef {Object} DiffFile
+ * @property {string} oldPath
+ * @property {string} newPath
+ * @property {string} displayPath - The path to display (usually newPath or oldPath if deleted)
+ * @property {boolean} isNew
+ * @property {boolean} isDeleted
+ * @property {boolean} isRenamed
+ * @property {DiffHunk[]} hunks
+ * @property {number} additions
+ * @property {number} deletions
+ */
+
+/**
+ * Parse a unified diff string into structured file objects
+ * @param {string} diffText - Raw git diff output
+ * @returns {DiffFile[]}
+ */
+export function parseDiff(diffText) {
+  if (!diffText || !diffText.trim()) {
+    return [];
+  }
+
+  const files = [];
+  const lines = diffText.split('\n');
+  let currentFile = null;
+  let currentHunk = null;
+  let oldLineNum = 0;
+  let newLineNum = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // File header: diff --git a/path b/path
+    if (line.startsWith('diff --git')) {
+      if (currentFile) {
+        if (currentHunk) {
+          currentFile.hunks.push(currentHunk);
+        }
+        files.push(currentFile);
+      }
+
+      const match = line.match(/diff --git a\/(.+) b\/(.+)/);
+      currentFile = {
+        oldPath: match ? match[1] : '',
+        newPath: match ? match[2] : '',
+        displayPath: match ? match[2] : '',
+        isNew: false,
+        isDeleted: false,
+        isRenamed: false,
+        hunks: [],
+        additions: 0,
+        deletions: 0,
+      };
+      currentHunk = null;
+      continue;
+    }
+
+    if (!currentFile) continue;
+
+    // New file mode
+    if (line.startsWith('new file mode')) {
+      currentFile.isNew = true;
+      continue;
+    }
+
+    // Deleted file mode
+    if (line.startsWith('deleted file mode')) {
+      currentFile.isDeleted = true;
+      currentFile.displayPath = currentFile.oldPath;
+      continue;
+    }
+
+    // Rename detection
+    if (line.startsWith('rename from') || line.startsWith('rename to')) {
+      currentFile.isRenamed = true;
+      continue;
+    }
+
+    // Skip index, ---, +++ lines (we already have paths from diff --git)
+    if (
+      line.startsWith('index ') ||
+      line.startsWith('--- ') ||
+      line.startsWith('+++ ') ||
+      line.startsWith('Binary files')
+    ) {
+      continue;
+    }
+
+    // Hunk header: @@ -oldStart,oldCount +newStart,newCount @@ optional context
+    if (line.startsWith('@@')) {
+      if (currentHunk) {
+        currentFile.hunks.push(currentHunk);
+      }
+
+      const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)?/);
+      if (match) {
+        oldLineNum = parseInt(match[1], 10);
+        newLineNum = parseInt(match[3], 10);
+        currentHunk = {
+          header: line,
+          oldStart: oldLineNum,
+          oldCount: match[2] ? parseInt(match[2], 10) : 1,
+          newStart: newLineNum,
+          newCount: match[4] ? parseInt(match[4], 10) : 1,
+          lines: [],
+        };
+      }
+      continue;
+    }
+
+    // Diff content lines
+    if (currentHunk) {
+      if (line.startsWith('+')) {
+        currentHunk.lines.push({
+          type: 'addition',
+          content: line.slice(1),
+          oldLineNumber: null,
+          newLineNumber: newLineNum++,
+        });
+        currentFile.additions++;
+      } else if (line.startsWith('-')) {
+        currentHunk.lines.push({
+          type: 'deletion',
+          content: line.slice(1),
+          oldLineNumber: oldLineNum++,
+          newLineNumber: null,
+        });
+        currentFile.deletions++;
+      } else if (line.startsWith(' ') || line === '') {
+        // Context line (starts with space) or empty line
+        currentHunk.lines.push({
+          type: 'context',
+          content: line.startsWith(' ') ? line.slice(1) : line,
+          oldLineNumber: oldLineNum++,
+          newLineNumber: newLineNum++,
+        });
+      }
+      // Skip \ No newline at end of file
+    }
+  }
+
+  // Don't forget the last file/hunk
+  if (currentFile) {
+    if (currentHunk) {
+      currentFile.hunks.push(currentHunk);
+    }
+    files.push(currentFile);
+  }
+
+  return files;
+}
+
+/**
+ * Get a summary of changes for a diff
+ * @param {DiffFile[]} files
+ * @returns {{ filesChanged: number, additions: number, deletions: number }}
+ */
+export function getDiffSummary(files) {
+  return files.reduce(
+    (acc, file) => ({
+      filesChanged: acc.filesChanged + 1,
+      additions: acc.additions + file.additions,
+      deletions: acc.deletions + file.deletions,
+    }),
+    { filesChanged: 0, additions: 0, deletions: 0 }
+  );
+}


### PR DESCRIPTION
## Summary
- Replace raw git diff output with a styled diff viewer component
- Add collapsible file sections with file status badges (A=Added, D=Deleted, R=Renamed, M=Modified)
- Show line numbers in left gutter (old/new columns)
- Color-coded lines: green background for additions, red for deletions
- Display per-file addition/deletion stats (+N/-N)

## Test plan
- [ ] Navigate to a session's Changes tab
- [ ] Verify staged and unstaged changes display with proper formatting
- [ ] Confirm files can be expanded/collapsed by clicking the header
- [ ] Check line numbers display correctly for additions, deletions, and context lines
- [ ] Verify untracked files still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)