### PR TITLE
feat: enable preview for untracked files in Changes tab

### DIFF
--- a/packages/server/src/services/diffService.js
+++ b/packages/server/src/services/diffService.js
@@ -1,16 +1,148 @@
 import * as gitService from './gitService.js';
 
 /**
+ * Format file size in human readable format
+ * @param {number} bytes
+ * @returns {string}
+ */
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}
+
+/**
+ * Generate a unified diff string for a new file (all additions)
+ * @param {string} filePath - File path
+ * @param {string} content - File content
+ * @returns {string}
+ */
+function generateNewFileDiff(filePath, content) {
+  const lines = content.split('\n');
+  // Handle trailing newline - if content ends with \n, last element will be empty
+  const hasTrailingNewline = content.endsWith('\n');
+  const contentLines = hasTrailingNewline ? lines.slice(0, -1) : lines;
+  const lineCount = contentLines.length;
+
+  if (lineCount === 0) {
+    // Empty file
+    return [
+      `diff --git a/${filePath} b/${filePath}`,
+      'new file mode 100644',
+      `--- /dev/null`,
+      `+++ b/${filePath}`,
+    ].join('\n');
+  }
+
+  const header = [
+    `diff --git a/${filePath} b/${filePath}`,
+    'new file mode 100644',
+    `--- /dev/null`,
+    `+++ b/${filePath}`,
+    `@@ -0,0 +1,${lineCount} @@`,
+  ].join('\n');
+
+  const additions = contentLines.map((line) => `+${line}`).join('\n');
+
+  let result = header + '\n' + additions;
+  if (!hasTrailingNewline && contentLines.length > 0) {
+    result += '\n\\ No newline at end of file';
+  }
+
+  return result;
+}
+
+/**
+ * Generate a placeholder diff for a binary file
+ * @param {string} filePath
+ * @returns {string}
+ */
+function generateBinaryFileDiff(filePath) {
+  return [
+    `diff --git a/${filePath} b/${filePath}`,
+    'new file mode 100644',
+    `Binary files /dev/null and b/${filePath} differ`,
+  ].join('\n');
+}
+
+/**
+ * Generate a placeholder diff for a file that's too large
+ * @param {string} filePath
+ * @param {number} size
+ * @returns {string}
+ */
+function generateTooLargeFileDiff(filePath, size) {
+  return [
+    `diff --git a/${filePath} b/${filePath}`,
+    'new file mode 100644',
+    `--- /dev/null`,
+    `+++ b/${filePath}`,
+    `@@ -0,0 +1,1 @@`,
+    `+[File too large to preview: ${formatBytes(size)}]`,
+  ].join('\n');
+}
+
+/**
+ * Generate synthetic diffs for untracked files
+ * @param {string} directory
+ * @param {string[]} filePaths
+ * @param {Object} options
+ * @returns {Promise<string>}
+ */
+async function generateUntrackedDiffs(directory, filePaths, options = {}) {
+  const { maxFileSize = 100 * 1024 } = options;
+
+  const diffs = await Promise.all(
+    filePaths.map(async (filePath) => {
+      const result = await gitService.getUntrackedFileContent(directory, filePath, {
+        maxSize: maxFileSize,
+      });
+
+      if (result.error) {
+        // Skip files that can't be read
+        return null;
+      }
+
+      if (result.isBinary) {
+        return generateBinaryFileDiff(filePath);
+      }
+
+      if (result.isTooLarge) {
+        return generateTooLargeFileDiff(filePath, result.size);
+      }
+
+      return generateNewFileDiff(filePath, result.content);
+    })
+  );
+
+  return diffs.filter(Boolean).join('\n');
+}
+
+/**
  * Get the combined diff (staged + unstaged + untracked) for a directory
  * @param {string} directory
- * @returns {Promise<{staged: string, unstaged: string, untracked: string[]}>}
+ * @param {Object} options
+ * @param {number} options.maxUntrackedFiles - Max number of untracked files to process (default: 50)
+ * @param {number} options.maxFileSize - Max file size in bytes (default: 100KB)
+ * @returns {Promise<{staged: string, unstaged: string, untracked: string}>}
  */
