### PR TITLE
Add mode switching UI for plan/standard/yolo modes

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -242,7 +242,7 @@ router.patch('/:id', (req, res) => {
     return res.status(404).json({ error: 'Session not found' });
   }
 
-  const { thinkingEnabled, status } = req.body;
+  const { thinkingEnabled, status, mode } = req.body;
 
   // Build update object with only provided fields
   const updateData = {};
@@ -255,6 +255,13 @@ router.patch('/:id', (req, res) => {
       return res.status(400).json({ error: 'Invalid status' });
     }
     updateData.status = status;
+  }
+  if (mode !== undefined) {
+    const validModes = ['plan', 'standard', 'yolo'];
+    if (!validModes.includes(mode)) {
+      return res.status(400).json({ error: 'Invalid mode. Must be one of: plan, standard, yolo' });
+    }
+    updateData.mode = mode;
   }
 
   if (Object.keys(updateData).length === 0) {

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -18,6 +18,40 @@ const activeSessions = new Map();
 const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
 
 /**
+ * Map session mode to SDK permissionMode
+ * @param {string} mode - Session mode ('plan', 'standard', 'yolo')
+ * @returns {string} SDK permissionMode value
+ */
+function getPermissionModeForSession(mode) {
+  switch (mode) {
+    case 'yolo':
+      return 'bypassPermissions';
+    case 'plan':
+    case 'standard':
+    default:
+      return 'default';
+  }
+}
+
+/** Plan mode system prompt instructions */
+const PLAN_MODE_PROMPT = `## Plan Mode Active
+
+You are in PLAN mode. Before implementing any changes:
+
+1. **Analyze the Request**: Understand what the user is asking for
+2. **Create a Plan**: Write a detailed implementation plan with:
+   - Files that need to be created or modified
+   - Order of changes
+   - Key implementation decisions
+   - Potential risks or edge cases
+3. **Get Approval**: Present the plan and wait for user approval before proceeding
+4. **Implement**: Only after approval, implement the changes step by step
+
+Do NOT start coding until you have presented a plan and received approval.
+
+`;
+
+/**
  * Mock query generator for E2E testing
  * Simulates the Claude SDK's behavior for multi-turn conversations
  * @param {Object} params
@@ -210,13 +244,18 @@ function buildSessionEnv(session) {
  * @param {string} sessionId
  * @param {string} projectId
  * @param {string|null} customSystemPrompt - Custom system prompt from project settings
+ * @param {string} mode - Session mode ('plan', 'standard', 'yolo')
  * @returns {string} System prompt string
  */
-function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt) {
+function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
   const canvasInstructions = buildCanvasSystemPrompt(sessionId);
   const sessionApiInstructions = buildSessionApiInstructions(sessionId, projectId);
   const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;
-  return `${basePrompt}\n\n${canvasInstructions}\n\n${sessionApiInstructions}`;
+
+  // Prepend plan mode instructions if in plan mode
+  const modePrompt = mode === 'plan' ? PLAN_MODE_PROMPT : '';
+
+  return `${modePrompt}${basePrompt}\n\n${canvasInstructions}\n\n${sessionApiInstructions}`;
 }
 
 /**
@@ -257,9 +296,9 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
             cwd: workingDirectory,
             abortController: controller,
             includePartialMessages: true,
-            permissionMode: 'bypassPermissions',
+            permissionMode: getPermissionModeForSession(session.mode),
             ...(sessionEnv && { env: sessionEnv }),
-            systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt),
+            systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };
 
@@ -345,10 +384,10 @@ export async function continueSession(sessionId, content, workingDirectory, syst
             cwd: workingDirectory,
             abortController: controller,
             includePartialMessages: true,
-            permissionMode: 'bypassPermissions',
+            permissionMode: getPermissionModeForSession(session.mode),
             resume: session.claudeSessionId,
             ...(sessionEnv && { env: sessionEnv }),
-            systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt),
+            systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };
 

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -22,7 +22,7 @@ const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
  * @param {string} mode - Session mode ('plan', 'standard', 'yolo')
  * @returns {string} SDK permissionMode value
  */
-function getPermissionModeForSession(mode) {
+export function getPermissionModeForSession(mode) {
   switch (mode) {
     case 'yolo':
       return 'bypassPermissions';
@@ -34,7 +34,7 @@ function getPermissionModeForSession(mode) {
 }
 
 /** Plan mode system prompt instructions */
-const PLAN_MODE_PROMPT = `## Plan Mode Active
+export const PLAN_MODE_PROMPT = `## Plan Mode Active
 
 You are in PLAN mode. Before implementing any changes:
 
@@ -247,7 +247,7 @@ function buildSessionEnv(session) {
  * @param {string} mode - Session mode ('plan', 'standard', 'yolo')
  * @returns {string} System prompt string
  */
-function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
+export function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
   const canvasInstructions = buildCanvasSystemPrompt(sessionId);
   const sessionApiInstructions = buildSessionApiInstructions(sessionId, projectId);
   const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;

--- a/packages/server/src/services/sessionManager.test.js
+++ b/packages/server/src/services/sessionManager.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPermissionModeForSession,
+  buildSystemPromptConfig,
+  PLAN_MODE_PROMPT,
+} from './sessionManager.js';
+
+describe('sessionManager', () => {
+  describe('getPermissionModeForSession', () => {
+    it('returns "bypassPermissions" for yolo mode', () => {
+      expect(getPermissionModeForSession('yolo')).toBe('bypassPermissions');
+    });
+
+    it('returns "default" for plan mode', () => {
+      expect(getPermissionModeForSession('plan')).toBe('default');
+    });
+
+    it('returns "default" for standard mode', () => {
+      expect(getPermissionModeForSession('standard')).toBe('default');
+    });
+
+    it('returns "default" for undefined mode', () => {
+      expect(getPermissionModeForSession(undefined)).toBe('default');
+    });
+
+    it('returns "default" for null mode', () => {
+      expect(getPermissionModeForSession(null)).toBe('default');
+    });
+
+    it('returns "default" for unknown mode', () => {
+      expect(getPermissionModeForSession('unknown')).toBe('default');
+    });
+  });
+
+  describe('PLAN_MODE_PROMPT', () => {
+    it('contains plan mode instructions', () => {
+      expect(PLAN_MODE_PROMPT).toContain('Plan Mode Active');
+      expect(PLAN_MODE_PROMPT).toContain('Analyze the Request');
+      expect(PLAN_MODE_PROMPT).toContain('Create a Plan');
+      expect(PLAN_MODE_PROMPT).toContain('Get Approval');
+      expect(PLAN_MODE_PROMPT).toContain('Do NOT start coding');
+    });
+  });
+
+  describe('buildSystemPromptConfig', () => {
+    const sessionId = 'test-session-123';
+    const projectId = 'test-project-456';
+
+    it('includes plan mode prompt when mode is plan', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'plan');
+
+      expect(result).toContain('Plan Mode Active');
+      expect(result).toContain('Do NOT start coding');
+    });
+
+    it('does not include plan mode prompt for standard mode', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+      expect(result).not.toContain('Plan Mode Active');
+      expect(result).not.toContain('Do NOT start coding');
+    });
+
+    it('does not include plan mode prompt for yolo mode', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'yolo');
+
+      expect(result).not.toContain('Plan Mode Active');
+      expect(result).not.toContain('Do NOT start coding');
+    });
+
+    it('includes canvas instructions for all modes', () => {
+      const planResult = buildSystemPromptConfig(sessionId, projectId, null, 'plan');
+      const standardResult = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+      const yoloResult = buildSystemPromptConfig(sessionId, projectId, null, 'yolo');
+
+      expect(planResult).toContain('/api/sessions/');
+      expect(planResult).toContain('/canvas');
+      expect(standardResult).toContain('/api/sessions/');
+      expect(standardResult).toContain('/canvas');
+      expect(yoloResult).toContain('/api/sessions/');
+      expect(yoloResult).toContain('/canvas');
+    });
+
+    it('includes session API instructions for all modes', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+      expect(result).toContain('Session Management API');
+      expect(result).toContain(sessionId);
+      expect(result).toContain(projectId);
+    });
+
+    it('uses custom system prompt when provided', () => {
+      const customPrompt = 'Custom system prompt for testing';
+      const result = buildSystemPromptConfig(sessionId, projectId, customPrompt, 'standard');
+
+      expect(result).toContain(customPrompt);
+    });
+
+    it('plan mode prompt is prepended to the system prompt', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'plan');
+
+      // Plan mode prompt should come first
+      const planModeIndex = result.indexOf('Plan Mode Active');
+      const canvasIndex = result.indexOf('canvas');
+
+      expect(planModeIndex).toBeLessThan(canvasIndex);
+    });
+  });
+});

