### PR TITLE
Fix session summary generation by adding missing DB migration

### DIFF
--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -71,6 +71,26 @@ export class DatabaseManager {
     // Migrate sessions table to add 'stopped' status to CHECK constraint
     // SQLite doesn't allow modifying CHECK constraints, so we need to recreate the table
     this.#migrateSessionsStatusConstraint();
+
+    // Check if session_summaries table has the PR status columns, add them if not
+    const summariesTableInfo = this.#db.prepare('PRAGMA table_info(session_summaries)').all();
+    const summariesColumns = summariesTableInfo.map((col) => col.name);
+
+    if (!summariesColumns.includes('pr_merged')) {
+      this.#db.exec('ALTER TABLE session_summaries ADD COLUMN pr_merged INTEGER');
+    }
+    if (!summariesColumns.includes('pr_state')) {
+      this.#db.exec('ALTER TABLE session_summaries ADD COLUMN pr_state TEXT');
+    }
+    if (!summariesColumns.includes('has_merge_conflicts')) {
+      this.#db.exec('ALTER TABLE session_summaries ADD COLUMN has_merge_conflicts INTEGER');
+    }
+    if (!summariesColumns.includes('ci_status')) {
+      this.#db.exec('ALTER TABLE session_summaries ADD COLUMN ci_status TEXT');
+    }
+    if (!summariesColumns.includes('ci_failures')) {
+      this.#db.exec('ALTER TABLE session_summaries ADD COLUMN ci_failures TEXT');
+    }
   }
 
   /**

--- a/packages/server/src/services/ghService.js
+++ b/packages/server/src/services/ghService.js
@@ -39,13 +39,13 @@ export async function getPrInfo(prUrl) {
 
   try {
     const { stdout } = await execAsync(
-      `gh pr view "${prUrl}" --json state,merged,mergeable,isDraft,statusCheckRollup`
+      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft,statusCheckRollup`
     );
     const data = JSON.parse(stdout);
 
     // Determine PR state
     let state = data.state.toLowerCase();
-    if (data.merged) state = 'merged';
+    if (data.mergedAt) state = 'merged';
     else if (data.isDraft) state = 'draft';
 
     // Check for merge conflicts
@@ -80,7 +80,7 @@ export async function getPrInfo(prUrl) {
 
     return {
       state,
-      merged: data.merged,
+      merged: !!data.mergedAt,
       hasMergeConflicts,
       ciStatus,
       ciFailures,


### PR DESCRIPTION
## Summary

- **Root cause identified**: Session summaries were failing because `session_summaries` table was missing 5 columns that were added to `schema.sql` but never migrated to existing databases
- **Added database migration** for the missing columns: `pr_merged`, `pr_state`, `has_merge_conflicts`, `ci_status`, `ci_failures`
- **Fixed gh CLI field**: Changed from invalid `merged` to `mergedAt` in ghService.js

## Error that was occurring

```
SqliteError: table session_summaries has no column named pr_merged
    at SessionSummaryRepository.create
    at SessionSummaryRepository.upsert
    at Module.generateSummary
```

## Test plan

- [x] All 364 server tests pass
- [x] Verified migration adds missing columns to existing database
- [x] Verified summary generation works after fix
- [x] Generated summaries for all sessions that were previously missing them

🤖 Generated with [Claude Code](https://claude.com/claude-code)