### PR TITLE
Add session API instructions to Claude Code system prompt

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -69,6 +69,127 @@ For images, use base64 encoding in the content field.`;
 }
 
 /**
+ * Build session API instructions for Claude to create/modify sessions
+ * @param {string} sessionId - Current session ID
+ * @param {string} projectId - Current project ID
+ * @returns {string}
+ */
+function buildSessionApiInstructions(sessionId, projectId) {
+  const apiUrl = process.env.CLAUDETOOLS_API_URL || `http://localhost:${process.env.PORT || DEFAULT_SERVER_PORT}`;
+
+  return `## Session Management API
+
+You can create and modify sessions in this system using curl or similar HTTP tools. Use the Bash tool to execute these commands.
+
+**Base URL:** ${apiUrl}
+**Current Session ID:** ${sessionId}
+**Current Project ID:** ${projectId}
+
+### Create a New Session
+\`\`\`bash
+curl -X POST ${apiUrl}/api/projects/${projectId}/sessions \\
+  -H "Content-Type: application/json" \\
+  -d '{"prompt": "Your task description here", "name": "Optional session name"}'
+\`\`\`
+Optional fields: \`name\`, \`mode\`, \`thinkingEnabled\` (boolean), \`gitBranch\`, \`gitMode\`
+
+### Send a Follow-up Message to a Session
+\`\`\`bash
+curl -X POST ${apiUrl}/api/sessions/<session_id>/message \\
+  -H "Content-Type: application/json" \\
+  -d '{"content": "Your follow-up message"}'
+\`\`\`
+
+### List All Active Sessions
+\`\`\`bash
+curl ${apiUrl}/api/sessions
+\`\`\`
+
+### Get Session Details
+\`\`\`bash
+curl ${apiUrl}/api/sessions/<session_id>
+\`\`\`
+
+### Get Session Messages
+\`\`\`bash
+curl ${apiUrl}/api/sessions/<session_id>/messages
+\`\`\`
+
+### Stop a Running Session
+\`\`\`bash
+curl -X POST ${apiUrl}/api/sessions/<session_id>/stop
+\`\`\`
+
+### Restart a Completed/Errored Session
+\`\`\`bash
+curl -X POST ${apiUrl}/api/sessions/<session_id>/restart
+\`\`\`
+
+### Update Session Settings
+\`\`\`bash
+curl -X PATCH ${apiUrl}/api/sessions/<session_id> \\
+  -H "Content-Type: application/json" \\
+  -d '{"thinkingEnabled": true}'
+\`\`\`
+
+### Delete a Session
+\`\`\`bash
+curl -X DELETE ${apiUrl}/api/sessions/<session_id>
+\`\`\`
+
+### Project Operations
+
+#### List All Projects
+\`\`\`bash
+curl ${apiUrl}/api/projects
+\`\`\`
+
+#### Get Project Details
+\`\`\`bash
+curl ${apiUrl}/api/projects/<project_id>
+\`\`\`
+
+#### List Sessions for a Project
+\`\`\`bash
+curl ${apiUrl}/api/projects/<project_id>/sessions
+\`\`\`
+
+#### Create a New Project
+\`\`\`bash
+curl -X POST ${apiUrl}/api/projects \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "Project Name", "workingDirectory": "/path/to/directory"}'
+\`\`\`
+Optional field: \`systemPrompt\`
+
+### Session Notes
+
+#### Get Session Notes
+\`\`\`bash
+curl ${apiUrl}/api/sessions/<session_id>/notes
+\`\`\`
+
+#### Create a Note
+\`\`\`bash
+curl -X POST ${apiUrl}/api/sessions/<session_id>/notes \\
+  -H "Content-Type: application/json" \\
+  -d '{"content": "Note content"}'
+\`\`\`
+
+### Session Summary
+
+#### Get Session Summary
+\`\`\`bash
+curl "${apiUrl}/api/sessions/<session_id>/summary?generate=true"
+\`\`\`
+
+#### Regenerate Summary
+\`\`\`bash
+curl -X POST ${apiUrl}/api/sessions/<session_id>/summary
+\`\`\``;
+}
+
+/**
  * Build environment variables for Claude SDK based on session settings
  * @param {Object} session
  * @returns {Object|undefined}
@@ -87,13 +208,15 @@ function buildSessionEnv(session) {
 /**
  * Build the full system prompt configuration
  * @param {string} sessionId
+ * @param {string} projectId
  * @param {string|null} customSystemPrompt - Custom system prompt from project settings
  * @returns {string} System prompt string
  */
-function buildSystemPromptConfig(sessionId, customSystemPrompt) {
+function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt) {
   const canvasInstructions = buildCanvasSystemPrompt(sessionId);
+  const sessionApiInstructions = buildSessionApiInstructions(sessionId, projectId);
   const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;
-  return `${basePrompt}\n\n${canvasInstructions}`;
+  return `${basePrompt}\n\n${canvasInstructions}\n\n${sessionApiInstructions}`;
 }
 
 /**
@@ -136,7 +259,7 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
             includePartialMessages: true,
             permissionMode: 'bypassPermissions',
             ...(sessionEnv && { env: sessionEnv }),
-            systemPrompt: buildSystemPromptConfig(sessionId, systemPrompt),
+            systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt),
           },
         };
 
@@ -225,7 +348,7 @@ export async function continueSession(sessionId, content, workingDirectory, syst
             permissionMode: 'bypassPermissions',
             resume: session.claudeSessionId,
             ...(sessionEnv && { env: sessionEnv }),
-            systemPrompt: buildSystemPromptConfig(sessionId, systemPrompt),
+            systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt),
           },
         };
 


### PR DESCRIPTION
## Summary
- Adds a new `buildSessionApiInstructions()` function that generates comprehensive curl examples for all major API endpoints
- Integrates API instructions into the system prompt so Claude Code can create and modify sessions programmatically
- Dynamically injects current session ID, project ID, and API base URL into the instructions

## What Claude Code Can Now Do
With these instructions in the system prompt, Claude Code can:
- Create new sessions via `POST /api/projects/:id/sessions`
- Send follow-up messages to sessions
- List, get, stop, restart, and delete sessions
- Manage projects (list, create, get)
- Create and read session notes
- Get and regenerate session summaries

## Test plan
- [ ] Start a new session and verify the system prompt includes the API instructions
- [ ] Ask Claude Code to create a new session and verify it uses the correct curl command
- [ ] Ask Claude Code to list active sessions and verify it works
- [ ] Verify the injected session ID and project ID are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)