### PR TITLE
Fix work log real-time updates and thinking message stacking

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -6,6 +6,9 @@ import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT, DEFAULT_SYSTEM_PROMPT } from '@c
 /** @type {Map<string, string|null>} Track current message ID for work log association */
 const currentMessageIds = new Map();
 
+/** @type {Map<string, string>} Accumulate thinking content per session */
+const thinkingAccumulators = new Map();
+
 /** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
 
@@ -351,9 +354,18 @@ async function handleStreamEvent(sessionId, event) {
         currentMessageIds.set(sessionId, message.id);
 
         // Associate any pending work logs with this message
-        workLogs.associatePendingLogs(sessionId, message.id);
+        const associatedCount = workLogs.associatePendingLogs(sessionId, message.id);
 
+        // Broadcast message first
         broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, { message });
+
+        // Notify client to re-associate work logs in their state
+        if (associatedCount > 0) {
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_WORK_LOGS_ASSOCIATED, {
+            sessionId,
+            messageId: message.id,
+          });
+        }
       }
 
       // Log thinking content
@@ -404,9 +416,33 @@ async function handleStreamEvent(sessionId, event) {
           });
         }
 
-        // Handle thinking delta for real-time thinking updates
+        // Handle thinking delta - accumulate and broadcast partial (don't create work log yet)
         if (delta?.type === 'thinking_delta' && delta.thinking) {
-          createWorkLog(sessionId, 'thinking', delta.thinking);
+          const current = thinkingAccumulators.get(sessionId) || '';
+          const accumulated = current + delta.thinking;
+          thinkingAccumulators.set(sessionId, accumulated);
+
+          // Broadcast partial thinking for real-time display
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_THINKING_PARTIAL, {
+            sessionId,
+            thinking: accumulated,
+          });
+        }
+      }
+
+      // Handle content_block_stop - finalize accumulated thinking
+      if (event.event?.type === 'content_block_stop') {
+        const accumulated = thinkingAccumulators.get(sessionId);
+        if (accumulated) {
+          // Create a single work log entry with the complete thinking content
+          createWorkLog(sessionId, 'thinking', accumulated);
+          thinkingAccumulators.delete(sessionId);
+
+          // Clear partial thinking on client
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_THINKING_PARTIAL, {
+            sessionId,
+            thinking: null,
+          });
         }
       }
       break;

--- a/packages/shared/src/protocol.js
+++ b/packages/shared/src/protocol.js
@@ -14,6 +14,8 @@ export const WS_MESSAGE_TYPES = {
   SESSION_ERROR: 'session:error',
   SESSION_DELETED: 'session:deleted',
   SESSION_WORK_LOG: 'session:work_log',
+  SESSION_WORK_LOGS_ASSOCIATED: 'session:work_logs_associated',
+  SESSION_THINKING_PARTIAL: 'session:thinking_partial',
   CANVAS_ADD: 'canvas:add',
   CANVAS_REMOVE: 'canvas:remove',
 };

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -25,6 +25,23 @@
         />
       </div>
 
+      <!-- Streaming thinking indicator -->
+      <div v-if="sessionsStore.partialThinking" class="message message-assistant message-streaming">
+        <div class="message-header">
+          <span class="message-role">assistant</span>
+          <span class="streaming-indicator">
+            <span class="dot"></span>
+            <span class="dot"></span>
+            <span class="dot"></span>
+          </span>
+        </div>
+        <WorkLogPanel
+          :work-logs="[]"
+          :partial-thinking="sessionsStore.partialThinking"
+          :is-latest-message="true"
+        />
+      </div>
+
       <!-- Streaming partial message -->
       <div v-if="partialText" class="message message-assistant message-streaming">
         <div class="message-header">
@@ -135,10 +152,12 @@ const isStopped = computed(() => {
 });
 
 // Subscribe to partial messages for streaming and work logs
-const { onPartial, onMessage, onWorkLog } = useSessionSubscription(props.sessionId);
+const { onPartial, onMessage, onWorkLog, onWorkLogsAssociated, onThinkingPartial } = useSessionSubscription(props.sessionId);
 let unsubPartial = null;
 let unsubMessage = null;
 let unsubWorkLog = null;
+let unsubWorkLogsAssociated = null;
+let unsubThinkingPartial = null;
 
 function handleScroll() {
   if (!messagesContainer.value) return;
@@ -180,6 +199,21 @@ onMounted(async () => {
     scrollToBottom();
   });
 
+  // Subscribe to work log association events (re-associate _unassociated logs)
+  unsubWorkLogsAssociated = onWorkLogsAssociated((messageId) => {
+    sessionsStore.associateWorkLogs(messageId);
+  });
+
+  // Subscribe to partial thinking updates for streaming display
+  unsubThinkingPartial = onThinkingPartial((thinking) => {
+    if (thinking === null) {
+      sessionsStore.clearPartialThinking();
+    } else {
+      sessionsStore.setPartialThinking(thinking);
+    }
+    scrollToBottom();
+  });
+
   // Fetch initial work logs
   await sessionsStore.fetchWorkLogs(props.sessionId);
 
@@ -191,6 +225,8 @@ onUnmounted(() => {
   if (unsubPartial) unsubPartial();
   if (unsubMessage) unsubMessage();
   if (unsubWorkLog) unsubWorkLog();
+  if (unsubWorkLogsAssociated) unsubWorkLogsAssociated();
+  if (unsubThinkingPartial) unsubThinkingPartial();
   if (debounceTimer) clearTimeout(debounceTimer);
   if (messagesContainer.value) {
     messagesContainer.value.removeEventListener('scroll', handleScroll);

--- a/packages/web/src/components/ThinkingBlock.vue
+++ b/packages/web/src/components/ThinkingBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="thinking-block">
+  <div class="thinking-block" :class="{ 'thinking-streaming': streaming }">
     <div class="thinking-header">
       <span class="thinking-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -8,8 +8,13 @@
           <path d="M12 8h.01"/>
         </svg>
       </span>
-      <span class="thinking-label">Thinking</span>
-      <span v-if="timestamp" class="thinking-time">{{ formatTime(timestamp) }}</span>
+      <span class="thinking-label">{{ streaming ? 'Thinking...' : 'Thinking' }}</span>
+      <span v-if="streaming" class="streaming-dots">
+        <span class="dot"></span>
+        <span class="dot"></span>
+        <span class="dot"></span>
+      </span>
+      <span v-else-if="timestamp" class="thinking-time">{{ formatTime(timestamp) }}</span>
     </div>
     <div class="thinking-content" :class="{ expanded: isExpanded }">
       <div class="thinking-text">{{ displayContent }}</div>
@@ -29,6 +34,7 @@ import { ref, computed } from 'vue';
 const props = defineProps({
   content: { type: String, required: true },
   timestamp: { type: Number, default: null },
+  streaming: { type: Boolean, default: false },
 });
 
 const MAX_LENGTH = 500;
@@ -109,5 +115,54 @@ function formatTime(ts) {
 
 .show-more-btn:hover {
   opacity: 1;
+}
+
+/* Streaming state */
+.thinking-streaming {
+  border-style: dashed;
+  animation: streamPulse 2s ease-in-out infinite;
+}
+
+@keyframes streamPulse {
+  0%, 100% {
+    border-color: rgba(88, 166, 255, 0.2);
+  }
+  50% {
+    border-color: rgba(88, 166, 255, 0.5);
+  }
+}
+
+.streaming-dots {
+  display: flex;
+  gap: 0.15rem;
+  align-items: center;
+  margin-left: 0.25rem;
+}
+
+.streaming-dots .dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background-color: var(--color-primary);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.streaming-dots .dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.streaming-dots .dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 </style>