--- a/packages/server/test/session-modes.test.js
+++ b/packages/server/test/session-modes.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { projects, sessions } from '../src/database.js';
+
+describe('Session Modes', () => {
+  let project;
+
+  beforeEach(() => {
+    project = projects.create('Test Project', '/tmp/test');
+  });
+
+  afterEach(() => {
+    // Clean up
+    const allSessions = sessions.getByProjectId(project.id);
+    allSessions.forEach((s) => sessions.delete(s.id));
+    projects.delete(project.id);
+  });
+
+  describe('Session creation with mode', () => {
+    it('creates session with default mode (standard)', () => {
+      const session = sessions.create(project.id, 'Default Mode', 'prompt');
+      expect(session.mode).toBe('standard');
+    });
+
+    it('creates session with plan mode', () => {
+      const session = sessions.create(project.id, 'Plan Mode', 'prompt', 'plan');
+      expect(session.mode).toBe('plan');
+    });
+
+    it('creates session with standard mode', () => {
+      const session = sessions.create(project.id, 'Standard Mode', 'prompt', 'standard');
+      expect(session.mode).toBe('standard');
+    });
+
+    it('creates session with yolo mode', () => {
+      const session = sessions.create(project.id, 'Yolo Mode', 'prompt', 'yolo');
+      expect(session.mode).toBe('yolo');
+    });
+  });
+
+  describe('Session mode updates', () => {
+    it('updates mode from standard to plan', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'standard');
+      const updated = sessions.update(session.id, { mode: 'plan' });
+      expect(updated.mode).toBe('plan');
+    });
+
+    it('updates mode from standard to yolo', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'standard');
+      const updated = sessions.update(session.id, { mode: 'yolo' });
+      expect(updated.mode).toBe('yolo');
+    });
+
+    it('updates mode from yolo to plan', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'yolo');
+      const updated = sessions.update(session.id, { mode: 'plan' });
+      expect(updated.mode).toBe('plan');
+    });
+
+    it('preserves other fields when updating mode', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'standard');
+      sessions.update(session.id, { thinkingEnabled: true });
+      const updated = sessions.update(session.id, { mode: 'yolo' });
+      expect(updated.mode).toBe('yolo');
+      expect(updated.thinkingEnabled).toBe(true);
+    });
+
+    it('returns null when updating non-existent session', () => {
+      const result = sessions.update('non-existent-id', { mode: 'plan' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Session mode retrieval', () => {
+    it('retrieves session with correct mode', () => {
+      const created = sessions.create(project.id, 'Test', 'prompt', 'plan');
+      const retrieved = sessions.getById(created.id);
+      expect(retrieved.mode).toBe('plan');
+    });
+
+    it('retrieves all sessions with different modes', () => {
+      sessions.create(project.id, 'Plan Session', 'prompt', 'plan');
+      sessions.create(project.id, 'Standard Session', 'prompt', 'standard');
+      sessions.create(project.id, 'Yolo Session', 'prompt', 'yolo');
+
+      const allSessions = sessions.getByProjectId(project.id);
+      expect(allSessions).toHaveLength(3);
+
+      const modes = allSessions.map((s) => s.mode).sort();
+      expect(modes).toEqual(['plan', 'standard', 'yolo']);
+    });
+  });
+});

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -87,17 +87,36 @@
         @keydown.enter.ctrl="handleSend"
       ></textarea>
       <div class="input-controls">
