### PR TITLE
fix: Capture session ID to prevent navigation race condition

### DIFF
--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -1,12 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { nextTick, defineComponent } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 
+// Create a mutable route object that can be modified during tests
+const mockRouteParams = { id: 'test-session-id', tab: 'conversation' };
+
 // Mock vue-router
 vi.mock('vue-router', () => ({
   useRoute: vi.fn(() => ({
-    params: { id: 'test-session-id', tab: 'conversation' },
+    params: mockRouteParams,
   })),
   useRouter: vi.fn(() => ({
     push: vi.fn(),
@@ -71,6 +74,7 @@ vi.mock('../components/SummaryTab.vue', () => ({
 
 import SessionDetailView from './SessionDetailView.vue';
 import { useSessionsStore } from '../stores/sessions.js';
+import { useSessionSubscription } from '../composables/useWebSocket.js';
 
 describe('SessionDetailView', () => {
   let mockSessionsStore;
@@ -78,6 +82,10 @@ describe('SessionDetailView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setActivePinia(createPinia());
+
+    // Reset route params to default values
+    mockRouteParams.id = 'test-session-id';
+    mockRouteParams.tab = 'conversation';
 
     mockSessionsStore = {
       loading: false,
@@ -238,6 +246,90 @@ describe('SessionDetailView', () => {
 
       expect(wrapper.find('.loading-state').exists()).toBe(true);
       expect(wrapper.text()).toContain('Loading session...');
+    });
+  });
+
+  describe('session ID capturing (race condition prevention)', () => {
+    it('captures session ID at component creation time', async () => {
+      // Mount component with initial session ID
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Verify initial fetch was called with the correct session ID
+      expect(mockSessionsStore.fetchSession).toHaveBeenCalledWith('test-session-id');
+      expect(mockSessionsStore.fetchMessages).toHaveBeenCalledWith('test-session-id');
+    });
+
+    it('uses captured session ID for WebSocket subscription', async () => {
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Verify useSessionSubscription was called with the session ID
+      expect(useSessionSubscription).toHaveBeenCalledWith('test-session-id');
+    });
+
+    it('uses captured session ID even after route params change (simulating navigation)', async () => {
+      // Start with the original session ID
+      mockRouteParams.id = 'original-session-id';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Verify initial fetch used original session ID
+      expect(mockSessionsStore.fetchSession).toHaveBeenCalledWith('original-session-id');
+
+      // Clear mock call history
+      mockSessionsStore.fetchSession.mockClear();
+      mockSessionsStore.fetchMessages.mockClear();
+
+      // Simulate what happens during navigation: route params change
+      // (In real navigation, Vue Router updates params BEFORE component unmounts)
+      mockRouteParams.id = 'different-project-id';
+
+      // Verify that useSessionSubscription was called with the ORIGINAL ID
+      // (captured at component creation), not the new route param
+      expect(useSessionSubscription).toHaveBeenCalledWith('original-session-id');
+      expect(useSessionSubscription).not.toHaveBeenCalledWith('different-project-id');
+    });
+
+    it('passes captured session ID to updateSessionStatus', async () => {
+      // Get the mock onStatus callback registrar
+      let capturedOnStatusCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn((callback) => {
+          capturedOnStatusCallback = callback;
+          return vi.fn();
+        }),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Simulate route change (as happens during navigation)
+      mockRouteParams.id = 'some-other-id';
+
+      // Trigger a status update through WebSocket
+      if (capturedOnStatusCallback) {
+        capturedOnStatusCallback('completed');
+      }
+
+      // Verify updateSessionStatus was called with the ORIGINAL session ID
+      expect(mockSessionsStore.updateSessionStatus).toHaveBeenCalledWith(
+        'test-session-id',
+        'completed'
+      );
     });
   });
 });

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -111,6 +111,10 @@ const canvasStore = useCanvasStore();
 const todosStore = useTodosStore();
 const uiStore = useUiStore();
 
+// Capture session ID at component creation to avoid race conditions during navigation.
+// When navigating away, Vue Router updates route.params BEFORE unmounting the component.
+// If polling reads route.params.id after navigation starts, it would get the wrong ID.
+const sessionId = route.params.id;
 
 const activeTab = computed(() => route.params.tab || 'conversation');
 
@@ -127,7 +131,7 @@ function navigateToTab(tabId) {
 }
 
 const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate } =
-  useSessionSubscription(route.params.id);
+  useSessionSubscription(sessionId);
 
 let cleanups = [];
 const pollIntervalId = ref(null);
@@ -141,9 +145,9 @@ function startPolling() {
     // Only poll while actively processing, not while waiting for user input
     // Use showLoading=false to avoid flickering
     if (status === 'running' || status === 'starting') {
-      await sessionsStore.fetchSession(route.params.id, false);
-      await sessionsStore.fetchMessages(route.params.id, false);
-      await sessionsStore.fetchWorkLogs(route.params.id);
+      await sessionsStore.fetchSession(sessionId, false);
+      await sessionsStore.fetchMessages(sessionId, false);
+      await sessionsStore.fetchWorkLogs(sessionId);
     } else {
       // Session no longer actively processing, stop polling
       stopPolling();
@@ -176,10 +180,10 @@ onMounted(async () => {
   subscribe();
 
   // Then fetch data - this ensures we don't miss updates
-  await sessionsStore.fetchSession(route.params.id);
-  await sessionsStore.fetchMessages(route.params.id);
-  canvasStore.fetchItems(route.params.id);
-  todosStore.fetchTodos(route.params.id);
+  await sessionsStore.fetchSession(sessionId);
+  await sessionsStore.fetchMessages(sessionId);
+  canvasStore.fetchItems(sessionId);
+  todosStore.fetchTodos(sessionId);
 
   // Start polling if session is actively processing (handles race condition where session
   // completes before WebSocket subscription is established)
@@ -190,7 +194,7 @@ onMounted(async () => {
 
   cleanups.push(
     onStatus((status) => {
-      sessionsStore.updateSessionStatus(route.params.id, status);
+      sessionsStore.updateSessionStatus(sessionId, status);
       // Start polling when session starts processing, stop when done
       if (status === 'running' || status === 'starting') {
         startPolling();
@@ -248,7 +252,7 @@ async function handleDelete() {
 
   try {
     const projectId = sessionsStore.currentSession?.projectId;
-    await sessionsStore.deleteSession(route.params.id);
+    await sessionsStore.deleteSession(sessionId);
     uiStore.success('Session deleted');
     // Navigate to project sessions list
     if (projectId) {


### PR DESCRIPTION
## Summary

- Fixes intermittent "Session not found" error when navigating from a session detail view back to the session list
- The root cause was a race condition: Vue Router updates `route.params` **before** unmounting components, so if polling fired during navigation, it would use the new route's project ID as a session ID
- Captures the session ID at component creation time and uses that captured value for all fetches, polling, and WebSocket operations

## Root Cause

When navigating from `/sessions/:sessionId` to `/projects/:projectId/sessions`:
1. User clicks "← Sessions" back link
2. Vue Router updates `route.params.id` from session ID to project ID
3. If a polling interval fires at this moment (before component unmounts), `fetchSession(route.params.id)` calls the API with the project ID
4. API returns 404 "Session not found" (project ID is not a valid session ID)
5. Error is stored in sessions store
6. SessionListView mounts and displays the stale error

## Test plan

- [x] All existing tests pass (141 tests)
- [x] Added 4 new tests specifically for session ID capturing behavior
- [ ] Manual testing: Navigate between session detail and session list multiple times - no "Session not found" errors should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)