### PR TITLE
Remove end session button and related code

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { sessions, messages, sessionNotes, projects, todos, workLogs } from '../database.js';
-import { continueSession, stopSession, endSession, restartSession, cleanupActiveSession } from '../services/sessionManager.js';
+import { continueSession, stopSession, restartSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges } from '../services/diffService.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
@@ -121,25 +121,6 @@ router.post('/:id/stop', async (req, res) => {
 
   try {
     await stopSession(session.id);
-    res.json({ success: true });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
-
-// POST /api/sessions/:id/end - End session (mark as completed)
-router.post('/:id/end', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) {
-    return res.status(404).json({ error: 'Session not found' });
-  }
-
-  if (session.status === 'completed') {
-    return res.status(400).json({ error: 'Session is already completed' });
-  }
-
-  try {
-    endSession(session.id);
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -271,25 +271,6 @@ export async function stopSession(sessionId) {
 }
 
 /**
- * End a session (mark as completed)
- * @param {string} sessionId
- */
-export function endSession(sessionId) {
-  // If actively running, abort first
-  const sessionData = activeSessions.get(sessionId);
-  if (sessionData) {
-    sessionData.controller.abort();
-    activeSessions.delete(sessionId);
-  }
-
-  sessions.update(sessionId, { status: 'completed' });
-  broadcastSessionStatus(sessionId, 'completed');
-
-  // Generate summary immediately on session completion
-  summaryService.onSessionComplete(sessionId);
-}
-
-/**
  * Restart a completed or errored session (set back to stopped so it can receive messages)
  * @param {string} sessionId
  */

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -185,15 +185,6 @@ export class ApiClient {
   }
 
   /**
-   * End a session (mark as completed)
-   * @param {string} id - Session ID
-   * @returns {Promise<Object>}
-   */
-  async endSession(id) {
-    return this.#request('POST', `/sessions/${id}/end`);
-  }
-
-  /**
    * Restart a completed or errored session
    * @param {string} id - Session ID
    * @returns {Promise<Object>}

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -104,9 +104,6 @@
             <span v-if="sending" class="loading-spinner"></span>
             Send
           </button>
-          <button type="button" class="btn btn-secondary" @click="handleEndSession" :disabled="ending">
-            End Session
-          </button>
         </div>
       </div>
     </form>
@@ -153,7 +150,6 @@ const uiStore = useUiStore();
 
 const input = ref('');
 const sending = ref(false);
-const ending = ref(false);
 const stopping = ref(false);
 const restarting = ref(false);
 const togglingThinking = ref(false);
@@ -317,19 +313,6 @@ async function handleSend() {
     uiStore.error(err.message);
   } finally {
     sending.value = false;
-  }
-}
-
-async function handleEndSession() {
-  if (ending.value) return;
-
-  ending.value = true;
-  try {
-    await sessionsStore.endSession(props.sessionId);
-  } catch (err) {
-    uiStore.error(err.message);
-  } finally {
-    ending.value = false;
   }
 }
 

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -125,23 +125,6 @@ export const useSessionsStore = defineStore('sessions', {
       }
     },
 
-    async endSession(id) {
-      this.error = null;
-      try {
-        await api.endSession(id);
-        if (this.currentSession?.id === id) {
-          this.currentSession.status = 'completed';
-        }
-        const session = this.sessions.find((s) => s.id === id);
-        if (session) {
-          session.status = 'completed';
-        }
-      } catch (err) {
-        this.error = err.message;
-        throw err;
-      }
-    },
-
     async restartSession(id) {
       this.error = null;
       try {


### PR DESCRIPTION
## Summary
- Removed the "End Session" button from the session detail view (ConversationTab)
- Removed associated handler, state, and store action from frontend
- Removed `endSession` API client method
- Removed `/api/sessions/:id/end` backend route
- Removed `endSession` function from sessionManager service

## Test plan
- [ ] Verify session detail view loads correctly without the End Session button
- [ ] Verify sending messages still works
- [ ] Verify the Stop button still functions for running sessions
- [ ] Verify session can be deleted from the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)