### PR TITLE
Improve work log input display with command summaries

### DIFF
--- a/packages/web/src/components/CommandBlock.test.js
+++ b/packages/web/src/components/CommandBlock.test.js
@@ -1,0 +1,367 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CommandBlock from './CommandBlock.vue';
+
+describe('CommandBlock', () => {
+  function mountComponent(log) {
+    return mount(CommandBlock, {
+      props: { log },
+    });
+  }
+
+  describe('tool output display', () => {
+    it('displays raw content for tool_output logs', () => {
+      const wrapper = mountComponent({
+        type: 'tool_output',
+        toolName: 'Bash',
+        content: 'command output here',
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary').exists()).toBe(false);
+      expect(wrapper.find('.raw-json-details').exists()).toBe(false);
+      expect(wrapper.find('.command-pre').text()).toBe('command output here');
+    });
+
+    it('shows Output label for tool_output', () => {
+      const wrapper = mountComponent({
+        type: 'tool_output',
+        toolName: 'Bash',
+        content: 'output',
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-label').text()).toBe('Output');
+    });
+  });
+
+  describe('command summary extraction', () => {
+    it('extracts command from Bash tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify({ command: 'git status', timeout: 30000 }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('git status');
+      expect(wrapper.find('.raw-json-details').exists()).toBe(true);
+    });
+
+    it('extracts file_path from Read tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Read',
+        content: JSON.stringify({ file_path: '/src/index.js' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('/src/index.js');
+    });
+
+    it('extracts file_path from Edit tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Edit',
+        content: JSON.stringify({
+          file_path: '/src/app.js',
+          old_string: 'foo',
+          new_string: 'bar',
+        }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('/src/app.js');
+    });
+
+    it('extracts file_path from Write tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Write',
+        content: JSON.stringify({ file_path: '/new-file.js', content: 'file content' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('/new-file.js');
+    });
+
+    it('extracts pattern from Grep tool input without path', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Grep',
+        content: JSON.stringify({ pattern: 'TODO' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('"TODO"');
+    });
+
+    it('extracts pattern and path from Grep tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Grep',
+        content: JSON.stringify({ pattern: 'import.*vue', path: '/src' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('"import.*vue" in /src');
+    });
+
+    it('extracts pattern from Glob tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Glob',
+        content: JSON.stringify({ pattern: '**/*.vue' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('**/*.vue');
+    });
+
+    it('extracts description from Task tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Task',
+        content: JSON.stringify({
+          description: 'Find all Vue components',
+          prompt: 'Search for Vue components...',
+        }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('Find all Vue components');
+    });
+
+    it('extracts prompt when Task has no description', () => {
+      const prompt = 'A'.repeat(150);
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Task',
+        content: JSON.stringify({ prompt }),
+        timestamp: Date.now(),
+      });
+
+      // Should truncate to 100 characters
+      expect(wrapper.find('.command-summary code').text()).toBe(prompt.slice(0, 100));
+    });
+
+    it('extracts url from WebFetch tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'WebFetch',
+        content: JSON.stringify({ url: 'https://example.com/docs', prompt: 'get info' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('https://example.com/docs');
+    });
+
+    it('extracts query from WebSearch tool input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'WebSearch',
+        content: JSON.stringify({ query: 'vue 3 composition api' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('vue 3 composition api');
+    });
+
+    it('handles case-insensitive tool names', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'BASH',
+        content: JSON.stringify({ command: 'npm test' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary code').text()).toBe('npm test');
+    });
+  });
+
+  describe('fallback to raw JSON display', () => {
+    it('shows raw JSON for unknown tool types', () => {
+      const content = JSON.stringify({ some: 'data' });
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'UnknownTool',
+        content,
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary').exists()).toBe(false);
+      expect(wrapper.find('.command-pre').text()).toBe(content);
+    });
+
+    it('shows raw content when JSON parsing fails', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: 'not valid json',
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-summary').exists()).toBe(false);
+      expect(wrapper.find('.command-pre').text()).toBe('not valid json');
+    });
+
+    it('shows raw JSON when tool input lacks expected field', () => {
+      const content = JSON.stringify({ other_field: 'value' });
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content,
+        timestamp: Date.now(),
+      });
+
+      // command field is undefined, so commandSummary returns undefined/null
+      expect(wrapper.find('.command-summary').exists()).toBe(false);
+    });
+  });
+
+  describe('collapsible raw JSON', () => {
+    it('hides raw JSON by default when summary is shown', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify({ command: 'ls -la' }),
+        timestamp: Date.now(),
+      });
+
+      const details = wrapper.find('.raw-json-details');
+      expect(details.exists()).toBe(true);
+      expect(details.attributes('open')).toBeUndefined();
+    });
+
+    it('contains Show raw JSON summary text', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify({ command: 'ls -la' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.raw-json-details summary').text()).toBe('Show raw JSON');
+    });
+
+    it('shows full JSON content in details', () => {
+      const inputJson = { command: 'ls -la', timeout: 5000 };
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify(inputJson, null, 2),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.raw-json-details .command-pre').text()).toBe(
+        JSON.stringify(inputJson, null, 2)
+      );
+    });
+  });
+
+  describe('header display', () => {
+    it('shows Input label for tool_input', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify({ command: 'test' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-label').text()).toBe('Input');
+    });
+
+    it('displays tool name', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Grep',
+        content: JSON.stringify({ pattern: 'test' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-tool-name').text()).toBe('Grep');
+    });
+
+    it('displays formatted timestamp', () => {
+      const timestamp = new Date('2024-01-15T10:30:00').getTime();
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify({ command: 'test' }),
+        timestamp,
+      });
+
+      const timeText = wrapper.find('.command-time').text();
+      expect(timeText).toMatch(/10:30/);
+    });
+  });
+
+  describe('content truncation for outputs', () => {
+    it('truncates long output content', async () => {
+      const longContent = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join('\n');
+      const wrapper = mountComponent({
+        type: 'tool_output',
+        toolName: 'Bash',
+        content: longContent,
+        timestamp: Date.now(),
+      });
+
+      // Should be truncated to 10 lines + "..."
+      const displayedLines = wrapper.find('.command-pre').text().split('\n');
+      expect(displayedLines.length).toBe(11); // 10 lines + "..."
+      expect(displayedLines[10]).toBe('...');
+    });
+
+    it('shows "Show more" button for truncated content', () => {
+      const longContent = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join('\n');
+      const wrapper = mountComponent({
+        type: 'tool_output',
+        toolName: 'Bash',
+        content: longContent,
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.show-more-btn').text()).toContain('Show more');
+      expect(wrapper.find('.show-more-btn').text()).toContain('20 lines');
+    });
+
+    it('expands content when "Show more" is clicked', async () => {
+      const longContent = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join('\n');
+      const wrapper = mountComponent({
+        type: 'tool_output',
+        toolName: 'Bash',
+        content: longContent,
+        timestamp: Date.now(),
+      });
+
+      await wrapper.find('.show-more-btn').trigger('click');
+
+      expect(wrapper.find('.command-pre').text()).toBe(longContent);
+      expect(wrapper.find('.show-more-btn').text()).toBe('Show less');
+    });
+  });
+
+  describe('styling classes', () => {
+    it('applies tool_input class for input logs', () => {
+      const wrapper = mountComponent({
+        type: 'tool_input',
+        toolName: 'Bash',
+        content: JSON.stringify({ command: 'test' }),
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-block').classes()).toContain('command-tool_input');
+    });
+
+    it('applies tool_output class for output logs', () => {
+      const wrapper = mountComponent({
+        type: 'tool_output',
+        toolName: 'Bash',
+        content: 'output',
+        timestamp: Date.now(),
+      });
+
+      expect(wrapper.find('.command-block').classes()).toContain('command-tool_output');
+    });
+  });
+});

--- a/packages/web/src/components/CommandBlock.vue
+++ b/packages/web/src/components/CommandBlock.vue
@@ -16,13 +16,27 @@
       <span v-if="log.timestamp" class="command-time">{{ formatTime(log.timestamp) }}</span>
     </div>
     <div class="command-content">
-      <pre class="command-pre" :class="{ expanded: isExpanded }">{{ displayContent }}</pre>
-      <button v-if="shouldTruncate && !isExpanded" class="show-more-btn" @click="isExpanded = true">
-        Show more ({{ lineCount }} lines)
-      </button>
-      <button v-if="isExpanded && shouldTruncate" class="show-more-btn" @click="isExpanded = false">
-        Show less
-      </button>
+      <!-- Tool input: show command summary with collapsible raw JSON -->
+      <template v-if="commandSummary">
+        <div class="command-summary">
+          <code>{{ commandSummary }}</code>
+        </div>
+        <details class="raw-json-details">
+          <summary>Show raw JSON</summary>
+          <pre class="command-pre">{{ displayContent }}</pre>
+        </details>
+      </template>
+
+      <!-- Fallback: Original display for outputs or when no summary available -->
+      <template v-else>
+        <pre class="command-pre" :class="{ expanded: isExpanded }">{{ displayContent }}</pre>
+        <button v-if="shouldTruncate && !isExpanded" class="show-more-btn" @click="isExpanded = true">
+          Show more ({{ lineCount }} lines)
+        </button>
+        <button v-if="isExpanded && shouldTruncate" class="show-more-btn" @click="isExpanded = false">
+          Show less
+        </button>
+      </template>
     </div>
   </div>
 </template>
@@ -46,6 +60,44 @@ const displayContent = computed(() => {
     return props.log.content;
   }
   return lines.value.slice(0, MAX_LINES).join('\n') + '\n...';
+});
+
+/**
+ * Extracts a human-readable command summary from tool input JSON.
+ * Returns null for tool outputs or when parsing fails (falls back to raw JSON display).
+ */
+const commandSummary = computed(() => {
+  if (props.log.type !== 'tool_input') return null;
+
+  try {
+    const input = JSON.parse(props.log.content);
+    const toolName = props.log.toolName?.toLowerCase();
+
+    switch (toolName) {
+      case 'bash':
+        return input.command;
+      case 'read':
+        return input.file_path;
+      case 'edit':
+        return input.file_path;
+      case 'write':
+        return input.file_path;
+      case 'grep':
+        return `"${input.pattern}"${input.path ? ` in ${input.path}` : ''}`;
+      case 'glob':
+        return input.pattern;
+      case 'task':
+        return input.description || input.prompt?.slice(0, 100);
+      case 'webfetch':
+        return input.url;
+      case 'websearch':
+        return input.query;
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
 });
 
 function formatTime(ts) {
@@ -116,6 +168,42 @@ function formatTime(ts) {
 
 .command-content {
   position: relative;
+}
+
+.command-summary {
+  margin-bottom: 0.5rem;
+}
+
+.command-summary code {
+  display: block;
+  padding: 0.5rem;
+  background: var(--color-background);
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  font-family: var(--font-mono, 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace);
+  color: var(--color-text);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.raw-json-details {
+  margin-top: 0.25rem;
+}
+
+.raw-json-details summary {
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  user-select: none;
+  padding: 0.25rem 0;
+}
+
+.raw-json-details summary:hover {
+  color: var(--color-primary);
+}
+
+.raw-json-details[open] summary {
+  margin-bottom: 0.375rem;
 }
 
 .command-pre {


### PR DESCRIPTION
## Summary
- Show human-readable command summaries for tool inputs in work logs (e.g., `git status` instead of raw JSON `{"command": "git status", ...}`)
- Add collapsible "Show raw JSON" section for drilling into full details when needed
- Support for Bash, Read, Edit, Write, Grep, Glob, Task, WebFetch, and WebSearch tools with graceful fallback for unknown tools

## Test plan
- [x] Verify Bash tool inputs show the command (e.g., `git status`)
- [x] Verify Read/Edit/Write tool inputs show the file path
- [x] Verify Grep tool inputs show pattern and path
- [x] Verify "Show raw JSON" expands to show full JSON content
- [x] Verify tool outputs still display raw content (unchanged behavior)
- [x] Verify unknown tools fall back to raw JSON display
- [x] All 28 new tests pass with no mocking required

🤖 Generated with [Claude Code](https://claude.com/claude-code)