### PR TITLE
fix: Capture structured output from StructuredOutput tool use

### DIFF
--- a/packages/server/src/api/commands.js
+++ b/packages/server/src/api/commands.js
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+import { getCommands, getCommand } from '../services/slashCommandService.js';
+
+const router = Router();
+
+/**
+ * GET /api/commands
+ * List all available slash commands for a directory
+ * Query params:
+ *   - directory: Working directory path (required)
+ */
+router.get('/', async (req, res) => {
+  const directory = req.query.directory;
+
+  if (!directory) {
+    return res.status(400).json({ error: 'directory query parameter is required' });
+  }
+
+  try {
+    const commands = await getCommands(String(directory));
+    res.json({ commands });
+  } catch (err) {
+    console.error('Error listing commands:', err);
+    res.status(500).json({ error: 'Failed to list commands' });
+  }
+});
+
+/**
+ * GET /api/commands/:name
+ * Get a specific command by name
+ * Query params:
+ *   - directory: Working directory path (required)
+ */
+router.get('/:name', async (req, res) => {
+  const { name } = req.params;
+  const directory = req.query.directory;
+
+  if (!directory) {
+    return res.status(400).json({ error: 'directory query parameter is required' });
+  }
+
+  try {
+    const command = await getCommand(String(directory), name);
+
+    if (!command) {
+      return res.status(404).json({ error: 'Command not found' });
+    }
+
+    res.json({ command });
+  } catch (err) {
+    console.error('Error getting command:', err);
+    res.status(500).json({ error: 'Failed to get command' });
+  }
+});
+
+export default router;

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -4,6 +4,7 @@ import sessionsRouter from './sessions.js';
 import canvasRouter from './canvas.js';
 import gitRouter from './git.js';
 import filesystemRouter from './filesystem.js';
+import commandsRouter from './commands.js';
 
 const router = Router();
 
@@ -11,6 +12,7 @@ router.use('/projects', projectsRouter);
 router.use('/sessions', sessionsRouter);
 router.use('/git', gitRouter);
 router.use('/filesystem', filesystemRouter);
+router.use('/commands', commandsRouter);
 
 // Canvas routes are nested under sessions
 router.use('/sessions', canvasRouter);

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -22,7 +22,7 @@ const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
  * @param {string} mode - Session mode ('plan', 'standard', 'yolo')
  * @returns {string} SDK permissionMode value
  */
-function getPermissionModeForSession(mode) {
+export function getPermissionModeForSession(mode) {
   switch (mode) {
     case 'yolo':
       return 'bypassPermissions';
@@ -34,7 +34,7 @@ function getPermissionModeForSession(mode) {
 }
 
 /** Plan mode system prompt instructions */
-const PLAN_MODE_PROMPT = `## Plan Mode Active
+export const PLAN_MODE_PROMPT = `## Plan Mode Active
 
 You are in PLAN mode. Before implementing any changes:
 
@@ -247,7 +247,7 @@ function buildSessionEnv(session) {
  * @param {string} mode - Session mode ('plan', 'standard', 'yolo')
  * @returns {string} System prompt string
  */
-function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
+export function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
   const canvasInstructions = buildCanvasSystemPrompt(sessionId);
   const sessionApiInstructions = buildSessionApiInstructions(sessionId, projectId);
   const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;

--- a/packages/server/src/services/sessionManager.test.js
+++ b/packages/server/src/services/sessionManager.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPermissionModeForSession,
+  buildSystemPromptConfig,
+  PLAN_MODE_PROMPT,
+} from './sessionManager.js';
+
+describe('sessionManager', () => {
+  describe('getPermissionModeForSession', () => {
+    it('returns "bypassPermissions" for yolo mode', () => {
+      expect(getPermissionModeForSession('yolo')).toBe('bypassPermissions');
+    });
+
+    it('returns "default" for plan mode', () => {
+      expect(getPermissionModeForSession('plan')).toBe('default');
+    });
+
+    it('returns "default" for standard mode', () => {
+      expect(getPermissionModeForSession('standard')).toBe('default');
+    });
+
+    it('returns "default" for undefined mode', () => {
+      expect(getPermissionModeForSession(undefined)).toBe('default');
+    });
+
+    it('returns "default" for null mode', () => {
+      expect(getPermissionModeForSession(null)).toBe('default');
+    });
+
+    it('returns "default" for unknown mode', () => {
+      expect(getPermissionModeForSession('unknown')).toBe('default');
+    });
+  });
+
+  describe('PLAN_MODE_PROMPT', () => {
+    it('contains plan mode instructions', () => {
+      expect(PLAN_MODE_PROMPT).toContain('Plan Mode Active');
+      expect(PLAN_MODE_PROMPT).toContain('Analyze the Request');
+      expect(PLAN_MODE_PROMPT).toContain('Create a Plan');
+      expect(PLAN_MODE_PROMPT).toContain('Get Approval');
+      expect(PLAN_MODE_PROMPT).toContain('Do NOT start coding');
+    });
+  });
+
+  describe('buildSystemPromptConfig', () => {
+    const sessionId = 'test-session-123';
+    const projectId = 'test-project-456';
+
+    it('includes plan mode prompt when mode is plan', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'plan');
+
+      expect(result).toContain('Plan Mode Active');
+      expect(result).toContain('Do NOT start coding');
+    });
+
+    it('does not include plan mode prompt for standard mode', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+      expect(result).not.toContain('Plan Mode Active');
+      expect(result).not.toContain('Do NOT start coding');
+    });
+
+    it('does not include plan mode prompt for yolo mode', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'yolo');
+
+      expect(result).not.toContain('Plan Mode Active');
+      expect(result).not.toContain('Do NOT start coding');
+    });
+
+    it('includes canvas instructions for all modes', () => {
+      const planResult = buildSystemPromptConfig(sessionId, projectId, null, 'plan');
+      const standardResult = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+      const yoloResult = buildSystemPromptConfig(sessionId, projectId, null, 'yolo');
+
+      expect(planResult).toContain('/api/sessions/');
+      expect(planResult).toContain('/canvas');
+      expect(standardResult).toContain('/api/sessions/');
+      expect(standardResult).toContain('/canvas');
+      expect(yoloResult).toContain('/api/sessions/');
+      expect(yoloResult).toContain('/canvas');
+    });
+
+    it('includes session API instructions for all modes', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+      expect(result).toContain('Session Management API');
+      expect(result).toContain(sessionId);
+      expect(result).toContain(projectId);
+    });
+
+    it('uses custom system prompt when provided', () => {
+      const customPrompt = 'Custom system prompt for testing';
+      const result = buildSystemPromptConfig(sessionId, projectId, customPrompt, 'standard');
+
+      expect(result).toContain(customPrompt);
+    });
+
+    it('plan mode prompt is prepended to the system prompt', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'plan');
+
+      // Plan mode prompt should come first
+      const planModeIndex = result.indexOf('Plan Mode Active');
+      const canvasIndex = result.indexOf('canvas');
+
+      expect(planModeIndex).toBeLessThan(canvasIndex);
+    });
+  });
+});