--- a/packages/web/src/components/WorkLogPanel.vue
+++ b/packages/web/src/components/WorkLogPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="workLogs?.length" class="work-log-panel">
+  <div v-if="workLogs?.length || partialThinking" class="work-log-panel">
     <details :open="isExpanded" ref="detailsRef" @toggle="handleToggle">
       <summary class="work-log-header">
         <span class="work-log-icon">
@@ -8,7 +8,12 @@
           </svg>
         </span>
         <span class="work-log-title">Work Log</span>
-        <span class="work-log-count">({{ workLogs.length }})</span>
+        <span class="work-log-count">({{ totalCount }})</span>
+        <span v-if="partialThinking" class="streaming-indicator">
+          <span class="dot"></span>
+          <span class="dot"></span>
+          <span class="dot"></span>
+        </span>
         <span class="work-log-chevron" :class="{ expanded: isExpanded }">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="9 18 15 12 9 6"/>
@@ -16,9 +21,14 @@
         </span>
       </summary>
       <div class="work-log-content">
+        <!-- Existing work logs -->
         <div v-for="log in workLogs" :key="log.id" class="work-log-item">
           <ThinkingBlock v-if="log.type === 'thinking'" :content="log.content" :timestamp="log.timestamp" />
           <CommandBlock v-else :log="log" />
+        </div>
+        <!-- Streaming partial thinking -->
+        <div v-if="partialThinking" class="work-log-item work-log-streaming">
+          <ThinkingBlock :content="partialThinking" :streaming="true" />
         </div>
       </div>
     </details>
@@ -26,18 +36,24 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import ThinkingBlock from './ThinkingBlock.vue';
 import CommandBlock from './CommandBlock.vue';
 
 const props = defineProps({
   workLogs: { type: Array, default: () => [] },
   isLatestMessage: { type: Boolean, default: false },
+  partialThinking: { type: String, default: null },
 });
 
 const detailsRef = ref(null);
 const manuallyToggled = ref(false);
