### PR TITLE
fix: Prevent date overflow on session list view for small screens

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -388,5 +388,15 @@ function formatDate(timestamp) {
   .project-path {
     word-break: break-all;
   }
+
+  .session-header-row {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .session-date {
+    flex-shrink: 1;
+    align-self: flex-start;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Fixed date overflow issue on the project session list view where the date was running off the right side of the screen on small screens
- Added responsive CSS styles that stack the date below session info on mobile viewports (< 480px)
- Updated `.session-header-row` to use column flex-direction and `.session-date` to allow shrinking on small screens

## Test plan
- [ ] View session list page on desktop viewport - layout unchanged
- [ ] View session list page on mobile viewport (< 480px) - date should now stack below session info
- [ ] Verify date text is fully visible and not cut off on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)