### PR TITLE
Make top navigation sticky

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -33,6 +33,10 @@ import ToastContainer from './components/ToastContainer.vue';
   background-color: var(--color-background-soft);
   border-bottom: 1px solid var(--color-border);
   padding: 0.75rem 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .app-header .container {


### PR DESCRIPTION
## Summary
- Added sticky positioning to the top navigation header so it remains visible when scrolling
- Added subtle box-shadow for visual depth and separation from content
- Used z-index: 100 to stay above content but below modals/toasts

## Test plan
- [ ] Scroll the page and verify the header stays pinned at the top
- [ ] Verify toast notifications still appear above the header
- [ ] Test that modal overlays (PathChooser) appear above the header
- [ ] Check appearance at different viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)