-export async function getChanges(directory) {
-  const [staged, unstaged, untracked] = await Promise.all([
+export async function getChanges(directory, options = {}) {
+  const { maxUntrackedFiles = 50, maxFileSize = 100 * 1024 } = options;
+
+  const [staged, unstaged, untrackedPaths] = await Promise.all([
     gitService.getStagedDiff(directory),
     gitService.getDiff(directory),
     gitService.getUntrackedFiles(directory),
   ]);
+
+  // Generate synthetic diffs for untracked files (limited to maxUntrackedFiles)
+  const untracked = await generateUntrackedDiffs(
+    directory,
+    untrackedPaths.slice(0, maxUntrackedFiles),
+    { maxFileSize }
+  );
 
   return { staged, unstaged, untracked };
 }

--- a/packages/server/src/services/diffService.test.js
+++ b/packages/server/src/services/diffService.test.js
@@ -18,14 +18,23 @@ describe('diffService', () => {
       gitService.getStagedDiff.mockResolvedValue('staged diff content');
       gitService.getDiff.mockResolvedValue('unstaged diff content');
       gitService.getUntrackedFiles.mockResolvedValue(['new-file.txt', 'another.js']);
+      gitService.getUntrackedFileContent.mockImplementation(async (dir, filePath) => {
+        if (filePath === 'new-file.txt') {
+          return { content: 'file content\n', isBinary: false, isTooLarge: false, size: 13 };
+        }
+        if (filePath === 'another.js') {
+          return { content: 'const x = 1;\n', isBinary: false, isTooLarge: false, size: 13 };
+        }
+        return { content: null, isBinary: false, isTooLarge: false, size: 0, error: 'not found' };
+      });
 
       const result = await getChanges('/test/dir');
 
-      expect(result).toEqual({
-        staged: 'staged diff content',
-        unstaged: 'unstaged diff content',
-        untracked: ['new-file.txt', 'another.js'],
-      });
+      expect(result.staged).toBe('staged diff content');
+      expect(result.unstaged).toBe('unstaged diff content');
+      // untracked is now a unified diff string containing synthetic diffs for untracked files
+      expect(result.untracked).toContain('diff --git a/new-file.txt b/new-file.txt');
+      expect(result.untracked).toContain('diff --git a/another.js b/another.js');
     });
 
     it('calls git service with correct directory', async () => {
@@ -47,7 +56,7 @@ describe('diffService', () => {
 
       const result = await getChanges('/test/dir');
 
-      expect(result).toEqual({ staged: '', unstaged: '', untracked: [] });
+      expect(result).toEqual({ staged: '', unstaged: '', untracked: '' });
     });
 
     it('fetches all git info in parallel', async () => {
@@ -70,6 +79,12 @@ describe('diffService', () => {
           untrackedResolve = resolve;
         })
       );
+      gitService.getUntrackedFileContent.mockResolvedValue({
+        content: 'test content\n',
+        isBinary: false,
+        isTooLarge: false,
+        size: 13,
+      });
 
       const promise = getChanges('/test/dir');
 
@@ -84,7 +99,10 @@ describe('diffService', () => {
       untrackedResolve(['file.txt']);
 
       const result = await promise;
-      expect(result).toEqual({ staged: 'staged', unstaged: 'unstaged', untracked: ['file.txt'] });
+      expect(result.staged).toBe('staged');
+      expect(result.unstaged).toBe('unstaged');
+      // untracked is now a unified diff string
+      expect(result.untracked).toContain('diff --git a/file.txt b/file.txt');
     });
 
     it('propagates errors from getStagedDiff', async () => {

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -1,5 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { readFile, stat } from 'fs/promises';
+import { join } from 'path';
 
 const execAsync = promisify(exec);
 
@@ -192,5 +194,61 @@ export async function getUntrackedFiles(directory) {
     return output.split('\n').filter((line) => line.trim());
   } catch {
     return [];
+  }
+}
+
+/**
+ * Check if content is binary by looking for null bytes
+ * @param {Buffer} buffer
+ * @returns {boolean}
+ */
+function isBinaryContent(buffer) {
+  // Check first 8KB for null bytes
+  const checkLength = Math.min(buffer.length, 8192);
+  for (let i = 0; i < checkLength; i++) {
+    if (buffer[i] === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Get content of an untracked file
+ * @param {string} directory - Git repo directory
+ * @param {string} filePath - Relative path to the file
+ * @param {Object} options - Options
+ * @param {number} options.maxSize - Maximum file size in bytes (default: 100KB)
+ * @returns {Promise<{content: string|null, isBinary: boolean, size: number}>}
+ */
+export async function getUntrackedFileContent(directory, filePath, options = {}) {
+  const { maxSize = 100 * 1024 } = options;
+  const fullPath = join(directory, filePath);
+
+  try {
+    const fileStat = await stat(fullPath);
+    const size = fileStat.size;
+
+    // Check if file is too large
+    if (size > maxSize) {
+      return { content: null, isBinary: false, isTooLarge: true, size };
+    }
+
+    const buffer = await readFile(fullPath);
+
+    // Check if binary
+    if (isBinaryContent(buffer)) {
+      return { content: null, isBinary: true, isTooLarge: false, size };
+    }
+
+    return {
+      content: buffer.toString('utf-8'),
+      isBinary: false,
+      isTooLarge: false,
+      size,
+    };
+  } catch (error) {
+    // File might have been deleted or is unreadable
+    return { content: null, isBinary: false, isTooLarge: false, size: 0, error: error.message };
   }
 }

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -30,13 +30,9 @@
         <DiffViewer ref="unstagedDiffViewer" :files="unstagedFiles" />
       </div>
 
-      <div v-if="untracked.length > 0" class="diff-section">
+      <div v-if="untrackedFiles.length > 0" class="diff-section">
         <h3>Untracked Files</h3>
-        <ul class="untracked-list">
-          <li v-for="file in untracked" :key="file" class="untracked-file">
-            {{ file }}
-          </li>
-        </ul>
+        <DiffViewer ref="untrackedDiffViewer" :files="untrackedFiles" />
       </div>
     </template>
   </div>
@@ -54,25 +50,29 @@ const props = defineProps({
 
 const staged = ref('');
 const unstaged = ref('');
-const untracked = ref([]);
+const untracked = ref('');
 const loading = ref(false);
 const error = ref(null);
 const allExpanded = ref(true);
 
 const stagedDiffViewer = ref(null);
 const unstagedDiffViewer = ref(null);
+const untrackedDiffViewer = ref(null);
 
 const stagedFiles = computed(() => parseDiff(staged.value));
 const unstagedFiles = computed(() => parseDiff(unstaged.value));
-const hasChanges = computed(() => staged.value || unstaged.value || untracked.value.length > 0);
+const untrackedFiles = computed(() => parseDiff(untracked.value));
+const hasChanges = computed(() => staged.value || unstaged.value || untracked.value);
 
 function toggleAllFiles() {
   if (allExpanded.value) {
     stagedDiffViewer.value?.collapseAll();
     unstagedDiffViewer.value?.collapseAll();
+    untrackedDiffViewer.value?.collapseAll();
   } else {
     stagedDiffViewer.value?.expandAll();
     unstagedDiffViewer.value?.expandAll();
+    untrackedDiffViewer.value?.expandAll();
   }
   allExpanded.value = !allExpanded.value;
 }
@@ -84,7 +84,7 @@ async function fetchChanges() {
     const changes = await api.getSessionChanges(props.sessionId);
     staged.value = changes.staged || '';
     unstaged.value = changes.unstaged || '';
-    untracked.value = changes.untracked || [];
+    untracked.value = changes.untracked || '';
   } catch (err) {
     error.value = err.message;
   } finally {
@@ -107,6 +107,7 @@ defineExpose({
   hasChanges,
   stagedFiles,
   unstagedFiles,
+  untrackedFiles,
 });
 </script>
 
@@ -163,23 +164,5 @@ defineExpose({
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
   color: var(--color-text-soft);
-}
-
-.untracked-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  font-family: monospace;
-  font-size: 0.75rem;
-}
-
-.untracked-file {
-  padding: 0.25rem 0.5rem;
-  color: var(--color-success, #22c55e);
-}
-
-.untracked-file::before {
-  content: '+ ';
-  color: var(--color-success, #22c55e);
 }
 </style>

--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -31,8 +31,13 @@
       </div>
 
       <div v-if="expandedFiles[fileIndex]" class="diff-file-content">
+        <!-- Binary file notice -->
+        <div v-if="file.isBinary" class="binary-file-notice">
+          Binary file - cannot display preview
+        </div>
+
         <!-- Markdown preview mode -->
-        <div v-if="previewMode[fileIndex] && isMarkdownFile(file.displayPath)" class="markdown-preview-container">
+        <div v-else-if="previewMode[fileIndex] && isMarkdownFile(file.displayPath)" class="markdown-preview-container">
           <div v-if="!file.isDeleted && !file.isNew" class="markdown-preview-split">
             <div class="markdown-preview-pane">
               <div class="markdown-preview-label markdown-preview-label-old">Before</div>
@@ -257,6 +262,15 @@ function getLinePrefix(type) {
 
 .diff-file-content {
   background-color: var(--color-background);
+}
+
+.binary-file-notice {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-soft);
+  background-color: var(--color-background-mute);
+  border-top: 1px solid var(--color-border);
+  font-style: italic;
 }
 
 .diff-hunk {

--- a/packages/web/src/utils/diffParser.js
+++ b/packages/web/src/utils/diffParser.js
@@ -28,6 +28,7 @@
  * @property {boolean} isNew
  * @property {boolean} isDeleted
  * @property {boolean} isRenamed
+ * @property {boolean} isBinary
  * @property {DiffHunk[]} hunks
  * @property {number} additions
  * @property {number} deletions
@@ -70,6 +71,7 @@ export function parseDiff(diffText) {
         isNew: false,
         isDeleted: false,
         isRenamed: false,
+        isBinary: false,
         hunks: [],
         additions: 0,
         deletions: 0,
@@ -99,13 +101,14 @@ export function parseDiff(diffText) {
       continue;
     }
 
+    // Detect binary files
+    if (line.startsWith('Binary files')) {
+      currentFile.isBinary = true;
+      continue;
+    }
+
     // Skip index, ---, +++ lines (we already have paths from diff --git)
-    if (
-      line.startsWith('index ') ||
-      line.startsWith('--- ') ||
-      line.startsWith('+++ ') ||
-      line.startsWith('Binary files')
-    ) {
+    if (line.startsWith('index ') || line.startsWith('--- ') || line.startsWith('+++ ')) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Untracked files now display with full preview capabilities in the Changes tab, matching the UI treatment of staged/unstaged files
- Added synthetic diff generation for untracked files on the backend
- Binary file detection with placeholder message
- Large file handling with configurable size limit (100KB default)

## Changes

### Backend
- **gitService.js**: Added `getUntrackedFileContent()` function to read untracked file content with binary detection
- **diffService.js**: Added synthetic diff generation for untracked files, changing return type from `string[]` to unified diff format `string`

### Frontend
- **ChangesTab.vue**: Updated to use `DiffViewer` component for untracked files instead of simple `<ul>` list
- **DiffViewer.vue**: Added binary file notice display
- **diffParser.js**: Added `isBinary` flag support for parsing binary file diffs

## Test plan

- [ ] Create an untracked text file and verify it shows in the "Untracked Files" section with full diff preview
- [ ] Create an untracked markdown file and verify the preview toggle works
- [ ] Create a binary file (e.g., image) and verify it shows "Binary file - cannot display preview"
- [ ] Create a large file (>100KB) and verify it shows the truncation message
- [ ] Verify staged and unstaged files still display correctly
- [ ] Verify "Expand All" / "Collapse All" works for all three sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)