### PR TITLE
Add PR status, CI failures, and merge conflicts to session summaries

### DIFF
--- a/packages/server/src/db/SessionSummaryRepository.js
+++ b/packages/server/src/db/SessionSummaryRepository.js
@@ -19,6 +19,11 @@ export class SessionSummaryRepository extends BaseRepository {
       filesModified: row.files_modified ? JSON.parse(row.files_modified) : [],
       outcome: row.outcome,
       messageCount: row.message_count,
+      prMerged: row.pr_merged ? Boolean(row.pr_merged) : null,
+      prState: row.pr_state,
+      hasMergeConflicts: row.has_merge_conflicts ? Boolean(row.has_merge_conflicts) : null,
+      ciStatus: row.ci_status,
+      ciFailures: row.ci_failures ? JSON.parse(row.ci_failures) : [],
       generatedAt: row.generated_at,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
@@ -49,8 +54,8 @@ export class SessionSummaryRepository extends BaseRepository {
     this.db
       .prepare(
         `INSERT INTO session_summaries
-         (id, session_id, short_summary, full_summary, key_actions, files_modified, outcome, message_count, generated_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         (id, session_id, short_summary, full_summary, key_actions, files_modified, outcome, message_count, pr_merged, pr_state, has_merge_conflicts, ci_status, ci_failures, generated_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -61,6 +66,11 @@ export class SessionSummaryRepository extends BaseRepository {
         data.filesModified ? JSON.stringify(data.filesModified) : null,
         data.outcome || 'ongoing',
         data.messageCount || 0,
+        data.prMerged !== undefined ? (data.prMerged ? 1 : 0) : null,
+        data.prState || null,
+        data.hasMergeConflicts !== undefined ? (data.hasMergeConflicts ? 1 : 0) : null,
+        data.ciStatus || null,
+        data.ciFailures ? JSON.stringify(data.ciFailures) : null,
         now,
         now,
         now
@@ -101,6 +111,26 @@ export class SessionSummaryRepository extends BaseRepository {
     if (data.messageCount !== undefined) {
       updates.push('message_count = ?');
       values.push(data.messageCount);
+    }
+    if (data.prMerged !== undefined) {
+      updates.push('pr_merged = ?');
+      values.push(data.prMerged ? 1 : 0);
+    }
+    if (data.prState !== undefined) {
+      updates.push('pr_state = ?');
+      values.push(data.prState);
+    }
+    if (data.hasMergeConflicts !== undefined) {
+      updates.push('has_merge_conflicts = ?');
+      values.push(data.hasMergeConflicts ? 1 : 0);
+    }
+    if (data.ciStatus !== undefined) {
+      updates.push('ci_status = ?');
+      values.push(data.ciStatus);
+    }
+    if (data.ciFailures !== undefined) {
+      updates.push('ci_failures = ?');
+      values.push(JSON.stringify(data.ciFailures));
     }
 
     if (updates.length === 0) return this.getById(id);

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -114,6 +114,11 @@ CREATE TABLE IF NOT EXISTS session_summaries (
   files_modified TEXT,              -- JSON array of files touched
   outcome TEXT,                     -- 'completed' | 'partial' | 'failed' | 'ongoing'
   message_count INTEGER,            -- Track what was summarized (staleness detection)
+  pr_merged INTEGER,                -- 0/1 boolean - whether PR is merged
+  pr_state TEXT,                    -- 'open' | 'closed' | 'merged' | 'draft'
+  has_merge_conflicts INTEGER,      -- 0/1 boolean - whether PR has merge conflicts
+  ci_status TEXT,                   -- 'success' | 'failure' | 'pending' | null
+  ci_failures TEXT,                 -- JSON array of failed check names
   generated_at INTEGER NOT NULL,
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)

--- a/packages/server/src/services/ghService.js
+++ b/packages/server/src/services/ghService.js
@@ -1,0 +1,92 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+// Cache gh availability check
+let ghAvailable = null;
+
+/**
+ * Check if gh CLI is installed and authenticated
+ * @returns {Promise<boolean>}
+ */
+export async function isGhAvailable() {
+  if (ghAvailable !== null) return ghAvailable;
+  try {
+    await execAsync('gh --version');
+    await execAsync('gh auth status');
+    ghAvailable = true;
+  } catch {
+    ghAvailable = false;
+  }
+  return ghAvailable;
+}
+
+/**
+ * Reset the gh availability cache (useful for testing)
+ */
+export function resetGhAvailableCache() {
+  ghAvailable = null;
+}
+
+/**
+ * Get comprehensive PR info including state, merge conflicts, and CI status
+ * @param {string} prUrl - GitHub PR URL
+ * @returns {Promise<Object|null>} PR info or null if unavailable
+ */
+export async function getPrInfo(prUrl) {
+  if (!(await isGhAvailable())) return null;
+
+  try {
+    const { stdout } = await execAsync(
+      `gh pr view "${prUrl}" --json state,merged,mergeable,isDraft,statusCheckRollup`
+    );
+    const data = JSON.parse(stdout);
+
+    // Determine PR state
+    let state = data.state.toLowerCase();
+    if (data.merged) state = 'merged';
+    else if (data.isDraft) state = 'draft';
+
+    // Check for merge conflicts
+    // mergeable can be: 'MERGEABLE', 'CONFLICTING', 'UNKNOWN'
+    const hasMergeConflicts = data.mergeable === 'CONFLICTING';
+
+    // Process CI checks
+    const checks = data.statusCheckRollup || [];
+    let ciStatus = null;
+    let ciFailures = [];
+
+    if (checks.length > 0) {
+      // Get failed checks with their names
+      const failedChecks = checks.filter(
+        (c) => c.conclusion === 'FAILURE' || c.conclusion === 'TIMED_OUT'
+      );
+      ciFailures = failedChecks.map((c) => c.name || c.context || 'Unknown check');
+
+      // Determine overall CI status
+      const hasPending = checks.some(
+        (c) => c.status === 'IN_PROGRESS' || c.status === 'QUEUED' || c.status === 'PENDING'
+      );
+
+      if (failedChecks.length > 0) {
+        ciStatus = 'failure';
+      } else if (hasPending) {
+        ciStatus = 'pending';
+      } else {
+        ciStatus = 'success';
+      }
+    }
+
+    return {
+      state,
+      merged: data.merged,
+      hasMergeConflicts,
+      ciStatus,
+      ciFailures,
+    };
+  } catch (error) {
+    console.warn('[ghService] Failed to get PR info:', error.message);
+    return null;
+  }
+}

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -2,6 +2,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk';
 import { sessions, messages, sessionSummaries } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import * as ghService from './ghService.js';
 
 // Debounce timers per session
 const debounceTimers = new Map();
@@ -271,6 +272,23 @@ export async function generateSummary(sessionId) {
 
     // Add message count for staleness tracking
     summaryData.messageCount = allMessages.length;
+
+    // Enrich with GitHub PR status if we have a PR URL
+    const prUrl = summaryData.prUrl || session.prUrl;
+    if (prUrl) {
+      try {
+        const prInfo = await ghService.getPrInfo(prUrl);
+        if (prInfo) {
+          summaryData.prState = prInfo.state;
+          summaryData.prMerged = prInfo.merged;
+          summaryData.hasMergeConflicts = prInfo.hasMergeConflicts;
+          summaryData.ciStatus = prInfo.ciStatus;
+          summaryData.ciFailures = prInfo.ciFailures;
+        }
+      } catch (error) {
+        console.warn(`[SummaryService] Failed to get PR info for ${prUrl}:`, error.message);
+      }
+    }
 
     // Upsert summary
     const summary = sessionSummaries.upsert(sessionId, summaryData);

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -56,6 +56,48 @@
         </span>
       </section>
 
+      <section v-if="hasPrInfo" class="summary-section">
+        <h3>Pull Request</h3>
+        <div class="pr-info">
+          <!-- PR Link and State -->
+          <div class="pr-header">
+            <a :href="prUrl" target="_blank" class="pr-link">
+              {{ extractPrNumber(prUrl) }}
+            </a>
+            <span :class="['status-badge', `pr-${summary.prState}`]">
+              {{ formatPrState(summary.prState) }}
+            </span>
+          </div>
+
+          <!-- Warnings Section -->
+          <div v-if="summary.hasMergeConflicts || summary.ciStatus === 'failure'" class="pr-warnings">
+            <!-- Merge Conflicts Warning -->
+            <div v-if="summary.hasMergeConflicts" class="warning-item conflict-warning">
+              <span class="warning-icon">⚠️</span>
+              <span>Merge conflicts detected</span>
+            </div>
+
+            <!-- CI Failures Warning -->
+            <div v-if="summary.ciStatus === 'failure'" class="warning-item ci-warning">
+              <span class="warning-icon">❌</span>
+              <span>CI checks failing</span>
+              <ul v-if="summary.ciFailures?.length" class="failure-list">
+                <li v-for="failure in summary.ciFailures" :key="failure">
+                  {{ failure }}
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- CI Status Badge (when not failing) -->
+          <div v-if="summary.ciStatus && summary.ciStatus !== 'failure'" class="ci-status">
+            <span :class="['status-badge', `ci-${summary.ciStatus}`]">
+              {{ summary.ciStatus === 'success' ? '✓ CI Passing' : '⏳ CI Pending' }}
+            </span>
+          </div>
+        </div>
+      </section>
+
       <div class="summary-footer">
         <span class="summary-date">
           Last updated: {{ formatDate(summary.generatedAt) }}
@@ -70,22 +112,29 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { api } from '../composables/useApi.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
+import { useSessionsStore } from '../stores/sessions.js';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
 });
 
 const uiStore = useUiStore();
+const sessionsStore = useSessionsStore();
 const { onSummaryUpdate, onSummaryGenerating } = useSessionSubscription(props.sessionId);
 
 const summary = ref(null);
 const loading = ref(false);
 const generating = ref(false);
 const generatingManual = ref(false);
+
+// Computed property to get the session's prUrl
+const session = computed(() => sessionsStore.sessions.find((s) => s.id === props.sessionId));
+const prUrl = computed(() => session.value?.prUrl || null);
+const hasPrInfo = computed(() => prUrl.value && summary.value?.prState);
 
 onMounted(async () => {
   loading.value = true;
@@ -126,6 +175,22 @@ function formatOutcome(outcome) {
     ongoing: 'In Progress',
   };
   return labels[outcome] || outcome;
+}
+
+function formatPrState(state) {
+  const labels = {
+    merged: 'Merged',
+    open: 'Open',
+    closed: 'Closed',
+    draft: 'Draft',
+  };
+  return labels[state] || state;
+}
+
+function extractPrNumber(url) {
+  if (!url) return 'PR';
+  const match = url.match(/\/pull\/(\d+)/);
+  return match ? `PR #${match[1]}` : 'PR';
 }
 
 async function handleGenerate() {
@@ -318,5 +383,105 @@ async function handleRegenerate() {
 .btn-link:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* PR Status Styles */
+.pr-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pr-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pr-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.pr-link:hover {
+  text-decoration: underline;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.status-badge.pr-merged {
+  background: rgba(130, 80, 223, 0.15);
+  color: #8250df;
+}
+
+.status-badge.pr-open {
+  background: rgba(46, 160, 67, 0.15);
+  color: var(--color-success);
+}
+
+.status-badge.pr-closed {
+  background: rgba(110, 119, 129, 0.15);
+  color: #6e7781;
+}
+
+.status-badge.pr-draft {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--color-warning);
+}
+
+.status-badge.ci-success {
+  background: rgba(46, 160, 67, 0.15);
+  color: var(--color-success);
+}
+
+.status-badge.ci-pending {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--color-warning);
+}
+
+.pr-warnings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.warning-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.conflict-warning {
+  background-color: rgba(248, 81, 73, 0.1);
+  color: var(--color-error);
+}
+
+.ci-warning {
+  background-color: rgba(248, 81, 73, 0.1);
+  color: var(--color-error);
+  flex-wrap: wrap;
+}
+
+.failure-list {
+  width: 100%;
+  margin: 0.25rem 0 0 1.5rem;
+  padding: 0;
+  font-size: 0.8rem;
+  opacity: 0.9;
+  list-style: disc;
+}
+
+.ci-status {
+  margin-top: 0.25rem;
 }
 </style>


### PR DESCRIPTION
## Summary

- Adds GitHub CLI integration to enrich session summaries with real-time PR information
- Displays PR state (open, merged, closed, draft) with color-coded badges
- Shows CI status with list of failed checks when CI is failing
- Warns users when merge conflicts are detected

## Changes

| File | Changes |
|------|---------|
| `ghService.js` | New service with `isGhAvailable()` and `getPrInfo()` functions |
| `schema.sql` | Added `pr_merged`, `pr_state`, `has_merge_conflicts`, `ci_status`, `ci_failures` columns |
| `SessionSummaryRepository.js` | Updated to handle new fields in create/update/map |
| `summaryService.js` | Integrated ghService to enrich summaries when PR URL exists |
| `SummaryTab.vue` | Added Pull Request section with status badges and warnings |

## Features

- **Graceful degradation**: Works normally if `gh` CLI is not installed
- **Color-coded badges**: Purple for merged, green for open/success, yellow for pending/draft, red for failures
- **CI failure details**: Lists individual failed checks (e.g., lint, test-unit)
- **Merge conflict warning**: Prominent warning when conflicts detected

## Test plan

- [ ] Test with session that has a PR URL
- [ ] Test with session that has no PR URL (should work as before)
- [ ] Test with gh CLI not installed (should gracefully skip enrichment)
- [ ] Test with PR in various states: open, merged, closed, draft
- [ ] Test with failing CI checks
- [ ] Test with merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)