### PR TITLE
Rename 'Active Sessions' to 'Sessions' in top nav

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -5,7 +5,7 @@
         <router-link to="/" class="logo">ClaudeTools.io</router-link>
         <nav class="nav">
           <router-link to="/" class="nav-link">Projects</router-link>
-          <router-link to="/sessions/active" class="nav-link">Active Sessions</router-link>
+          <router-link to="/sessions/active" class="nav-link">Sessions</router-link>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Simplifies the navigation label from "Active Sessions" to just "Sessions" for better readability

## Test plan
- [ ] Navigate to the application and verify the top nav shows "Sessions" instead of "Active Sessions"
- [ ] Verify the link still navigates to `/sessions/active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)