### PR TITLE
Remove duplicate delete button from bottom of session detail view

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -72,31 +72,6 @@
         <CanvasTab v-else-if="activeTab === 'canvas'" :session-id="route.params.id" />
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
       </div>
-
-      <div v-if="['stopped', 'completed', 'error'].includes(sessionsStore.currentSession?.status)" class="session-actions-bottom">
-        <button
-          v-if="!showDeleteConfirm"
-          class="btn btn-outline-danger"
-          @click="showDeleteConfirm = true"
-        >
-          Delete Session
-        </button>
-        <div v-else class="delete-confirm">
-          <span class="delete-confirm-text">Delete this session?</span>
-          <button
-            class="btn btn-danger btn-sm"
-            @click="handleDelete"
-          >
-            Confirm
-          </button>
-          <button
-            class="btn btn-secondary btn-sm"
-            @click="showDeleteConfirm = false"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
     </template>
   </div>
 </template>
@@ -322,14 +297,5 @@ async function handleDelete() {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-}
-
-.session-actions-bottom {
-  padding: 1rem 0;
-  border-top: 1px solid var(--color-border);
-  margin-top: 1rem;
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- Removed the redundant delete button at the bottom of the session detail view
- The delete button in the session header (top) remains intact
- Also removed the associated CSS styles that are no longer needed

## Test plan
- [ ] Navigate to a session detail view
- [ ] Verify the delete button at the top of the view still works
- [ ] Verify there is no longer a delete button at the bottom of the view

🤖 Generated with [Claude Code](https://claude.com/claude-code)