### PR TITLE
feat: Add session lifecycle hooks for setup and teardown events

### DIFF
--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { projects, sessions } from '../database.js';
 import { CreateProjectRequest, UpdateProjectRequest } from '@claudetools/shared/contracts/projects';
 import { setupGitForSession } from '../services/gitSessionSetup.js';
+import { executeHookAsync } from '../services/hookService.js';
 
 const router = Router();
 
@@ -18,8 +19,11 @@ router.post('/', (req, res) => {
     return res.status(400).json({ error: result.error.errors[0].message });
   }
 
-  const { name, workingDirectory, systemPrompt } = result.data;
-  const project = projects.create(name, workingDirectory, systemPrompt || null);
+  const { name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted } = result.data;
+  const project = projects.create(name, workingDirectory, systemPrompt || null, {
+    onSessionCreated: onSessionCreated || null,
+    onSessionDeleted: onSessionDeleted || null,
+  });
   res.status(201).json(project);
 });
 
@@ -108,6 +112,16 @@ router.post('/:id/sessions', async (req, res) => {
 
     // Return updated session with gitWorktree if set
     const updatedSession = sessions.getById(session.id);
+
+    // Execute on_session_created hook if configured (non-blocking)
+    if (project.onSessionCreated) {
+      executeHookAsync(project.onSessionCreated, workingDirectory, {
+        sessionId: session.id,
+        projectId: project.id,
+        sessionName: session.name,
+      });
+    }
+
     res.status(201).json(updatedSession);
   } catch (error) {
     console.error('Git setup error:', error);

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -6,6 +6,7 @@ import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 import * as gitService from '../services/gitService.js';
 import * as summaryService from '../services/summaryService.js';
+import { executeHookAsync } from '../services/hookService.js';
 
 const router = Router();
 
@@ -280,6 +281,9 @@ router.delete('/:id', async (req, res) => {
     return res.status(404).json({ error: 'Session not found' });
   }
 
+  // Get project info before deletion for hook execution
+  const project = projects.getById(session.projectId);
+
   // Clean up active session if running
   cleanupActiveSession(req.params.id);
 
@@ -287,15 +291,12 @@ router.delete('/:id', async (req, res) => {
   summaryService.cleanupSession(req.params.id);
 
   // Remove git worktree if session has one
-  if (session.gitWorktree) {
-    const project = projects.getById(session.projectId);
-    if (project) {
-      try {
-        await gitService.removeWorktree(project.workingDirectory, session.gitWorktree, true);
-      } catch (error) {
-        // Log but don't fail - worktree may already be removed or have issues
-        console.warn(`Failed to remove worktree for session ${session.id}:`, error.message);
-      }
+  if (session.gitWorktree && project) {
+    try {
+      await gitService.removeWorktree(project.workingDirectory, session.gitWorktree, true);
+    } catch (error) {
+      // Log but don't fail - worktree may already be removed or have issues
+      console.warn(`Failed to remove worktree for session ${session.id}:`, error.message);
     }
   }
 
@@ -304,6 +305,15 @@ router.delete('/:id', async (req, res) => {
 
   // Delete session (cascade will handle messages, canvas items, notes)
   sessions.delete(req.params.id);
+
+  // Execute on_session_deleted hook if configured (non-blocking)
+  if (project?.onSessionDeleted) {
+    executeHookAsync(project.onSessionDeleted, project.workingDirectory, {
+      sessionId: session.id,
+      projectId: project.id,
+      sessionName: session.name,
+    });
+  }
 
   res.status(204).send();
 });

--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -61,6 +61,12 @@ export class DatabaseManager {
     if (!projectsColumns.includes('system_prompt')) {
       this.#db.exec('ALTER TABLE projects ADD COLUMN system_prompt TEXT');
     }
+    if (!projectsColumns.includes('on_session_created')) {
+      this.#db.exec('ALTER TABLE projects ADD COLUMN on_session_created TEXT');
+    }
+    if (!projectsColumns.includes('on_session_deleted')) {
+      this.#db.exec('ALTER TABLE projects ADD COLUMN on_session_deleted TEXT');
+    }
 
     // Migrate sessions table to add 'stopped' status to CHECK constraint
     // SQLite doesn't allow modifying CHECK constraints, so we need to recreate the table

--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -15,20 +15,23 @@ export class ProjectRepository extends BaseRepository {
       name: row.name,
       workingDirectory: row.working_directory,
       systemPrompt: row.system_prompt,
+      onSessionCreated: row.on_session_created,
+      onSessionDeleted: row.on_session_deleted,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
   }
 
-  create(name, workingDirectory, systemPrompt = null) {
+  create(name, workingDirectory, systemPrompt = null, options = {}) {
     const id = databaseManager.generateId();
     const now = Date.now();
+    const { onSessionCreated = null, onSessionDeleted = null } = options;
     this.db
       .prepare(
-        `INSERT INTO projects (id, name, working_directory, system_prompt, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?)`
+        `INSERT INTO projects (id, name, working_directory, system_prompt, on_session_created, on_session_deleted, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       )
-      .run(id, name, workingDirectory, systemPrompt, now, now);
+      .run(id, name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, now, now);
     return this.getById(id);
   }
 
@@ -52,6 +55,14 @@ export class ProjectRepository extends BaseRepository {
     if (data.systemPrompt !== undefined) {
       updates.push('system_prompt = ?');
       values.push(data.systemPrompt);
+    }
+    if (data.onSessionCreated !== undefined) {
+      updates.push('on_session_created = ?');
+      values.push(data.onSessionCreated);
+    }
+    if (data.onSessionDeleted !== undefined) {
+      updates.push('on_session_deleted = ?');
+      values.push(data.onSessionDeleted);
     }
 
     if (updates.length === 0) return this.getById(id);

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -38,6 +38,23 @@ describe('ProjectRepository', () => {
       const project = repo.create('Test', '/tmp');
       expect(project.createdAt).toBe(project.updatedAt);
     });
+
+    it('creates project with session lifecycle hooks', () => {
+      const project = repo.create('Test Project', '/tmp/test', null, {
+        onSessionCreated: 'echo "session created"',
+        onSessionDeleted: 'echo "session deleted"',
+      });
+
+      expect(project.onSessionCreated).toBe('echo "session created"');
+      expect(project.onSessionDeleted).toBe('echo "session deleted"');
+    });
+
+    it('creates project with null hooks by default', () => {
+      const project = repo.create('Test Project', '/tmp/test');
+
+      expect(project.onSessionCreated).toBeNull();
+      expect(project.onSessionDeleted).toBeNull();
+    });
   });
 
   describe('getById', () => {
@@ -132,6 +149,38 @@ describe('ProjectRepository', () => {
 
       expect(result.name).toBe('Test');
       expect(result.workingDirectory).toBe('/tmp/test');
+    });
+
+    it('updates onSessionCreated hook', () => {
+      const project = repo.create('Test', '/tmp/test');
+      const updated = repo.update(project.id, {
+        onSessionCreated: 'echo "hook updated"',
+      });
+
+      expect(updated.onSessionCreated).toBe('echo "hook updated"');
+    });
+
+    it('updates onSessionDeleted hook', () => {
+      const project = repo.create('Test', '/tmp/test');
+      const updated = repo.update(project.id, {
+        onSessionDeleted: './cleanup.sh',
+      });
+
+      expect(updated.onSessionDeleted).toBe('./cleanup.sh');
+    });
+
+    it('clears hooks when set to null', () => {
+      const project = repo.create('Test', '/tmp/test', null, {
+        onSessionCreated: 'echo "created"',
+        onSessionDeleted: 'echo "deleted"',
+      });
+      const updated = repo.update(project.id, {
+        onSessionCreated: null,
+        onSessionDeleted: null,
+      });
+
+      expect(updated.onSessionCreated).toBeNull();
+      expect(updated.onSessionDeleted).toBeNull();
     });
   });
 

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -4,6 +4,8 @@ CREATE TABLE IF NOT EXISTS projects (
   name TEXT NOT NULL,
   working_directory TEXT NOT NULL,
   system_prompt TEXT,
+  on_session_created TEXT,
+  on_session_deleted TEXT,
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/server/src/services/hookService.js
+++ b/packages/server/src/services/hookService.js
@@ -1,0 +1,60 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Execute a hook script asynchronously (fire-and-forget)
+ * @param {string} hookCommand - The shell command to execute
+ * @param {string} workingDirectory - The directory to run the command in
+ * @param {Object} context - Context variables to pass as environment variables
+ * @param {string} context.sessionId - The session ID
+ * @param {string} context.projectId - The project ID
+ * @param {string} [context.sessionName] - The session name
+ */
+export function executeHookAsync(hookCommand, workingDirectory, context = {}) {
+  if (!hookCommand) return;
+
+  const env = {
+    ...process.env,
+    CLAUDETOOLS_SESSION_ID: context.sessionId || '',
+    CLAUDETOOLS_PROJECT_ID: context.projectId || '',
+    CLAUDETOOLS_SESSION_NAME: context.sessionName || '',
+  };
+
+  execAsync(hookCommand, { cwd: workingDirectory, env, shell: true })
+    .then(({ stdout, stderr }) => {
+      if (stdout) console.log(`[Hook] stdout: ${stdout.trim()}`);
+      if (stderr) console.warn(`[Hook] stderr: ${stderr.trim()}`);
+    })
+    .catch((error) => {
+      console.error(`[Hook] Execution failed: ${error.message}`);
+    });
+}
+
+/**
+ * Execute a hook script and wait for the result
+ * @param {string} hookCommand - The shell command to execute
+ * @param {string} workingDirectory - The directory to run the command in
+ * @param {Object} context - Context variables to pass as environment variables
+ * @returns {Promise<{success: boolean, stdout?: string, stderr?: string, error?: string}>}
+ */
+export async function executeHook(hookCommand, workingDirectory, context = {}) {
+  if (!hookCommand) {
+    return { success: true, stdout: '', stderr: '' };
+  }
+
+  const env = {
+    ...process.env,
+    CLAUDETOOLS_SESSION_ID: context.sessionId || '',
+    CLAUDETOOLS_PROJECT_ID: context.projectId || '',
+    CLAUDETOOLS_SESSION_NAME: context.sessionName || '',
+  };
+
+  try {
+    const { stdout, stderr } = await execAsync(hookCommand, { cwd: workingDirectory, env, shell: true });
+    return { success: true, stdout: stdout.trim(), stderr: stderr.trim() };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}

--- a/packages/server/src/services/hookService.test.js
+++ b/packages/server/src/services/hookService.test.js
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { executeHook, executeHookAsync } from './hookService.js';
-import { mkdtemp, rm, writeFile, readFile } from 'fs/promises';
+import { mkdtemp, rm, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 

--- a/packages/server/src/services/hookService.test.js
+++ b/packages/server/src/services/hookService.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { executeHook, executeHookAsync } from './hookService.js';
+import { mkdtemp, rm, writeFile, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('hookService', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'hookservice-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('executeHook', () => {
+    it('returns success with empty command', async () => {
+      const result = await executeHook('', tempDir, {});
+      expect(result.success).toBe(true);
+    });
+
+    it('returns success with null command', async () => {
+      const result = await executeHook(null, tempDir, {});
+      expect(result.success).toBe(true);
+    });
+
+    it('executes a simple shell command', async () => {
+      const result = await executeHook('echo "hello"', tempDir, {});
+      expect(result.success).toBe(true);
+      expect(result.stdout).toBe('hello');
+    });
+
+    it('executes command in specified working directory', async () => {
+      const result = await executeHook('pwd', tempDir, {});
+      expect(result.success).toBe(true);
+      expect(result.stdout).toBe(tempDir);
+    });
+
+    it('passes context as environment variables', async () => {
+      const context = {
+        sessionId: 'test-session-123',
+        projectId: 'test-project-456',
+        sessionName: 'My Test Session',
+      };
+      const result = await executeHook(
+        'echo "$CLAUDETOOLS_SESSION_ID|$CLAUDETOOLS_PROJECT_ID|$CLAUDETOOLS_SESSION_NAME"',
+        tempDir,
+        context
+      );
+      expect(result.success).toBe(true);
+      expect(result.stdout).toBe('test-session-123|test-project-456|My Test Session');
+    });
+
+    it('returns error for failed command', async () => {
+      const result = await executeHook('exit 1', tempDir, {});
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('can create files in working directory', async () => {
+      const testFile = join(tempDir, 'hook-output.txt');
+      const result = await executeHook(`echo "hook executed" > "${testFile}"`, tempDir, {});
+      expect(result.success).toBe(true);
+
+      const content = await readFile(testFile, 'utf-8');
+      expect(content.trim()).toBe('hook executed');
+    });
+
+    it('can execute multi-line scripts', async () => {
+      const testFile = join(tempDir, 'multi-line.txt');
+      const script = `
+        echo "line1" > "${testFile}"
+        echo "line2" >> "${testFile}"
+      `;
+      const result = await executeHook(script, tempDir, {});
+      expect(result.success).toBe(true);
+
+      const content = await readFile(testFile, 'utf-8');
+      expect(content.trim()).toBe('line1\nline2');
+    });
+  });
+
+  describe('executeHookAsync', () => {
+    it('does not throw with null command', () => {
+      expect(() => executeHookAsync(null, tempDir, {})).not.toThrow();
+    });
+
+    it('does not throw with empty command', () => {
+      expect(() => executeHookAsync('', tempDir, {})).not.toThrow();
+    });
+
+    it('executes command asynchronously and creates file', async () => {
+      const testFile = join(tempDir, 'async-output.txt');
+      executeHookAsync(`echo "async hook" > "${testFile}"`, tempDir, {
+        sessionId: 'async-test',
+        projectId: 'async-project',
+      });
+
+      // Wait for the async execution to complete
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      const content = await readFile(testFile, 'utf-8');
+      expect(content.trim()).toBe('async hook');
+    });
+
+    it('does not block the caller', async () => {
+      const startTime = Date.now();
+
+      // This command takes 500ms to complete
+      executeHookAsync('sleep 0.5 && echo "done"', tempDir, {});
+
+      const elapsed = Date.now() - startTime;
+      // Should return much faster than the command execution time (500ms)
+      // Allow generous margin for CI environments
+      expect(elapsed).toBeLessThan(300);
+    });
+  });
+});

--- a/packages/server/test/session-hooks.test.js
+++ b/packages/server/test/session-hooks.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { projects, sessions } from '../src/database.js';
+
+describe('Session Lifecycle Hooks', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'session-hooks-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Project hook configuration', () => {
+    it('stores onSessionCreated hook in project', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionCreated: 'echo "created" >> log.txt',
+      });
+
+      expect(project.onSessionCreated).toBe('echo "created" >> log.txt');
+      expect(project.onSessionDeleted).toBeNull();
+    });
+
+    it('stores onSessionDeleted hook in project', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionDeleted: './cleanup.sh',
+      });
+
+      expect(project.onSessionCreated).toBeNull();
+      expect(project.onSessionDeleted).toBe('./cleanup.sh');
+    });
+
+    it('stores both hooks in project', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionCreated: 'echo "start"',
+        onSessionDeleted: 'echo "end"',
+      });
+
+      expect(project.onSessionCreated).toBe('echo "start"');
+      expect(project.onSessionDeleted).toBe('echo "end"');
+    });
+
+    it('updates hooks via project update', () => {
+      const project = projects.create('Test', tempDir);
+      const updated = projects.update(project.id, {
+        onSessionCreated: 'new-hook.sh',
+        onSessionDeleted: 'cleanup-hook.sh',
+      });
+
+      expect(updated.onSessionCreated).toBe('new-hook.sh');
+      expect(updated.onSessionDeleted).toBe('cleanup-hook.sh');
+    });
+
+    it('clears hooks by setting to null', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionCreated: 'echo "hook"',
+        onSessionDeleted: 'echo "hook"',
+      });
+
+      const updated = projects.update(project.id, {
+        onSessionCreated: null,
+        onSessionDeleted: null,
+      });
+
+      expect(updated.onSessionCreated).toBeNull();
+      expect(updated.onSessionDeleted).toBeNull();
+    });
+  });
+
+  describe('Hook execution context', () => {
+    it('project includes hook fields when retrieved', () => {
+      const created = projects.create('Test', tempDir, null, {
+        onSessionCreated: 'echo $CLAUDETOOLS_SESSION_ID',
+        onSessionDeleted: 'echo $CLAUDETOOLS_PROJECT_ID',
+      });
+
+      const retrieved = projects.getById(created.id);
+
+      expect(retrieved.onSessionCreated).toBe('echo $CLAUDETOOLS_SESSION_ID');
+      expect(retrieved.onSessionDeleted).toBe('echo $CLAUDETOOLS_PROJECT_ID');
+    });
+
+    it('hook fields appear in project list', () => {
+      projects.create('Project 1', tempDir, null, {
+        onSessionCreated: 'hook1.sh',
+      });
+      projects.create('Project 2', tempDir, null, {
+        onSessionDeleted: 'hook2.sh',
+      });
+
+      const allProjects = projects.getAll();
+
+      expect(allProjects).toHaveLength(2);
+      // Projects are ordered by updatedAt DESC, so Project 2 comes first
+      expect(allProjects.some(p => p.onSessionCreated === 'hook1.sh')).toBe(true);
+      expect(allProjects.some(p => p.onSessionDeleted === 'hook2.sh')).toBe(true);
+    });
+  });
+
+  describe('Session operations with hooks configured', () => {
+    it('creates session for project with hooks', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionCreated: 'echo "session created"',
+        onSessionDeleted: 'echo "session deleted"',
+      });
+
+      const session = sessions.create(project.id, 'Test Session', 'Hello');
+
+      expect(session.id).toBeDefined();
+      expect(session.projectId).toBe(project.id);
+      expect(session.name).toBe('Test Session');
+    });
+
+    it('deletes session for project with hooks', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionDeleted: 'echo "cleanup"',
+      });
+      const session = sessions.create(project.id, 'Test Session', 'Hello');
+
+      sessions.delete(session.id);
+
+      expect(sessions.getById(session.id)).toBeNull();
+    });
+
+    it('project with hooks is accessible when session is retrieved', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionCreated: 'start.sh',
+        onSessionDeleted: 'stop.sh',
+      });
+      const session = sessions.create(project.id, 'Test Session', 'Hello');
+
+      const retrievedProject = projects.getById(session.projectId);
+
+      expect(retrievedProject.onSessionCreated).toBe('start.sh');
+      expect(retrievedProject.onSessionDeleted).toBe('stop.sh');
+    });
+  });
+});

--- a/packages/shared/src/contracts/projects.js
+++ b/packages/shared/src/contracts/projects.js
@@ -4,12 +4,16 @@ export const CreateProjectRequest = z.object({
   name: z.string().min(1),
   workingDirectory: z.string().min(1),
   systemPrompt: z.string().optional(),
+  onSessionCreated: z.string().nullable().optional(),
+  onSessionDeleted: z.string().nullable().optional(),
 });
 
 export const UpdateProjectRequest = z.object({
   name: z.string().min(1).optional(),
   workingDirectory: z.string().min(1).optional(),
   systemPrompt: z.string().nullable().optional(),
+  onSessionCreated: z.string().nullable().optional(),
+  onSessionDeleted: z.string().nullable().optional(),
 });
 
 export const ProjectResponse = z.object({
@@ -17,6 +21,8 @@ export const ProjectResponse = z.object({
   name: z.string(),
   workingDirectory: z.string(),
   systemPrompt: z.string().nullable(),
+  onSessionCreated: z.string().nullable(),
+  onSessionDeleted: z.string().nullable(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -38,6 +38,37 @@
         </p>
       </div>
 
+      <details class="advanced-settings">
+        <summary>Session Lifecycle Hooks</summary>
+        <div class="form-group">
+          <label class="form-label" for="onSessionCreated">On Session Created</label>
+          <textarea
+            id="onSessionCreated"
+            v-model="onSessionCreated"
+            class="form-input form-textarea-small"
+            rows="3"
+            placeholder="Shell command to run when a session is created..."
+          ></textarea>
+          <p class="form-help">
+            Runs in the background after session creation. Environment variables: CLAUDETOOLS_SESSION_ID, CLAUDETOOLS_PROJECT_ID, CLAUDETOOLS_SESSION_NAME
+          </p>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label" for="onSessionDeleted">On Session Deleted</label>
+          <textarea
+            id="onSessionDeleted"
+            v-model="onSessionDeleted"
+            class="form-input form-textarea-small"
+            rows="3"
+            placeholder="Shell command to run when a session is deleted..."
+          ></textarea>
+          <p class="form-help">
+            Runs in the background after session deletion. Environment variables: CLAUDETOOLS_SESSION_ID, CLAUDETOOLS_PROJECT_ID, CLAUDETOOLS_SESSION_NAME
+          </p>
+        </div>
+      </details>
+
       <div v-if="error" class="error-message">{{ error }}</div>
 
       <div class="form-actions">
@@ -70,6 +101,8 @@ const uiStore = useUiStore();
 const name = ref('');
 const workingDirectory = ref('');
 const systemPrompt = ref('');
+const onSessionCreated = ref('');
+const onSessionDeleted = ref('');
 const saving = ref(false);
 const error = ref(null);
 
@@ -82,6 +115,8 @@ watch(() => projectsStore.currentProject, (project) => {
     name.value = project.name;
     workingDirectory.value = project.workingDirectory;
     systemPrompt.value = project.systemPrompt || '';
+    onSessionCreated.value = project.onSessionCreated || '';
+    onSessionDeleted.value = project.onSessionDeleted || '';
   }
 }, { immediate: true });
 
@@ -94,6 +129,8 @@ async function handleSubmit() {
       name: name.value,
       workingDirectory: workingDirectory.value,
       systemPrompt: systemPrompt.value || null,
+      onSessionCreated: onSessionCreated.value || null,
+      onSessionDeleted: onSessionDeleted.value || null,
     });
     uiStore.success('Project updated successfully');
     router.push(`/projects/${route.params.id}/sessions`);
@@ -162,5 +199,28 @@ h1 {
   margin-top: 0.5rem;
   font-size: 0.875rem;
   color: var(--color-text-muted);
+}
+
+.advanced-settings {
+  margin-bottom: 1rem;
+}
+
+.advanced-settings summary {
+  cursor: pointer;
+  color: var(--color-primary);
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+.advanced-settings[open] summary {
+  margin-bottom: 1rem;
+}
+
+.form-textarea-small {
+  resize: vertical;
+  min-height: 60px;
+  font-family: monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
 </style>

--- a/packages/web/src/views/ProjectNewView.vue
+++ b/packages/web/src/views/ProjectNewView.vue
@@ -35,6 +35,34 @@
             Customize the system prompt for the AI agent. Leave empty to use the default prompt shown above.
           </p>
         </div>
+
+        <div class="form-group">
+          <label class="form-label" for="onSessionCreated">On Session Created</label>
+          <textarea
+            id="onSessionCreated"
+            v-model="onSessionCreated"
+            class="form-input form-textarea-small"
+            rows="3"
+            placeholder="Shell command to run when a session is created..."
+          ></textarea>
+          <p class="form-help">
+            Runs in the background after session creation. Environment variables: CLAUDETOOLS_SESSION_ID, CLAUDETOOLS_PROJECT_ID, CLAUDETOOLS_SESSION_NAME
+          </p>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label" for="onSessionDeleted">On Session Deleted</label>
+          <textarea
+            id="onSessionDeleted"
+            v-model="onSessionDeleted"
+            class="form-input form-textarea-small"
+            rows="3"
+            placeholder="Shell command to run when a session is deleted..."
+          ></textarea>
+          <p class="form-help">
+            Runs in the background after session deletion. Environment variables: CLAUDETOOLS_SESSION_ID, CLAUDETOOLS_PROJECT_ID, CLAUDETOOLS_SESSION_NAME
+          </p>
+        </div>
       </details>
 
       <div v-if="error" class="error-message">{{ error }}</div>
@@ -65,6 +93,8 @@ const uiStore = useUiStore();
 const name = ref('');
 const workingDirectory = ref('');
 const systemPrompt = ref('');
+const onSessionCreated = ref('');
+const onSessionDeleted = ref('');
 const loading = ref(false);
 const error = ref(null);
 
@@ -77,6 +107,8 @@ async function handleSubmit() {
       name: name.value,
       workingDirectory: workingDirectory.value,
       systemPrompt: systemPrompt.value || undefined,
+      onSessionCreated: onSessionCreated.value || undefined,
+      onSessionDeleted: onSessionDeleted.value || undefined,
     });
     uiStore.success('Project created successfully');
     router.push(`/projects/${project.id}/sessions`);
@@ -135,5 +167,13 @@ h1 {
   margin-top: 0.5rem;
   font-size: 0.875rem;
   color: var(--color-text-muted);
+}
+
+.form-textarea-small {
+  resize: vertical;
+  min-height: 60px;
+  font-family: monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
 }
 </style>


### PR DESCRIPTION
## Summary
- Implements Issue #56 - Setup and tear down events that users can hook scripts to
- Users can now configure shell scripts that run when sessions are created or deleted
- Scripts run in the background (non-blocking) and receive context via environment variables

## Changes
- **Database**: Added `on_session_created` and `on_session_deleted` columns to projects table with migration
- **Backend**: Created `hookService.js` for async script execution with environment context
- **API**: Integrated hooks in session creation (`POST /api/projects/:id/sessions`) and deletion (`DELETE /api/sessions/:id`) endpoints
- **Frontend**: Added form fields in project edit/new views under "Session Lifecycle Hooks" section
- **Tests**: Added comprehensive tests for hookService, ProjectRepository, and integration tests

## Environment Variables Passed to Hooks
- `CLAUDETOOLS_SESSION_ID` - The session ID
- `CLAUDETOOLS_PROJECT_ID` - The project ID  
- `CLAUDETOOLS_SESSION_NAME` - The session name

## Test plan
- [x] Create a project with hook scripts configured
- [x] Create a session → verify on_session_created hook runs (check server logs)
- [x] Delete the session → verify on_session_deleted hook runs (check server logs)
- [x] Test with empty hooks → verify no errors when hooks are not configured
- [x] All 339 tests pass

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)