### PR TITLE
feat: Add filePath support for canvas images with validation

### DIFF
--- a/packages/server/src/api/canvas.js
+++ b/packages/server/src/api/canvas.js
@@ -1,11 +1,25 @@
 import { Router } from 'express';
 import multer from 'multer';
+import { readFileSync, existsSync } from 'fs';
+import { extname } from 'path';
 import { sessions, canvasItems } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
+
+// Map file extensions to MIME types
+const MIME_TYPES = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+};
 
 // POST /api/sessions/:id/canvas - Add canvas item
 router.post('/:id/canvas', upload.single('file'), (req, res) => {
@@ -28,37 +42,75 @@ router.post('/:id/canvas', upload.single('file'), (req, res) => {
     };
   } else {
     // JSON body (markdown, text, json, image)
-    const { type, content, data, label, title, width, height, mimeType } = req.body;
+    const { type, content, data, label, title, width, height, mimeType, filePath } = req.body;
     if (!type) {
       return res.status(400).json({ error: 'Type is required' });
     }
 
-    // Handle data URL format: extract mimeType and base64 data from "data:image/jpeg;base64,..."
-    let extractedMimeType = mimeType || null;
-    let extractedData = typeof data === 'object' ? JSON.stringify(data) : data || null;
-
-    if (type === 'image' && content && !data) {
-      const dataUrlMatch = content.match(/^data:([^;]+);base64,(.+)$/);
-      if (dataUrlMatch) {
-        extractedMimeType = dataUrlMatch[1];
-        extractedData = dataUrlMatch[2];
+    // Handle image from file path
+    if (type === 'image' && filePath) {
+      if (!existsSync(filePath)) {
+        return res.status(400).json({ error: `File not found: ${filePath}` });
       }
-    }
 
-    // Ensure image types always have a valid mimeType to prevent broken images in the frontend
-    if (type === 'image' && !extractedMimeType) {
-      extractedMimeType = 'image/png';
-    }
+      const ext = extname(filePath).toLowerCase();
+      const detectedMimeType = MIME_TYPES[ext];
+      if (!detectedMimeType) {
+        return res.status(400).json({
+          error: `Unsupported image format: ${ext}. Supported formats: ${Object.keys(MIME_TYPES).join(', ')}`
+        });
+      }
 
-    itemData = {
-      type,
-      content: content || null,
-      data: extractedData,
-      mimeType: extractedMimeType,
-      label: label || title || null, // Support both 'label' and 'title' fields
-      width: width || null,
-      height: height || null,
-    };
+      try {
+        const fileBuffer = readFileSync(filePath);
+        const base64 = fileBuffer.toString('base64');
+        itemData = {
+          type: 'image',
+          data: base64,
+          mimeType: detectedMimeType,
+          filename: filePath.split('/').pop(),
+          label: label || title || null,
+          width: width || null,
+          height: height || null,
+        };
+      } catch (err) {
+        return res.status(400).json({ error: `Failed to read file: ${err.message}` });
+      }
+    } else {
+      // Handle data URL format: extract mimeType and base64 data from "data:image/jpeg;base64,..."
+      let extractedMimeType = mimeType || null;
+      let extractedData = typeof data === 'object' ? JSON.stringify(data) : data || null;
+
+      if (type === 'image' && content && !data) {
+        const dataUrlMatch = content.match(/^data:([^;]+);base64,(.+)$/);
+        if (dataUrlMatch) {
+          extractedMimeType = dataUrlMatch[1];
+          extractedData = dataUrlMatch[2];
+        }
+      }
+
+      // Validate image has required data
+      if (type === 'image' && !extractedData && !extractedMimeType) {
+        return res.status(400).json({
+          error: 'Image requires either: filePath, data+mimeType, or content as data URL (data:image/...;base64,...)'
+        });
+      }
+
+      // Ensure image types always have a valid mimeType to prevent broken images in the frontend
+      if (type === 'image' && !extractedMimeType) {
+        extractedMimeType = 'image/png';
+      }
+
+      itemData = {
+        type,
+        content: content || null,
+        data: extractedData,
+        mimeType: extractedMimeType,
+        label: label || title || null, // Support both 'label' and 'title' fields
+        width: width || null,
+        height: height || null,
+      };
+    }
   }
 
   const item = canvasItems.create(req.params.id, itemData);

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -99,7 +99,8 @@ function buildCanvasSystemPrompt(sessionId) {
 POST ${apiUrl}/api/sessions/${sessionId}/canvas
 Body: {"type": "image|markdown|text|json", "content": "...", "title": "..."}
 
-For images, use base64 encoding in the content field.`;
+For images, use filePath to reference an image file on disk:
+Body: {"type": "image", "filePath": "/path/to/image.png", "title": "..."}`;
 }
 
 /**

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { seedProject, seedSession, seedCanvasItem, cleanupAll, getCanvasItems } from './helpers';
 
+// A minimal 1x1 red PNG image in base64
+const TEST_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+
 test.describe('Canvas Management', () => {
   let project: any;
   let session: any;
@@ -161,5 +164,184 @@ test.describe('Canvas Management', () => {
     expect(apiJsonItem).toBeTruthy();
     expect(apiJsonItem.type).toBe('json');
     expect(JSON.parse(apiJsonItem.content)).toEqual({ key: 'value' });
+  });
+
+  test('image renders correctly when using data and mimeType fields', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'image',
+      data: TEST_PNG_BASE64,
+      mimeType: 'image/png',
+      label: 'Test Image',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Verify the image label and type are visible
+    await expect(page.getByText('Test Image')).toBeVisible();
+    await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible();
+
+    // Verify the image renders correctly (not broken)
+    const image = page.locator('.canvas-image');
+    await expect(image).toBeVisible();
+
+    // Check that the image has loaded successfully by verifying naturalWidth > 0
+    const naturalWidth = await image.evaluate((img: HTMLImageElement) => img.naturalWidth);
+    expect(naturalWidth).toBeGreaterThan(0);
+  });
+
+  test('image renders correctly when using data URL in content field', async ({ page }) => {
+    const dataUrl = `data:image/png;base64,${TEST_PNG_BASE64}`;
+
+    await seedCanvasItem(session.id, {
+      type: 'image',
+      content: dataUrl,
+      label: 'Data URL Image',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Verify the image label and type are visible
+    await expect(page.getByText('Data URL Image')).toBeVisible();
+    await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible();
+
+    // Verify the image renders correctly (not broken)
+    const image = page.locator('.canvas-image');
+    await expect(image).toBeVisible();
+
+    // Check that the image has loaded successfully by verifying naturalWidth > 0
+    const naturalWidth = await image.evaluate((img: HTMLImageElement) => img.naturalWidth);
+    expect(naturalWidth).toBeGreaterThan(0);
+  });
+
+  test('image with invalid data shows as broken', async ({ page }) => {
+    // Seed an image with invalid base64 data
+    await seedCanvasItem(session.id, {
+      type: 'image',
+      data: 'invalid-base64-data',
+      mimeType: 'image/png',
+      label: 'Broken Image',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Verify the image element is present
+    const image = page.locator('.canvas-image');
+    await expect(image).toBeVisible();
+
+    // Check that the image is broken (naturalWidth === 0 for broken images)
+    const naturalWidth = await image.evaluate((img: HTMLImageElement) => img.naturalWidth);
+    expect(naturalWidth).toBe(0);
+  });
+
+  // Skip in CI - filePath requires shared filesystem between test runner and server
+  test('image renders correctly when using filePath', async ({ page }) => {
+    test.skip(!!process.env.CI, 'Skipped in CI - requires shared filesystem');
+
+    // First, create a test image file
+    const fs = await import('fs');
+    const testImagePath = '/tmp/test-canvas-image.png';
+
+    // Write the test PNG to a file
+    const imageBuffer = Buffer.from(TEST_PNG_BASE64, 'base64');
+    fs.writeFileSync(testImagePath, imageBuffer);
+
+    try {
+      await seedCanvasItem(session.id, {
+        type: 'image',
+        filePath: testImagePath,
+        label: 'File Path Image',
+      });
+
+      await page.goto(`/sessions/${session.id}/canvas`);
+
+      // Verify the image label and type are visible
+      await expect(page.getByText('File Path Image')).toBeVisible();
+      await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible();
+
+      // Verify the image renders correctly (not broken)
+      const image = page.locator('.canvas-image');
+      await expect(image).toBeVisible();
+
+      // Check that the image has loaded successfully by verifying naturalWidth > 0
+      const naturalWidth = await image.evaluate((img: HTMLImageElement) => img.naturalWidth);
+      expect(naturalWidth).toBeGreaterThan(0);
+    } finally {
+      // Clean up the test file
+      if (fs.existsSync(testImagePath)) {
+        fs.unlinkSync(testImagePath);
+      }
+    }
+  });
+
+  test('API returns error when image posted with raw base64 content (no data URL)', async () => {
+    const API_URL = process.env.API_URL || 'http://localhost:5000';
+
+    // Try to post an image with raw base64 in content (incorrect format)
+    const response = await fetch(`${API_URL}/api/sessions/${session.id}/canvas`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'image',
+        content: TEST_PNG_BASE64, // Raw base64, not a data URL
+        label: 'Bad Image',
+      }),
+    });
+
+    // Should return 400 error with helpful message
+    expect(response.status).toBe(400);
+    const error = await response.json();
+    expect(error.error).toContain('Image requires either');
+    expect(error.error).toContain('filePath');
+    expect(error.error).toContain('data URL');
+  });
+
+  test('API returns error when image file path does not exist', async () => {
+    const API_URL = process.env.API_URL || 'http://localhost:5000';
+
+    const response = await fetch(`${API_URL}/api/sessions/${session.id}/canvas`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'image',
+        filePath: '/nonexistent/path/to/image.png',
+        label: 'Missing File',
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const error = await response.json();
+    expect(error.error).toContain('File not found');
+  });
+
+  // Skip in CI - filePath requires shared filesystem between test runner and server
+  test('API returns error for unsupported image format', async () => {
+    test.skip(!!process.env.CI, 'Skipped in CI - requires shared filesystem');
+
+    const API_URL = process.env.API_URL || 'http://localhost:5000';
+    const fs = await import('fs');
+    const testFilePath = '/tmp/test-unsupported.xyz';
+
+    // Create a file with unsupported extension
+    fs.writeFileSync(testFilePath, 'fake image data');
+
+    try {
+      const response = await fetch(`${API_URL}/api/sessions/${session.id}/canvas`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'image',
+          filePath: testFilePath,
+          label: 'Unsupported Format',
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const error = await response.json();
+      expect(error.error).toContain('Unsupported image format');
+    } finally {
+      if (fs.existsSync(testFilePath)) {
+        fs.unlinkSync(testFilePath);
+      }
+    }
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -67,7 +67,7 @@ export async function seedSession(
 
 export async function seedCanvasItem(
   sessionId: string,
-  data: { type: string; content?: string; label?: string }
+  data: { type: string; content?: string; data?: string; mimeType?: string; label?: string; filePath?: string }
 ) {
   const response = await fetch(`${API_URL}/api/sessions/${sessionId}/canvas`, {
     method: 'POST',


### PR DESCRIPTION
## Summary

- Add `filePath` field to canvas POST endpoint for images - server reads file, detects MIME type from extension, and encodes as base64
- Add validation with helpful error messages when image data is malformed
- Update system prompt to instruct Claude to use `filePath` for images
- Add comprehensive Playwright tests for image rendering and error handling

## Details

### API Changes

The canvas POST endpoint now accepts a `filePath` field for images:

```json
{
  "type": "image",
  "filePath": "/path/to/screenshot.png",
  "title": "My Screenshot"
}
```

The server will:
1. Check if the file exists
2. Detect MIME type from file extension
3. Read and encode the file as base64
4. Store the image properly

### System Prompt Update

Updated the canvas instructions in the system prompt from:
```
For images, use base64 encoding in the content field.
```

To:
```
For images, use filePath to reference an image file on disk:
Body: {"type": "image", "filePath": "/path/to/image.png", "title": "..."}
```

### Error Messages

- `"File not found: <path>"` - when filePath doesn't exist
- `"Unsupported image format: <ext>"` - for unknown extensions  
- `"Image requires either: filePath, data+mimeType, or content as data URL..."` - when image data is malformed (e.g., raw base64 without data URL prefix)

### Supported Formats

PNG, JPG/JPEG, GIF, WEBP, SVG, BMP, ICO

## Test plan

- [x] Test image renders correctly with `data` + `mimeType` fields
- [x] Test image renders correctly with data URL in `content` field
- [x] Test broken image is detected (`naturalWidth === 0`)
- [x] Test image renders correctly with `filePath`
- [x] Test API returns error for raw base64 content (no data URL)
- [x] Test API returns error for non-existent file path
- [x] Test API returns error for unsupported image format

🤖 Generated with [Claude Code](https://claude.com/claude-code)