-const isExpanded = ref(props.isLatestMessage);
+const isExpanded = ref(props.isLatestMessage || !!props.partialThinking);
+
+// Total count includes work logs + 1 if partial thinking is present
+const totalCount = computed(() => {
+  return (props.workLogs?.length || 0) + (props.partialThinking ? 1 : 0);
+});
 
 // Watch for changes in isLatestMessage to auto-collapse/expand
 watch(() => props.isLatestMessage, (newVal) => {
@@ -50,6 +66,13 @@ watch(() => props.isLatestMessage, (newVal) => {
 // Watch for new work logs to expand panel for latest message
 watch(() => props.workLogs?.length, (newLen, oldLen) => {
   if (props.isLatestMessage && newLen > (oldLen || 0)) {
+    isExpanded.value = true;
+  }
+});
+
+// Watch for partial thinking to auto-expand
+watch(() => props.partialThinking, (newVal) => {
+  if (newVal && !manuallyToggled.value) {
     isExpanded.value = true;
   }
 });
@@ -131,6 +154,46 @@ function handleToggle(event) {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+.work-log-streaming {
+  border-left: 2px solid var(--color-primary);
+  padding-left: 0.5rem;
+}
+
+/* Streaming indicator animation */
+.streaming-indicator {
+  display: flex;
+  gap: 0.15rem;
+  align-items: center;
+  margin-left: 0.5rem;
+}
+
+.streaming-indicator .dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background-color: var(--color-primary);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.streaming-indicator .dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.streaming-indicator .dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 </style>

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -190,6 +190,26 @@ export function useSessionSubscription(sessionId) {
     return () => off(WS_MESSAGE_TYPES.SESSION_WORK_LOG, handler);
   };
 
+  const onWorkLogsAssociated = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.messageId);
+      }
+    };
+    on(WS_MESSAGE_TYPES.SESSION_WORK_LOGS_ASSOCIATED, handler);
+    return () => off(WS_MESSAGE_TYPES.SESSION_WORK_LOGS_ASSOCIATED, handler);
+  };
+
+  const onThinkingPartial = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.thinking);
+      }
+    };
+    on(WS_MESSAGE_TYPES.SESSION_THINKING_PARTIAL, handler);
+    return () => off(WS_MESSAGE_TYPES.SESSION_THINKING_PARTIAL, handler);
+  };
+
   // Auto-cleanup on unmount
   onUnmounted(() => {
     unsubscribe();
@@ -205,5 +225,7 @@ export function useSessionSubscription(sessionId) {
     onCanvasAdd,
     onCanvasRemove,
     onWorkLog,
+    onWorkLogsAssociated,
+    onThinkingPartial,
   };
 }

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -8,6 +8,7 @@ export const useSessionsStore = defineStore('sessions', {
     currentSession: null,
     messages: [],
     workLogs: {}, // Keyed by messageId: { [messageId]: WorkLog[] }
+    partialThinking: null, // Current streaming thinking content
     loading: false,
     error: null,
   }),
@@ -182,6 +183,30 @@ export const useSessionsStore = defineStore('sessions', {
 
     clearWorkLogs() {
       this.workLogs = {};
+      this.partialThinking = null;
+    },
+
+    // Associate unassociated work logs with a message ID
+    associateWorkLogs(messageId) {
+      const unassociated = this.workLogs['_unassociated'] || [];
+      if (unassociated.length > 0) {
+        if (!this.workLogs[messageId]) {
+          this.workLogs[messageId] = [];
+        }
+        // Move logs from _unassociated to the messageId
+        this.workLogs[messageId].push(...unassociated);
+        this.workLogs['_unassociated'] = [];
+      }
+    },
+
+    // Set partial thinking content for streaming display
+    setPartialThinking(thinking) {
+      this.partialThinking = thinking;
+    },
+
+    // Clear partial thinking when complete
+    clearPartialThinking() {
+      this.partialThinking = null;
     },
 
     updateSessionStatus(sessionId, status) {


### PR DESCRIPTION
## Summary

- **Fix work log not showing for current message**: Work logs now update in real-time without requiring a page refresh. Added `SESSION_WORK_LOGS_ASSOCIATED` WebSocket event that notifies the client when pending logs are associated with a message.

- **Fix thinking messages stacking as fragments**: Thinking content is now accumulated on the server and displayed as a single block instead of multiple fragmented entries. Added `SESSION_THINKING_PARTIAL` for real-time streaming display with visual indicators.

## Changes

| File | Description |
|------|-------------|
| `packages/shared/src/protocol.js` | Added `SESSION_WORK_LOGS_ASSOCIATED` and `SESSION_THINKING_PARTIAL` WebSocket message types |
| `packages/server/src/services/sessionManager.js` | Added thinking accumulator, broadcast partial thinking, broadcast association event |
| `packages/web/src/composables/useWebSocket.js` | Added `onWorkLogsAssociated` and `onThinkingPartial` handlers |
| `packages/web/src/stores/sessions.js` | Added `partialThinking` state, `associateWorkLogs()`, `setPartialThinking()` actions |
| `packages/web/src/components/ConversationTab.vue` | Subscribed to new events, added streaming thinking display |
| `packages/web/src/components/WorkLogPanel.vue` | Added `partialThinking` prop, streaming indicator |
| `packages/web/src/components/ThinkingBlock.vue` | Added `streaming` prop with visual indicators |

## Test plan

- [ ] Enable thinking mode on a session
- [ ] Send a message and verify thinking streams in real-time as a single block (not fragmented)
- [ ] Verify the work log panel shows entries without needing to refresh
- [ ] Verify work logs are correctly associated with messages after they complete
- [ ] Test that streaming indicators animate while thinking is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)