### PR TITLE
Add stop/resume session functionality

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -69,7 +69,7 @@ router.post('/:id/message', async (req, res) => {
     return res.status(400).json({ error: 'Content is required' });
   }
 
-  if (session.status !== 'waiting') {
+  if (session.status !== 'waiting' && session.status !== 'stopped') {
     return res.status(400).json({ error: 'Session is not waiting for input' });
   }
 
@@ -100,7 +100,9 @@ router.post('/:id/stop', async (req, res) => {
     return res.status(404).json({ error: 'Session not found' });
   }
 
-  if (session.status !== 'running' && session.status !== 'waiting') {
+  // Allow stopping running, waiting, or stuck sessions (crashed sessions may be stuck in 'running')
+  // Don't allow stopping already completed or errored sessions
+  if (session.status === 'completed' || session.status === 'error' || session.status === 'stopped') {
     return res.status(400).json({ error: 'Session is not active' });
   }
 

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY,
   project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'starting' CHECK (status IN ('starting', 'running', 'waiting', 'completed', 'error')),
+  status TEXT NOT NULL DEFAULT 'starting' CHECK (status IN ('starting', 'running', 'waiting', 'stopped', 'completed', 'error')),
   mode TEXT NOT NULL DEFAULT 'standard' CHECK (mode IN ('plan', 'standard', 'yolo')),
   thinking_enabled INTEGER NOT NULL DEFAULT 0,
   git_branch TEXT,

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -236,18 +236,22 @@ export async function continueSession(sessionId, content, workingDirectory, syst
 }
 
 /**
- * Stop a running session
+ * Stop a running or waiting session
  * @param {string} sessionId
  */
 export async function stopSession(sessionId) {
   const sessionData = activeSessions.get(sessionId);
-  if (!sessionData) {
-    throw new Error('Session is not active');
-  }
 
-  sessionData.controller.abort();
-  sessions.update(sessionId, { status: 'completed' });
-  broadcastSessionStatus(sessionId, 'completed');
+  if (sessionData) {
+    // Session is actively processing - abort it
+    sessionData.controller.abort();
+    activeSessions.delete(sessionId);
+  }
+  // If not in activeSessions, session may have crashed or be waiting
+  // Either way, we can still update the status to stopped
+
+  sessions.update(sessionId, { status: 'stopped' });
+  broadcastSessionStatus(sessionId, 'stopped');
 }
 
 /**

--- a/packages/shared/src/types.js
+++ b/packages/shared/src/types.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {'starting' | 'running' | 'waiting' | 'completed' | 'error'} SessionStatus
+ * @typedef {'starting' | 'running' | 'waiting' | 'stopped' | 'completed' | 'error'} SessionStatus
  */
 
 /**
@@ -97,7 +97,7 @@
  * @property {number} updatedAt
  */
 
-export const SESSION_STATUSES = ['starting', 'running', 'waiting', 'completed', 'error'];
+export const SESSION_STATUSES = ['starting', 'running', 'waiting', 'stopped', 'completed', 'error'];
 export const SESSION_MODES = ['plan', 'standard', 'yolo'];
 export const MESSAGE_ROLES = ['user', 'assistant', 'system'];
 export const CANVAS_ITEM_TYPES = ['image', 'markdown', 'text', 'json'];

--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -193,6 +193,11 @@ input, textarea, select {
   color: var(--color-text-soft);
 }
 
+.status-stopped {
+  background-color: rgba(245, 158, 11, 0.2);
+  color: #f59e0b;
+}
+
 .status-error {
   background-color: rgba(248, 81, 73, 0.2);
   color: var(--color-error);

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -42,11 +42,16 @@
       </button>
     </div>
 
+    <div v-if="isStopped" class="status-message status-stopped">
+      <span class="stopped-icon">⏸</span>
+      Session stopped - send a message to resume
+    </div>
+
     <form v-if="canSendMessage" @submit.prevent="handleSend" class="input-form">
       <textarea
         v-model="input"
         class="form-input form-textarea"
-        placeholder="Send a follow-up message..."
+        :placeholder="isStopped ? 'Send a message to resume session...' : 'Send a follow-up message...'"
         rows="3"
         @keydown.enter.ctrl="handleSend"
       ></textarea>
@@ -114,7 +119,12 @@ const SCROLL_THRESHOLD = 100; // pixels from bottom to consider "at bottom"
 const STORAGE_KEY = `session-draft-${props.sessionId}`;
 
 const canSendMessage = computed(() => {
-  return sessionsStore.currentSession?.status === 'waiting';
+  const status = sessionsStore.currentSession?.status;
+  return status === 'waiting' || status === 'stopped';
+});
+
+const isStopped = computed(() => {
+  return sessionsStore.currentSession?.status === 'stopped';
 });
 
 // Subscribe to partial messages for streaming
@@ -447,6 +457,17 @@ async function handleThinkingToggle(event) {
 
 .status-completed {
   color: var(--color-success, #10b981);
+}
+
+.status-stopped {
+  color: var(--color-warning, #f59e0b);
+  background-color: rgba(245, 158, 11, 0.1);
+  border-radius: var(--border-radius);
+  margin-bottom: 0.5rem;
+}
+
+.stopped-icon {
+  font-size: 1rem;
 }
 
 .jump-to-latest {

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -105,7 +105,11 @@ export const useSessionsStore = defineStore('sessions', {
       try {
         await api.stopSession(id);
         if (this.currentSession?.id === id) {
-          this.currentSession.status = 'completed';
+          this.currentSession.status = 'stopped';
+        }
+        const session = this.sessions.find((s) => s.id === id);
+        if (session) {
+          session.status = 'stopped';
         }
       } catch (err) {
         this.error = err.message;

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -24,7 +24,7 @@
         </div>
         <div class="session-actions">
           <button
-            v-if="isActive"
+            v-if="canStop"
             class="btn btn-danger"
             @click="handleStop"
           >
@@ -115,6 +115,12 @@ const showDeleteConfirm = ref(false);
 const activeTab = computed(() => route.params.tab || 'conversation');
 const isActive = computed(() => {
   const status = sessionsStore.currentSession?.status;
+  return status === 'running' || status === 'waiting' || status === 'stopped';
+});
+
+const canStop = computed(() => {
+  const status = sessionsStore.currentSession?.status;
+  // Can stop running or waiting sessions, but not already stopped ones
   return status === 'running' || status === 'waiting';
 });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -113,10 +113,6 @@ const uiStore = useUiStore();
 const showDeleteConfirm = ref(false);
 
 const activeTab = computed(() => route.params.tab || 'conversation');
-const isActive = computed(() => {
-  const status = sessionsStore.currentSession?.status;
-  return status === 'running' || status === 'waiting' || status === 'stopped';
-});
 
 const canStop = computed(() => {
   const status = sessionsStore.currentSession?.status;


### PR DESCRIPTION
## Summary
- Add 'stopped' session status to allow sessions to be stopped and later resumed
- Fix `stopSession()` to handle crashed sessions that are stuck in 'running' status  
- Enable message sending for stopped sessions to resume them
- Add visual indicator and updated placeholder text for stopped sessions

## Problem
Previously, clicking "Stop Session" on a crashed or waiting session would fail with "Session is not active" because the session wasn't in the `activeSessions` map. Sessions that crashed would get stuck in 'running' status with no way to recover.

## Solution
- Added new `stopped` status that indicates user-interrupted sessions
- Modified `stopSession()` to no longer require the session to be in `activeSessions` - it now works for crashed/stuck sessions
- Allow sending messages to `stopped` sessions to resume them
- Added UI feedback showing "Session stopped - send a message to resume"

## Test plan
- [ ] Create a session and let it run
- [ ] Click "Stop Session" while session is running - should stop and show stopped status
- [ ] Send a message to resume the stopped session
- [ ] Verify crashed sessions (stuck in 'running') can now be stopped
- [ ] Verify stopped sessions show proper UI indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)