### PR TITLE
Improve session detail view UI and work log behavior

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -103,9 +103,17 @@
       </div>
     </form>
 
-    <div v-else-if="sessionsStore.currentSession?.status === 'running'" class="status-message">
-      <span class="loading-spinner"></span>
-      Claude is working...
+    <div v-else-if="sessionsStore.currentSession?.status === 'running'" class="running-state">
+      <LiveWorkLogPanel
+        :work-logs="unassociatedWorkLogs"
+        :partial-thinking="sessionsStore.partialThinking"
+      />
+      <div class="running-actions">
+        <button type="button" class="btn btn-danger btn-send" @click="handleStop" :disabled="stopping">
+          <span v-if="stopping" class="loading-spinner"></span>
+          Stop
+        </button>
+      </div>
     </div>
 
     <div v-else-if="sessionsStore.currentSession?.status === 'completed'" class="status-message status-completed">
@@ -120,6 +128,7 @@ import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
 import WorkLogPanel from './WorkLogPanel.vue';
+import LiveWorkLogPanel from './LiveWorkLogPanel.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -131,6 +140,7 @@ const uiStore = useUiStore();
 const input = ref('');
 const sending = ref(false);
 const ending = ref(false);
+const stopping = ref(false);
 const togglingThinking = ref(false);
 const messagesContainer = ref(null);
 const partialText = ref('');
@@ -149,6 +159,10 @@ const canSendMessage = computed(() => {
 
 const isStopped = computed(() => {
   return sessionsStore.currentSession?.status === 'stopped';
+});
+
+const unassociatedWorkLogs = computed(() => {
+  return sessionsStore.getUnassociatedWorkLogs;
 });
 
 // Subscribe to partial messages for streaming and work logs
@@ -301,6 +315,20 @@ async function handleEndSession() {
     uiStore.error(err.message);
   } finally {
     ending.value = false;
+  }
+}
+
+async function handleStop() {
+  if (stopping.value) return;
+
+  stopping.value = true;
+  try {
+    await sessionsStore.stopSession(props.sessionId);
+    uiStore.success('Session stopped');
+  } catch (err) {
+    uiStore.error(err.message);
+  } finally {
+    stopping.value = false;
   }
 }
 
@@ -591,5 +619,16 @@ async function handleThinkingToggle(event) {
     opacity: 1;
     transform: scale(1);
   }
+}
+
+.running-state {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+}
+
+.running-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
 }
 </style>

--- a/packages/web/src/components/LiveWorkLogPanel.vue
+++ b/packages/web/src/components/LiveWorkLogPanel.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="live-work-log-panel">
+    <div class="live-header">
+      <span class="loading-spinner"></span>
+      <span class="live-title">Claude is working...</span>
+      <span v-if="totalCount" class="live-count">({{ totalCount }} {{ totalCount === 1 ? 'item' : 'items' }})</span>
+    </div>
+    <div v-if="hasContent" class="live-logs" ref="logsContainer">
+      <div v-for="log in workLogs" :key="log.id" class="live-log-item">
+        <ThinkingBlock v-if="log.type === 'thinking'" :content="log.content" :timestamp="log.timestamp" />
+        <CommandBlock v-else :log="log" />
+      </div>
+      <!-- Streaming partial thinking -->
+      <div v-if="partialThinking" class="live-log-item">
+        <ThinkingBlock :content="partialThinking" :streaming="true" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick } from 'vue';
+import ThinkingBlock from './ThinkingBlock.vue';
+import CommandBlock from './CommandBlock.vue';
+
+const props = defineProps({
+  workLogs: { type: Array, default: () => [] },
+  partialThinking: { type: String, default: null },
+});
+
+const logsContainer = ref(null);
+
+const totalCount = computed(() => {
+  return (props.workLogs?.length || 0) + (props.partialThinking ? 1 : 0);
+});
+
+const hasContent = computed(() => {
+  return props.workLogs?.length > 0 || props.partialThinking;
+});
+
+// Auto-scroll to bottom when new logs arrive
+function scrollToBottom() {
+  nextTick(() => {
+    if (logsContainer.value) {
+      logsContainer.value.scrollTop = logsContainer.value.scrollHeight;
+    }
+  });
+}
+
+// Watch for new work logs
+watch(() => props.workLogs?.length, () => {
+  scrollToBottom();
+});
+
+// Watch for partial thinking changes
+watch(() => props.partialThinking, () => {
+  scrollToBottom();
+});
+</script>
+
+<style scoped>
+.live-work-log-panel {
+  border-top: 1px solid var(--color-border);
+  padding: 0.75rem 0;
+}
+
+.live-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-soft);
+  font-size: 0.875rem;
+}
+
+.live-title {
+  font-weight: 500;
+}
+
+.live-count {
+  opacity: 0.7;
+  font-size: 0.8125rem;
+}
+
+.live-logs {
+  margin-top: 0.75rem;
+  max-height: 250px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-right: 0.25rem;
+  border-left: 2px solid var(--color-primary);
+  padding-left: 0.75rem;
+}
+
+.live-log-item {
+  animation: slideIn 0.2s ease;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Custom scrollbar for logs container */
+.live-logs::-webkit-scrollbar {
+  width: 6px;
+}
+
+.live-logs::-webkit-scrollbar-track {
+  background: var(--color-background-soft);
+  border-radius: 3px;
+}
+
+.live-logs::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 3px;
+}
+
+.live-logs::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-soft);
+}
+</style>