-        <div class="thinking-toggle">
-          <label class="toggle-switch">
-            <input
-              type="checkbox"
-              :checked="sessionsStore.currentSession?.thinkingEnabled"
-              @change="handleThinkingToggle"
-              :disabled="togglingThinking"
-            />
-            <span class="toggle-slider"></span>
-          </label>
-          <span class="toggle-label">Thinking</span>
+        <div class="session-options">
+          <div class="thinking-toggle">
+            <label class="toggle-switch">
+              <input
+                type="checkbox"
+                :checked="sessionsStore.currentSession?.thinkingEnabled"
+                @change="handleThinkingToggle"
+                :disabled="togglingThinking"
+              />
+              <span class="toggle-slider"></span>
+            </label>
+            <span class="toggle-label">Thinking</span>
+          </div>
+
+          <div class="mode-switcher">
+            <span class="mode-label">Mode:</span>
+            <div class="mode-buttons">
+              <button
+                v-for="m in modes"
+                :key="m.value"
+                type="button"
+                :class="['mode-btn', { active: sessionsStore.currentSession?.mode === m.value }]"
+                @click="handleModeChange(m.value)"
+                :disabled="togglingMode"
+                :title="m.description"
+              >
+                {{ m.label }}
+              </button>
+            </div>
+          </div>
         </div>
         <div class="input-actions">
           <button type="submit" class="btn btn-primary btn-send" :disabled="!input.trim() || sending">
