### PR TITLE
Fix work logs not displaying in real-time during streaming

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -105,6 +105,9 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
+  // Reset message tracking for this turn - ensures work logs start as unassociated
+  currentMessageIds.set(sessionId, null);
+
   try {
     // Get session for settings
     const session = sessions.getById(sessionId);
@@ -186,6 +189,9 @@ export async function continueSession(sessionId, content, workingDirectory, syst
 
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
+
+  // Reset message tracking for this turn - ensures work logs start as unassociated
+  currentMessageIds.set(sessionId, null);
 
   try {
     // Store the user message
@@ -347,12 +353,6 @@ async function handleStreamEvent(sessionId, event) {
         ?.map((c) => c.text)
         ?.join('\n');
 
-      // Extract thinking content
-      const thinkingContent = event.message?.content
-        ?.filter((c) => c.type === 'thinking')
-        ?.map((c) => c.thinking)
-        ?.join('\n');
-
       // Extract tool use for logging
       const toolUseBlocks = event.message?.content?.filter((c) => c.type === 'tool_use') || [];
 
@@ -378,10 +378,8 @@ async function handleStreamEvent(sessionId, event) {
         }
       }
 
-      // Log thinking content
-      if (thinkingContent) {
-        createWorkLog(sessionId, 'thinking', thinkingContent);
-      }
+      // Note: Thinking content is logged via stream_event -> content_block_stop
+      // to avoid duplicates (since includePartialMessages is always enabled)
 
       // Log tool use inputs
       for (const toolUse of toolUseBlocks) {


### PR DESCRIPTION
## Summary

- **Fixed work logs not appearing in LiveWorkLogPanel** during Claude's processing
  - Root cause: `currentMessageIds` was not reset at the start of each conversation turn, causing new work logs to be incorrectly associated with the previous assistant message instead of being unassociated
  - Work logs now correctly start as unassociated and appear in real-time

- **Fixed duplicate thinking work logs** being created
  - Thinking content was being logged twice: once in `content_block_stop` (streaming) and again in the `assistant` event
  - Now only logged via streaming path to avoid duplicates

## Test plan

- [ ] Start a session with thinking mode enabled
- [ ] Send a follow-up message in an existing session
- [ ] Verify work logs (thinking, tool inputs/outputs) appear in the "Claude is working..." panel in real-time
- [ ] Verify work logs are correctly associated with the assistant message after it arrives
- [ ] Verify no duplicate thinking entries appear in work logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)