### PR TITLE
Make send button larger for tablet touch targets

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -64,7 +64,7 @@
           <span class="toggle-label">Thinking</span>
         </div>
         <div class="input-actions">
-          <button type="submit" class="btn btn-primary" :disabled="!input.trim() || sending">
+          <button type="submit" class="btn btn-primary btn-send" :disabled="!input.trim() || sending">
             <span v-if="sending" class="loading-spinner"></span>
             Send
           </button>
@@ -424,6 +424,14 @@ async function handleThinkingToggle(event) {
 .input-actions {
   display: flex;
   gap: 0.5rem;
+}
+
+.btn-send {
+  min-width: 100px;
+  min-height: 48px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 .btn-secondary {


### PR DESCRIPTION
## Summary
- Increase the send button size in the conversation tab to meet recommended touch target guidelines (48px minimum height) for better tablet usability
- Added `btn-send` class with larger padding (0.75rem x 1.5rem), minimum width (100px), and bolder font weight

## Test plan
- [ ] Verify send button is visually larger on the session detail conversation tab
- [ ] Test on tablet or tablet emulator to confirm easy touch targeting
- [ ] Verify send button still functions correctly (sends messages when clicked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)