@@ -153,7 +172,14 @@ const sending = ref(false);
 const stopping = ref(false);
 const restarting = ref(false);
 const togglingThinking = ref(false);
+const togglingMode = ref(false);
 const messagesContainer = ref(null);
+
+const modes = [
+  { value: 'plan', label: 'Plan', description: 'Agent plans before implementing' },
+  { value: 'standard', label: 'Standard', description: 'Balanced approach' },
+  { value: 'yolo', label: 'Auto', description: 'Auto-approve mode' },
+];
 const partialText = ref('');
 const isNearBottom = ref(true);
 const hasNewMessages = ref(false);
@@ -359,6 +385,20 @@ async function handleThinkingToggle(event) {
     togglingThinking.value = false;
   }
 }
+
+async function handleModeChange(newMode) {
+  if (togglingMode.value) return;
+  if (sessionsStore.currentSession?.mode === newMode) return;
+
+  togglingMode.value = true;
+  try {
+    await sessionsStore.updateSessionMode(props.sessionId, newMode);
+  } catch (err) {
+    uiStore.error(err.message);
+  } finally {
+    togglingMode.value = false;
+  }
+}
 </script>
 
 <style scoped>
@@ -463,6 +503,13 @@ async function handleThinkingToggle(event) {
   gap: 1rem;
 }
 
