### PR TITLE
Fix work logs not streaming in real-time

### DIFF
--- a/packages/server/src/db/WorkLogRepository.js
+++ b/packages/server/src/db/WorkLogRepository.js
@@ -88,11 +88,13 @@ export class WorkLogRepository extends BaseRepository {
    * Update the message ID for work logs (used when associating pending logs with a message)
    * @param {string} sessionId - Session ID
    * @param {string} messageId - Message ID to associate
+   * @returns {number} Number of work logs that were associated
    */
   associatePendingLogs(sessionId, messageId) {
-    this.db
+    const result = this.db
       .prepare('UPDATE work_logs SET message_id = ? WHERE session_id = ? AND message_id IS NULL')
       .run(messageId, sessionId);
+    return result.changes;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix `WorkLogRepository.associatePendingLogs()` to return the count of affected rows
- This enables the `SESSION_WORK_LOGS_ASSOCIATED` WebSocket broadcast to fire correctly
- Work logs now stream in real-time instead of requiring a page refresh

## Root Cause

The `associatePendingLogs()` method wasn't returning the count of updated rows from `better-sqlite3`'s `.run()` method. This caused the condition `if (associatedCount > 0)` to always be false (since `undefined > 0` is false), so the WebSocket notification was never sent to the frontend.

## Test plan

- [ ] Start a new session and send a message to Claude
- [ ] Verify work logs appear in real-time as Claude works
- [ ] Verify logs are properly associated with the message without needing to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)