### PR TITLE
Add restart and delete functionality for completed sessions

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { sessions, messages, sessionNotes, projects, workLogs } from '../database.js';
-import { continueSession, stopSession, endSession, cleanupActiveSession } from '../services/sessionManager.js';
+import { continueSession, stopSession, endSession, restartSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges } from '../services/diffService.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
@@ -139,6 +139,25 @@ router.post('/:id/end', (req, res) => {
 
   try {
     endSession(session.id);
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// POST /api/sessions/:id/restart - Restart a completed/error session
+router.post('/:id/restart', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  if (session.status !== 'completed' && session.status !== 'error') {
+    return res.status(400).json({ error: 'Session can only be restarted when completed or in error state' });
+  }
+
+  try {
+    restartSession(session.id);
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -279,6 +279,16 @@ export function endSession(sessionId) {
 }
 
 /**
+ * Restart a completed or errored session (set back to stopped so it can receive messages)
+ * @param {string} sessionId
+ */
+export function restartSession(sessionId) {
+  // Clear any error and set status to stopped (allows sending new messages)
+  sessions.update(sessionId, { status: 'stopped', error: null });
+  broadcastSessionStatus(sessionId, 'stopped');
+}
+
+/**
  * Clean up an active session before deletion
  * @param {string} sessionId
  * @returns {boolean} true if session was active and cleaned up

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -194,6 +194,15 @@ export class ApiClient {
   }
 
   /**
+   * Restart a completed or errored session
+   * @param {string} id - Session ID
+   * @returns {Promise<Object>}
+   */
+  async restartSession(id) {
+    return this.#request('POST', `/sessions/${id}/restart`);
+  }
+
+  /**
    * Update session settings
    * @param {string} id - Session ID
    * @param {Object} data - Update data (e.g., { thinkingEnabled: true })

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -116,8 +116,12 @@
       </div>
     </div>
 
-    <div v-else-if="sessionsStore.currentSession?.status === 'completed'" class="status-message status-completed">
-      Session completed
+    <div v-else-if="sessionsStore.currentSession?.status === 'completed' || sessionsStore.currentSession?.status === 'error'" class="status-message" :class="sessionsStore.currentSession?.status === 'completed' ? 'status-completed' : 'status-error'">
+      <span>{{ sessionsStore.currentSession?.status === 'completed' ? 'Session completed' : 'Session error' }}</span>
+      <button type="button" class="btn btn-primary btn-restart" @click="handleRestart" :disabled="restarting">
+        <span v-if="restarting" class="loading-spinner"></span>
+        Restart Session
+      </button>
     </div>
   </div>
 </template>
@@ -141,6 +145,7 @@ const input = ref('');
 const sending = ref(false);
 const ending = ref(false);
 const stopping = ref(false);
+const restarting = ref(false);
 const togglingThinking = ref(false);
 const messagesContainer = ref(null);
 const partialText = ref('');
@@ -329,6 +334,20 @@ async function handleStop() {
     uiStore.error(err.message);
   } finally {
     stopping.value = false;
+  }
+}
+
+async function handleRestart() {
+  if (restarting.value) return;
+
+  restarting.value = true;
+  try {
+    await sessionsStore.restartSession(props.sessionId);
+    uiStore.success('Session restarted');
+  } catch (err) {
+    uiStore.error(err.message);
+  } finally {
+    restarting.value = false;
   }
 }
 
@@ -541,6 +560,7 @@ async function handleThinkingToggle(event) {
 .status-message {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   padding: 1rem;
   color: var(--color-text-soft);
@@ -549,6 +569,14 @@ async function handleThinkingToggle(event) {
 
 .status-completed {
   color: var(--color-success, #10b981);
+}
+
+.status-error {
+  color: var(--color-danger, #ef4444);
+}
+
+.btn-restart {
+  min-width: 140px;
 }
 
 .status-stopped {

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -103,9 +103,17 @@
       </div>
     </form>
 
-    <div v-else-if="sessionsStore.currentSession?.status === 'running'" class="status-message">
-      <span class="loading-spinner"></span>
-      Claude is working...
+    <div v-else-if="sessionsStore.currentSession?.status === 'running'" class="running-state">
+      <LiveWorkLogPanel
+        :work-logs="unassociatedWorkLogs"
+        :partial-thinking="sessionsStore.partialThinking"
+      />
+      <div class="running-actions">
+        <button type="button" class="btn btn-danger btn-send" @click="handleStop" :disabled="stopping">
+          <span v-if="stopping" class="loading-spinner"></span>
+          Stop
+        </button>
+      </div>
     </div>
 
     <div v-else-if="sessionsStore.currentSession?.status === 'completed'" class="status-message status-completed">
@@ -120,6 +128,7 @@ import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
 import WorkLogPanel from './WorkLogPanel.vue';
+import LiveWorkLogPanel from './LiveWorkLogPanel.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -131,6 +140,7 @@ const uiStore = useUiStore();
 const input = ref('');
 const sending = ref(false);
 const ending = ref(false);
+const stopping = ref(false);
 const togglingThinking = ref(false);
 const messagesContainer = ref(null);
 const partialText = ref('');
@@ -149,6 +159,10 @@ const canSendMessage = computed(() => {
 
 const isStopped = computed(() => {
   return sessionsStore.currentSession?.status === 'stopped';
+});
+
+const unassociatedWorkLogs = computed(() => {
+  return sessionsStore.getUnassociatedWorkLogs;
 });
 
 // Subscribe to partial messages for streaming and work logs
@@ -301,6 +315,20 @@ async function handleEndSession() {
     uiStore.error(err.message);
   } finally {
     ending.value = false;
+  }
+}
+
+async function handleStop() {
+  if (stopping.value) return;
+
+  stopping.value = true;
+  try {
+    await sessionsStore.stopSession(props.sessionId);
+    uiStore.success('Session stopped');
+  } catch (err) {
+    uiStore.error(err.message);
+  } finally {
+    stopping.value = false;
   }
 }
 
@@ -591,5 +619,16 @@ async function handleThinkingToggle(event) {
     opacity: 1;
     transform: scale(1);
   }
+}
+
+.running-state {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+}
+
+.running-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
 }
 </style>

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -142,6 +142,25 @@ export const useSessionsStore = defineStore('sessions', {
       }
     },
 
+    async restartSession(id) {
+      this.error = null;
+      try {
+        await api.restartSession(id);
+        if (this.currentSession?.id === id) {
+          this.currentSession.status = 'stopped';
+          this.currentSession.error = null;
+        }
+        const session = this.sessions.find((s) => s.id === id);
+        if (session) {
+          session.status = 'stopped';
+          session.error = null;
+        }
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
     async deleteSession(id) {
       this.error = null;
       try {

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -20,6 +20,9 @@ export const useSessionsStore = defineStore('sessions', {
     getWorkLogsForMessage: (state) => (messageId) => {
       return state.workLogs[messageId] || [];
     },
+    getUnassociatedWorkLogs: (state) => {
+      return state.workLogs['_unassociated'] || [];
+    },
   },
 
   actions: {
@@ -171,10 +174,12 @@ export const useSessionsStore = defineStore('sessions', {
 
     addWorkLog(log) {
       const messageId = log.messageId || '_unassociated';
-      if (!this.workLogs[messageId]) {
-        this.workLogs[messageId] = [];
-      }
-      this.workLogs[messageId].push(log);
+      const currentLogs = this.workLogs[messageId] || [];
+      // Use spread to ensure new object reference for Vue reactivity
+      this.workLogs = {
+        ...this.workLogs,
+        [messageId]: [...currentLogs, log],
+      };
     },
 
     setWorkLogs(workLogs) {
@@ -190,12 +195,13 @@ export const useSessionsStore = defineStore('sessions', {
     associateWorkLogs(messageId) {
       const unassociated = this.workLogs['_unassociated'] || [];
       if (unassociated.length > 0) {
-        if (!this.workLogs[messageId]) {
-          this.workLogs[messageId] = [];
-        }
-        // Move logs from _unassociated to the messageId
-        this.workLogs[messageId].push(...unassociated);
-        this.workLogs['_unassociated'] = [];
+        const currentLogs = this.workLogs[messageId] || [];
+        // Use spread to ensure new object reference for Vue reactivity
+        this.workLogs = {
+          ...this.workLogs,
+          [messageId]: [...currentLogs, ...unassociated],
+          '_unassociated': [],
+        };
       }
     },
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -58,7 +58,7 @@
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
       </div>
 
-      <div v-if="sessionsStore.currentSession?.status === 'stopped'" class="session-actions-bottom">
+      <div v-if="['stopped', 'completed', 'error'].includes(sessionsStore.currentSession?.status)" class="session-actions-bottom">
         <button
           v-if="!showDeleteConfirm"
           class="btn btn-outline-danger"

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -11,7 +11,7 @@
           <router-link :to="`/projects/${sessionsStore.currentSession.projectId}/sessions`" class="back-link">
             &larr; Sessions
           </router-link>
-          <h1>{{ sessionsStore.currentSession.name }}</h1>
+          <h3 class="session-name">{{ sessionsStore.currentSession.name }}</h3>
           <div class="session-meta">
             <span :class="['status-badge', `status-${sessionsStore.currentSession.status}`]">
               {{ sessionsStore.currentSession.status }}
@@ -20,37 +20,6 @@
             <span v-if="sessionsStore.currentSession.gitBranch" class="session-branch">
               {{ sessionsStore.currentSession.gitBranch }}
             </span>
-          </div>
-        </div>
-        <div class="session-actions">
-          <button
-            v-if="canStop"
-            class="btn btn-danger"
-            @click="handleStop"
-          >
-            Stop Session
-          </button>
-          <button
-            v-if="!showDeleteConfirm"
-            class="btn btn-outline-danger"
-            @click="showDeleteConfirm = true"
-          >
-            Delete Session
-          </button>
-          <div v-else class="delete-confirm">
-            <span class="delete-confirm-text">Delete this session?</span>
-            <button
-              class="btn btn-danger btn-sm"
-              @click="handleDelete"
-            >
-              Confirm
-            </button>
-            <button
-              class="btn btn-secondary btn-sm"
-              @click="showDeleteConfirm = false"
-            >
-              Cancel
-            </button>
           </div>
         </div>
       </div>
@@ -88,6 +57,31 @@
         <CanvasTab v-else-if="activeTab === 'canvas'" :session-id="route.params.id" />
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
       </div>
+
+      <div v-if="sessionsStore.currentSession?.status === 'stopped'" class="session-actions-bottom">
+        <button
+          v-if="!showDeleteConfirm"
+          class="btn btn-outline-danger"
+          @click="showDeleteConfirm = true"
+        >
+          Delete Session
+        </button>
+        <div v-else class="delete-confirm">
+          <span class="delete-confirm-text">Delete this session?</span>
+          <button
+            class="btn btn-danger btn-sm"
+            @click="handleDelete"
+          >
+            Confirm
+          </button>
+          <button
+            class="btn btn-secondary btn-sm"
+            @click="showDeleteConfirm = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
     </template>
   </div>
 </template>
@@ -113,12 +107,6 @@ const uiStore = useUiStore();
 const showDeleteConfirm = ref(false);
 
 const activeTab = computed(() => route.params.tab || 'conversation');
-
-const canStop = computed(() => {
-  const status = sessionsStore.currentSession?.status;
-  // Can stop running or waiting sessions, but not already stopped ones
-  return status === 'running' || status === 'waiting';
-});
 
 const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove } =
   useSessionSubscription(route.params.id);
@@ -222,15 +210,6 @@ onUnmounted(() => {
   cleanups.forEach((cleanup) => cleanup());
 });
 
-async function handleStop() {
-  try {
-    await sessionsStore.stopSession(route.params.id);
-    uiStore.success('Session stopped');
-  } catch (err) {
-    uiStore.error(err.message);
-  }
-}
-
 async function handleDelete() {
   try {
     const projectId = sessionsStore.currentSession?.projectId;
@@ -272,8 +251,10 @@ async function handleDelete() {
   margin-bottom: 0.5rem;
 }
 
-.session-header h1 {
+.session-name {
   margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
 }
 
 .session-meta {
@@ -298,10 +279,13 @@ async function handleDelete() {
   min-height: 400px;
 }
 
-.session-actions {
+.session-actions-bottom {
+  padding: 1rem 0;
+  border-top: 1px solid var(--color-border);
+  margin-top: 1rem;
   display: flex;
+  justify-content: flex-end;
   gap: 0.5rem;
-  align-items: center;
 }
 
 .delete-confirm {


### PR DESCRIPTION
## Summary
- Added ability to restart completed or errored sessions via new "Restart Session" button
- Extended delete functionality to work with completed and error sessions (was only available for stopped sessions)
- New `POST /api/sessions/:id/restart` endpoint that resets session status from completed/error back to stopped

## Test plan
- [ ] Create a session and let it complete naturally
- [ ] Verify "Restart Session" button appears when session is completed
- [ ] Click restart and confirm session goes back to "stopped" state with message input enabled
- [ ] Verify "Delete Session" button now appears for completed sessions
- [ ] Test that delete works correctly for completed sessions
- [ ] Test restart also works for sessions in error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)