### PR TITLE
Add configurable system prompt to project settings

### DIFF
--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -18,8 +18,8 @@ router.post('/', (req, res) => {
     return res.status(400).json({ error: result.error.errors[0].message });
   }
 
-  const { name, workingDirectory } = result.data;
-  const project = projects.create(name, workingDirectory);
+  const { name, workingDirectory, systemPrompt } = result.data;
+  const project = projects.create(name, workingDirectory, systemPrompt || null);
   res.status(201).json(project);
 });
 
@@ -101,7 +101,7 @@ router.post('/:id/sessions', async (req, res) => {
 
     // Start session manager (non-blocking)
     const { runSession } = await import('../services/sessionManager.js');
-    runSession(session.id, prompt, workingDirectory).catch((error) => {
+    runSession(session.id, prompt, workingDirectory, project.systemPrompt).catch((error) => {
       console.error('Session error:', error);
       sessions.update(session.id, { status: 'error', error: error.message });
     });

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -84,7 +84,7 @@ router.post('/:id/message', async (req, res) => {
     const workingDirectory = session.gitWorktree || project.workingDirectory;
 
     // Start continuation (non-blocking)
-    continueSession(session.id, content, workingDirectory).catch((error) => {
+    continueSession(session.id, content, workingDirectory, project.systemPrompt).catch((error) => {
       console.error('Continue session error:', error);
     });
     res.json({ success: true });

--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -41,17 +41,25 @@ export class DatabaseManager {
    */
   #runMigrations() {
     // Check if sessions table has the new columns, add them if not
-    const tableInfo = this.#db.prepare('PRAGMA table_info(sessions)').all();
-    const columns = tableInfo.map((col) => col.name);
+    const sessionsTableInfo = this.#db.prepare('PRAGMA table_info(sessions)').all();
+    const sessionsColumns = sessionsTableInfo.map((col) => col.name);
 
-    if (!columns.includes('cost_usd')) {
+    if (!sessionsColumns.includes('cost_usd')) {
       this.#db.exec('ALTER TABLE sessions ADD COLUMN cost_usd REAL DEFAULT 0');
     }
-    if (!columns.includes('claude_session_id')) {
+    if (!sessionsColumns.includes('claude_session_id')) {
       this.#db.exec('ALTER TABLE sessions ADD COLUMN claude_session_id TEXT');
     }
-    if (!columns.includes('model')) {
+    if (!sessionsColumns.includes('model')) {
       this.#db.exec('ALTER TABLE sessions ADD COLUMN model TEXT');
+    }
+
+    // Check if projects table has the system_prompt column, add it if not
+    const projectsTableInfo = this.#db.prepare('PRAGMA table_info(projects)').all();
+    const projectsColumns = projectsTableInfo.map((col) => col.name);
+
+    if (!projectsColumns.includes('system_prompt')) {
+      this.#db.exec('ALTER TABLE projects ADD COLUMN system_prompt TEXT');
     }
   }
 

--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -14,20 +14,21 @@ export class ProjectRepository extends BaseRepository {
       id: row.id,
       name: row.name,
       workingDirectory: row.working_directory,
+      systemPrompt: row.system_prompt,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
   }
 
-  create(name, workingDirectory) {
+  create(name, workingDirectory, systemPrompt = null) {
     const id = databaseManager.generateId();
     const now = Date.now();
     this.db
       .prepare(
-        `INSERT INTO projects (id, name, working_directory, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?)`
+        `INSERT INTO projects (id, name, working_directory, system_prompt, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
       )
-      .run(id, name, workingDirectory, now, now);
+      .run(id, name, workingDirectory, systemPrompt, now, now);
     return this.getById(id);
   }
 
@@ -47,6 +48,10 @@ export class ProjectRepository extends BaseRepository {
     if (data.workingDirectory !== undefined) {
       updates.push('working_directory = ?');
       values.push(data.workingDirectory);
+    }
+    if (data.systemPrompt !== undefined) {
+      updates.push('system_prompt = ?');
+      values.push(data.systemPrompt);
     }
 
     if (updates.length === 0) return this.getById(id);

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS projects (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
   working_directory TEXT NOT NULL,
+  system_prompt TEXT,
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -1,7 +1,7 @@
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { sessions, messages } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
-import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT } from '@claudetools/shared';
+import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT, DEFAULT_SYSTEM_PROMPT } from '@claudetools/shared';
 
 /** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
@@ -75,12 +75,25 @@ function buildSessionEnv(session) {
 }
 
 /**
+ * Build the full system prompt configuration
+ * @param {string} sessionId
+ * @param {string|null} customSystemPrompt - Custom system prompt from project settings
+ * @returns {string} System prompt string
+ */
+function buildSystemPromptConfig(sessionId, customSystemPrompt) {
+  const canvasInstructions = buildCanvasSystemPrompt(sessionId);
+  const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;
+  return `${basePrompt}\n\n${canvasInstructions}`;
+}
+
+/**
  * Run a Claude session
  * @param {string} sessionId
  * @param {string} prompt
  * @param {string} workingDirectory
+ * @param {string|null} systemPrompt - Custom system prompt from project settings
  */
-export async function runSession(sessionId, prompt, workingDirectory) {
+export async function runSession(sessionId, prompt, workingDirectory, systemPrompt = null) {
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
@@ -110,11 +123,7 @@ export async function runSession(sessionId, prompt, workingDirectory) {
             includePartialMessages: true,
             permissionMode: 'bypassPermissions',
             ...(sessionEnv && { env: sessionEnv }),
-            systemPrompt: {
-              type: 'preset',
-              preset: 'claude_code',
-              append: buildCanvasSystemPrompt(sessionId),
-            },
+            systemPrompt: buildSystemPromptConfig(sessionId, systemPrompt),
           },
         };
 
@@ -149,8 +158,9 @@ export async function runSession(sessionId, prompt, workingDirectory) {
  * @param {string} sessionId
  * @param {string} content
  * @param {string} workingDirectory
+ * @param {string|null} systemPrompt - Custom system prompt from project settings
  */
-export async function continueSession(sessionId, content, workingDirectory) {
+export async function continueSession(sessionId, content, workingDirectory, systemPrompt = null) {
   // Check if session is already running
   if (activeSessions.has(sessionId)) {
     throw new Error('Session is already processing');
@@ -195,11 +205,7 @@ export async function continueSession(sessionId, content, workingDirectory) {
             permissionMode: 'bypassPermissions',
             resume: session.claudeSessionId,
             ...(sessionEnv && { env: sessionEnv }),
-            systemPrompt: {
-              type: 'preset',
-              preset: 'claude_code',
-              append: buildCanvasSystemPrompt(sessionId),
-            },
+            systemPrompt: buildSystemPromptConfig(sessionId, systemPrompt),
           },
         };
 

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -9,3 +9,5 @@ export const WS_RECONNECT_BASE_DELAY = 2000;
 export const WS_RECONNECT_MAX_DELAY = 30000;
 
 export const TOAST_DURATION = 5000;
+
+export const DEFAULT_SYSTEM_PROMPT = `You are Claude Code, an AI coding assistant. You help users with software engineering tasks including writing code, debugging, refactoring, and explaining code. You have full access to the shell and can execute any commands needed to assist the user. Be helpful, accurate, and thorough.`;

--- a/packages/shared/src/contracts/projects.js
+++ b/packages/shared/src/contracts/projects.js
@@ -3,17 +3,20 @@ import { z } from 'zod';
 export const CreateProjectRequest = z.object({
   name: z.string().min(1),
   workingDirectory: z.string().min(1),
+  systemPrompt: z.string().optional(),
 });
 
 export const UpdateProjectRequest = z.object({
   name: z.string().min(1).optional(),
   workingDirectory: z.string().min(1).optional(),
+  systemPrompt: z.string().nullable().optional(),
 });
 
 export const ProjectResponse = z.object({
   id: z.string().uuid(),
   name: z.string(),
   workingDirectory: z.string(),
+  systemPrompt: z.string().nullable(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -24,6 +24,20 @@
         <PathChooser v-model="workingDirectory" />
       </div>
 
+      <div class="form-group">
+        <label class="form-label" for="systemPrompt">System Prompt</label>
+        <textarea
+          id="systemPrompt"
+          v-model="systemPrompt"
+          class="form-input form-textarea"
+          rows="8"
+          :placeholder="defaultSystemPrompt"
+        ></textarea>
+        <p class="form-help">
+          Customize the system prompt for the AI agent. Leave empty to use the default prompt shown above.
+        </p>
+      </div>
+
       <div v-if="error" class="error-message">{{ error }}</div>
 
       <div class="form-actions">
@@ -46,6 +60,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 import { useUiStore } from '../stores/ui.js';
 import PathChooser from '../components/PathChooser.vue';
+import { DEFAULT_SYSTEM_PROMPT as defaultSystemPrompt } from '@claudetools/shared/constants';
 
 const route = useRoute();
 const router = useRouter();
@@ -54,6 +69,7 @@ const uiStore = useUiStore();
 
 const name = ref('');
 const workingDirectory = ref('');
+const systemPrompt = ref('');
 const saving = ref(false);
 const error = ref(null);
 
@@ -65,6 +81,7 @@ watch(() => projectsStore.currentProject, (project) => {
   if (project) {
     name.value = project.name;
     workingDirectory.value = project.workingDirectory;
+    systemPrompt.value = project.systemPrompt || '';
   }
 }, { immediate: true });
 
@@ -76,6 +93,7 @@ async function handleSubmit() {
     await projectsStore.updateProject(route.params.id, {
       name: name.value,
       workingDirectory: workingDirectory.value,
+      systemPrompt: systemPrompt.value || null,
     });
     uiStore.success('Project updated successfully');
     router.push(`/projects/${route.params.id}/sessions`);
@@ -130,5 +148,19 @@ h1 {
 .error-message {
   color: var(--color-error);
   margin-bottom: 1rem;
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 120px;
+  font-family: monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.form-help {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
 }
 </style>

--- a/packages/web/src/views/ProjectNewView.vue
+++ b/packages/web/src/views/ProjectNewView.vue
@@ -20,6 +20,23 @@
         <PathChooser v-model="workingDirectory" />
       </div>
 
+      <details class="advanced-settings">
+        <summary>Advanced Settings</summary>
+        <div class="form-group">
+          <label class="form-label" for="systemPrompt">System Prompt</label>
+          <textarea
+            id="systemPrompt"
+            v-model="systemPrompt"
+            class="form-input form-textarea"
+            rows="8"
+            :placeholder="defaultSystemPrompt"
+          ></textarea>
+          <p class="form-help">
+            Customize the system prompt for the AI agent. Leave empty to use the default prompt shown above.
+          </p>
+        </div>
+      </details>
+
       <div v-if="error" class="error-message">{{ error }}</div>
 
       <div class="form-actions">
@@ -39,6 +56,7 @@ import { useRouter } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 import { useUiStore } from '../stores/ui.js';
 import PathChooser from '../components/PathChooser.vue';
+import { DEFAULT_SYSTEM_PROMPT as defaultSystemPrompt } from '@claudetools/shared/constants';
 
 const router = useRouter();
 const projectsStore = useProjectsStore();
@@ -46,6 +64,7 @@ const uiStore = useUiStore();
 
 const name = ref('');
 const workingDirectory = ref('');
+const systemPrompt = ref('');
 const loading = ref(false);
 const error = ref(null);
 
@@ -57,6 +76,7 @@ async function handleSubmit() {
     const project = await projectsStore.createProject({
       name: name.value,
       workingDirectory: workingDirectory.value,
+      systemPrompt: systemPrompt.value || undefined,
     });
     uiStore.success('Project created successfully');
     router.push(`/projects/${project.id}/sessions`);
@@ -86,5 +106,34 @@ h1 {
 .error-message {
   color: var(--color-error);
   margin-bottom: 1rem;
+}
+
+.advanced-settings {
+  margin-bottom: 1rem;
+}
+
+.advanced-settings summary {
+  cursor: pointer;
+  color: var(--color-primary);
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+.advanced-settings[open] summary {
+  margin-bottom: 1rem;
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 120px;
+  font-family: monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.form-help {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
 }
 </style>


### PR DESCRIPTION
## Summary

- Adds a configurable system prompt field to project settings, allowing users to customize the AI agent's behavior
- Replaces the restrictive `claude_code` SDK preset with a custom system prompt when configured
- Fixes the "limited shell environment" issue where the agent would refuse commands like `ps`

## Changes

- **Database**: Added `system_prompt` column to projects table with migration for existing DBs
- **Backend**: Updated ProjectRepository, projects API, sessions API, and sessionManager to handle system prompts
- **Frontend**: Added system prompt textarea to Project Edit and New Project views
- **Default prompt**: Grants full shell access for coding tasks

## Test plan

- [ ] Create new project with default system prompt
- [ ] Create new project with custom system prompt
- [ ] Edit existing project to add/modify system prompt
- [ ] Verify agent has full shell access (can run `ps`, etc.)
- [ ] Verify existing projects still work (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)