--- a/packages/web/src/components/WorkLogPanel.vue
+++ b/packages/web/src/components/WorkLogPanel.vue
@@ -48,19 +48,11 @@ const props = defineProps({
 
 const detailsRef = ref(null);
 const manuallyToggled = ref(false);
-const isExpanded = ref(props.isLatestMessage || !!props.partialThinking);
+const isExpanded = ref(!!props.partialThinking);
 
 // Total count includes work logs + 1 if partial thinking is present
 const totalCount = computed(() => {
   return (props.workLogs?.length || 0) + (props.partialThinking ? 1 : 0);
-});
-
-// Watch for changes in isLatestMessage to auto-collapse/expand
-watch(() => props.isLatestMessage, (newVal) => {
-  // Only auto-collapse if user hasn't manually interacted
-  if (!manuallyToggled.value) {
-    isExpanded.value = newVal;
-  }
 });
 
 // Watch for new work logs to expand panel for latest message
@@ -70,10 +62,14 @@ watch(() => props.workLogs?.length, (newLen, oldLen) => {
   }
 });
 
-// Watch for partial thinking to auto-expand
-watch(() => props.partialThinking, (newVal) => {
+// Watch for partial thinking to auto-expand/collapse
+watch(() => props.partialThinking, (newVal, oldVal) => {
   if (newVal && !manuallyToggled.value) {
+    // Expand when streaming starts
     isExpanded.value = true;
+  } else if (!newVal && oldVal && !manuallyToggled.value) {
+    // Collapse when streaming finishes
+    isExpanded.value = false;
   }
 });
 

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -20,6 +20,9 @@ export const useSessionsStore = defineStore('sessions', {
     getWorkLogsForMessage: (state) => (messageId) => {
       return state.workLogs[messageId] || [];
     },
+    getUnassociatedWorkLogs: (state) => {
+      return state.workLogs['_unassociated'] || [];
+    },
   },
 
   actions: {
@@ -171,10 +174,12 @@ export const useSessionsStore = defineStore('sessions', {
 
     addWorkLog(log) {
       const messageId = log.messageId || '_unassociated';
-      if (!this.workLogs[messageId]) {
-        this.workLogs[messageId] = [];
-      }
-      this.workLogs[messageId].push(log);
+      const currentLogs = this.workLogs[messageId] || [];
+      // Use spread to ensure new object reference for Vue reactivity
+      this.workLogs = {
+        ...this.workLogs,
+        [messageId]: [...currentLogs, log],
+      };
     },
 
     setWorkLogs(workLogs) {
@@ -190,12 +195,13 @@ export const useSessionsStore = defineStore('sessions', {
     associateWorkLogs(messageId) {
       const unassociated = this.workLogs['_unassociated'] || [];
       if (unassociated.length > 0) {
-        if (!this.workLogs[messageId]) {
-          this.workLogs[messageId] = [];
-        }
-        // Move logs from _unassociated to the messageId
-        this.workLogs[messageId].push(...unassociated);
-        this.workLogs['_unassociated'] = [];
+        const currentLogs = this.workLogs[messageId] || [];
+        // Use spread to ensure new object reference for Vue reactivity
+        this.workLogs = {
+          ...this.workLogs,
+          [messageId]: [...currentLogs, ...unassociated],
+          '_unassociated': [],
+        };
       }
     },
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -11,7 +11,7 @@
           <router-link :to="`/projects/${sessionsStore.currentSession.projectId}/sessions`" class="back-link">
             &larr; Sessions
           </router-link>
-          <h1>{{ sessionsStore.currentSession.name }}</h1>
+          <h3 class="session-name">{{ sessionsStore.currentSession.name }}</h3>
           <div class="session-meta">
             <span :class="['status-badge', `status-${sessionsStore.currentSession.status}`]">
               {{ sessionsStore.currentSession.status }}
@@ -20,37 +20,6 @@
             <span v-if="sessionsStore.currentSession.gitBranch" class="session-branch">
               {{ sessionsStore.currentSession.gitBranch }}
             </span>
-          </div>
-        </div>
-        <div class="session-actions">
-          <button
-            v-if="canStop"
-            class="btn btn-danger"
-            @click="handleStop"
-          >
-            Stop Session
-          </button>
-          <button
-            v-if="!showDeleteConfirm"
-            class="btn btn-outline-danger"
-            @click="showDeleteConfirm = true"
-          >
-            Delete Session
-          </button>
-          <div v-else class="delete-confirm">
-            <span class="delete-confirm-text">Delete this session?</span>
-            <button
-              class="btn btn-danger btn-sm"
-              @click="handleDelete"
-            >
-              Confirm
-            </button>
-            <button
-              class="btn btn-secondary btn-sm"
-              @click="showDeleteConfirm = false"
-            >
-              Cancel
-            </button>
           </div>
         </div>
       </div>
@@ -88,6 +57,31 @@
         <CanvasTab v-else-if="activeTab === 'canvas'" :session-id="route.params.id" />
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
       </div>
+
+      <div v-if="sessionsStore.currentSession?.status === 'stopped'" class="session-actions-bottom">
+        <button
+          v-if="!showDeleteConfirm"
+          class="btn btn-outline-danger"
+          @click="showDeleteConfirm = true"
+        >
+          Delete Session
+        </button>
+        <div v-else class="delete-confirm">
+          <span class="delete-confirm-text">Delete this session?</span>
+          <button
+            class="btn btn-danger btn-sm"
+            @click="handleDelete"
+          >
+            Confirm
+          </button>
+          <button
+            class="btn btn-secondary btn-sm"
+            @click="showDeleteConfirm = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
     </template>
   </div>
 </template>
@@ -113,12 +107,6 @@ const uiStore = useUiStore();
 const showDeleteConfirm = ref(false);
 
 const activeTab = computed(() => route.params.tab || 'conversation');
-
-const canStop = computed(() => {
-  const status = sessionsStore.currentSession?.status;
-  // Can stop running or waiting sessions, but not already stopped ones
-  return status === 'running' || status === 'waiting';
-});
 
 const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove } =
   useSessionSubscription(route.params.id);
@@ -222,15 +210,6 @@ onUnmounted(() => {
   cleanups.forEach((cleanup) => cleanup());
 });
 
-async function handleStop() {
-  try {
-    await sessionsStore.stopSession(route.params.id);
-    uiStore.success('Session stopped');
-  } catch (err) {
-    uiStore.error(err.message);
-  }
-}
-
 async function handleDelete() {
   try {
     const projectId = sessionsStore.currentSession?.projectId;
@@ -272,8 +251,10 @@ async function handleDelete() {
   margin-bottom: 0.5rem;
 }
 
-.session-header h1 {
+.session-name {
   margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
 }
 
 .session-meta {
@@ -298,10 +279,13 @@ async function handleDelete() {
   min-height: 400px;
 }
 
-.session-actions {
+.session-actions-bottom {
+  padding: 1rem 0;
+  border-top: 1px solid var(--color-border);
+  margin-top: 1rem;
   display: flex;
+  justify-content: flex-end;
   gap: 0.5rem;
-  align-items: center;
 }
 
 .delete-confirm {


### PR DESCRIPTION
## Summary

- **Smaller session name**: Changed from `<h1>` to `<h3>` for better visual hierarchy
- **Stop button placement**: Added stop button in conversation tab that replaces send button when Claude is working
- **Delete button moved**: Only visible when session is stopped, moved to bottom (fixes viewport overflow on small screens)
- **Auto-collapse work log**: Work log now collapses automatically when Claude finishes working

## Test plan

- [ ] Verify session name appears smaller in the header
- [ ] When Claude is working, verify the Stop button appears where the Send button normally is
- [ ] When Claude finishes, verify the Send button returns
- [ ] On a small screen, verify the delete button no longer overflows
- [ ] Verify the delete button only shows when session is stopped
- [ ] Verify work log collapses when Claude finishes working
- [ ] Verify work log expands when Claude starts streaming
- [ ] Verify manual expand/collapse is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)