### PR TITLE
Remove projects link from session list view

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -2,7 +2,6 @@
   <div class="container">
     <div class="page-header">
       <div>
-        <router-link to="/" class="back-link">&larr; Projects</router-link>
         <h1>{{ projectsStore.currentProject?.name || 'Sessions' }}</h1>
         <p v-if="projectsStore.currentProject" class="project-path">
           {{ projectsStore.currentProject.workingDirectory }}
@@ -156,13 +155,6 @@ function formatDate(timestamp) {
   justify-content: space-between;
   align-items: flex-start;
   margin-bottom: 2rem;
-}
-
-.back-link {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  display: inline-block;
-  margin-bottom: 0.5rem;
 }
 
 .page-header h1 {


### PR DESCRIPTION
## Summary
- Removed the "← Projects" back link from the session list view header
- Cleaned up unused `.back-link` CSS styles from the component

## Test plan
- [ ] Navigate to a project's session list
- [ ] Verify the header no longer shows "← Projects" link
- [ ] Verify page layout looks correct without the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)