### PR TITLE
Unify session list views with shared SessionCard component

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { h, defineComponent } from 'vue';
+import SessionCard from './SessionCard.vue';
+
+// Custom RouterLink stub that renders slot content
+const RouterLinkStub = defineComponent({
+  name: 'RouterLink',
+  props: ['to'],
+  setup(props, { slots }) {
+    return () => h('a', { href: props.to, class: 'router-link-stub' }, slots.default?.());
+  },
+});
+
+describe('SessionCard', () => {
+  const baseSession = {
+    id: 'session-123',
+    name: 'Test Session',
+    status: 'running',
+    mode: 'code',
+    createdAt: '2024-01-15T10:30:00Z',
+    updatedAt: '2024-01-15T11:45:00Z',
+  };
+
+  function mountComponent(props = {}) {
+    return mount(SessionCard, {
+      props: {
+        session: baseSession,
+        ...props,
+      },
+      global: {
+        components: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    });
+  }
+
+  describe('basic rendering', () => {
+    it('renders session name', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.session-name').text()).toBe('Test Session');
+    });
+
+    it('renders session status badge', () => {
+      const wrapper = mountComponent();
+      const badge = wrapper.find('.status-badge');
+      expect(badge.text()).toBe('running');
+      expect(badge.classes()).toContain('status-running');
+    });
+
+    it('renders session mode', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.session-mode').text()).toBe('code');
+    });
+
+    it('links to session detail page', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.router-link-stub').attributes('href')).toBe('/sessions/session-123');
+    });
+
+    it('renders formatted date', () => {
+      const wrapper = mountComponent();
+      const dateText = wrapper.find('.session-date').text();
+      expect(dateText).toMatch(/Jan/);
+      expect(dateText).toMatch(/15/);
+      expect(dateText).toMatch(/2024/);
+    });
+  });
+
+  describe('git branch display', () => {
+    it('shows git branch when present', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, gitBranch: 'feature/test' },
+      });
+      expect(wrapper.find('.session-branch').text()).toBe('feature/test');
+    });
+
+    it('hides git branch when not present', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.session-branch').exists()).toBe(false);
+    });
+  });
+
+  describe('PR link display', () => {
+    it('shows PR link when prUrl is present', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+      });
+      const prLink = wrapper.find('.pr-link');
+      expect(prLink.exists()).toBe(true);
+      expect(prLink.attributes('href')).toBe('https://github.com/org/repo/pull/123');
+      expect(prLink.attributes('target')).toBe('_blank');
+    });
+
+    it('hides PR link when prUrl is not present', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.pr-link').exists()).toBe(false);
+    });
+  });
+
+  describe('project name display', () => {
+    it('shows project name when showProject is true', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, projectName: 'My Project' },
+        showProject: true,
+      });
+      expect(wrapper.find('.project-name').text()).toBe('My Project');
+    });
+
+    it('hides project name when showProject is false', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, projectName: 'My Project' },
+        showProject: false,
+      });
+      expect(wrapper.find('.session-project').exists()).toBe(false);
+    });
+
+    it('hides project name section when project name is not present', () => {
+      const wrapper = mountComponent({
+        showProject: true,
+      });
+      expect(wrapper.find('.session-project').exists()).toBe(false);
+    });
+  });
+
+  describe('date display logic', () => {
+    it('shows createdAt when showProject is false (project view)', () => {
+      const wrapper = mountComponent({
+        session: {
+          ...baseSession,
+          createdAt: '2024-01-10T09:00:00Z',
+          updatedAt: '2024-01-15T14:00:00Z',
+        },
+        showProject: false,
+      });
+      const dateText = wrapper.find('.session-date').text();
+      expect(dateText).toMatch(/Jan.*10.*2024/);
+    });
+
+    it('shows updatedAt when showProject is true (active sessions view)', () => {
+      const wrapper = mountComponent({
+        session: {
+          ...baseSession,
+          createdAt: '2024-01-10T09:00:00Z',
+          updatedAt: '2024-01-15T14:00:00Z',
+        },
+        showProject: true,
+      });
+      const dateText = wrapper.find('.session-date').text();
+      expect(dateText).toMatch(/Jan.*15.*2024/);
+    });
+  });
+
+  describe('summary display', () => {
+    const testSummary = {
+      shortSummary: 'Implemented new feature',
+      filesModified: ['src/app.js', 'src/utils.js'],
+    };
+
+    it('shows summary when showSummary is true and summary is provided', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summary: testSummary,
+      });
+      expect(wrapper.find('.summary-text').text()).toBe('Implemented new feature');
+      expect(wrapper.find('.summary-files').text()).toBe('2 files modified');
+    });
+
+    it('hides summary section when showSummary is false', () => {
+      const wrapper = mountComponent({
+        showSummary: false,
+        summary: testSummary,
+      });
+      expect(wrapper.find('.session-summary').exists()).toBe(false);
+    });
+
+    it('shows loading state when summaryLoading is true', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summaryLoading: true,
+      });
+      expect(wrapper.find('.session-summary-loading').exists()).toBe(true);
+      expect(wrapper.find('.loading-spinner-small').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Loading summary...');
+    });
+
+    it('shows error state when summaryError is true', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summaryError: true,
+      });
+      expect(wrapper.find('.session-summary-error').exists()).toBe(true);
+      expect(wrapper.find('.error-icon').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Summary unavailable');
+    });
+
+    it('shows retry button on error', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summaryError: true,
+      });
+      expect(wrapper.find('.retry-btn').exists()).toBe(true);
+      expect(wrapper.find('.retry-btn').text()).toBe('Retry');
+    });
+
+    it('retry button is clickable', async () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summaryError: true,
+      });
+      const btn = wrapper.find('.retry-btn');
+      expect(btn.exists()).toBe(true);
+      // Verify button can be clicked without errors
+      await btn.trigger('click');
+      // The click event is captured, confirming the button is interactive
+      expect(wrapper.emitted('click')).toBeTruthy();
+    });
+
+    it('hides files modified count when filesModified is empty', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summary: { shortSummary: 'Test', filesModified: [] },
+      });
+      expect(wrapper.find('.summary-files').exists()).toBe(false);
+    });
+
+    it('hides files modified count when filesModified is undefined', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summary: { shortSummary: 'Test' },
+      });
+      expect(wrapper.find('.summary-files').exists()).toBe(false);
+    });
+
+    it('does not show summary, loading, or error when all are falsy', () => {
+      const wrapper = mountComponent({
+        showSummary: true,
+        summary: null,
+        summaryLoading: false,
+        summaryError: false,
+      });
+      expect(wrapper.find('.session-summary').exists()).toBe(false);
+      expect(wrapper.find('.session-summary-loading').exists()).toBe(false);
+      expect(wrapper.find('.session-summary-error').exists()).toBe(false);
+    });
+  });
+
+  describe('status badge classes', () => {
+    const statuses = ['running', 'waiting', 'completed', 'error', 'stopped'];
+
+    statuses.forEach((status) => {
+      it(`applies correct class for ${status} status`, () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, status },
+        });
+        expect(wrapper.find('.status-badge').classes()).toContain(`status-${status}`);
+      });
+    });
+  });
+});

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -1,0 +1,274 @@
+<template>
+  <router-link :to="`/sessions/${session.id}`" class="session-card card">
+    <div class="session-header-row">
+      <div class="session-info">
+        <h3 class="session-name">{{ session.name }}</h3>
+        <p class="session-meta">
+          <span :class="['status-badge', `status-${session.status}`]">{{ session.status }}</span>
+          <span class="session-mode">{{ session.mode }}</span>
+          <span v-if="session.gitBranch" class="session-branch">{{ session.gitBranch }}</span>
+          <a
+            v-if="session.prUrl"
+            :href="session.prUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="pr-link"
+            @click.stop
+          >
+            <svg class="pr-icon" viewBox="0 0 16 16" fill="currentColor">
+              <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
+            </svg>
+            PR
+          </a>
+        </p>
+        <p v-if="showProject && session.projectName" class="session-project">
+          <span class="project-name">{{ session.projectName }}</span>
+        </p>
+      </div>
+      <div class="session-date">
+        {{ formatDate(dateToShow) }}
+      </div>
+    </div>
+    <div v-if="showSummary">
+      <div v-if="summary" class="session-summary">
+        <p class="summary-text">{{ summary.shortSummary }}</p>
+        <div class="summary-meta">
+          <span v-if="summary.filesModified?.length" class="summary-files">
+            {{ summary.filesModified.length }} files modified
+          </span>
+        </div>
+      </div>
+      <div v-else-if="summaryLoading" class="session-summary session-summary-loading">
+        <span class="loading-spinner-small"></span>
+        <span>Loading summary...</span>
+      </div>
+      <div v-else-if="summaryError" class="session-summary session-summary-error">
+        <span class="error-icon">!</span>
+        <span>Summary unavailable</span>
+        <button class="retry-btn" @click.prevent="$emit('retrySummary', session.id)">Retry</button>
+      </div>
+    </div>
+  </router-link>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { formatDate } from '../utils/formatters.js';
+
+const props = defineProps({
+  session: {
+    type: Object,
+    required: true,
+  },
+  showSummary: {
+    type: Boolean,
+    default: false,
+  },
+  showProject: {
+    type: Boolean,
+    default: false,
+  },
+  summary: {
+    type: Object,
+    default: null,
+  },
+  summaryLoading: {
+    type: Boolean,
+    default: false,
+  },
+  summaryError: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits(['retrySummary']);
+
+const dateToShow = computed(() => {
+  // For active sessions view, prefer updatedAt; for project view, prefer createdAt
+  return props.showProject ? props.session.updatedAt : props.session.createdAt;
+});
+</script>
+
+<style scoped>
+.session-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: var(--color-text);
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+
+.session-card:hover {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.session-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.session-name {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.session-meta {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.session-mode {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  text-transform: capitalize;
+}
+
+.session-branch {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  font-family: var(--font-mono);
+}
+
+.pr-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  border-radius: 3px;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.pr-link:hover {
+  background: var(--color-primary);
+  color: white;
+}
+
+.pr-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.session-project {
+  margin: 0.5rem 0 0;
+}
+
+.project-name {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.session-date {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+  flex-shrink: 0;
+}
+
+.session-summary {
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.session-summary-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-soft);
+  font-size: 0.75rem;
+}
+
+.session-summary-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-soft);
+  font-size: 0.75rem;
+}
+
+.error-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  background-color: var(--color-warning);
+  color: white;
+  border-radius: 50%;
+  font-size: 0.625rem;
+  font-weight: bold;
+}
+
+.retry-btn {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+  margin-left: auto;
+}
+
+.retry-btn:hover {
+  text-decoration: underline;
+}
+
+.summary-text {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.summary-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.summary-files {
+  opacity: 0.8;
+}
+
+.loading-spinner-small {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 480px) {
+  .session-header-row {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .session-date {
+    flex-shrink: 1;
+    align-self: flex-start;
+  }
+}
+</style>

--- a/packages/web/src/utils/formatters.js
+++ b/packages/web/src/utils/formatters.js
@@ -1,0 +1,14 @@
+/**
+ * Format a timestamp for display in the UI
+ * @param {number|string|Date} timestamp - The timestamp to format
+ * @returns {string} Formatted date string
+ */
+export function formatDate(timestamp) {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/packages/web/src/utils/formatters.test.js
+++ b/packages/web/src/utils/formatters.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from './formatters.js';
+
+describe('formatters', () => {
+  describe('formatDate', () => {
+    it('formats a timestamp string', () => {
+      const result = formatDate('2024-01-15T10:30:00Z');
+      expect(result).toMatch(/Jan/);
+      expect(result).toMatch(/15/);
+      expect(result).toMatch(/2024/);
+    });
+
+    it('formats a numeric timestamp', () => {
+      const timestamp = new Date('2024-06-20T14:45:00Z').getTime();
+      const result = formatDate(timestamp);
+      expect(result).toMatch(/Jun/);
+      expect(result).toMatch(/20/);
+      expect(result).toMatch(/2024/);
+    });
+
+    it('formats a Date object', () => {
+      const date = new Date('2024-12-25T08:00:00Z');
+      const result = formatDate(date);
+      expect(result).toMatch(/Dec/);
+      expect(result).toMatch(/25/);
+      expect(result).toMatch(/2024/);
+    });
+
+    it('includes time in the output', () => {
+      const result = formatDate('2024-01-15T10:30:00Z');
+      // The exact time format depends on locale, but should include hours and minutes
+      expect(result).toMatch(/\d{1,2}:\d{2}/);
+    });
+  });
+});

--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -9,7 +9,7 @@
     </div>
 
     <div v-if="sessionsStore.loading" class="skeleton-list">
-      <div v-for="i in 3" :key="i" class="skeleton card" style="height: 80px"></div>
+      <div v-for="i in 3" :key="i" class="skeleton card" style="height: 120px"></div>
     </div>
 
     <div v-else-if="sessionsStore.error" class="error-message">
@@ -22,49 +22,33 @@
     </div>
 
     <div v-else class="session-list">
-      <router-link
+      <SessionCard
         v-for="session in sessionsStore.activeSessions"
         :key="session.id"
-        :to="`/sessions/${session.id}`"
-        class="session-card card"
-      >
-        <div class="session-info">
-          <h3 class="session-name">{{ session.name }}</h3>
-          <p class="session-meta">
-            <span :class="['status-badge', `status-${session.status}`]">{{ session.status }}</span>
-            <span class="session-mode">{{ session.mode }}</span>
-            <span v-if="session.gitBranch" class="session-branch">{{ session.gitBranch }}</span>
-            <a
-              v-if="session.prUrl"
-              :href="session.prUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="pr-link"
-              @click.stop
-            >
-              <svg class="pr-icon" viewBox="0 0 16 16" fill="currentColor">
-                <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
-              </svg>
-              PR
-            </a>
-          </p>
-          <p class="session-project">
-            <span class="project-name">{{ session.projectName }}</span>
-          </p>
-        </div>
-        <div class="session-date">
-          {{ formatDate(session.updatedAt) }}
-        </div>
-      </router-link>
+        :session="session"
+        :show-project="true"
+        :show-summary="true"
+        :summary="summaries[session.id]"
+        :summary-loading="loadingSummaries[session.id]"
+        :summary-error="summaryErrors[session.id]"
+        @retry-summary="retryFetchSummary"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
-import { onMounted, onUnmounted } from 'vue';
+import { onMounted, onUnmounted, reactive, watch } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
+import { api } from '../composables/useApi.js';
+import SessionCard from '../components/SessionCard.vue';
 
 const sessionsStore = useSessionsStore();
+
+// Store summaries keyed by session ID
+const summaries = reactive({});
+const loadingSummaries = reactive({});
+const summaryErrors = reactive({});
 
 let refreshInterval = null;
 
@@ -83,14 +67,45 @@ onUnmounted(() => {
   }
 });
 
-function formatDate(timestamp) {
-  return new Date(timestamp).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+// Watch for sessions changes and fetch summaries
+watch(
+  () => sessionsStore.activeSessions,
+  () => {
+    fetchSummaries();
+  },
+  { immediate: true }
+);
+
+async function fetchSummaries() {
+  const sessions = sessionsStore.activeSessions;
+  for (const session of sessions) {
+    if (!summaries[session.id] && !loadingSummaries[session.id]) {
+      fetchSummary(session.id);
+    }
+  }
+}
+
+async function fetchSummary(sessionId) {
+  loadingSummaries[sessionId] = true;
+  summaryErrors[sessionId] = false;
+  try {
+    const summary = await api.getSessionSummary(sessionId);
+    if (summary) {
+      summaries[sessionId] = summary;
+    }
+  } catch (error) {
+    if (error.response?.status !== 404) {
+      console.warn(`Failed to fetch summary for session ${sessionId}:`, error.message);
+      summaryErrors[sessionId] = true;
+    }
+  } finally {
+    loadingSummaries[sessionId] = false;
+  }
+}
+
+async function retryFetchSummary(sessionId) {
+  summaryErrors[sessionId] = false;
+  await fetchSummary(sessionId);
 }
 </script>
 
@@ -146,81 +161,5 @@ function formatDate(timestamp) {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.session-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: var(--color-text);
-  text-decoration: none;
-  transition: border-color 0.2s;
-}
-
-.session-card:hover {
-  border-color: var(--color-primary);
-  text-decoration: none;
-}
-
-.session-name {
-  margin: 0 0 0.5rem;
-  font-size: 1rem;
-}
-
-.session-meta {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.session-mode {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-  text-transform: capitalize;
-}
-
-.session-branch {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-  font-family: var(--font-mono);
-}
-
-.pr-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.125rem 0.375rem;
-  font-size: 0.6875rem;
-  font-weight: 500;
-  color: var(--color-primary);
-  background: var(--color-primary-soft);
-  border-radius: 3px;
-  text-decoration: none;
-  transition: background-color 0.2s, color 0.2s;
-}
-
-.pr-link:hover {
-  background: var(--color-primary);
-  color: white;
-}
-
-.pr-icon {
-  width: 12px;
-  height: 12px;
-}
-
-.session-project {
-  margin: 0.5rem 0 0;
-}
-
-.project-name {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-}
-
-.session-date {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
 }
 </style>

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -28,56 +28,16 @@
     </div>
 
     <div v-else class="session-list">
-      <router-link
+      <SessionCard
         v-for="session in sessionsStore.sessions"
         :key="session.id"
-        :to="`/sessions/${session.id}`"
-        class="session-card card"
-      >
-        <div class="session-header-row">
-          <div class="session-info">
-            <h3 class="session-name">{{ session.name }}</h3>
-            <p class="session-meta">
-              <span :class="['status-badge', `status-${session.status}`]">{{ session.status }}</span>
-              <span class="session-mode">{{ session.mode }}</span>
-              <span v-if="session.gitBranch" class="session-branch">{{ session.gitBranch }}</span>
-              <a
-                v-if="session.prUrl"
-                :href="session.prUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="pr-link"
-                @click.stop
-              >
-                <svg class="pr-icon" viewBox="0 0 16 16" fill="currentColor">
-                  <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
-                </svg>
-                PR
-              </a>
-            </p>
-          </div>
-          <div class="session-date">
-            {{ formatDate(session.createdAt) }}
-          </div>
-        </div>
-        <div v-if="summaries[session.id]" class="session-summary">
-          <p class="summary-text">{{ summaries[session.id].shortSummary }}</p>
-          <div class="summary-meta">
-            <span v-if="summaries[session.id].filesModified?.length" class="summary-files">
-              {{ summaries[session.id].filesModified.length }} files modified
-            </span>
-          </div>
-        </div>
-        <div v-else-if="loadingSummaries[session.id]" class="session-summary session-summary-loading">
-          <span class="loading-spinner-small"></span>
-          <span>Loading summary...</span>
-        </div>
-        <div v-else-if="summaryErrors[session.id]" class="session-summary session-summary-error">
-          <span class="error-icon">!</span>
-          <span>Summary unavailable</span>
-          <button class="retry-btn" @click.prevent="retryFetchSummary(session.id)">Retry</button>
-        </div>
-      </router-link>
+        :session="session"
+        :show-summary="true"
+        :summary="summaries[session.id]"
+        :summary-loading="loadingSummaries[session.id]"
+        :summary-error="summaryErrors[session.id]"
+        @retry-summary="retryFetchSummary"
+      />
     </div>
   </div>
 </template>
@@ -88,6 +48,7 @@ import { useRoute } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 import { useSessionsStore } from '../stores/sessions.js';
 import { api } from '../composables/useApi.js';
+import SessionCard from '../components/SessionCard.vue';
 
 const route = useRoute();
 const projectsStore = useProjectsStore();
@@ -147,16 +108,6 @@ async function retryFetchSummary(sessionId) {
   summaryErrors[sessionId] = false;
   await fetchSummary(sessionId);
 }
-
-function formatDate(timestamp) {
-  return new Date(timestamp).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
 </script>
 
 <style scoped>
@@ -207,166 +158,6 @@ function formatDate(timestamp) {
   gap: 1rem;
 }
 
-.session-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  color: var(--color-text);
-  text-decoration: none;
-  transition: border-color 0.2s;
-}
-
-.session-card:hover {
-  border-color: var(--color-primary);
-  text-decoration: none;
-}
-
-.session-header-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-}
-
-.session-name {
-  margin: 0 0 0.5rem;
-  font-size: 1rem;
-}
-
-.session-meta {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.session-mode {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-  text-transform: capitalize;
-}
-
-.session-branch {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-  font-family: var(--font-mono);
-}
-
-.pr-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.125rem 0.375rem;
-  font-size: 0.6875rem;
-  font-weight: 500;
-  color: var(--color-primary);
-  background: var(--color-primary-soft);
-  border-radius: 3px;
-  text-decoration: none;
-  transition: background-color 0.2s, color 0.2s;
-}
-
-.pr-link:hover {
-  background: var(--color-primary);
-  color: white;
-}
-
-.pr-icon {
-  width: 12px;
-  height: 12px;
-}
-
-.session-date {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  flex-shrink: 0;
-}
-
-.session-summary {
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--color-border);
-}
-
-.session-summary-loading {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--color-text-soft);
-  font-size: 0.75rem;
-}
-
-.session-summary-error {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--color-text-soft);
-  font-size: 0.75rem;
-}
-
-.error-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  background-color: var(--color-warning);
-  color: white;
-  border-radius: 50%;
-  font-size: 0.625rem;
-  font-weight: bold;
-}
-
-.retry-btn {
-  background: none;
-  border: none;
-  color: var(--color-primary);
-  font-size: 0.75rem;
-  cursor: pointer;
-  padding: 0;
-  margin-left: auto;
-}
-
-.retry-btn:hover {
-  text-decoration: underline;
-}
-
-.summary-text {
-  margin: 0 0 0.5rem;
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  line-height: 1.4;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.summary-meta {
-  display: flex;
-  gap: 1rem;
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-}
-
-.summary-files {
-  opacity: 0.8;
-}
-
-.loading-spinner-small {
-  width: 12px;
-  height: 12px;
-  border: 2px solid var(--color-border);
-  border-top-color: var(--color-primary);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 @media (max-width: 480px) {
   .page-header {
     flex-direction: column;
@@ -380,16 +171,6 @@ function formatDate(timestamp) {
 
   .project-path {
     word-break: break-all;
-  }
-
-  .session-header-row {
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .session-date {
-    flex-shrink: 1;
-    align-self: flex-start;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Created `SessionCard.vue` component to display session information consistently across both views
- Added `formatters.js` utility with shared `formatDate` function
- Refactored `SessionListView` and `ActiveSessionsView` to use the new shared component
- **ActiveSessionsView now shows summaries** just like the project session list

## Changes
- **New:** `SessionCard.vue` - Reusable component with props for `showSummary`, `showProject`, and summary state management
- **New:** `formatters.js` - Shared date formatting utility  
- **Updated:** `SessionListView.vue` - Now uses SessionCard, removed ~130 lines of duplicate code
- **Updated:** `ActiveSessionsView.vue` - Now uses SessionCard with summary support added

## Code Reduction
- Removed ~150 lines of duplicate CSS and template code
- Single source of truth for session card styling and behavior

## Test plan
- [x] All 137 existing tests pass
- [x] Added 28 new tests for SessionCard component
- [x] Added 4 new tests for formatters utility
- [ ] Manual verification: Project session list displays correctly with summaries
- [ ] Manual verification: Active sessions list displays correctly with summaries and project names

🤖 Generated with [Claude Code](https://claude.com/claude-code)