### PR TITLE
feat: Make session detail tabs responsive with dropdown on small screens

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -289,6 +289,50 @@ input, textarea, select {
   align-self: stretch;
 }
 
+/* Desktop tabs container */
+.tabs-desktop {
+  display: flex;
+}
+
+/* Mobile dropdown container - hidden by default */
+.tabs-mobile {
+  display: none;
+  flex: 1;
+}
+
+.tab-select {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-background-soft);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='%238b949e'%3E%3Cpath d='M2.5 4.5L6 8L9.5 4.5' stroke='%238b949e' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2rem;
+}
+
+.tab-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.3);
+}
+
+/* Mobile breakpoint - switch to dropdown */
+@media (max-width: 640px) {
+  .tabs-desktop {
+    display: none;
+  }
+
+  .tabs-mobile {
+    display: flex;
+  }
+}
+
 /* Code */
 pre, code {
   font-family: var(--font-mono);

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -49,36 +49,27 @@
           ← Sessions
         </router-link>
         <span class="tab-separator"></span>
-        <router-link
-          :to="`/sessions/${route.params.id}/summary`"
-          :class="['tab', { active: activeTab === 'summary' }]"
-        >
-          Summary
-        </router-link>
-        <router-link
-          :to="`/sessions/${route.params.id}/conversation`"
-          :class="['tab', { active: activeTab === 'conversation' }]"
-        >
-          Conversation
-        </router-link>
-        <router-link
-          :to="`/sessions/${route.params.id}/changes`"
-          :class="['tab', { active: activeTab === 'changes' }]"
-        >
-          Changes
-        </router-link>
-        <router-link
-          :to="`/sessions/${route.params.id}/canvas`"
-          :class="['tab', { active: activeTab === 'canvas' }]"
-        >
-          Canvas
-        </router-link>
-        <router-link
-          :to="`/sessions/${route.params.id}/notes`"
-          :class="['tab', { active: activeTab === 'notes' }]"
-        >
-          Notes
-        </router-link>
+
+        <!-- Desktop tabs -->
+        <div class="tabs-desktop">
+          <router-link
+            v-for="tab in tabs"
+            :key="tab.id"
+            :to="`/sessions/${route.params.id}/${tab.id}`"
+            :class="['tab', { active: activeTab === tab.id }]"
+          >
+            {{ tab.label }}
+          </router-link>
+        </div>
+
+        <!-- Mobile dropdown -->
+        <div class="tabs-mobile">
+          <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
+            <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
+              {{ tab.label }}
+            </option>
+          </select>
+        </div>
       </div>
 
       <div class="tab-content">
@@ -115,6 +106,18 @@ const uiStore = useUiStore();
 
 
 const activeTab = computed(() => route.params.tab || 'conversation');
+
+const tabs = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'conversation', label: 'Conversation' },
+  { id: 'changes', label: 'Changes' },
+  { id: 'canvas', label: 'Canvas' },
+  { id: 'notes', label: 'Notes' }
+];
+
+function navigateToTab(tabId) {
+  router.push(`/sessions/${route.params.id}/${tabId}`);
+}
 
 const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate } =
   useSessionSubscription(route.params.id);


### PR DESCRIPTION
## Summary
- On screens < 640px, navigation tabs collapse into a styled dropdown select menu
- The "← Sessions" back link remains visible at all screen sizes
- Dropdown automatically reflects the current active tab and navigates on selection

## Test plan
- [ ] Verify tabs display normally on desktop (≥ 640px)
- [ ] Verify dropdown appears on mobile (< 640px) with back link still visible
- [ ] Verify dropdown selection navigates to correct tab
- [ ] Verify active tab is reflected in dropdown value
- [ ] Test at the 640px breakpoint for smooth transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)