### PR TITLE
Remove dollar amounts from session list view

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -66,9 +66,6 @@
             <span v-if="summaries[session.id].filesModified?.length" class="summary-files">
               {{ summaries[session.id].filesModified.length }} files modified
             </span>
-            <span v-if="session.costUsd" class="summary-cost">
-              ${{ session.costUsd.toFixed(2) }}
-            </span>
           </div>
         </div>
         <div v-else-if="loadingSummaries[session.id]" class="session-summary session-summary-loading">
@@ -353,10 +350,6 @@ function formatDate(timestamp) {
 
 .summary-files {
   opacity: 0.8;
-}
-
-.summary-cost {
-  font-family: var(--font-mono);
 }
 
 .loading-spinner-small {


### PR DESCRIPTION
## Summary
- Remove session cost (`costUsd`) display from session list cards
- Remove associated `.summary-cost` CSS styling
- Declutter the UI to focus on more relevant session information

## Test plan
- [ ] Navigate to a project's session list
- [ ] Verify that session cards no longer display dollar amounts
- [ ] Confirm other session information (status, mode, branch, files modified) still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)