### PR TITLE
Migrate summary service to Claude Code SDK and fix reliability issues

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -152,6 +152,8 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
     if (activeSession && !controller.signal.aborted) {
       sessions.update(sessionId, { status: 'waiting' });
       broadcastSessionStatus(sessionId, 'waiting');
+      // Trigger summary generation when session completes a turn
+      summaryService.onSessionActivity(sessionId);
     }
   } catch (error) {
     console.error('Session error:', error);
@@ -159,6 +161,8 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
     if (!controller.signal.aborted) {
       sessions.update(sessionId, { status: 'error', error: error.message });
       broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
+      // Trigger summary generation on error
+      summaryService.onSessionComplete(sessionId);
     }
     throw error;
   } finally {
@@ -237,6 +241,8 @@ export async function continueSession(sessionId, content, workingDirectory, syst
     if (activeSession && !controller.signal.aborted) {
       sessions.update(sessionId, { status: 'waiting' });
       broadcastSessionStatus(sessionId, 'waiting');
+      // Trigger summary generation when session completes a turn
+      summaryService.onSessionActivity(sessionId);
     }
   } catch (error) {
     console.error('Continue session error:', error);
@@ -244,6 +250,8 @@ export async function continueSession(sessionId, content, workingDirectory, syst
     if (!controller.signal.aborted) {
       sessions.update(sessionId, { status: 'error', error: error.message });
       broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
+      // Trigger summary generation on error
+      summaryService.onSessionComplete(sessionId);
     }
     throw error;
   } finally {

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -23,7 +23,7 @@ const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
  * @param {Array} params.recentMessages - Messages for mock context
  * @param {string} params.sessionStatus - Session status for mock outcome
  */
-async function* mockSummaryQuery({ prompt, recentMessages, sessionStatus }) {
+async function* mockSummaryQuery({ prompt: _prompt, recentMessages, sessionStatus }) {
   // Yield system init event (matches SDK pattern)
   yield {
     type: 'system',

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -1,4 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
+import { query } from '@anthropic-ai/claude-agent-sdk';
 import { sessions, messages, sessionSummaries } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
@@ -6,26 +6,110 @@ import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 // Debounce timers per session
 const debounceTimers = new Map();
 
-// Debounce delay in milliseconds (15 seconds)
-const DEBOUNCE_DELAY = 15000;
+// Debounce delay in milliseconds (5 seconds - reduced from 15s for faster feedback)
+const DEBOUNCE_DELAY = 5000;
 
 // Maximum number of recent messages to include in generation
 const MAX_MESSAGES = 50;
 
-// Claude Haiku model for cost-effective generation
-const HAIKU_MODEL = 'claude-3-5-haiku-20241022';
-
 // Check if mock mode is enabled
 const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
 
-// Anthropic client (lazy initialized)
-let anthropicClient = null;
+/**
+ * Mock query generator for summary generation in test mode
+ * Mirrors the Claude Code SDK's async generator pattern
+ * @param {Object} params
+ * @param {string} params.prompt - The prompt string
+ * @param {Array} params.recentMessages - Messages for mock context
+ * @param {string} params.sessionStatus - Session status for mock outcome
+ */
+async function* mockSummaryQuery({ prompt, recentMessages, sessionStatus }) {
+  // Yield system init event (matches SDK pattern)
+  yield {
+    type: 'system',
+    subtype: 'init',
+    session_id: 'mock-summary-' + Date.now(),
+  };
 
-function getAnthropicClient() {
-  if (!anthropicClient && !isMockMode()) {
-    anthropicClient = new Anthropic();
+  // Small delay to simulate processing
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // Derive outcome from session status
+  let outcome = 'ongoing';
+  if (sessionStatus === 'completed') outcome = 'completed';
+  else if (sessionStatus === 'error') outcome = 'failed';
+
+  // Create contextual mock response
+  const lastMessage = recentMessages[recentMessages.length - 1];
+  const shortPreview = lastMessage ? lastMessage.content.substring(0, 100) : 'testing session';
+
+  const mockResponse = JSON.stringify({
+    short_summary: `Mock summary: ${shortPreview}...`.substring(0, 150),
+    full_summary: `This is a mock summary for testing purposes. The session has ${recentMessages.length} messages and is currently ${sessionStatus}.`,
+    key_actions: ['Mock action 1', 'Mock action 2'],
+    files_modified: ['mock-file.js'],
+    outcome: outcome,
+  });
+
+  // Yield assistant message with mock response
+  yield {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'text', text: mockResponse }],
+    },
+  };
+
+  // Yield result event
+  yield {
+    type: 'result',
+    subtype: 'success',
+    total_cost_usd: 0.0001,
+  };
+}
+
+/**
+ * Call Claude via SDK and extract text response
+ * @param {string} prompt - The prompt to send
+ * @param {Array} recentMessages - Messages (for mock mode context)
+ * @param {string} sessionStatus - Session status (for mock mode context)
+ * @returns {Promise<string>} The text response
+ */
+async function callClaude(prompt, recentMessages, sessionStatus) {
+  const queryFn = isMockMode() ? mockSummaryQuery : query;
+
+  const queryParams = isMockMode()
+    ? { prompt, recentMessages, sessionStatus }
+    : {
+        prompt,
+        options: {
+          cwd: process.cwd(),
+          permissionMode: 'bypassPermissions',
+          maxTurns: 1,
+        },
+      };
+
+  let responseText = '';
+
+  for await (const event of queryFn(queryParams)) {
+    switch (event.type) {
+      case 'assistant': {
+        const text = event.message?.content
+          ?.filter((c) => c.type === 'text')
+          ?.map((c) => c.text)
+          ?.join('');
+        if (text) responseText += text;
+        break;
+      }
+      case 'result': {
+        if (event.subtype === 'error') {
+          throw new Error(event.error || 'Claude SDK query failed');
+        }
+        break;
+      }
+    }
   }
-  return anthropicClient;
+
+  return responseText;
 }
 
 /**
@@ -104,27 +188,6 @@ Outcome guidelines:
 }
 
 /**
- * Generate a mock summary for testing
- * @param {Array} recentMessages
- * @param {string} sessionStatus
- * @returns {Object}
- */
-function generateMockSummary(recentMessages, sessionStatus) {
-  const lastMessage = recentMessages[recentMessages.length - 1];
-  const shortSummary = lastMessage
-    ? `Mock summary: ${lastMessage.content.substring(0, 100)}...`
-    : 'Mock session summary for testing';
-
-  return {
-    shortSummary: shortSummary.substring(0, 150),
-    fullSummary: `This is a mock summary for testing purposes. The session has ${recentMessages.length} messages and is currently ${sessionStatus}.`,
-    keyActions: ['Mock action 1', 'Mock action 2'],
-    filesModified: ['mock-file.js'],
-    outcome: sessionStatus === 'completed' ? 'completed' : sessionStatus === 'error' ? 'failed' : 'ongoing',
-  };
-}
-
-/**
  * Parse the Claude API response into a summary object
  * @param {string} responseText
  * @returns {Object}
@@ -142,7 +205,7 @@ function parseSummaryResponse(responseText) {
     };
   } catch {
     // If JSON parsing fails, try to extract from the response
-    console.warn('Failed to parse summary response as JSON, using fallback');
+    console.warn('[SummaryService] Failed to parse summary response as JSON, using fallback');
     return {
       shortSummary: responseText.substring(0, 150),
       fullSummary: responseText.substring(0, 500),
@@ -154,7 +217,7 @@ function parseSummaryResponse(responseText) {
 }
 
 /**
- * Generate summary for a session using Claude API
+ * Generate summary for a session using Claude Code SDK
  * @param {string} sessionId
  * @returns {Promise<Object|null>}
  */
@@ -163,7 +226,7 @@ export async function generateSummary(sessionId) {
     // Get session info
     const session = sessions.getById(sessionId);
     if (!session) {
-      console.warn(`Session ${sessionId} not found for summary generation`);
+      console.warn(`[SummaryService] Session ${sessionId} not found for summary generation`);
       return null;
     }
 
@@ -175,7 +238,7 @@ export async function generateSummary(sessionId) {
     const recentMessages = allMessages.slice(-MAX_MESSAGES);
 
     if (recentMessages.length === 0) {
-      console.warn(`No messages found for session ${sessionId}`);
+      console.warn(`[SummaryService] No messages found for session ${sessionId}`);
       return null;
     }
 
@@ -185,37 +248,14 @@ export async function generateSummary(sessionId) {
       generating: true,
     });
 
-    let summaryData;
+    // Build prompt
+    const prompt = buildIncrementalPrompt(existingSummary, recentMessages, session.status);
 
-    if (isMockMode()) {
-      // Use mock summary for testing
-      summaryData = generateMockSummary(recentMessages, session.status);
-    } else {
-      // Build prompt
-      const prompt = buildIncrementalPrompt(existingSummary, recentMessages, session.status);
+    // Call Claude via SDK (or mock in test mode)
+    const responseText = await callClaude(prompt, recentMessages, session.status);
 
-      // Call Claude API
-      const client = getAnthropicClient();
-      const response = await client.messages.create({
-        model: HAIKU_MODEL,
-        max_tokens: 1024,
-        messages: [
-          {
-            role: 'user',
-            content: prompt,
-          },
-        ],
-      });
-
-      // Extract text from response
-      const responseText = response.content
-        .filter((c) => c.type === 'text')
-        .map((c) => c.text)
-        .join('');
-
-      // Parse response
-      summaryData = parseSummaryResponse(responseText);
-    }
+    // Parse response
+    const summaryData = parseSummaryResponse(responseText);
 
     // Add message count for staleness tracking
     summaryData.messageCount = allMessages.length;
@@ -229,9 +269,14 @@ export async function generateSummary(sessionId) {
       summary,
     });
 
+    console.log(`[SummaryService] Successfully generated summary for session ${sessionId}`);
     return summary;
   } catch (error) {
-    console.error(`Error generating summary for session ${sessionId}:`, error);
+    console.error(`[SummaryService] Failed to generate summary for session ${sessionId}:`, {
+      error: error.message,
+      stack: error.stack,
+      sessionId,
+    });
 
     // Broadcast that generation stopped
     broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_SUMMARY_GENERATING, {
@@ -253,7 +298,7 @@ export function onSessionActivity(sessionId) {
     clearTimeout(debounceTimers.get(sessionId));
   }
 
-  // Set new 15s timer
+  // Set new debounce timer
   const timer = setTimeout(() => {
     generateSummary(sessionId);
     debounceTimers.delete(sessionId);
@@ -325,3 +370,6 @@ export function cleanupSession(sessionId) {
     debounceTimers.delete(sessionId);
   }
 }
+
+// Export for testing
+export { DEBOUNCE_DELAY, MAX_MESSAGES, isMockMode, callClaude, formatMessages, buildIncrementalPrompt, parseSummaryResponse };

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -10,6 +10,14 @@ vi.mock('../websocket.js', () => ({
 // Import after mock setup
 import * as summaryService from './summaryService.js';
 import { broadcastToSession } from '../websocket.js';
+import {
+  DEBOUNCE_DELAY,
+  MAX_MESSAGES,
+  formatMessages,
+  buildIncrementalPrompt,
+  parseSummaryResponse,
+  callClaude,
+} from './summaryService.js';
 
 describe('summaryService', () => {
   let projectId;
@@ -36,6 +44,250 @@ describe('summaryService', () => {
     vi.unstubAllEnvs();
   });
 
+  describe('constants', () => {
+    it('has a 5 second debounce delay', () => {
+      expect(DEBOUNCE_DELAY).toBe(5000);
+    });
+
+    it('has a maximum of 50 messages', () => {
+      expect(MAX_MESSAGES).toBe(50);
+    });
+  });
+
+  describe('formatMessages', () => {
+    it('formats user messages correctly', () => {
+      const messageList = [{ role: 'user', content: 'Hello world' }];
+      const result = formatMessages(messageList);
+      expect(result).toBe('User: Hello world');
+    });
+
+    it('formats assistant messages correctly', () => {
+      const messageList = [{ role: 'assistant', content: 'Hi there' }];
+      const result = formatMessages(messageList);
+      expect(result).toBe('Assistant: Hi there');
+    });
+
+    it('formats multiple messages with double newlines', () => {
+      const messageList = [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi' },
+      ];
+      const result = formatMessages(messageList);
+      expect(result).toBe('User: Hello\n\nAssistant: Hi');
+    });
+
+    it('truncates messages longer than 2000 characters', () => {
+      const longContent = 'A'.repeat(2500);
+      const messageList = [{ role: 'user', content: longContent }];
+      const result = formatMessages(messageList);
+      expect(result).toContain('... [truncated]');
+      expect(result.length).toBeLessThan(2500);
+    });
+
+    it('includes tool use information when present', () => {
+      const messageList = [
+        {
+          role: 'assistant',
+          content: 'Let me read that file',
+          toolUse: [{ name: 'Read' }, { name: 'Write' }],
+        },
+      ];
+      const result = formatMessages(messageList);
+      expect(result).toContain('[Tools used: Read, Write]');
+    });
+
+    it('handles empty tool use array', () => {
+      const messageList = [{ role: 'assistant', content: 'Hello', toolUse: [] }];
+      const result = formatMessages(messageList);
+      expect(result).toBe('Assistant: Hello');
+      expect(result).not.toContain('Tools used');
+    });
+
+    it('handles missing tool use', () => {
+      const messageList = [{ role: 'assistant', content: 'Hello' }];
+      const result = formatMessages(messageList);
+      expect(result).toBe('Assistant: Hello');
+    });
+  });
+
+  describe('buildIncrementalPrompt', () => {
+    it('includes no previous summary when existingSummary is null', () => {
+      const recentMessages = [{ role: 'user', content: 'Test message' }];
+      const result = buildIncrementalPrompt(null, recentMessages, 'running');
+      expect(result).toContain('No previous summary - this is the first generation');
+    });
+
+    it('includes existing summary when provided', () => {
+      const existingSummary = {
+        fullSummary: 'Previous summary content',
+        keyActions: ['action1'],
+        filesModified: ['file1.js'],
+        outcome: 'ongoing',
+      };
+      const recentMessages = [{ role: 'user', content: 'Test message' }];
+      const result = buildIncrementalPrompt(existingSummary, recentMessages, 'running');
+      expect(result).toContain('Previous summary content');
+      expect(result).toContain('action1');
+      expect(result).toContain('file1.js');
+    });
+
+    it('includes session status', () => {
+      const recentMessages = [{ role: 'user', content: 'Test message' }];
+      const result = buildIncrementalPrompt(null, recentMessages, 'completed');
+      expect(result).toContain('Current session status: completed');
+    });
+
+    it('includes formatted messages', () => {
+      const recentMessages = [{ role: 'user', content: 'My question' }];
+      const result = buildIncrementalPrompt(null, recentMessages, 'running');
+      expect(result).toContain('User: My question');
+    });
+
+    it('includes JSON format instructions', () => {
+      const recentMessages = [{ role: 'user', content: 'Test' }];
+      const result = buildIncrementalPrompt(null, recentMessages, 'running');
+      expect(result).toContain('"short_summary"');
+      expect(result).toContain('"full_summary"');
+      expect(result).toContain('"key_actions"');
+      expect(result).toContain('"files_modified"');
+      expect(result).toContain('"outcome"');
+    });
+
+    it('includes outcome guidelines', () => {
+      const recentMessages = [{ role: 'user', content: 'Test' }];
+      const result = buildIncrementalPrompt(null, recentMessages, 'running');
+      expect(result).toContain('completed');
+      expect(result).toContain('partial');
+      expect(result).toContain('failed');
+      expect(result).toContain('ongoing');
+    });
+  });
+
+  describe('parseSummaryResponse', () => {
+    it('parses valid JSON response', () => {
+      const responseText = JSON.stringify({
+        short_summary: 'Short test',
+        full_summary: 'Full test summary',
+        key_actions: ['action1', 'action2'],
+        files_modified: ['file1.js'],
+        outcome: 'completed',
+      });
+
+      const result = parseSummaryResponse(responseText);
+
+      expect(result.shortSummary).toBe('Short test');
+      expect(result.fullSummary).toBe('Full test summary');
+      expect(result.keyActions).toEqual(['action1', 'action2']);
+      expect(result.filesModified).toEqual(['file1.js']);
+      expect(result.outcome).toBe('completed');
+    });
+
+    it('provides defaults for missing fields', () => {
+      const responseText = JSON.stringify({});
+
+      const result = parseSummaryResponse(responseText);
+
+      expect(result.shortSummary).toBe('Summary generation failed');
+      expect(result.fullSummary).toBe('Unable to generate summary');
+      expect(result.keyActions).toEqual([]);
+      expect(result.filesModified).toEqual([]);
+      expect(result.outcome).toBe('ongoing');
+    });
+
+    it('handles invalid JSON with fallback', () => {
+      const responseText = 'This is not valid JSON at all';
+
+      const result = parseSummaryResponse(responseText);
+
+      expect(result.shortSummary).toBe('This is not valid JSON at all');
+      expect(result.fullSummary).toBe('This is not valid JSON at all');
+      expect(result.keyActions).toEqual([]);
+      expect(result.filesModified).toEqual([]);
+      expect(result.outcome).toBe('ongoing');
+    });
+
+    it('truncates fallback short summary to 150 chars', () => {
+      const longText = 'A'.repeat(200);
+
+      const result = parseSummaryResponse(longText);
+
+      expect(result.shortSummary.length).toBe(150);
+    });
+
+    it('truncates fallback full summary to 500 chars', () => {
+      const longText = 'A'.repeat(600);
+
+      const result = parseSummaryResponse(longText);
+
+      expect(result.fullSummary.length).toBe(500);
+    });
+  });
+
+  describe('callClaude (mock mode)', () => {
+    it('returns mock response in mock mode', async () => {
+      const recentMessages = [{ role: 'user', content: 'Test message' }];
+
+      const result = await callClaude('Test prompt', recentMessages, 'running');
+
+      // Should return valid JSON that can be parsed
+      const parsed = JSON.parse(result);
+      expect(parsed.short_summary).toBeDefined();
+      expect(parsed.full_summary).toBeDefined();
+      expect(parsed.key_actions).toBeDefined();
+      expect(parsed.files_modified).toBeDefined();
+      expect(parsed.outcome).toBeDefined();
+    });
+
+    it('derives outcome from session status - completed', async () => {
+      const recentMessages = [{ role: 'user', content: 'Test' }];
+
+      const result = await callClaude('Test prompt', recentMessages, 'completed');
+      const parsed = JSON.parse(result);
+
+      expect(parsed.outcome).toBe('completed');
+    });
+
+    it('derives outcome from session status - error', async () => {
+      const recentMessages = [{ role: 'user', content: 'Test' }];
+
+      const result = await callClaude('Test prompt', recentMessages, 'error');
+      const parsed = JSON.parse(result);
+
+      expect(parsed.outcome).toBe('failed');
+    });
+
+    it('derives outcome from session status - ongoing', async () => {
+      const recentMessages = [{ role: 'user', content: 'Test' }];
+
+      const result = await callClaude('Test prompt', recentMessages, 'running');
+      const parsed = JSON.parse(result);
+
+      expect(parsed.outcome).toBe('ongoing');
+    });
+
+    it('includes message content in mock summary', async () => {
+      const recentMessages = [{ role: 'user', content: 'Unique test content here' }];
+
+      const result = await callClaude('Test prompt', recentMessages, 'running');
+      const parsed = JSON.parse(result);
+
+      expect(parsed.short_summary).toContain('Unique test content');
+    });
+
+    it('includes message count in mock summary', async () => {
+      const recentMessages = [
+        { role: 'user', content: 'Message 1' },
+        { role: 'assistant', content: 'Message 2' },
+        { role: 'user', content: 'Message 3' },
+      ];
+
+      const result = await callClaude('Test prompt', recentMessages, 'running');
+      const parsed = JSON.parse(result);
+
+      expect(parsed.full_summary).toContain('3 messages');
+    });
+  });
+
   describe('generateSummary', () => {
     it('returns null for non-existent session', async () => {
       const result = await summaryService.generateSummary('non-existent-id');
@@ -46,9 +298,12 @@ describe('summaryService', () => {
       // Create a new session directly via database without any messages
       const now = Date.now();
       const emptySessionId = databaseManager.generateId();
-      databaseManager.get().prepare(
-        'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-      ).run(emptySessionId, projectId, 'Empty Session', 'running', 'standard', now, now);
+      databaseManager
+        .get()
+        .prepare(
+          'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        )
+        .run(emptySessionId, projectId, 'Empty Session', 'running', 'standard', now, now);
 
       const result = await summaryService.generateSummary(emptySessionId);
       expect(result).toBeNull();
@@ -148,6 +403,18 @@ describe('summaryService', () => {
 
       expect(result.outcome).toBe('ongoing');
     });
+
+    it('logs success message on completion', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await summaryService.generateSummary(sessionId);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[SummaryService] Successfully generated summary')
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe('getSummary', () => {
@@ -231,8 +498,10 @@ describe('summaryService', () => {
       // Summary should not be generated immediately
       expect(sessionSummaries.getBySessionId(sessionId)).toBeNull();
 
-      // Fast-forward time
-      await vi.advanceTimersByTimeAsync(15000);
+      // Fast-forward time (5 seconds now instead of 15)
+      await vi.advanceTimersByTimeAsync(5000);
+      // Allow pending promises to resolve
+      await vi.runAllTimersAsync();
 
       // Now summary should be generated
       expect(sessionSummaries.getBySessionId(sessionId)).not.toBeNull();
@@ -245,19 +514,37 @@ describe('summaryService', () => {
 
       summaryService.onSessionActivity(sessionId);
 
-      // Advance 10 seconds
-      await vi.advanceTimersByTimeAsync(10000);
+      // Advance 3 seconds
+      await vi.advanceTimersByTimeAsync(3000);
       expect(sessionSummaries.getBySessionId(sessionId)).toBeNull();
 
       // Call again (resets timer)
       summaryService.onSessionActivity(sessionId);
 
-      // Advance another 10 seconds (total 20 from first call, but only 10 from second)
-      await vi.advanceTimersByTimeAsync(10000);
+      // Advance another 3 seconds (total 6 from first call, but only 3 from second)
+      await vi.advanceTimersByTimeAsync(3000);
       expect(sessionSummaries.getBySessionId(sessionId)).toBeNull();
 
-      // Advance remaining 5 seconds
-      await vi.advanceTimersByTimeAsync(5000);
+      // Advance remaining 2 seconds plus some buffer for async
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.runAllTimersAsync();
+      expect(sessionSummaries.getBySessionId(sessionId)).not.toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it('uses the configured DEBOUNCE_DELAY', async () => {
+      vi.useFakeTimers();
+
+      summaryService.onSessionActivity(sessionId);
+
+      // Just before debounce delay
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_DELAY - 100);
+      expect(sessionSummaries.getBySessionId(sessionId)).toBeNull();
+
+      // After debounce delay
+      await vi.advanceTimersByTimeAsync(200);
+      await vi.runAllTimersAsync();
       expect(sessionSummaries.getBySessionId(sessionId)).not.toBeNull();
 
       vi.useRealTimers();
@@ -269,8 +556,8 @@ describe('summaryService', () => {
       // Use real timers for this test
       summaryService.onSessionComplete(sessionId);
 
-      // Wait a tick for the async operation
-      await new Promise(resolve => setImmediate(resolve));
+      // Wait for the async operation - need longer wait for async generator
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(sessionSummaries.getBySessionId(sessionId)).not.toBeNull();
     });
@@ -284,8 +571,8 @@ describe('summaryService', () => {
       // Call onSessionComplete (should cancel debounce and generate immediately)
       summaryService.onSessionComplete(sessionId);
 
-      // Wait for async operation
-      await vi.advanceTimersByTimeAsync(0);
+      // Wait for async operation to complete
+      await vi.runAllTimersAsync();
 
       const summary = sessionSummaries.getBySessionId(sessionId);
       expect(summary).not.toBeNull();
@@ -302,7 +589,7 @@ describe('summaryService', () => {
       summaryService.cleanupSession(sessionId);
 
       // Fast-forward past debounce time
-      await vi.advanceTimersByTimeAsync(20000);
+      await vi.advanceTimersByTimeAsync(10000);
 
       // Summary should NOT have been generated
       expect(sessionSummaries.getBySessionId(sessionId)).toBeNull();
@@ -315,7 +602,7 @@ describe('summaryService', () => {
     });
   });
 
-  describe('message formatting', () => {
+  describe('message formatting edge cases', () => {
     it('handles messages with tool use', async () => {
       // Add a message with tool use
       messages.create(sessionId, 'assistant', 'I will read the file', null, [
@@ -337,6 +624,123 @@ describe('summaryService', () => {
       const result = await summaryService.generateSummary(sessionId);
 
       expect(result).not.toBeNull();
+    });
+
+    it('handles many messages beyond MAX_MESSAGES', async () => {
+      // Add more than MAX_MESSAGES
+      for (let i = 0; i < MAX_MESSAGES + 10; i++) {
+        messages.create(sessionId, i % 2 === 0 ? 'user' : 'assistant', `Message ${i}`);
+      }
+
+      const result = await summaryService.generateSummary(sessionId);
+
+      expect(result).not.toBeNull();
+      // Should still generate successfully
+      expect(result.sessionId).toBe(sessionId);
+    });
+  });
+
+  describe('error handling', () => {
+    it('broadcasts generating: false on error', async () => {
+      // Force an error by mocking sessionSummaries.upsert to throw
+      const originalUpsert = sessionSummaries.upsert;
+      sessionSummaries.upsert = vi.fn().mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await summaryService.generateSummary(sessionId);
+
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        sessionId,
+        'session:summary_generating',
+        expect.objectContaining({
+          sessionId,
+          generating: false,
+        })
+      );
+
+      // Restore original
+      sessionSummaries.upsert = originalUpsert;
+    });
+
+    it('returns null on error', async () => {
+      // Force an error by mocking sessionSummaries.upsert to throw
+      const originalUpsert = sessionSummaries.upsert;
+      sessionSummaries.upsert = vi.fn().mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      const result = await summaryService.generateSummary(sessionId);
+
+      expect(result).toBeNull();
+
+      // Restore original
+      sessionSummaries.upsert = originalUpsert;
+    });
+
+    it('logs error with context', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Force an error by mocking sessionSummaries.upsert to throw
+      const originalUpsert = sessionSummaries.upsert;
+      sessionSummaries.upsert = vi.fn().mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await summaryService.generateSummary(sessionId);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[SummaryService] Failed to generate summary'),
+        expect.objectContaining({
+          error: 'Database error',
+          sessionId,
+        })
+      );
+
+      consoleSpy.mockRestore();
+      sessionSummaries.upsert = originalUpsert;
+    });
+  });
+
+  describe('integration with database', () => {
+    it('creates summary that can be retrieved', async () => {
+      const generated = await summaryService.generateSummary(sessionId);
+      const retrieved = sessionSummaries.getBySessionId(sessionId);
+
+      expect(retrieved.id).toBe(generated.id);
+      expect(retrieved.sessionId).toBe(sessionId);
+      expect(retrieved.shortSummary).toBe(generated.shortSummary);
+      expect(retrieved.fullSummary).toBe(generated.fullSummary);
+    });
+
+    it('updates existing summary on regeneration', async () => {
+      const first = await summaryService.generateSummary(sessionId);
+      const firstTimestamp = first.generatedAt;
+
+      // Add a message
+      messages.create(sessionId, 'assistant', 'New content');
+
+      // Wait a bit to ensure different timestamp
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const second = await summaryService.regenerateSummary(sessionId);
+
+      expect(second.id).toBe(first.id); // Same record updated
+      expect(second.generatedAt).toBeGreaterThan(firstTimestamp);
+      expect(second.messageCount).toBeGreaterThan(first.messageCount);
+    });
+
+    it('cascades delete when session is deleted', async () => {
+      await summaryService.generateSummary(sessionId);
+
+      // Verify summary exists
+      expect(sessionSummaries.getBySessionId(sessionId)).not.toBeNull();
+
+      // Delete the session
+      sessions.delete(sessionId);
+
+      // Summary should be gone too
+      expect(sessionSummaries.getBySessionId(sessionId)).toBeNull();
     });
   });
 });

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -63,6 +63,11 @@
           <span class="loading-spinner-small"></span>
           <span>Loading summary...</span>
         </div>
+        <div v-else-if="summaryErrors[session.id]" class="session-summary session-summary-error">
+          <span class="error-icon">!</span>
+          <span>Summary unavailable</span>
+          <button class="retry-btn" @click.prevent="retryFetchSummary(session.id)">Retry</button>
+        </div>
       </router-link>
     </div>
   </div>
@@ -82,6 +87,7 @@ const sessionsStore = useSessionsStore();
 // Store summaries keyed by session ID
 const summaries = reactive({});
 const loadingSummaries = reactive({});
+const summaryErrors = reactive({});
 
 onMounted(async () => {
   projectsStore.fetchProject(route.params.id);
@@ -110,16 +116,27 @@ async function fetchSummaries() {
 
 async function fetchSummary(sessionId) {
   loadingSummaries[sessionId] = true;
+  summaryErrors[sessionId] = false;
   try {
     const summary = await api.getSessionSummary(sessionId);
     if (summary) {
       summaries[sessionId] = summary;
     }
-  } catch {
-    // Silently ignore errors for summary fetching
+    // No summary yet is not an error - it just means one hasn't been generated
+  } catch (error) {
+    // Log error for debugging but don't show as error if it's just a 404 (no summary yet)
+    if (error.response?.status !== 404) {
+      console.warn(`Failed to fetch summary for session ${sessionId}:`, error.message);
+      summaryErrors[sessionId] = true;
+    }
   } finally {
     loadingSummaries[sessionId] = false;
   }
+}
+
+async function retryFetchSummary(sessionId) {
+  summaryErrors[sessionId] = false;
+  await fetchSummary(sessionId);
 }
 
 function formatDate(timestamp) {
@@ -249,6 +266,41 @@ function formatDate(timestamp) {
   gap: 0.5rem;
   color: var(--color-text-soft);
   font-size: 0.75rem;
+}
+
+.session-summary-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-soft);
+  font-size: 0.75rem;
+}
+
+.error-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  background-color: var(--color-warning);
+  color: white;
+  border-radius: 50%;
+  font-size: 0.625rem;
+  font-weight: bold;
+}
+
+.retry-btn {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+  margin-left: auto;
+}
+
+.retry-btn:hover {
+  text-decoration: underline;
 }
 
 .summary-text {


### PR DESCRIPTION
## Summary

This PR addresses the issues with session summaries not being generated and migrates the summary service to use the Claude Code SDK (`@anthropic-ai/claude-agent-sdk`) instead of the direct Anthropic API.

### Key Changes

- **SDK Migration**: Replaced direct `@anthropic-ai/sdk` usage with `query()` from Claude Code SDK
- **Faster Feedback**: Reduced debounce from 15s to 5s for quicker summary generation
- **Better Triggers**: Added summary generation triggers when sessions enter "waiting" status
- **Error Visibility**: Fixed silent error swallowing - errors are now logged and displayed in the UI
- **Retry UI**: Added visual error state with retry button in session list

### Technical Details

**summaryService.js**:
- Added `mockSummaryQuery` async generator matching SDK patterns for testing
- Added `callClaude` helper to handle async generator response extraction
- Improved logging with `[SummaryService]` prefix for debugging

**sessionManager.js**:
- Added `summaryService.onSessionActivity()` call when session enters "waiting" status
- Added `summaryService.onSessionComplete()` call on session errors

**SessionListView.vue**:
- Added `summaryErrors` tracking for failed fetches
- Added error UI with retry button
- Console logging for debugging failed fetches

### Testing

- 63 comprehensive tests covering all functionality
- Tests for helper functions: `formatMessages`, `buildIncrementalPrompt`, `parseSummaryResponse`
- Tests for `callClaude` mock mode behavior
- Tests for error handling and database integration
- All 298 server tests pass

## Test plan

- [ ] Create a new session and verify summary is generated after messages
- [ ] End a session and verify summary generates immediately
- [ ] Check Summary tab displays all summary sections correctly
- [ ] Verify session list shows short summary previews
- [ ] Test manual regenerate button
- [ ] Verify error state appears and retry works when summary fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)