### PR TITLE
Use consistent markdown rendering in canvas and changes views

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -318,3 +318,28 @@ pre {
 .toast-info {
   border-color: var(--color-info);
 }
+
+/* Preview toggle button (used in DiffViewer and CanvasTab) */
+.preview-toggle {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.625rem;
+  font-weight: 500;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  color: var(--color-text-soft);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.preview-toggle:hover {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
+}
+
+.preview-toggle.active {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
+}

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -17,6 +17,15 @@
       >
         <div class="canvas-item-header">
           <span class="canvas-item-type">{{ item.type }}</span>
+          <button
+            v-if="item.type === 'markdown'"
+            class="preview-toggle"
+            :class="{ active: previewMode[item.id] }"
+            @click="togglePreview(item.id)"
+            :title="previewMode[item.id] ? 'Show raw markdown' : 'Preview markdown'"
+          >
+            {{ previewMode[item.id] ? '📝 Raw' : '👁 Preview' }}
+          </button>
           <button class="btn-icon" @click="handleDelete(item.id)" title="Delete">
             &times;
           </button>
@@ -32,8 +41,10 @@
             class="canvas-image"
           />
 
-          <div v-else-if="item.type === 'markdown'" class="canvas-markdown" v-html="item.content">
-          </div>
+          <template v-else-if="item.type === 'markdown'">
+            <MarkdownViewer v-if="previewMode[item.id]" :content="item.content" class="canvas-markdown" />
+            <pre v-else class="canvas-markdown-raw">{{ item.content }}</pre>
+          </template>
 
           <pre v-else-if="item.type === 'json'" class="canvas-json">{{ formatJson(item.data) }}</pre>
 
@@ -45,8 +56,10 @@
 </template>
 
 <script setup>
+import { ref, watch } from 'vue';
 import { useCanvasStore } from '../stores/canvas.js';
 import { useUiStore } from '../stores/ui.js';
+import MarkdownViewer from './MarkdownViewer.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -54,6 +67,24 @@ const props = defineProps({
 
 const canvasStore = useCanvasStore();
 const uiStore = useUiStore();
+const previewMode = ref({});
+
+// Initialize preview mode to true (preview by default) for markdown items
+watch(
+  () => canvasStore.items,
+  (items) => {
+    items.forEach((item) => {
+      if (item.type === 'markdown' && previewMode.value[item.id] === undefined) {
+        previewMode.value[item.id] = true;
+      }
+    });
+  },
+  { immediate: true }
+);
+
+function togglePreview(itemId) {
+  previewMode.value[itemId] = !previewMode.value[itemId];
+}
 
 function formatJson(data) {
   try {
@@ -150,6 +181,18 @@ async function handleDelete(itemId) {
 
 .canvas-markdown {
   font-size: 0.875rem;
+}
+
+.canvas-markdown-raw {
+  font-size: 0.75rem;
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* Preview toggle button - layout only (base styles in main.css) */
+.preview-toggle {
+  margin-left: auto;
 }
 
 .canvas-json {

--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -106,13 +106,13 @@ const previewMode = ref({});
 watch(
   () => props.files,
   (newFiles) => {
-    newFiles.forEach((_, index) => {
+    newFiles.forEach((file, index) => {
       if (expandedFiles.value[index] === undefined) {
         expandedFiles.value[index] = props.expandAll;
       }
-      // Initialize preview mode to false (diff view by default)
+      // Initialize preview mode to true for markdown files (preview by default)
       if (previewMode.value[index] === undefined) {
-        previewMode.value[index] = false;
+        previewMode.value[index] = isMarkdownFile(file.displayPath);
       }
     });
   },
@@ -335,30 +335,9 @@ function getLinePrefix(type) {
   vertical-align: top;
 }
 
-/* Markdown preview toggle button */
+/* Markdown preview toggle button - layout only (base styles in main.css) */
 .preview-toggle {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.625rem;
-  font-weight: 500;
-  background-color: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: 3px;
-  color: var(--color-text-soft);
-  cursor: pointer;
-  transition: all 0.2s ease;
   margin-left: auto;
-}
-
-.preview-toggle:hover {
-  background-color: var(--color-primary);
-  border-color: var(--color-primary);
-  color: white;
-}
-
-.preview-toggle.active {
-  background-color: var(--color-primary);
-  border-color: var(--color-primary);
-  color: white;
 }
 
 /* Markdown preview container */

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -42,6 +42,60 @@ test.describe('Canvas Management', () => {
     expect(items[0].content).toBe('# Test Markdown');
   });
 
+  test('markdown items default to preview mode and can toggle to raw', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'markdown',
+      content: '# Heading\n\nSome **bold** text',
+      label: 'Markdown Test',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Should be in preview mode by default - shows rendered markdown
+    const canvasItem = page.locator('.canvas-item').first();
+    await expect(canvasItem.locator('.markdown-viewer')).toBeVisible();
+    await expect(canvasItem.locator('.canvas-markdown-raw')).not.toBeVisible();
+
+    // Preview toggle button should show "Raw" option (since we're in preview mode)
+    const toggleButton = canvasItem.locator('.preview-toggle');
+    await expect(toggleButton).toContainText('Raw');
+
+    // Click to switch to raw mode
+    await toggleButton.click();
+
+    // Should now show raw markdown
+    await expect(canvasItem.locator('.canvas-markdown-raw')).toBeVisible();
+    await expect(canvasItem.locator('.markdown-viewer')).not.toBeVisible();
+    await expect(canvasItem.locator('.canvas-markdown-raw')).toContainText('# Heading');
+
+    // Toggle button should now show "Preview" option
+    await expect(toggleButton).toContainText('Preview');
+
+    // Click to switch back to preview mode
+    await toggleButton.click();
+
+    // Should be back in preview mode
+    await expect(canvasItem.locator('.markdown-viewer')).toBeVisible();
+    await expect(canvasItem.locator('.canvas-markdown-raw')).not.toBeVisible();
+  });
+
+  test('markdown items render properly with MarkdownViewer', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'markdown',
+      content: '# Main Heading\n\n- List item 1\n- List item 2\n\n```js\nconst x = 1;\n```',
+      label: 'Rich Markdown',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    const canvasItem = page.locator('.canvas-item').first();
+
+    // Verify markdown is rendered (not raw)
+    await expect(canvasItem.locator('.markdown-viewer h1')).toContainText('Main Heading');
+    await expect(canvasItem.locator('.markdown-viewer ul li').first()).toContainText('List item 1');
+    await expect(canvasItem.locator('.markdown-viewer pre code')).toContainText('const x = 1;');
+  });
+
   test('can delete canvas item', async ({ page }) => {
     const item = await seedCanvasItem(session.id, {
       type: 'text',


### PR DESCRIPTION
## Summary
- CanvasTab now uses the same `MarkdownViewer` component as the changes view for consistent markdown rendering
- Added preview/raw toggle button for markdown items in canvas (defaults to preview mode)
- DiffViewer now defaults to preview mode for markdown files instead of diff view
- Extracted shared preview toggle button styles to `main.css` to eliminate duplication

## Test plan
- [ ] Open a session with markdown canvas items and verify they render properly
- [ ] Toggle between preview and raw modes on canvas markdown items
- [ ] Open the changes tab with markdown file changes and verify it defaults to preview mode
- [ ] Toggle between preview and diff modes on markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)