### PR TITLE
Add collapse/expand all button to Changes tab

### DIFF
--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -14,14 +14,20 @@
     </div>
 
     <template v-else>
+      <div class="changes-toolbar">
+        <button class="btn-link" @click="toggleAllFiles">
+          {{ allExpanded ? 'Collapse All' : 'Expand All' }}
+        </button>
+      </div>
+
       <div v-if="stagedFiles.length > 0" class="diff-section">
         <h3>Staged Changes</h3>
-        <DiffViewer :files="stagedFiles" />
+        <DiffViewer ref="stagedDiffViewer" :files="stagedFiles" />
       </div>
 
       <div v-if="unstagedFiles.length > 0" class="diff-section">
         <h3>Unstaged Changes</h3>
-        <DiffViewer :files="unstagedFiles" />
+        <DiffViewer ref="unstagedDiffViewer" :files="unstagedFiles" />
       </div>
 
       <div v-if="untracked.length > 0" class="diff-section">
@@ -51,10 +57,25 @@ const unstaged = ref('');
 const untracked = ref([]);
 const loading = ref(false);
 const error = ref(null);
+const allExpanded = ref(true);
+
+const stagedDiffViewer = ref(null);
+const unstagedDiffViewer = ref(null);
 
 const stagedFiles = computed(() => parseDiff(staged.value));
 const unstagedFiles = computed(() => parseDiff(unstaged.value));
 const hasChanges = computed(() => staged.value || unstaged.value || untracked.value.length > 0);
+
+function toggleAllFiles() {
+  if (allExpanded.value) {
+    stagedDiffViewer.value?.collapseAll();
+    unstagedDiffViewer.value?.collapseAll();
+  } else {
+    stagedDiffViewer.value?.expandAll();
+    unstagedDiffViewer.value?.expandAll();
+  }
+  allExpanded.value = !allExpanded.value;
+}
 
 async function fetchChanges() {
   loading.value = true;
@@ -100,6 +121,25 @@ onMounted(() => {
   text-align: center;
   padding: 2rem;
   color: var(--color-text-soft);
+}
+
+.changes-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.btn-link:hover {
+  text-decoration: underline;
 }
 
 .diff-section {

--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -77,6 +77,23 @@ function toggleFile(index) {
   expandedFiles.value[index] = !expandedFiles.value[index];
 }
 
+function collapseAll() {
+  props.files.forEach((_, index) => {
+    expandedFiles.value[index] = false;
+  });
+}
+
+function expandAll() {
+  props.files.forEach((_, index) => {
+    expandedFiles.value[index] = true;
+  });
+}
+
+defineExpose({
+  collapseAll,
+  expandAll,
+});
+
 function getLinePrefix(type) {
   switch (type) {
     case 'addition':

--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -77,21 +77,21 @@ function toggleFile(index) {
   expandedFiles.value[index] = !expandedFiles.value[index];
 }
 
-function collapseAll() {
+function collapseAllFiles() {
   props.files.forEach((_, index) => {
     expandedFiles.value[index] = false;
   });
 }
 
-function expandAll() {
+function expandAllFiles() {
   props.files.forEach((_, index) => {
     expandedFiles.value[index] = true;
   });
 }
 
 defineExpose({
-  collapseAll,
-  expandAll,
+  collapseAll: collapseAllFiles,
+  expandAll: expandAllFiles,
 });
 
 function getLinePrefix(type) {


### PR DESCRIPTION
## Summary
- Add a "Collapse All" / "Expand All" toggle button to the Changes tab in the session detail view
- Button appears above the first file in the diff when there are changes to display
- Toggles all file diffs in both staged and unstaged sections simultaneously

## Test plan
- [ ] Navigate to a session with git changes
- [ ] Verify the "Collapse All" button appears above the staged/unstaged sections
- [ ] Click "Collapse All" and verify all file diffs collapse
- [ ] Verify button text changes to "Expand All"
- [ ] Click "Expand All" and verify all file diffs expand
- [ ] Verify individual file toggle still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)