### PR TITLE
feat: Display Claude's work logs as it works

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { sessions, messages, sessionNotes, projects } from '../database.js';
+import { sessions, messages, sessionNotes, projects, workLogs } from '../database.js';
 import { continueSession, stopSession, endSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges } from '../services/diffService.js';
 import { broadcastToSession } from '../websocket.js';
@@ -55,6 +55,18 @@ router.get('/:id/messages', (req, res) => {
 
   const sessionMessages = messages.getBySessionId(req.params.id);
   res.json(sessionMessages);
+});
+
+// GET /api/sessions/:id/work-logs - Get work logs for session
+router.get('/:id/work-logs', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  // Return work logs grouped by message ID
+  const grouped = workLogs.getBySessionIdGrouped(req.params.id);
+  res.json(grouped);
 });
 
 // POST /api/sessions/:id/message - Send follow-up message

--- a/packages/server/src/database.js
+++ b/packages/server/src/database.js
@@ -8,6 +8,7 @@ export {
   MessageRepository,
   CanvasItemRepository,
   SessionNoteRepository,
+  WorkLogRepository,
   // Singleton instances
   databaseManager,
   projects,
@@ -15,6 +16,7 @@ export {
   messages,
   canvasItems,
   sessionNotes,
+  workLogs,
   // Legacy functions
   initDatabase,
   getDatabase,

--- a/packages/server/src/db/WorkLogRepository.js
+++ b/packages/server/src/db/WorkLogRepository.js
@@ -1,0 +1,105 @@
+import { BaseRepository } from './BaseRepository.js';
+import { databaseManager } from './DatabaseManager.js';
+
+/**
+ * Work log repository class
+ */
+export class WorkLogRepository extends BaseRepository {
+  constructor() {
+    super('work_logs', WorkLogRepository.#mapWorkLog);
+  }
+
+  static #mapWorkLog(row) {
+    return {
+      id: row.id,
+      sessionId: row.session_id,
+      messageId: row.message_id,
+      type: row.type,
+      toolName: row.tool_name,
+      content: row.content,
+      timestamp: row.timestamp,
+    };
+  }
+
+  /**
+   * Create a new work log entry
+   * @param {string} sessionId - Session ID
+   * @param {string} type - Log type ('thinking', 'tool_input', 'tool_output')
+   * @param {string} content - Log content
+   * @param {string|null} messageId - Associated message ID
+   * @param {string|null} toolName - Tool name for tool-related logs
+   * @returns {Object} Created work log
+   */
+  create(sessionId, type, content, messageId = null, toolName = null) {
+    const id = databaseManager.generateId();
+    const now = Date.now();
+    this.db
+      .prepare(
+        `INSERT INTO work_logs (id, session_id, message_id, type, tool_name, content, timestamp)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(id, sessionId, messageId, type, toolName, content, now);
+    return this.getById(id);
+  }
+
+  /**
+   * Get all work logs for a session
+   * @param {string} sessionId - Session ID
+   * @returns {Array} Work logs ordered by timestamp
+   */
+  getBySessionId(sessionId) {
+    const rows = this.db
+      .prepare('SELECT * FROM work_logs WHERE session_id = ? ORDER BY timestamp ASC')
+      .all(sessionId);
+    return this.mapAll(rows);
+  }
+
+  /**
+   * Get work logs for a specific message
+   * @param {string} messageId - Message ID
+   * @returns {Array} Work logs for the message
+   */
+  getByMessageId(messageId) {
+    const rows = this.db
+      .prepare('SELECT * FROM work_logs WHERE message_id = ? ORDER BY timestamp ASC')
+      .all(messageId);
+    return this.mapAll(rows);
+  }
+
+  /**
+   * Get work logs grouped by message for a session
+   * @param {string} sessionId - Session ID
+   * @returns {Object} Work logs keyed by message ID
+   */
+  getBySessionIdGrouped(sessionId) {
+    const logs = this.getBySessionId(sessionId);
+    const grouped = {};
+    for (const log of logs) {
+      const key = log.messageId || '_unassociated';
+      if (!grouped[key]) {
+        grouped[key] = [];
+      }
+      grouped[key].push(log);
+    }
+    return grouped;
+  }
+
+  /**
+   * Update the message ID for work logs (used when associating pending logs with a message)
+   * @param {string} sessionId - Session ID
+   * @param {string} messageId - Message ID to associate
+   */
+  associatePendingLogs(sessionId, messageId) {
+    this.db
+      .prepare('UPDATE work_logs SET message_id = ? WHERE session_id = ? AND message_id IS NULL')
+      .run(messageId, sessionId);
+  }
+
+  /**
+   * Delete all work logs for a session
+   * @param {string} sessionId - Session ID
+   */
+  deleteBySessionId(sessionId) {
+    this.db.prepare('DELETE FROM work_logs WHERE session_id = ?').run(sessionId);
+  }
+}

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -10,17 +10,20 @@ export { SessionRepository } from './SessionRepository.js';
 export { MessageRepository } from './MessageRepository.js';
 export { CanvasItemRepository } from './CanvasItemRepository.js';
 export { SessionNoteRepository } from './SessionNoteRepository.js';
+export { WorkLogRepository } from './WorkLogRepository.js';
 
 // Singleton instances
 import { ProjectRepository } from './ProjectRepository.js';
 import { MessageRepository } from './MessageRepository.js';
 import { CanvasItemRepository } from './CanvasItemRepository.js';
 import { SessionNoteRepository } from './SessionNoteRepository.js';
+import { WorkLogRepository } from './WorkLogRepository.js';
 
 export const projects = new ProjectRepository();
 export const messages = new MessageRepository();
 export const canvasItems = new CanvasItemRepository();
 export const sessionNotes = new SessionNoteRepository();
+export const workLogs = new WorkLogRepository();
 
 // SessionRepository needs to be instantiated after messages is available
 import { SessionRepository } from './SessionRepository.js';

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -82,6 +82,17 @@ CREATE TABLE IF NOT EXISTS project_tool_templates (
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );
 
+-- Work logs (thinking, command outputs, tool executions)
+CREATE TABLE IF NOT EXISTS work_logs (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  message_id TEXT REFERENCES conversation_messages(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN ('thinking', 'tool_input', 'tool_output')),
+  tool_name TEXT,                -- Tool name for tool_input/tool_output types
+  content TEXT NOT NULL,         -- The actual log content
+  timestamp INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+);
+
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
@@ -89,3 +100,5 @@ CREATE INDEX IF NOT EXISTS idx_messages_session ON conversation_messages(session
 CREATE INDEX IF NOT EXISTS idx_canvas_session ON canvas_items(session_id);
 CREATE INDEX IF NOT EXISTS idx_notes_session ON session_notes(session_id);
 CREATE INDEX IF NOT EXISTS idx_project_tools ON project_tool_templates(project_id);
+CREATE INDEX IF NOT EXISTS idx_work_logs_session ON work_logs(session_id);
+CREATE INDEX IF NOT EXISTS idx_work_logs_message ON work_logs(message_id);

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -1,7 +1,10 @@
 import { query } from '@anthropic-ai/claude-agent-sdk';
-import { sessions, messages } from '../database.js';
+import { sessions, messages, workLogs } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT, DEFAULT_SYSTEM_PROMPT } from '@claudetools/shared';
+
+/** @type {Map<string, string|null>} Track current message ID for work log association */
+const currentMessageIds = new Map();
 
 /** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
@@ -288,6 +291,23 @@ export function cleanupActiveSession(sessionId) {
 }
 
 /**
+ * Create and broadcast a work log entry
+ * @param {string} sessionId
+ * @param {string} type - 'thinking', 'tool_input', or 'tool_output'
+ * @param {string} content
+ * @param {string|null} toolName
+ */
+function createWorkLog(sessionId, type, content, toolName = null) {
+  const messageId = currentMessageIds.get(sessionId) || null;
+  const log = workLogs.create(sessionId, type, content, messageId, toolName);
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_WORK_LOG, {
+    sessionId,
+    log
+  });
+  return log;
+}
+
+/**
  * Handle a stream event from Claude SDK
  * @param {string} sessionId
  * @param {Object} event
@@ -301,6 +321,8 @@ async function handleStreamEvent(sessionId, event) {
           claudeSessionId: event.session_id,
           model: event.model,
         });
+        // Reset message tracking for new session
+        currentMessageIds.set(sessionId, null);
       }
       break;
     }
@@ -312,23 +334,79 @@ async function handleStreamEvent(sessionId, event) {
         ?.map((c) => c.text)
         ?.join('\n');
 
+      // Extract thinking content
+      const thinkingContent = event.message?.content
+        ?.filter((c) => c.type === 'thinking')
+        ?.map((c) => c.thinking)
+        ?.join('\n');
+
+      // Extract tool use for logging
+      const toolUseBlocks = event.message?.content?.filter((c) => c.type === 'tool_use') || [];
+
       if (textContent) {
-        const toolUse = event.message?.content?.filter((c) => c.type === 'tool_use') || null;
+        const toolUse = toolUseBlocks.length > 0 ? toolUseBlocks : null;
         const message = messages.create(sessionId, 'assistant', textContent, toolUse);
+
+        // Update current message ID for work log association
+        currentMessageIds.set(sessionId, message.id);
+
+        // Associate any pending work logs with this message
+        workLogs.associatePendingLogs(sessionId, message.id);
+
         broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, { message });
+      }
+
+      // Log thinking content
+      if (thinkingContent) {
+        createWorkLog(sessionId, 'thinking', thinkingContent);
+      }
+
+      // Log tool use inputs
+      for (const toolUse of toolUseBlocks) {
+        const toolInput = JSON.stringify(toolUse.input, null, 2);
+        createWorkLog(sessionId, 'tool_input', toolInput, toolUse.name);
+      }
+      break;
+    }
+
+    case 'tool_result': {
+      // Log tool results/outputs
+      const content = event.content || event.result || '';
+      const toolName = event.tool_name || event.name || 'unknown';
+
+      // Handle different content formats
+      let logContent;
+      if (typeof content === 'string') {
+        logContent = content;
+      } else if (Array.isArray(content)) {
+        logContent = content
+          .map((c) => (c.type === 'text' ? c.text : JSON.stringify(c)))
+          .join('\n');
+      } else {
+        logContent = JSON.stringify(content, null, 2);
+      }
+
+      if (logContent) {
+        createWorkLog(sessionId, 'tool_output', logContent, toolName);
       }
       break;
     }
 
     case 'stream_event': {
       // Real-time streaming - handle content_block_delta events
-      if (event.event?.type === 'content_block_delta' && event.event?.delta?.type === 'text_delta') {
-        const partialText = event.event.delta.text;
-        if (partialText) {
+      if (event.event?.type === 'content_block_delta') {
+        const delta = event.event.delta;
+
+        if (delta?.type === 'text_delta' && delta.text) {
           broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_PARTIAL, {
             sessionId,
-            text: partialText,
+            text: delta.text,
           });
+        }
+
+        // Handle thinking delta for real-time thinking updates
+        if (delta?.type === 'thinking_delta' && delta.thinking) {
+          createWorkLog(sessionId, 'thinking', delta.thinking);
         }
       }
       break;
@@ -344,6 +422,8 @@ async function handleStreamEvent(sessionId, event) {
           sessions.update(sessionId, { costUsd: event.total_cost_usd });
         }
       }
+      // Clear message tracking when session completes
+      currentMessageIds.delete(sessionId);
       break;
     }
   }

--- a/packages/shared/src/protocol.js
+++ b/packages/shared/src/protocol.js
@@ -13,6 +13,7 @@ export const WS_MESSAGE_TYPES = {
   SESSION_PARTIAL: 'session:partial',
   SESSION_ERROR: 'session:error',
   SESSION_DELETED: 'session:deleted',
+  SESSION_WORK_LOG: 'session:work_log',
   CANVAS_ADD: 'canvas:add',
   CANVAS_REMOVE: 'canvas:remove',
 };

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -148,6 +148,15 @@ export class ApiClient {
   }
 
   /**
+   * Get work logs for a session (grouped by message ID)
+   * @param {string} sessionId - Session ID
+   * @returns {Promise<Object>} Work logs grouped by message ID
+   */
+  async getSessionWorkLogs(sessionId) {
+    return this.#request('GET', `/sessions/${sessionId}/work-logs`);
+  }
+
+  /**
    * Send a message to a session
    * @param {string} sessionId - Session ID
    * @param {string} content - Message content

--- a/packages/web/src/components/CommandBlock.vue
+++ b/packages/web/src/components/CommandBlock.vue
@@ -1,0 +1,155 @@
+<template>
+  <div class="command-block" :class="`command-${log.type}`">
+    <div class="command-header">
+      <span class="command-icon">
+        <svg v-if="log.type === 'tool_input'" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="4 17 10 11 4 5"/>
+          <line x1="12" y1="19" x2="20" y2="19"/>
+        </svg>
+        <svg v-else xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="16 18 22 12 16 6"/>
+          <polyline points="8 6 2 12 8 18"/>
+        </svg>
+      </span>
+      <span class="command-label">{{ log.type === 'tool_input' ? 'Input' : 'Output' }}</span>
+      <span v-if="log.toolName" class="command-tool-name">{{ log.toolName }}</span>
+      <span v-if="log.timestamp" class="command-time">{{ formatTime(log.timestamp) }}</span>
+    </div>
+    <div class="command-content">
+      <pre class="command-pre" :class="{ expanded: isExpanded }">{{ displayContent }}</pre>
+      <button v-if="shouldTruncate && !isExpanded" class="show-more-btn" @click="isExpanded = true">
+        Show more ({{ lineCount }} lines)
+      </button>
+      <button v-if="isExpanded && shouldTruncate" class="show-more-btn" @click="isExpanded = false">
+        Show less
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  log: { type: Object, required: true },
+});
+
+const MAX_LINES = 10;
+const isExpanded = ref(false);
+
+const lines = computed(() => props.log.content.split('\n'));
+const lineCount = computed(() => lines.value.length);
+const shouldTruncate = computed(() => lineCount.value > MAX_LINES);
+
+const displayContent = computed(() => {
+  if (isExpanded.value || !shouldTruncate.value) {
+    return props.log.content;
+  }
+  return lines.value.slice(0, MAX_LINES).join('\n') + '\n...';
+});
+
+function formatTime(ts) {
+  return new Date(ts).toLocaleTimeString();
+}
+</script>
+
+<style scoped>
+.command-block {
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.625rem;
+  font-size: 0.8125rem;
+}
+
+.command-tool_input {
+  border-left: 3px solid var(--color-warning, #d29922);
+}
+
+.command-tool_output {
+  border-left: 3px solid var(--color-success, #3fb950);
+}
+
+.command-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
+}
+
+.command-icon {
+  display: flex;
+  align-items: center;
+  opacity: 0.7;
+}
+
+.command-tool_input .command-icon {
+  color: var(--color-warning, #d29922);
+}
+
+.command-tool_output .command-icon {
+  color: var(--color-success, #3fb950);
+}
+
+.command-label {
+  font-weight: 500;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  color: var(--color-text-soft);
+}
+
+.command-tool-name {
+  background: var(--color-background-mute);
+  padding: 0.125rem 0.375rem;
+  border-radius: 3px;
+  font-size: 0.6875rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--color-text);
+}
+
+.command-time {
+  margin-left: auto;
+  font-size: 0.6875rem;
+  color: var(--color-text-soft);
+}
+
+.command-content {
+  position: relative;
+}
+
+.command-pre {
+  margin: 0;
+  padding: 0.5rem;
+  background: var(--color-background);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-family: var(--font-mono, 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text);
+  line-height: 1.4;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.command-pre.expanded {
+  max-height: none;
+}
+
+.show-more-btn {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0.25rem 0;
+  font-size: 0.75rem;
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
+.show-more-btn:hover {
+  opacity: 1;
+}
+</style>

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -2,7 +2,7 @@
   <div class="conversation-tab">
     <div class="messages" ref="messagesContainer">
       <div
-        v-for="message in sessionsStore.messages"
+        v-for="(message, index) in sessionsStore.messages"
         :key="message.id"
         :class="['message', `message-${message.role}`]"
       >
@@ -17,6 +17,12 @@
             <pre>{{ JSON.stringify(tool.input, null, 2) }}</pre>
           </details>
         </div>
+        <!-- Work Log Panel for assistant messages -->
+        <WorkLogPanel
+          v-if="message.role === 'assistant'"
+          :work-logs="sessionsStore.getWorkLogsForMessage(message.id)"
+          :is-latest-message="index === sessionsStore.messages.length - 1"
+        />
       </div>
 
       <!-- Streaming partial message -->
@@ -96,6 +102,7 @@ import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
+import WorkLogPanel from './WorkLogPanel.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -127,10 +134,11 @@ const isStopped = computed(() => {
   return sessionsStore.currentSession?.status === 'stopped';
 });
 
-// Subscribe to partial messages for streaming
-const { onPartial, onMessage } = useSessionSubscription(props.sessionId);
+// Subscribe to partial messages for streaming and work logs
+const { onPartial, onMessage, onWorkLog } = useSessionSubscription(props.sessionId);
 let unsubPartial = null;
 let unsubMessage = null;
+let unsubWorkLog = null;
 
 function handleScroll() {
   if (!messagesContainer.value) return;
@@ -144,7 +152,7 @@ function handleScroll() {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   // Load draft from localStorage
   const savedDraft = localStorage.getItem(STORAGE_KEY);
   if (savedDraft) {
@@ -166,6 +174,15 @@ onMounted(() => {
     partialText.value = '';
   });
 
+  // Subscribe to work log updates
+  unsubWorkLog = onWorkLog((log) => {
+    sessionsStore.addWorkLog(log);
+    scrollToBottom();
+  });
+
+  // Fetch initial work logs
+  await sessionsStore.fetchWorkLogs(props.sessionId);
+
   // Scroll to bottom on initial load
   scrollToBottom(true);
 });
@@ -173,10 +190,13 @@ onMounted(() => {
 onUnmounted(() => {
   if (unsubPartial) unsubPartial();
   if (unsubMessage) unsubMessage();
+  if (unsubWorkLog) unsubWorkLog();
   if (debounceTimer) clearTimeout(debounceTimer);
   if (messagesContainer.value) {
     messagesContainer.value.removeEventListener('scroll', handleScroll);
   }
+  // Clear work logs when leaving the conversation
+  sessionsStore.clearWorkLogs();
 });
 
 // Save draft to localStorage with debounce

--- a/packages/web/src/components/ThinkingBlock.vue
+++ b/packages/web/src/components/ThinkingBlock.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="thinking-block">
+    <div class="thinking-header">
+      <span class="thinking-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"/>
+          <path d="M12 16v-4"/>
+          <path d="M12 8h.01"/>
+        </svg>
+      </span>
+      <span class="thinking-label">Thinking</span>
+      <span v-if="timestamp" class="thinking-time">{{ formatTime(timestamp) }}</span>
+    </div>
+    <div class="thinking-content" :class="{ expanded: isExpanded }">
+      <div class="thinking-text">{{ displayContent }}</div>
+      <button v-if="shouldTruncate && !isExpanded" class="show-more-btn" @click="isExpanded = true">
+        Show more...
+      </button>
+      <button v-if="isExpanded && shouldTruncate" class="show-more-btn" @click="isExpanded = false">
+        Show less
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  content: { type: String, required: true },
+  timestamp: { type: Number, default: null },
+});
+
+const MAX_LENGTH = 500;
+const isExpanded = ref(false);
+
+const shouldTruncate = computed(() => props.content.length > MAX_LENGTH);
+
+const displayContent = computed(() => {
+  if (isExpanded.value || !shouldTruncate.value) {
+    return props.content;
+  }
+  return props.content.slice(0, MAX_LENGTH) + '...';
+});
+
+function formatTime(ts) {
+  return new Date(ts).toLocaleTimeString();
+}
+</script>
+
+<style scoped>
+.thinking-block {
+  background: rgba(88, 166, 255, 0.08);
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  border-radius: 6px;
+  padding: 0.625rem;
+  font-size: 0.8125rem;
+}
+
+.thinking-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-primary);
+}
+
+.thinking-icon {
+  display: flex;
+  align-items: center;
+  opacity: 0.8;
+}
+
+.thinking-label {
+  font-weight: 500;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.thinking-time {
+  margin-left: auto;
+  font-size: 0.6875rem;
+  color: var(--color-text-soft);
+  font-weight: normal;
+}
+
+.thinking-content {
+  color: var(--color-text-soft);
+  line-height: 1.5;
+}
+
+.thinking-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-style: italic;
+}
+
+.show-more-btn {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0.25rem 0;
+  font-size: 0.75rem;
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
+.show-more-btn:hover {
+  opacity: 1;
+}
+</style>

--- a/packages/web/src/components/WorkLogPanel.vue
+++ b/packages/web/src/components/WorkLogPanel.vue
@@ -1,0 +1,136 @@
+<template>
+  <div v-if="workLogs?.length" class="work-log-panel">
+    <details :open="isExpanded" ref="detailsRef" @toggle="handleToggle">
+      <summary class="work-log-header">
+        <span class="work-log-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+          </svg>
+        </span>
+        <span class="work-log-title">Work Log</span>
+        <span class="work-log-count">({{ workLogs.length }})</span>
+        <span class="work-log-chevron" :class="{ expanded: isExpanded }">
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="9 18 15 12 9 6"/>
+          </svg>
+        </span>
+      </summary>
+      <div class="work-log-content">
+        <div v-for="log in workLogs" :key="log.id" class="work-log-item">
+          <ThinkingBlock v-if="log.type === 'thinking'" :content="log.content" :timestamp="log.timestamp" />
+          <CommandBlock v-else :log="log" />
+        </div>
+      </div>
+    </details>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import ThinkingBlock from './ThinkingBlock.vue';
+import CommandBlock from './CommandBlock.vue';
+
+const props = defineProps({
+  workLogs: { type: Array, default: () => [] },
+  isLatestMessage: { type: Boolean, default: false },
+});
+
+const detailsRef = ref(null);
+const manuallyToggled = ref(false);
+const isExpanded = ref(props.isLatestMessage);
+
+// Watch for changes in isLatestMessage to auto-collapse/expand
+watch(() => props.isLatestMessage, (newVal) => {
+  // Only auto-collapse if user hasn't manually interacted
+  if (!manuallyToggled.value) {
+    isExpanded.value = newVal;
+  }
+});
+
+// Watch for new work logs to expand panel for latest message
+watch(() => props.workLogs?.length, (newLen, oldLen) => {
+  if (props.isLatestMessage && newLen > (oldLen || 0)) {
+    isExpanded.value = true;
+  }
+});
+
+function handleToggle(event) {
+  manuallyToggled.value = true;
+  isExpanded.value = event.target.open;
+}
+</script>
+
+<style scoped>
+.work-log-panel {
+  margin-top: 0.75rem;
+  border-left: 2px solid var(--color-border);
+  padding-left: 0.75rem;
+}
+
+.work-log-header {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-soft);
+  padding: 0.25rem 0;
+  user-select: none;
+  list-style: none;
+}
+
+.work-log-header::-webkit-details-marker {
+  display: none;
+}
+
+.work-log-header:hover {
+  color: var(--color-text);
+}
+
+.work-log-icon {
+  display: flex;
+  align-items: center;
+  opacity: 0.7;
+}
+
+.work-log-title {
+  font-weight: 500;
+}
+
+.work-log-count {
+  opacity: 0.7;
+}
+
+.work-log-chevron {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  transition: transform 0.15s ease;
+}
+
+.work-log-chevron.expanded {
+  transform: rotate(90deg);
+}
+
+.work-log-content {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.work-log-item {
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -180,6 +180,16 @@ export function useSessionSubscription(sessionId) {
     return () => off(WS_MESSAGE_TYPES.SESSION_PARTIAL, handler);
   };
 
+  const onWorkLog = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId && msg.log) {
+        callback(msg.log);
+      }
+    };
+    on(WS_MESSAGE_TYPES.SESSION_WORK_LOG, handler);
+    return () => off(WS_MESSAGE_TYPES.SESSION_WORK_LOG, handler);
+  };
+
   // Auto-cleanup on unmount
   onUnmounted(() => {
     unsubscribe();
@@ -194,5 +204,6 @@ export function useSessionSubscription(sessionId) {
     onError,
     onCanvasAdd,
     onCanvasRemove,
+    onWorkLog,
   };
 }

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -7,6 +7,7 @@ export const useSessionsStore = defineStore('sessions', {
     activeSessions: [],
     currentSession: null,
     messages: [],
+    workLogs: {}, // Keyed by messageId: { [messageId]: WorkLog[] }
     loading: false,
     error: null,
   }),
@@ -14,6 +15,9 @@ export const useSessionsStore = defineStore('sessions', {
   getters: {
     getSessionById: (state) => (id) => {
       return state.sessions.find((s) => s.id === id);
+    },
+    getWorkLogsForMessage: (state) => (messageId) => {
+      return state.workLogs[messageId] || [];
     },
   },
 
@@ -152,6 +156,32 @@ export const useSessionsStore = defineStore('sessions', {
 
     addMessage(message) {
       this.messages.push(message);
+    },
+
+    async fetchWorkLogs(sessionId) {
+      this.error = null;
+      try {
+        const grouped = await api.getSessionWorkLogs(sessionId);
+        this.workLogs = grouped;
+      } catch (err) {
+        this.error = err.message;
+      }
+    },
+
+    addWorkLog(log) {
+      const messageId = log.messageId || '_unassociated';
+      if (!this.workLogs[messageId]) {
+        this.workLogs[messageId] = [];
+      }
+      this.workLogs[messageId].push(log);
+    },
+
+    setWorkLogs(workLogs) {
+      this.workLogs = workLogs;
+    },
+
+    clearWorkLogs() {
+      this.workLogs = {};
     },
 
     updateSessionStatus(sessionId, status) {


### PR DESCRIPTION
## Summary

- Adds a collapsible **Work Log** panel under each assistant message showing Claude's thinking and tool executions
- Captures thinking artifacts, tool inputs (parameters), and tool outputs (results) in real-time via WebSocket
- Auto-expands for the latest message, auto-collapses when new messages arrive
- Truncates long content with "Show more" buttons

## Changes

### Backend
- Added `work_logs` table to database schema
- Created `WorkLogRepository` for CRUD operations
- Added `SESSION_WORK_LOG` WebSocket message type
- Updated `sessionManager.js` to capture thinking blocks and tool events
- Added `GET /api/sessions/:id/work-logs` endpoint

### Frontend
- Created `WorkLogPanel.vue` - collapsible container for work logs
- Created `ThinkingBlock.vue` - displays thinking content with blue styling
- Created `CommandBlock.vue` - displays tool inputs/outputs with color coding
- Updated sessions store with `workLogs` state and actions
- Added `onWorkLog` handler to WebSocket composable
- Integrated `WorkLogPanel` into `ConversationTab.vue`

## Test plan

- [ ] Enable thinking mode and verify thinking blocks appear in work log
- [ ] Run a session with tool executions and verify inputs/outputs are logged
- [ ] Verify work log auto-expands for latest message
- [ ] Verify work log auto-collapses when new messages arrive
- [ ] Verify manual toggle is remembered (doesn't auto-collapse if user expanded)
- [ ] Verify "Show more" truncation works for long content
- [ ] Verify work logs persist and load correctly when revisiting a session

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)