### PR TITLE
Add branch indicator badge to session detail view

### DIFF
--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick, defineComponent } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({
+    params: { id: 'test-session-id', tab: 'conversation' },
+  })),
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+  })),
+}));
+
+// Mock WebSocket composable
+vi.mock('../composables/useWebSocket.js', () => ({
+  useSessionSubscription: vi.fn(() => ({
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    onStatus: vi.fn(() => vi.fn()),
+    onMessage: vi.fn(() => vi.fn()),
+    onError: vi.fn(() => vi.fn()),
+    onCanvasAdd: vi.fn(() => vi.fn()),
+    onCanvasRemove: vi.fn(() => vi.fn()),
+    onTodosUpdate: vi.fn(() => vi.fn()),
+    onSessionUpdate: vi.fn(() => vi.fn()),
+  })),
+}));
+
+// Mock the stores
+vi.mock('../stores/sessions.js', () => ({
+  useSessionsStore: vi.fn(),
+}));
+
+vi.mock('../stores/canvas.js', () => ({
+  useCanvasStore: vi.fn(() => ({
+    fetchItems: vi.fn(),
+  })),
+}));
+
+vi.mock('../stores/todos.js', () => ({
+  useTodosStore: vi.fn(() => ({
+    fetchTodos: vi.fn(),
+  })),
+}));
+
+vi.mock('../stores/ui.js', () => ({
+  useUiStore: vi.fn(() => ({
+    success: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// Mock child components to avoid their internal dependencies
+vi.mock('../components/ConversationTab.vue', () => ({
+  default: defineComponent({ name: 'ConversationTab', template: '<div />' }),
+}));
+vi.mock('../components/ChangesTab.vue', () => ({
+  default: defineComponent({ name: 'ChangesTab', template: '<div />' }),
+}));
+vi.mock('../components/CanvasTab.vue', () => ({
+  default: defineComponent({ name: 'CanvasTab', template: '<div />' }),
+}));
+vi.mock('../components/NotesTab.vue', () => ({
+  default: defineComponent({ name: 'NotesTab', template: '<div />' }),
+}));
+vi.mock('../components/SummaryTab.vue', () => ({
+  default: defineComponent({ name: 'SummaryTab', template: '<div />' }),
+}));
+
+import SessionDetailView from './SessionDetailView.vue';
+import { useSessionsStore } from '../stores/sessions.js';
+
+describe('SessionDetailView', () => {
+  let mockSessionsStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+
+    mockSessionsStore = {
+      loading: false,
+      currentSession: {
+        id: 'test-session-id',
+        projectId: 'test-project-id',
+        name: 'Test Session',
+        status: 'running',
+        mode: 'standard',
+        gitBranch: null,
+        prUrl: null,
+      },
+      fetchSession: vi.fn(),
+      fetchMessages: vi.fn(),
+      deleteSession: vi.fn(),
+      updateSessionStatus: vi.fn(),
+      addMessage: vi.fn(),
+      updateSession: vi.fn(),
+    };
+
+    useSessionsStore.mockReturnValue(mockSessionsStore);
+  });
+
+  function mountComponent() {
+    return mount(SessionDetailView, {
+      global: {
+        stubs: {
+          'router-link': {
+            template: '<a><slot /></a>',
+            props: ['to'],
+          },
+        },
+      },
+    });
+  }
+
+  describe('branch indicator', () => {
+    it('does not show branch indicator when gitBranch is null', async () => {
+      mockSessionsStore.currentSession.gitBranch = null;
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.branch-indicator').exists()).toBe(false);
+    });
+
+    it('shows branch indicator when gitBranch is set', async () => {
+      mockSessionsStore.currentSession.gitBranch = 'feature/auth-fix';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.branch-indicator').exists()).toBe(true);
+    });
+
+    it('displays the branch name in the indicator', async () => {
+      mockSessionsStore.currentSession.gitBranch = 'feature/auth-fix';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      const branchIndicator = wrapper.find('.branch-indicator');
+      expect(branchIndicator.text()).toContain('feature/auth-fix');
+    });
+
+    it('includes git branch icon (SVG)', async () => {
+      mockSessionsStore.currentSession.gitBranch = 'main';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      const branchIndicator = wrapper.find('.branch-indicator');
+      expect(branchIndicator.find('.branch-icon').exists()).toBe(true);
+      expect(branchIndicator.find('svg').exists()).toBe(true);
+    });
+
+    it('sets title attribute for tooltip on long branch names', async () => {
+      const longBranchName = 'feature/very-long-branch-name-that-might-get-truncated';
+      mockSessionsStore.currentSession.gitBranch = longBranchName;
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      const branchIndicator = wrapper.find('.branch-indicator');
+      expect(branchIndicator.attributes('title')).toBe(longBranchName);
+    });
+
+    it('icon has aria-hidden for accessibility', async () => {
+      mockSessionsStore.currentSession.gitBranch = 'main';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      const icon = wrapper.find('.branch-icon');
+      expect(icon.attributes('aria-hidden')).toBe('true');
+    });
+  });
+
+  describe('session meta display', () => {
+    it('shows status badge', async () => {
+      mockSessionsStore.currentSession.status = 'running';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.status-badge').exists()).toBe(true);
+      expect(wrapper.find('.status-badge').text()).toBe('running');
+    });
+
+    it('shows session mode', async () => {
+      mockSessionsStore.currentSession.mode = 'standard';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-mode').text()).toBe('standard');
+    });
+
+    it('shows PR link when prUrl is set', async () => {
+      mockSessionsStore.currentSession.prUrl = 'https://github.com/org/repo/pull/123';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      const prLink = wrapper.find('.pr-link');
+      expect(prLink.exists()).toBe(true);
+      expect(prLink.attributes('href')).toBe('https://github.com/org/repo/pull/123');
+    });
+
+    it('does not show PR link when prUrl is null', async () => {
+      mockSessionsStore.currentSession.prUrl = null;
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.pr-link').exists()).toBe(false);
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows loading spinner when loading', async () => {
+      mockSessionsStore.loading = true;
+      mockSessionsStore.currentSession = null;
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.loading-state').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Loading session...');
+    });
+  });
+});

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -14,7 +14,14 @@
               {{ sessionsStore.currentSession.status }}
             </span>
             <span class="session-mode">{{ sessionsStore.currentSession.mode }}</span>
-            <span v-if="sessionsStore.currentSession.gitBranch" class="session-branch">
+            <span
+              v-if="sessionsStore.currentSession.gitBranch"
+              class="branch-indicator"
+              :title="sessionsStore.currentSession.gitBranch"
+            >
+              <svg class="branch-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.492 2.492 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z"/>
+              </svg>
               {{ sessionsStore.currentSession.gitBranch }}
             </span>
             <a
@@ -285,10 +292,31 @@ async function handleDelete() {
   text-transform: capitalize;
 }
 
-.session-branch {
+.branch-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
-  color: var(--color-text-soft);
   font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--color-secondary, #8b5cf6);
+  background: var(--color-secondary-soft, rgba(139, 92, 246, 0.1));
+  border-radius: 4px;
+  max-width: 200px;
+  text-decoration: none;
+}
+
+.branch-indicator span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 .tab-content {


### PR DESCRIPTION
## Summary
- Transform plain text git branch display into a visually prominent badge with git branch icon
- Style badge to match existing PR link pattern with secondary color scheme
- Add tooltip showing full branch name for truncated branches
- Include comprehensive test suite for branch indicator functionality

## Test plan
- [ ] Verify branch indicator appears with git branch icon when session has gitBranch set
- [ ] Verify branch indicator is hidden when gitBranch is null
- [ ] Verify long branch names are truncated and show full name on hover
- [ ] Run `npm test` - all 105 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)