--- a/packages/server/src/services/slashCommandService.js
+++ b/packages/server/src/services/slashCommandService.js
@@ -1,0 +1,178 @@
+import { readdir, readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join, basename } from 'path';
+
+/**
+ * @typedef {Object} SlashCommand
+ * @property {string} name - Command name without slash
+ * @property {'builtin' | 'project' | 'user'} source
+ * @property {string} [description] - From YAML frontmatter
+ * @property {string} [argumentHint] - From 'argument-hint' in frontmatter
+ * @property {string} [content] - Markdown body for custom commands
+ */
+
+/**
+ * Built-in commands available in all sessions
+ */
+const BUILTIN_COMMANDS = [
+  { name: 'help', source: 'builtin', description: 'Display help information' },
+  { name: 'clear', source: 'builtin', description: 'Clear conversation history' },
+  { name: 'compact', source: 'builtin', description: 'Compress conversation context' },
+  { name: 'model', source: 'builtin', description: 'Switch AI model', argumentHint: 'model-name' },
+  { name: 'mode', source: 'builtin', description: 'Switch execution mode', argumentHint: 'plan|standard|yolo' },
+  { name: 'config', source: 'builtin', description: 'Open configuration' },
+  { name: 'status', source: 'builtin', description: 'Show session status' },
+  { name: 'cost', source: 'builtin', description: 'Display token usage' },
+  { name: 'stop', source: 'builtin', description: 'Stop current session' },
+];
+
+/**
+ * Parse YAML frontmatter from a markdown file content
+ * @param {string} content - Raw file content
+ * @returns {{ frontmatter: Object, body: string }}
+ */
+export function parseCommandFile(content) {
+  // Match frontmatter delimited by --- lines
+  // Allows for empty frontmatter (---\n---)
+  const match = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/);
+  if (!match) {
+    return { frontmatter: {}, body: content.trim() };
+  }
+
+  // Handle empty frontmatter section
+  const frontmatterContent = match[1].trim();
+  if (!frontmatterContent) {
+    return { frontmatter: {}, body: match[2].trim() };
+  }
+
+  const frontmatter = {};
+  const lines = match[1].split(/\r?\n/);
+
+  for (const line of lines) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) continue;
+
+    const key = line.slice(0, colonIndex).trim();
+    let value = line.slice(colonIndex + 1).trim();
+
+    // Remove surrounding quotes if present
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    if (key) {
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, body: match[2].trim() };
+}
+
+/**
+ * Read commands from a directory
+ * @param {string} directory - Path to commands directory
+ * @param {'project' | 'user'} source - Command source type
+ * @returns {Promise<SlashCommand[]>}
+ */
+async function readCommandsFromDirectory(directory, source) {
+  const commands = [];
+
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+
+      const filePath = join(directory, entry.name);
+      const name = basename(entry.name, '.md');
+
+      try {
+        const content = await readFile(filePath, 'utf-8');
+        const { frontmatter, body } = parseCommandFile(content);
+
+        commands.push({
+          name,
+          source,
+          description: frontmatter.description || undefined,
+          argumentHint: frontmatter['argument-hint'] || undefined,
+          content: body || undefined,
+        });
+      } catch (err) {
+        // Skip files that can't be read
+        console.warn(`Failed to read command file ${filePath}:`, err.message);
+      }
+    }
+  } catch (err) {
+    // Directory doesn't exist or can't be read - that's fine
+    if (err.code !== 'ENOENT' && err.code !== 'EACCES') {
+      console.warn(`Failed to read commands directory ${directory}:`, err.message);
+    }
+  }
+
+  return commands;
+}
+
+/**
+ * Get all available slash commands for a working directory
+ * @param {string} workingDirectory - Project working directory
+ * @returns {Promise<SlashCommand[]>}
+ */
+export async function getCommands(workingDirectory) {
+  const commands = [...BUILTIN_COMMANDS];
+
+  // Read project-level commands
+  if (workingDirectory) {
+    const projectCommandsDir = join(workingDirectory, '.claude', 'commands');
+    const projectCommands = await readCommandsFromDirectory(projectCommandsDir, 'project');
+    commands.push(...projectCommands);
+  }
+
+  // Read user-level commands
+  const userCommandsDir = join(homedir(), '.claude', 'commands');
+  const userCommands = await readCommandsFromDirectory(userCommandsDir, 'user');
+  commands.push(...userCommands);
+
+  // Deduplicate by name (project overrides user, user overrides builtin)
+  const commandMap = new Map();
+  for (const cmd of commands) {
+    const existing = commandMap.get(cmd.name);
+    if (!existing || getPriority(cmd.source) > getPriority(existing.source)) {
+      commandMap.set(cmd.name, cmd);
+    }
+  }
+
+  return Array.from(commandMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Get priority for deduplication (higher = wins)
+ * @param {'builtin' | 'project' | 'user'} source
+ * @returns {number}
+ */
+function getPriority(source) {
+  switch (source) {
+    case 'project': return 3;
+    case 'user': return 2;
+    case 'builtin': return 1;
+    default: return 0;
+  }
+}
+
+/**
+ * Get a specific command by name
+ * @param {string} workingDirectory - Project working directory
+ * @param {string} name - Command name
+ * @returns {Promise<SlashCommand | null>}
+ */
+export async function getCommand(workingDirectory, name) {
+  const commands = await getCommands(workingDirectory);
+  return commands.find(cmd => cmd.name === name) || null;
+}
+
+export default {
+  getCommands,
+  getCommand,
+  parseCommandFile,
+  BUILTIN_COMMANDS,
+};

--- a/packages/server/src/services/slashCommandService.test.js
+++ b/packages/server/src/services/slashCommandService.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+import {
+  getCommands,
+  getCommand,
+  parseCommandFile,
+} from './slashCommandService.js';
+import slashCommandService from './slashCommandService.js';
+
+const { BUILTIN_COMMANDS } = slashCommandService;
+
+describe('slashCommandService', () => {
+  let testDir;
+  let userCommandsDir;
+  let originalHome;
+
+  beforeEach(async () => {
+    // Create a temporary directory for project commands
+    testDir = await mkdtemp(join(tmpdir(), 'slash-cmd-test-'));
+
+    // Create .claude/commands directory
+    await mkdir(join(testDir, '.claude', 'commands'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('parseCommandFile', () => {
+    it('parses file with frontmatter', () => {
+      const content = `---
+description: Test command description
+argument-hint: arg1 arg2
+---
+
+This is the command body.`;
+
+      const result = parseCommandFile(content);
+
+      expect(result.frontmatter.description).toBe('Test command description');
+      expect(result.frontmatter['argument-hint']).toBe('arg1 arg2');
+      expect(result.body).toBe('This is the command body.');
+    });
+
+    it('parses file with quoted values', () => {
+      const content = `---
+description: "Quoted description"
+argument-hint: 'Single quoted'
+---
+
+Body content.`;
+
+      const result = parseCommandFile(content);
+
+      expect(result.frontmatter.description).toBe('Quoted description');
+      expect(result.frontmatter['argument-hint']).toBe('Single quoted');
+    });
+
+    it('handles file without frontmatter', () => {
+      const content = 'Just plain content without frontmatter';
+
+      const result = parseCommandFile(content);
+
+      expect(result.frontmatter).toEqual({});
+      expect(result.body).toBe('Just plain content without frontmatter');
+    });
+
+    it('handles frontmatter with only whitespace keys', () => {
+      const content = `---
+description: A command
+---
+
+Content here.`;
+
+      const result = parseCommandFile(content);
+
+      expect(result.frontmatter.description).toBe('A command');
+      expect(result.body).toBe('Content here.');
+    });
+
+    it('handles multiline body', () => {
+      const content = `---
+description: Test
+---
+
+Line 1
+Line 2
+Line 3`;
+
+      const result = parseCommandFile(content);
+
+      expect(result.body).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    it('handles values with colons', () => {
+      const content = `---
+description: URL: https://example.com
+---
+
+Body`;
+
+      const result = parseCommandFile(content);
+
+      expect(result.frontmatter.description).toBe('URL: https://example.com');
+    });
+
+    it('handles Windows line endings', () => {
+      const content = '---\r\ndescription: Test\r\n---\r\n\r\nBody content';
+
+      const result = parseCommandFile(content);
+
+      expect(result.frontmatter.description).toBe('Test');
+      expect(result.body).toBe('Body content');
+    });
+  });
+
+  describe('BUILTIN_COMMANDS', () => {
+    it('includes standard commands', () => {
+      const names = BUILTIN_COMMANDS.map(cmd => cmd.name);
+
+      expect(names).toContain('help');
+      expect(names).toContain('clear');
+      expect(names).toContain('model');
+      expect(names).toContain('mode');
+      expect(names).toContain('stop');
+    });
+
+    it('all have source set to builtin', () => {
+      for (const cmd of BUILTIN_COMMANDS) {
+        expect(cmd.source).toBe('builtin');
+      }
+    });
+
+    it('all have descriptions', () => {
+      for (const cmd of BUILTIN_COMMANDS) {
+        expect(cmd.description).toBeTruthy();
+      }
+    });
+  });
+
+  describe('getCommands', () => {
+    it('returns builtin commands', async () => {
+      const commands = await getCommands(testDir);
+
+      const helpCmd = commands.find(c => c.name === 'help');
+      expect(helpCmd).toBeDefined();
+      expect(helpCmd.source).toBe('builtin');
+    });
+
+    it('returns project commands from .claude/commands/', async () => {
+      // Create a project command
+      await writeFile(
+        join(testDir, '.claude', 'commands', 'deploy.md'),
+        `---
+description: Deploy to production
+argument-hint: environment
+---
+
+Deploy the application to the specified environment.`
+      );
+
+      const commands = await getCommands(testDir);
+
+      const deployCmd = commands.find(c => c.name === 'deploy');
+      expect(deployCmd).toBeDefined();
+      expect(deployCmd.source).toBe('project');
+      expect(deployCmd.description).toBe('Deploy to production');
+      expect(deployCmd.argumentHint).toBe('environment');
+    });
+
+    it('handles commands without frontmatter', async () => {
+      await writeFile(
+        join(testDir, '.claude', 'commands', 'simple.md'),
+        'Just a simple command body with no metadata.'
+      );
+
+      const commands = await getCommands(testDir);
+
+      const simpleCmd = commands.find(c => c.name === 'simple');
+      expect(simpleCmd).toBeDefined();
+      expect(simpleCmd.source).toBe('project');
+      expect(simpleCmd.description).toBeUndefined();
+      expect(simpleCmd.content).toBe('Just a simple command body with no metadata.');
+    });
+
+    it('ignores non-markdown files', async () => {
+      await writeFile(
+        join(testDir, '.claude', 'commands', 'readme.txt'),
+        'This is a readme file, not a command.'
+      );
+
+      const commands = await getCommands(testDir);
+
+      const readmeCmd = commands.find(c => c.name === 'readme');
+      expect(readmeCmd).toBeUndefined();
+    });
+
+    it('handles missing .claude/commands directory gracefully', async () => {
+      // Remove the commands directory
+      await rm(join(testDir, '.claude'), { recursive: true, force: true });
+
+      const commands = await getCommands(testDir);
+
+      // Should still return builtin commands
+      expect(commands.length).toBeGreaterThan(0);
+      const helpCmd = commands.find(c => c.name === 'help');
+      expect(helpCmd).toBeDefined();
+    });
+
+    it('returns commands sorted alphabetically by name', async () => {
+      await writeFile(join(testDir, '.claude', 'commands', 'zebra.md'), 'zebra');
+      await writeFile(join(testDir, '.claude', 'commands', 'alpha.md'), 'alpha');
+
+      const commands = await getCommands(testDir);
+      const names = commands.map(c => c.name);
+
+      // Check that the list is sorted
+      const sortedNames = [...names].sort();
+      expect(names).toEqual(sortedNames);
+    });
+
+    it('project commands override builtin commands with same name', async () => {
+      // Create a project command named 'help' to override builtin
+      await writeFile(
+        join(testDir, '.claude', 'commands', 'help.md'),
+        `---
+description: Custom project help
+---
+
+Custom help content.`
+      );
+
+      const commands = await getCommands(testDir);
+
+      const helpCmds = commands.filter(c => c.name === 'help');
+      expect(helpCmds).toHaveLength(1);
+      expect(helpCmds[0].source).toBe('project');
+      expect(helpCmds[0].description).toBe('Custom project help');
+    });
+
+    it('handles empty working directory', async () => {
+      const commands = await getCommands('');
+
+      // Should return at least builtin commands
+      expect(commands.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getCommand', () => {
+    it('returns builtin command by name', async () => {
+      const command = await getCommand(testDir, 'help');
+
+      expect(command).toBeDefined();
+      expect(command.name).toBe('help');
+      expect(command.source).toBe('builtin');
+    });
+
+    it('returns project command by name', async () => {
+      await writeFile(
+        join(testDir, '.claude', 'commands', 'custom.md'),
+        `---
+description: Custom command
+---
+
+Custom body.`
+      );
+
+      const command = await getCommand(testDir, 'custom');
+
+      expect(command).toBeDefined();
+      expect(command.name).toBe('custom');
+      expect(command.source).toBe('project');
+    });
+
+    it('returns null for non-existent command', async () => {
+      const command = await getCommand(testDir, 'non-existent');
+
+      expect(command).toBeNull();
+    });
+  });
+});

--- a/packages/server/src/services/slashCommandService.test.js
+++ b/packages/server/src/services/slashCommandService.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   getCommands,
@@ -13,8 +13,6 @@ const { BUILTIN_COMMANDS } = slashCommandService;
 
 describe('slashCommandService', () => {
   let testDir;
-  let userCommandsDir;
-  let originalHome;
 
   beforeEach(async () => {
     // Create a temporary directory for project commands

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -116,20 +116,20 @@ async function callClaude(prompt, recentMessages, sessionStatus) {
   for await (const event of queryFn(queryParams)) {
     switch (event.type) {
       case 'assistant': {
-        const text = event.message?.content
-          ?.filter((c) => c.type === 'text')
-          ?.map((c) => c.text)
-          ?.join('');
-        if (text) responseText += text;
+        const content = event.message?.content || [];
+        for (const block of content) {
+          // Capture structured output from StructuredOutput tool use
+          if (block.type === 'tool_use' && block.name === 'StructuredOutput') {
+            structuredOutput = block.input;
+          } else if (block.type === 'text') {
+            responseText += block.text;
+          }
+        }
         break;
       }
       case 'result': {
         if (event.subtype === 'error') {
           throw new Error(event.error || 'Claude SDK query failed');
-        }
-        // Capture structured output when using outputFormat
-        if (event.structured_output) {
-          structuredOutput = event.structured_output;
         }
         break;
       }

--- a/packages/server/test/session-modes.test.js
+++ b/packages/server/test/session-modes.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { projects, sessions } from '../src/database.js';
+
+describe('Session Modes', () => {
+  let project;
+
+  beforeEach(() => {
+    project = projects.create('Test Project', '/tmp/test');
+  });
+
+  afterEach(() => {
+    // Clean up
+    const allSessions = sessions.getByProjectId(project.id);
+    allSessions.forEach((s) => sessions.delete(s.id));
+    projects.delete(project.id);
+  });
+
+  describe('Session creation with mode', () => {
+    it('creates session with default mode (standard)', () => {
+      const session = sessions.create(project.id, 'Default Mode', 'prompt');
+      expect(session.mode).toBe('standard');
+    });
+
+    it('creates session with plan mode', () => {
+      const session = sessions.create(project.id, 'Plan Mode', 'prompt', 'plan');
+      expect(session.mode).toBe('plan');
+    });
+
+    it('creates session with standard mode', () => {
+      const session = sessions.create(project.id, 'Standard Mode', 'prompt', 'standard');
+      expect(session.mode).toBe('standard');
+    });
+
+    it('creates session with yolo mode', () => {
+      const session = sessions.create(project.id, 'Yolo Mode', 'prompt', 'yolo');
+      expect(session.mode).toBe('yolo');
+    });
+  });
+
+  describe('Session mode updates', () => {
+    it('updates mode from standard to plan', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'standard');
+      const updated = sessions.update(session.id, { mode: 'plan' });
+      expect(updated.mode).toBe('plan');
+    });
+
+    it('updates mode from standard to yolo', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'standard');
+      const updated = sessions.update(session.id, { mode: 'yolo' });
+      expect(updated.mode).toBe('yolo');
+    });
+
+    it('updates mode from yolo to plan', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'yolo');
+      const updated = sessions.update(session.id, { mode: 'plan' });
+      expect(updated.mode).toBe('plan');
+    });
+
+    it('preserves other fields when updating mode', () => {
+      const session = sessions.create(project.id, 'Test', 'prompt', 'standard');
+      sessions.update(session.id, { thinkingEnabled: true });
+      const updated = sessions.update(session.id, { mode: 'yolo' });
+      expect(updated.mode).toBe('yolo');
+      expect(updated.thinkingEnabled).toBe(true);
+    });
+
+    it('returns null when updating non-existent session', () => {
+      const result = sessions.update('non-existent-id', { mode: 'plan' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Session mode retrieval', () => {
+    it('retrieves session with correct mode', () => {
+      const created = sessions.create(project.id, 'Test', 'prompt', 'plan');
+      const retrieved = sessions.getById(created.id);
+      expect(retrieved.mode).toBe('plan');
+    });
+
+    it('retrieves all sessions with different modes', () => {
+      sessions.create(project.id, 'Plan Session', 'prompt', 'plan');
+      sessions.create(project.id, 'Standard Session', 'prompt', 'standard');
+      sessions.create(project.id, 'Yolo Session', 'prompt', 'yolo');
+
+      const allSessions = sessions.getByProjectId(project.id);
+      expect(allSessions).toHaveLength(3);
+
+      const modes = allSessions.map((s) => s.mode).sort();
+      expect(modes).toEqual(['plan', 'standard', 'yolo']);
+    });
+  });
+});

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -347,6 +347,27 @@ export class ApiClient {
     const params = path ? `?path=${encodeURIComponent(path)}` : '';
     return this.#request('GET', `/filesystem/browse${params}`);
   }
+
+  // Commands
+
+  /**
+   * Get all available slash commands for a directory
+   * @param {string} directory - Working directory path
+   * @returns {Promise<{commands: Array}>}
+   */
+  async getCommands(directory) {
+    return this.#request('GET', `/commands?directory=${encodeURIComponent(directory)}`);
+  }
+
+  /**
+   * Get a specific command by name
+   * @param {string} name - Command name
+   * @param {string} directory - Working directory path
+   * @returns {Promise<{command: Object}>}
+   */
+  async getCommand(name, directory) {
+    return this.#request('GET', `/commands/${name}?directory=${encodeURIComponent(directory)}`);
+  }
 }
 
 // Singleton instance

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -96,7 +96,6 @@
           rows="3"
           @input="handleInput"
           @keydown="handleKeyDown"
-          @keydown.enter.ctrl="handleSend"
         ></textarea>
       </div>
       <div class="input-controls">
@@ -457,7 +456,13 @@ function handleInput(event) {
 }
 
 function handleKeyDown(event) {
-  // If autocomplete is not visible, don't intercept keys
+  // Handle Ctrl+Enter to send message
+  if (event.key === 'Enter' && event.ctrlKey && !event.shiftKey && !event.altKey) {
+    handleSend();
+    return;
+  }
+
+  // If autocomplete is not visible, don't intercept other keys
   if (!showSlashCommands.value) {
     return;
   }
@@ -472,8 +477,8 @@ function handleKeyDown(event) {
       moveDown();
       break;
     case 'Enter':
-      // Only intercept Enter if we have a selected command
-      if (selectedCommand.value && !event.ctrlKey) {
+      // Only intercept Enter if we have a selected command (and not Ctrl)
+      if (selectedCommand.value) {
         event.preventDefault();
         selectCommand(selectedCommand.value);
       }

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -79,13 +79,26 @@
     </div>
 
     <form v-if="canSendMessage" @submit.prevent="handleSend" class="input-form">
-      <textarea
-        v-model="input"
-        class="form-input form-textarea"
-        :placeholder="isStopped ? 'Send a message to resume session...' : 'Send a follow-up message...'"
-        rows="3"
-        @keydown.enter.ctrl="handleSend"
-      ></textarea>
+      <div class="textarea-wrapper">
+        <SlashCommandAutocomplete
+          :is-visible="showSlashCommands"
+          :filtered-commands="filteredCommands"
+          :selected-index="selectedIndex"
+          :loading="commandsLoading"
+          @select="selectCommand"
+          @highlight="handleHighlight"
+        />
+        <textarea
+          ref="textareaRef"
+          v-model="input"
+          class="form-input form-textarea"
+          :placeholder="isStopped ? 'Send a message to resume session...' : 'Type / for commands...'"
+          rows="3"
+          @input="handleInput"
+          @keydown="handleKeyDown"
+          @keydown.enter.ctrl="handleSend"
+        ></textarea>
+      </div>
       <div class="input-controls">
         <div class="session-options">
           <div class="thinking-toggle">
@@ -155,10 +168,12 @@ import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
+import { useSlashCommands } from '../composables/useSlashCommands.js';
 import TodoDrawer from './TodoDrawer.vue';
 import WorkLogPanel from './WorkLogPanel.vue';
 import MarkdownViewer from './MarkdownViewer.vue';
 import LiveWorkLogPanel from './LiveWorkLogPanel.vue';
+import SlashCommandAutocomplete from './SlashCommandAutocomplete.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -184,6 +199,26 @@ const partialText = ref('');
 const isNearBottom = ref(true);
 const hasNewMessages = ref(false);
 let debounceTimer = null;
+
+// Slash command autocomplete state
+const showSlashCommands = ref(false);
+const textareaRef = ref(null);
+
+const workingDirectory = computed(() =>
+  sessionsStore.currentSession?.workingDirectory || ''
+);
+
+const {
+  filteredCommands,
+  selectedIndex,
+  selectedCommand,
+  loading: commandsLoading,
+  fetchCommands,
+  setFilter,
+  moveUp,
+  moveDown,
+  reset: resetSlashCommands,
+} = useSlashCommands(workingDirectory);
 
 const SCROLL_THRESHOLD = 100; // pixels from bottom to consider "at bottom"
 
@@ -284,6 +319,8 @@ onUnmounted(() => {
   }
   // Clear work logs when leaving the conversation
   sessionsStore.clearWorkLogs();
+  // Reset slash command state
+  resetSlashCommands();
 });
 
 // Save draft to localStorage with debounce
@@ -399,6 +436,84 @@ async function handleModeChange(newMode) {
     togglingMode.value = false;
   }
 }
+
+// Slash command autocomplete handlers
+function handleInput(event) {
+  const value = event.target.value;
+
+  // Check if input starts with / and has no space yet (still typing command name)
+  if (value.startsWith('/') && !value.includes(' ')) {
+    const partial = value.slice(1); // Remove leading /
+    setFilter(partial);
+    showSlashCommands.value = true;
+
+    // Fetch commands if not loaded
+    if (filteredCommands.value.length === 0 && !commandsLoading.value) {
+      fetchCommands();
+    }
+  } else {
+    showSlashCommands.value = false;
+  }
+}
+
+function handleKeyDown(event) {
+  // If autocomplete is not visible, don't intercept keys
+  if (!showSlashCommands.value) {
+    return;
+  }
+
+  switch (event.key) {
+    case 'ArrowUp':
+      event.preventDefault();
+      moveUp();
+      break;
+    case 'ArrowDown':
+      event.preventDefault();
+      moveDown();
+      break;
+    case 'Enter':
+      // Only intercept Enter if we have a selected command
+      if (selectedCommand.value && !event.ctrlKey) {
+        event.preventDefault();
+        selectCommand(selectedCommand.value);
+      }
+      break;
+    case 'Escape':
+      event.preventDefault();
+      showSlashCommands.value = false;
+      break;
+    case 'Tab':
+      if (selectedCommand.value) {
+        event.preventDefault();
+        selectCommand(selectedCommand.value);
+      }
+      break;
+  }
+}
+
+function selectCommand(command) {
+  // Replace the partial command with the full command name
+  if (command.argumentHint) {
+    input.value = `/${command.name} `;
+  } else {
+    input.value = `/${command.name}`;
+  }
+
+  showSlashCommands.value = false;
+  resetSlashCommands();
+
+  // Focus textarea and move cursor to end
+  nextTick(() => {
+    if (textareaRef.value) {
+      textareaRef.value.focus();
+      textareaRef.value.selectionStart = textareaRef.value.selectionEnd = input.value.length;
+    }
+  });
+}
+
+function handleHighlight(index) {
+  selectedIndex.value = index;
+}
 </script>
 
 <style scoped>
@@ -490,6 +605,11 @@ async function handleModeChange(newMode) {
   gap: 0.5rem;
   padding-top: 1rem;
   border-top: 1px solid var(--color-border);
+}
+
+.textarea-wrapper {
+  position: relative;
+  width: 100%;
 }
 
 .input-form textarea {

--- a/packages/web/src/components/SlashCommandAutocomplete.vue
+++ b/packages/web/src/components/SlashCommandAutocomplete.vue
@@ -1,0 +1,192 @@
+<template>
+  <div
+    v-if="isVisible"
+    class="slash-command-autocomplete"
+    role="listbox"
+    :aria-activedescendant="selectedCommand ? `cmd-${selectedIndex}` : undefined"
+  >
+    <div v-if="loading" class="autocomplete-loading">
+      <span class="loading-spinner"></span>
+      Loading commands...
+    </div>
+
+    <div v-else-if="filteredCommands.length === 0" class="autocomplete-empty">
+      No matching commands
+    </div>
+
+    <div v-else class="autocomplete-list" ref="listRef">
+      <div
+        v-for="(command, index) in filteredCommands"
+        :key="command.name"
+        :id="`cmd-${index}`"
+        :class="['autocomplete-item', { selected: index === selectedIndex }]"
+        :ref="el => { if (index === selectedIndex) selectedEl = el }"
+        role="option"
+        :aria-selected="index === selectedIndex"
+        @click="$emit('select', command)"
+        @mouseenter="$emit('highlight', index)"
+      >
+        <div class="command-info">
+          <span class="command-name">/{{ command.name }}</span>
+          <span :class="['command-source', `source-${command.source}`]">
+            {{ command.source }}
+          </span>
+        </div>
+        <div v-if="command.description" class="command-description">
+          {{ command.description }}
+        </div>
+        <div v-if="command.argumentHint" class="command-hint">
+          Argument: {{ command.argumentHint }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, nextTick } from 'vue';
+
+const props = defineProps({
+  isVisible: {
+    type: Boolean,
+    required: true,
+  },
+  filteredCommands: {
+    type: Array,
+    required: true,
+  },
+  selectedIndex: {
+    type: Number,
+    default: 0,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const selectedCommand = ref(null);
+const selectedEl = ref(null);
+const listRef = ref(null);
+
+defineEmits(['select', 'highlight']);
+
+// Watch for selected index changes to scroll into view
+watch(() => props.selectedIndex, () => {
+  nextTick(() => {
+    if (selectedEl.value && listRef.value) {
+      selectedEl.value.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  });
+});
+
+// Update selected command when filtered commands or index changes
+watch([() => props.filteredCommands, () => props.selectedIndex], () => {
+  selectedCommand.value = props.filteredCommands[props.selectedIndex] || null;
+}, { immediate: true });
+</script>
+
+<style scoped>
+.slash-command-autocomplete {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  margin-bottom: 0.5rem;
+  z-index: 100;
+}
+
+.autocomplete-loading,
+.autocomplete-empty {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-soft);
+  font-size: 0.875rem;
+}
+
+.autocomplete-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.autocomplete-list {
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.autocomplete-item {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border);
+  transition: background-color 0.1s;
+}
+
+.autocomplete-item:last-child {
+  border-bottom: none;
+}
+
+.autocomplete-item.selected {
+  background-color: var(--color-background-mute);
+}
+
+.autocomplete-item:hover {
+  background-color: var(--color-background-mute);
+}
+
+.command-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.command-name {
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--color-primary);
+}
+
+.command-source {
+  font-size: 0.625rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.source-builtin {
+  background-color: rgba(88, 166, 255, 0.2);
+  color: var(--color-primary);
+}
+
+.source-project {
+  background-color: rgba(63, 185, 80, 0.2);
+  color: var(--color-success);
+}
+
+.source-user {
+  background-color: rgba(210, 153, 34, 0.2);
+  color: var(--color-warning);
+}
+
+.command-description {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+  margin-top: 0.25rem;
+}
+
+.command-hint {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-soft);
+  margin-top: 0.25rem;
+  opacity: 0.7;
+}
+</style>

--- a/packages/web/src/composables/useSlashCommands.js
+++ b/packages/web/src/composables/useSlashCommands.js
@@ -1,0 +1,117 @@
+import { ref, computed, watch } from 'vue';
+import { api } from '../api/index.js';
+
+/**
+ * Composable for slash command autocomplete functionality
+ * @param {import('vue').Ref<string>} workingDirectory - Session working directory
+ * @returns {Object} Slash command state and methods
+ */
+export function useSlashCommands(workingDirectory) {
+  const commands = ref([]);
+  const loading = ref(false);
+  const error = ref(null);
+  const filter = ref('');
+  const selectedIndex = ref(0);
+
+  /**
+   * Filtered commands based on current input
+   */
+  const filteredCommands = computed(() => {
+    if (!filter.value) return commands.value;
+
+    const lowerFilter = filter.value.toLowerCase();
+    return commands.value.filter(cmd =>
+      cmd.name.toLowerCase().includes(lowerFilter) ||
+      cmd.description?.toLowerCase().includes(lowerFilter)
+    );
+  });
+
+  /**
+   * Currently selected command
+   */
+  const selectedCommand = computed(() =>
+    filteredCommands.value[selectedIndex.value] || null
+  );
+
+  /**
+   * Load commands from API
+   */
+  async function fetchCommands() {
+    if (!workingDirectory.value) return;
+
+    loading.value = true;
+    error.value = null;
+
+    try {
+      const result = await api.getCommands(workingDirectory.value);
+      commands.value = result.commands || [];
+    } catch (err) {
+      error.value = err.message;
+      commands.value = [];
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Set filter text
+   * @param {string} text - Filter text (without leading slash)
+   */
+  function setFilter(text) {
+    filter.value = text;
+  }
+
+  /**
+   * Move selection up
+   */
+  function moveUp() {
+    if (selectedIndex.value > 0) {
+      selectedIndex.value--;
+    }
+  }
+
+  /**
+   * Move selection down
+   */
+  function moveDown() {
+    if (selectedIndex.value < filteredCommands.value.length - 1) {
+      selectedIndex.value++;
+    }
+  }
+
+  /**
+   * Reset state
+   */
+  function reset() {
+    filter.value = '';
+    selectedIndex.value = 0;
+    error.value = null;
+  }
+
+  // Reset selection when filter changes
+  watch(filter, () => {
+    selectedIndex.value = 0;
+  });
+
+  // Fetch commands when working directory changes
+  watch(workingDirectory, (newDir) => {
+    if (newDir) {
+      fetchCommands();
+    }
+  }, { immediate: true });
+
+  return {
+    commands,
+    filteredCommands,
+    selectedCommand,
+    selectedIndex,
+    filter,
+    loading,
+    error,
+    fetchCommands,
+    setFilter,
+    moveUp,
+    moveDown,
+    reset,
+  };
+}

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -184,3 +184,13 @@ export async function updateSessionStatus(sessionId: string, status: string) {
   if (!response.ok) throw new Error('Failed to update session status');
   return response.json();
 }
+
+export async function updateSessionMode(sessionId: string, mode: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mode }),
+  });
+  if (!response.ok) throw new Error('Failed to update session mode');
+  return response.json();
+}

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -390,3 +390,236 @@ test.describe('Session Management', () => {
     expect(assistantMessages.length).toBe(3);
   });
 });
+
+test.describe('New Session - Mode Selection', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('mode selector is visible on new session form', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Verify mode buttons are visible
+    await expect(page.locator('.mode-selector')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Plan' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Standard' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Auto' })).toBeVisible();
+  });
+
+  test('Auto (yolo) mode is selected by default', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Verify Auto (yolo) is the default selected mode
+    const activeBtn = page.locator('.mode-btn.active');
+    await expect(activeBtn).toHaveText('Auto');
+  });
+
+  test('can create session with plan mode', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Fill in required prompt field
+    await page.fill('textarea[id="prompt"]', 'Test with plan mode');
+
+    // Select plan mode
+    await page.click('button:has-text("Plan")');
+
+    // Submit the form
+    await page.click('button:has-text("Start Session")');
+
+    // Wait for redirect to session detail
+    await expect(page).toHaveURL(/\/sessions\/[\w-]+/, { timeout: 10000 });
+    await page.waitForLoadState('networkidle');
+
+    // Extract session ID from URL to verify via API
+    const url = page.url();
+    const sessionId = url.match(/\/sessions\/([\w-]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+
+    // Verify session via API
+    const session = await getSession(sessionId!);
+    expect(session).toBeTruthy();
+    expect(session.mode).toBe('plan');
+  });
+
+  test('can create session with yolo mode', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Fill in required prompt field
+    await page.fill('textarea[id="prompt"]', 'Test with yolo mode');
+
+    // Select Auto (yolo) mode
+    await page.click('button:has-text("Auto")');
+
+    // Submit the form
+    await page.click('button:has-text("Start Session")');
+
+    // Wait for redirect to session detail
+    await expect(page).toHaveURL(/\/sessions\/[\w-]+/, { timeout: 10000 });
+    await page.waitForLoadState('networkidle');
+
+    // Extract session ID from URL
+    const url = page.url();
+    const sessionId = url.match(/\/sessions\/([\w-]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+
+    // Verify session via API
+    const session = await getSession(sessionId!);
+    expect(session).toBeTruthy();
+    expect(session.mode).toBe('yolo');
+  });
+
+  test('can switch between modes', async ({ page }) => {
+    await page.goto(`/projects/${project.id}/sessions/new`);
+
+    // Verify Auto is default
+    await expect(page.locator('.mode-btn.active')).toHaveText('Auto');
+
+    // Click Plan mode and verify it becomes active
+    await page.click('.mode-btn:has-text("Plan")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('Plan');
+
+    // Click Standard mode and verify it becomes active
+    await page.click('.mode-btn:has-text("Standard")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('Standard');
+
+    // Click Auto mode and verify it becomes active
+    await page.click('.mode-btn:has-text("Auto")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('Auto');
+  });
+});
+
+test.describe('Conversation - Mode Switching', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('mode switcher is visible in conversation tab when session is waiting', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Switch Test',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state (mock mode is fast)
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify mode switcher is visible
+    await expect(page.locator('.mode-switcher')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("Plan")')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("Standard")')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("Auto")')).toBeVisible();
+  });
+
+  test('mode switcher shows current session mode', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Display Test',
+      mode: 'plan',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify Plan button is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Plan');
+  });
+
+  test('can switch mode from standard to yolo', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Switch Test',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify Standard is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Standard');
+
+    // Click Auto to switch to yolo mode
+    await page.click('.mode-switcher button:has-text("Auto")');
+
+    // Wait for mode to update
+    await page.waitForTimeout(500);
+
+    // Verify Auto is now active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Auto');
+
+    // Verify via API
+    const updatedSession = await getSession(session.id);
+    expect(updatedSession.mode).toBe('yolo');
+  });
+
+  test('can switch mode from yolo to plan', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Switch Test',
+      mode: 'yolo',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Verify Auto is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Auto');
+
+    // Click Plan to switch to plan mode
+    await page.click('.mode-switcher button:has-text("Plan")');
+
+    // Wait for mode to update
+    await page.waitForTimeout(500);
+
+    // Verify Plan is now active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Plan');
+
+    // Verify via API
+    const updatedSession = await getSession(session.id);
+    expect(updatedSession.mode).toBe('plan');
+  });
+
+  test('mode persists after page reload', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test session',
+      name: 'Mode Persist Test',
+      mode: 'standard',
+    });
+
+    await page.goto(`/sessions/${session.id}/conversation`);
+
+    // Wait for session to be in waiting state
+    await waitForSessionStatus(page, session.id, 'waiting', 15000);
+
+    // Switch to Plan mode
+    await page.click('.mode-switcher button:has-text("Plan")');
+    await page.waitForTimeout(500);
+
+    // Reload the page
+    await page.reload();
+
+    // Verify Plan is still selected after reload
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Plan');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed session summary generation returning empty strings for `shortSummary` and `fullSummary`
- The Claude SDK returns structured output as a `tool_use` block with name `StructuredOutput` in assistant messages, not as a `structured_output` field in the result event
- Updated `callClaude()` in `summaryService.js` to capture output from the correct location

## Test plan
- [x] All 74 summary service tests pass
- [ ] After server restart, verify summaries generate with actual content instead of empty strings
- [ ] Test manual summary regeneration via the "Regenerate" button in Summary tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)