+.session-options {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
 .thinking-toggle {
   display: flex;
   align-items: center;
@@ -472,6 +519,54 @@ async function handleThinkingToggle(event) {
 .toggle-label {
   font-size: 0.875rem;
   color: var(--color-text-soft);
+}
+
+.mode-switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mode-label {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+}
+
+.mode-buttons {
+  display: flex;
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.mode-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--color-background);
+  border: none;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-soft);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.mode-btn:last-child {
+  border-right: none;
+}
+
+.mode-btn:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+}
+
+.mode-btn.active {
+  background: var(--color-primary);
+  color: white;
+}
+
+.mode-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .toggle-switch {

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -246,6 +246,25 @@ export const useSessionsStore = defineStore('sessions', {
       }
     },
 
+    async updateSessionMode(sessionId, mode) {
+      this.error = null;
+      try {
+        const updated = await api.updateSession(sessionId, { mode });
+        // Update local state
+        const session = this.sessions.find((s) => s.id === sessionId);
+        if (session) {
+          session.mode = mode;
+        }
+        if (this.currentSession?.id === sessionId) {
+          this.currentSession.mode = mode;
+        }
+        return updated;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
     /**
      * Update session with new data from WebSocket
      * @param {Object} sessionData - Updated session data

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -20,15 +20,33 @@
 
       <div class="form-group">
         <label class="form-label">Options</label>
-        <div class="thinking-toggle">
-          <label class="toggle-switch">
-            <input
-              type="checkbox"
-              v-model="thinkingEnabled"
-            />
-            <span class="toggle-slider"></span>
-          </label>
-          <span class="toggle-label">Enable Thinking</span>
+        <div class="options-row">
+          <div class="thinking-toggle">
+            <label class="toggle-switch">
+              <input
+                type="checkbox"
+                v-model="thinkingEnabled"
+              />
+              <span class="toggle-slider"></span>
+            </label>
+            <span class="toggle-label">Enable Thinking</span>
+          </div>
+
+          <div class="mode-selector">
+            <span class="mode-label">Mode:</span>
+            <div class="mode-buttons">
+              <button
+                type="button"
+                v-for="m in modes"
+                :key="m.value"
+                :class="['mode-btn', { active: mode === m.value }]"
+                @click="mode = m.value"
+                :title="m.description"
+              >
+                {{ m.label }}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -111,6 +129,12 @@ const uiStore = useUiStore();
 const prompt = ref('');
 const mode = ref('yolo');
 const gitStatus = ref(null);
+
+const modes = [
+  { value: 'plan', label: 'Plan', description: 'Agent plans before implementing - good for complex tasks' },
+  { value: 'standard', label: 'Standard', description: 'Balanced approach - asks for approval when needed' },
+  { value: 'yolo', label: 'Auto', description: 'Auto-approve mode - agent acts autonomously' },
+];
 const loading = ref(false);
 const loadingGit = ref(false);
 const error = ref(null);
@@ -308,6 +332,14 @@ h1 {
   font-size: 0.75rem;
 }
 
+/* Options row */
+.options-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+}
+
 /* Thinking toggle */
 .thinking-toggle {
   display: flex;
@@ -318,6 +350,50 @@ h1 {
 .toggle-label {
   font-size: 0.875rem;
   color: var(--color-text-soft);
+}
+
+/* Mode selector */
+.mode-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mode-label {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+}
+
+.mode-buttons {
+  display: flex;
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.mode-btn {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--color-background);
+  border: none;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-soft);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.mode-btn:last-child {
+  border-right: none;
+}
+
+.mode-btn:hover {
+  background: var(--color-bg-hover);
+}
+
+.mode-btn.active {
+  background: var(--color-primary);
+  color: white;
 }
 
 .toggle-switch {
@@ -373,6 +449,12 @@ h1 {
   h1 {
     margin-bottom: 1rem;
     font-size: 1.5rem;
+  }
+
+  .options-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
 
   .radio-option {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -184,3 +184,13 @@ export async function updateSessionStatus(sessionId: string, status: string) {
   if (!response.ok) throw new Error('Failed to update session status');
   return response.json();
 }
+
+export async function updateSessionMode(sessionId: string, mode: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mode }),
+  });
+  if (!response.ok) throw new Error('Failed to update session mode');
+  return response.json();
+}

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -243,8 +243,8 @@ test.describe('Session Management', () => {
 
     await page.goto(`/sessions/${session.id}`);
 
-    // Verify mode badge is visible with correct mode
-    await expect(page.locator('.mode-badge, [class*="mode"]').getByText('plan')).toBeVisible();
+    // Verify mode badge is visible with correct mode (use specific class to avoid matching mode switcher buttons)
+    await expect(page.locator('.session-mode').getByText('plan')).toBeVisible();
 
     // Verify via API that mode is correctly set
     const apiSession = await getSession(session.id);

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -390,3 +390,236 @@ test.describe('Session Management', () => {
     expect(assistantMessages.length).toBe(3);
   });
 });
+
+test.describe('New Session - Mode Selection', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('mode selector is visible on new session form', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Verify mode buttons are visible
+    await expect(page.locator('.mode-selector')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Plan' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Standard' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Auto' })).toBeVisible();
+  });
+
+  test('Auto (yolo) mode is selected by default', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Verify Auto (yolo) is the default selected mode
+    const activeBtn = page.locator('.mode-btn.active');
+    await expect(activeBtn).toHaveText('Auto');
+  });
+
+  test('can create session with plan mode', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Fill in required prompt field
+    await page.fill('textarea[id="prompt"]', 'Test with plan mode');
+
+    // Select plan mode
+    await page.click('button:has-text("Plan")');
+
+    // Submit the form
+    await page.click('button:has-text("Start Session")');
+
+    // Wait for redirect to session detail
+    await expect(page).toHaveURL(/\/sessions\/[\w-]+/, { timeout: 10000 });
+    await page.waitForLoadState('networkidle');
+
+    // Extract session ID from URL to verify via API
+    const url = page.url();
+    const sessionId = url.match(/\/sessions\/([\w-]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+
+    // Verify session via API
+    const session = await getSession(sessionId!);
+    expect(session).toBeTruthy();
+    expect(session.mode).toBe('plan');
+  });
+
+  test('can create session with yolo mode', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Fill in required prompt field
+    await page.fill('textarea[id="prompt"]', 'Test with yolo mode');
+
+    // Select Auto (yolo) mode
+    await page.click('button:has-text("Auto")');
+
+    // Submit the form
+    await page.click('button:has-text("Start Session")');
+
+    // Wait for redirect to session detail
+    await expect(page).toHaveURL(/\/sessions\/[\w-]+/, { timeout: 10000 });
+    await page.waitForLoadState('networkidle');
+
+    // Extract session ID from URL
+    const url = page.url();
+    const sessionId = url.match(/\/sessions\/([\w-]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+
+    // Verify session via API
+    const session = await getSession(sessionId!);
+    expect(session).toBeTruthy();
+    expect(session.mode).toBe('yolo');
+  });
+
+  test('can switch between modes', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Verify Auto is default
+    await expect(page.locator('.mode-btn.active')).toHaveText('Auto');
+
+    // Click Plan mode and verify it becomes active
+    await page.click('.mode-btn:has-text("Plan")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('Plan');
+
+    // Click Standard mode and verify it becomes active
+    await page.click('.mode-btn:has-text("Standard")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('Standard');
+
+    // Click Auto mode and verify it becomes active
+    await page.click('.mode-btn:has-text("Auto")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('Auto');
+  });
+});
+
+test.describe('Conversation - Mode Switching', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('mode switcher is visible in conversation tab when session is waiting', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Switch Test',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state (mock mode is fast)
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify mode switcher is visible
+    await expect(page.locator('.mode-switcher')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("Plan")')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("Standard")')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("Auto")')).toBeVisible();
+  });
+
+  test('mode switcher shows current session mode', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Display Test',
+      mode: 'plan',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify Plan button is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Plan');
+  });
+
+  test('can switch mode from standard to yolo', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Switch Test',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify Standard is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Standard');
+
+    // Click Auto to switch to yolo mode
+    await page.click('.mode-switcher button:has-text("Auto")');
+
+    // Wait for mode to update
+    await page.waitForTimeout(500);
+
+    // Verify Auto is now active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Auto');
+
+    // Verify via API
+    const updatedSession = await getSession(session.id);
+    expect(updatedSession.mode).toBe('yolo');
+  });
+
+  test('can switch mode from yolo to plan', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Switch Test',
+      mode: 'yolo',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify Auto is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Auto');
+
+    // Click Plan to switch to plan mode
+    await page.click('.mode-switcher button:has-text("Plan")');
+
+    // Wait for mode to update
+    await page.waitForTimeout(500);
+
+    // Verify Plan is now active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Plan');
+
+    // Verify via API
+    const updatedSession = await getSession(session.id);
+    expect(updatedSession.mode).toBe('plan');
+  });
+
+  test('mode persists after page reload', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Persist Test',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Switch to Plan mode
+    await page.click('.mode-switcher button:has-text("Plan")');
+    await page.waitForTimeout(500);
+
+    // Reload the page
+    await page.reload();
+
+    // Verify Plan is still selected after reload
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Plan');
+  });
+});


