### PR TITLE
Fix: preserve PATH when thinking mode is enabled

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -66,12 +66,14 @@ For images, use base64 encoding in the content field.`;
  * @returns {Object|undefined}
  */
 function buildSessionEnv(session) {
-  const env = {};
-  if (session.thinkingEnabled) {
-    // Enable extended thinking with a reasonable token budget
-    env.MAX_THINKING_TOKENS = '10240';
+  if (!session.thinkingEnabled) {
+    return undefined; // Let SDK use process.env by default
   }
-  return Object.keys(env).length > 0 ? env : undefined;
+  // Merge with process.env to preserve PATH and other essential env vars
+  return {
+    ...process.env,
+    MAX_THINKING_TOKENS: '10240',
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed bug where enabling thinking mode wiped out the `PATH` environment variable
- `buildSessionEnv()` was returning only `{ MAX_THINKING_TOKENS: '10240' }` which replaced the entire environment
- Commands like `ps`, `ls`, `head`, `grep` etc. failed with "No such file or directory"
- Now properly merges with `process.env` to preserve all essential environment variables

## Root Cause
When the Claude SDK receives an `env` option, it uses it as the **entire** environment (sdk.mjs line 15250-15252):
```javascript
let processEnv = env;
if (!processEnv) {
  processEnv = { ...process.env };
}
```

The old `buildSessionEnv()` created a minimal object without PATH, which replaced process.env entirely.

## Test plan
- [ ] Start a session with thinking mode enabled
- [ ] Run shell commands like `ps aux` or `ls -la`
- [ ] Verify commands execute successfully (previously they would fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)