### PR TITLE
Make session detail tabs sticky and add back navigation to tab bar

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -242,6 +242,12 @@ input, textarea, select {
   display: flex;
   border-bottom: 1px solid var(--color-border);
   margin-bottom: 1rem;
+  /* Sticky positioning */
+  position: sticky;
+  top: 0;
+  background-color: var(--color-background);
+  z-index: 100;
+  padding-top: 0.5rem;
 }
 
 .tab {
@@ -263,6 +269,24 @@ input, textarea, select {
 .tab.active {
   color: var(--color-primary);
   border-bottom-color: var(--color-primary);
+}
+
+/* Back navigation tab - visually distinct from content tabs */
+.tab.tab-back {
+  color: var(--color-text-soft);
+}
+
+.tab.tab-back:hover {
+  color: var(--color-text);
+  border-bottom-color: transparent;
+}
+
+/* Separator between back navigation and content tabs */
+.tab-separator {
+  width: 1px;
+  background-color: var(--color-border);
+  margin: 0.5rem 0.75rem;
+  align-self: stretch;
 }
 
 /* Code */

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -8,9 +8,6 @@
     <template v-else-if="sessionsStore.currentSession">
       <div class="session-header">
         <div>
-          <router-link :to="`/projects/${sessionsStore.currentSession.projectId}/sessions`" class="back-link">
-            &larr; Sessions
-          </router-link>
           <h3 class="session-name">{{ sessionsStore.currentSession.name }}</h3>
           <div class="session-meta">
             <span :class="['status-badge', `status-${sessionsStore.currentSession.status}`]">
@@ -33,6 +30,13 @@
       </div>
 
       <div class="tabs">
+        <router-link
+          :to="`/projects/${sessionsStore.currentSession.projectId}/sessions`"
+          class="tab tab-back"
+        >
+          ← Sessions
+        </router-link>
+        <span class="tab-separator"></span>
         <router-link
           :to="`/sessions/${route.params.id}/summary`"
           :class="['tab', { active: activeTab === 'summary' }]"
@@ -243,13 +247,6 @@ async function handleDelete() {
   justify-content: space-between;
   align-items: flex-start;
   margin-bottom: 1.5rem;
-}
-
-.back-link {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  display: inline-block;
-  margin-bottom: 0.5rem;
 }
 
 .session-name {


### PR DESCRIPTION
## Summary
- Make session detail tabs sticky so they remain visible while scrolling through conversation/content
- Move "back to sessions" link into the tab bar as the first element with a visual separator
- Style the back tab differently (no underline on hover) to indicate it navigates away rather than switching content

## Test plan
- [ ] Navigate to a session detail page
- [ ] Scroll down - tabs should stick to the top
- [ ] Click "← Sessions" tab - should navigate back to sessions list
- [ ] Verify separator is visible between back tab and content tabs
- [ ] Verify content tabs (Summary, Conversation, etc.) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)