### PR DESCRIPTION
## Summary

Implements GitHub Issue #130 - Allow users to switch modes (plan, standard, yolo) when starting a session and during a conversation.

- Add mode selector (segmented buttons) to new session form
- Add mode switcher to conversation input controls
- Wire up mode to Claude SDK `permissionMode` for proper behavior
- Add plan mode system prompt to guide Claude to plan before implementing

## Mode Mapping

| UI Mode | SDK `permissionMode` | Behavior |
|---------|---------------------|----------|
| Plan | `default` + plan prompt | Agent plans before implementing |
| Standard | `default` | Agent asks for approval when needed |
| Auto (yolo) | `bypassPermissions` | Agent acts fully autonomously |

## Changes

### Backend
- `packages/server/src/api/sessions.js`: Add `mode` validation to PATCH endpoint
- `packages/server/src/services/sessionManager.js`: 
  - Add `getPermissionModeForSession()` to map mode to SDK permissionMode
  - Add `PLAN_MODE_PROMPT` constant for plan mode instructions
  - Update `buildSystemPromptConfig()` to inject plan mode prompt
  - Update `runSession()` and `continueSession()` to use session mode

### Frontend
- `packages/web/src/stores/sessions.js`: Add `updateSessionMode()` action
- `packages/web/src/views/NewSessionView.vue`: Add mode selector to options row
- `packages/web/src/components/ConversationTab.vue`: Add mode switcher next to thinking toggle

## Screenshots

The mode selector appears as segmented buttons in both the new session form and during conversations.

## Test plan

- [ ] Create new session with each mode (plan, standard, yolo)
- [ ] Verify mode is saved correctly in database
- [ ] Switch mode during active conversation
- [ ] Verify mode persists after page refresh
- [ ] Test mode switching affects Claude behavior on next turn
- [ ] Test on mobile viewport (responsive design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)