### PR TITLE
Make Start Session button vertically larger for easier clicking

### DIFF
--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -240,6 +240,9 @@ h1 {
 
 .btn-full-width {
   width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  font-size: 1.1rem;
 }
 
 .error-message {


### PR DESCRIPTION
## Summary
- Increased vertical padding (`padding-top: 1rem` and `padding-bottom: 1rem`) on the Start Session button
- Slightly increased font size to `1.1rem` for better visual proportion
- Improves touch target size and overall usability on the New Session view

## Test plan
- [ ] Navigate to the New Session view
- [ ] Verify the Start Session button is visually larger/taller
- [ ] Test clicking the button on desktop and mobile to confirm improved usability

🤖 Generated with [Claude Code](https://claude.com/claude-code)