### PR TITLE
Remove redundant Stop Session button

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -71,15 +71,6 @@
         <ChangesTab v-else-if="activeTab === 'changes'" :session-id="route.params.id" />
         <CanvasTab v-else-if="activeTab === 'canvas'" :session-id="route.params.id" />
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
-
-        <div v-if="activeTab === 'conversation' && canStop" class="stop-session-bottom">
-          <button
-            class="btn btn-danger"
-            @click="handleStop"
-          >
-            Stop Session
-          </button>
-        </div>
       </div>
     </template>
   </div>
@@ -108,12 +99,6 @@ const uiStore = useUiStore();
 
 
 const activeTab = computed(() => route.params.tab || 'conversation');
-
-const canStop = computed(() => {
-  const status = sessionsStore.currentSession?.status;
-  // Can stop running or waiting sessions, but not already stopped ones
-  return status === 'running' || status === 'waiting';
-});
 
 const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate } =
   useSessionSubscription(route.params.id);
@@ -225,15 +210,6 @@ onUnmounted(() => {
   cleanups.forEach((cleanup) => cleanup());
 });
 
-async function handleStop() {
-  try {
-    await sessionsStore.stopSession(route.params.id);
-    uiStore.success('Session stopped');
-  } catch (err) {
-    uiStore.error(err.message);
-  }
-}
-
 async function handleDelete() {
   if (!confirm('Are you sure you want to delete this session?')) return;
 
@@ -308,13 +284,5 @@ async function handleDelete() {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-}
-
-.stop-session-bottom {
-  padding: 1rem 0;
-  border-top: 1px solid var(--color-border);
-  margin-top: 1rem;
-  display: flex;
-  justify-content: center;
 }
 </style>


### PR DESCRIPTION
## Summary
- Removed the duplicate "Stop Session" button from the bottom of SessionDetailView
- Both buttons called the same `stopSession()` function, which aborts the Claude Code process
- The "Stop" button in ConversationTab remains and provides the same functionality

## Test plan
- [ ] Start a session and verify the "Stop" button appears when Claude is running
- [ ] Click "Stop" and verify the session stops correctly
- [ ] Verify no "Stop Session" button appears at the bottom of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)