### PR TITLE
Fix mode selector highlight not updating and rename Auto to YOLO

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -178,7 +178,7 @@ const messagesContainer = ref(null);
 const modes = [
   { value: 'plan', label: 'Plan', description: 'Agent plans before implementing' },
   { value: 'standard', label: 'Standard', description: 'Balanced approach' },
-  { value: 'yolo', label: 'Auto', description: 'Auto-approve mode' },
+  { value: 'yolo', label: 'YOLO', description: 'Auto-approve mode' },
 ];
 const partialText = ref('');
 const isNearBottom = ref(true);

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -256,7 +256,7 @@ export const useSessionsStore = defineStore('sessions', {
           session.mode = mode;
         }
         if (this.currentSession?.id === sessionId) {
-          this.currentSession.mode = mode;
+          this.currentSession = { ...this.currentSession, mode };
         }
         return updated;
       } catch (err) {

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useSessionsStore } from './sessions.js';
+
+// Mock the API module
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getActiveSessions: vi.fn(),
+    getProjectSessions: vi.fn(),
+    getSession: vi.fn(),
+    getSessionMessages: vi.fn(),
+    createSession: vi.fn(),
+    sendMessage: vi.fn(),
+    stopSession: vi.fn(),
+    restartSession: vi.fn(),
+    deleteSession: vi.fn(),
+    getSessionWorkLogs: vi.fn(),
+    updateSession: vi.fn(),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+
+describe('Sessions Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  describe('updateSessionMode', () => {
+    it('updates mode in currentSession with new object reference for reactivity', async () => {
+      const store = useSessionsStore();
+
+      // Set up initial session
+      const initialSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        mode: 'standard',
+        status: 'waiting',
+      };
+      store.currentSession = initialSession;
+      store.sessions = [{ ...initialSession }];
+
+      // Mock the API response
+      api.updateSession.mockResolvedValue({ ...initialSession, mode: 'yolo' });
+
+      // Get original reference
+      const originalRef = store.currentSession;
+
+      // Update mode
+      await store.updateSessionMode('session-1', 'yolo');
+
+      // Verify mode was updated
+      expect(store.currentSession.mode).toBe('yolo');
+
+      // Verify new object reference was created (important for Vue reactivity)
+      expect(store.currentSession).not.toBe(originalRef);
+
+      // Verify other properties are preserved
+      expect(store.currentSession.id).toBe('session-1');
+      expect(store.currentSession.name).toBe('Test Session');
+      expect(store.currentSession.status).toBe('waiting');
+    });
+
+    it('updates mode in sessions list', async () => {
+      const store = useSessionsStore();
+
+      // Set up initial sessions
+      store.sessions = [
+        { id: 'session-1', mode: 'standard' },
+        { id: 'session-2', mode: 'plan' },
+      ];
+
+      // Mock the API response
+      api.updateSession.mockResolvedValue({ id: 'session-1', mode: 'yolo' });
+
+      // Update mode for session-1
+      await store.updateSessionMode('session-1', 'yolo');
+
+      // Verify correct session was updated
+      expect(store.sessions[0].mode).toBe('yolo');
+      expect(store.sessions[1].mode).toBe('plan');
+    });
+
+    it('does not update currentSession if IDs do not match', async () => {
+      const store = useSessionsStore();
+
+      // Set up initial session
+      store.currentSession = { id: 'session-1', mode: 'standard' };
+      store.sessions = [{ id: 'session-2', mode: 'plan' }];
+
+      // Mock the API response
+      api.updateSession.mockResolvedValue({ id: 'session-2', mode: 'yolo' });
+
+      // Update mode for different session
+      await store.updateSessionMode('session-2', 'yolo');
+
+      // currentSession should be unchanged
+      expect(store.currentSession.mode).toBe('standard');
+    });
+
+    it('throws error and sets store error on API failure', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', mode: 'standard' };
+
+      // Mock API error
+      api.updateSession.mockRejectedValue(new Error('API Error'));
+
+      // Should throw
+      await expect(store.updateSessionMode('session-1', 'yolo')).rejects.toThrow('API Error');
+
+      // Store error should be set
+      expect(store.error).toBe('API Error');
+
+      // Mode should not have changed
+      expect(store.currentSession.mode).toBe('standard');
+    });
+  });
+
+  describe('updateSessionThinking', () => {
+    it('updates thinkingEnabled in currentSession', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', thinkingEnabled: false };
+      store.sessions = [{ id: 'session-1', thinkingEnabled: false }];
+
+      api.updateSession.mockResolvedValue({ id: 'session-1', thinkingEnabled: true });
+
+      await store.updateSessionThinking('session-1', true);
+
+      expect(store.currentSession.thinkingEnabled).toBe(true);
+      expect(store.sessions[0].thinkingEnabled).toBe(true);
+    });
+  });
+
+  describe('updateSessionStatus', () => {
+    it('updates status in both sessions list and currentSession', () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', status: 'running' };
+      store.sessions = [{ id: 'session-1', status: 'running' }];
+
+      store.updateSessionStatus('session-1', 'completed');
+
+      expect(store.currentSession.status).toBe('completed');
+      expect(store.sessions[0].status).toBe('completed');
+    });
+  });
+
+  describe('work logs', () => {
+    it('adds work log with proper reactivity', () => {
+      const store = useSessionsStore();
+
+      const log1 = { id: 'log-1', messageId: 'msg-1', content: 'test' };
+      store.addWorkLog(log1);
+
+      expect(store.workLogs['msg-1']).toEqual([log1]);
+
+      // Adding second log should create new array reference
+      const log2 = { id: 'log-2', messageId: 'msg-1', content: 'test2' };
+      store.addWorkLog(log2);
+
+      expect(store.workLogs['msg-1']).toEqual([log1, log2]);
+    });
+
+    it('adds unassociated work log when messageId is missing', () => {
+      const store = useSessionsStore();
+
+      const log = { id: 'log-1', content: 'test' };
+      store.addWorkLog(log);
+
+      expect(store.workLogs['_unassociated']).toEqual([log]);
+    });
+
+    it('associates work logs with message ID', () => {
+      const store = useSessionsStore();
+
+      // Add unassociated logs
+      const log1 = { id: 'log-1', content: 'test1' };
+      const log2 = { id: 'log-2', content: 'test2' };
+      store.addWorkLog(log1);
+      store.addWorkLog(log2);
+
+      expect(store.workLogs['_unassociated']).toHaveLength(2);
+
+      // Associate with message
+      store.associateWorkLogs('msg-1');
+
+      expect(store.workLogs['_unassociated']).toEqual([]);
+      expect(store.workLogs['msg-1']).toEqual([log1, log2]);
+    });
+  });
+});

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -133,7 +133,7 @@ const gitStatus = ref(null);
 const modes = [
   { value: 'plan', label: 'Plan', description: 'Agent plans before implementing - good for complex tasks' },
   { value: 'standard', label: 'Standard', description: 'Balanced approach - asks for approval when needed' },
-  { value: 'yolo', label: 'Auto', description: 'Auto-approve mode - agent acts autonomously' },
+  { value: 'yolo', label: 'YOLO', description: 'Auto-approve mode - agent acts autonomously' },
 ];
 const loading = ref(false);
 const loadingGit = ref(false);

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -410,15 +410,15 @@ test.describe('New Session - Mode Selection', () => {
     await expect(page.locator('.mode-selector')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Plan' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Standard' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Auto' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'YOLO' })).toBeVisible();
   });
 
-  test('Auto (yolo) mode is selected by default', async ({ page }) => {
+  test('YOLO mode is selected by default', async ({ page }) => {
     await page.goto(`/projects/${project.id}/sessions/new`);
 
-    // Verify Auto (yolo) is the default selected mode
+    // Verify YOLO is the default selected mode
     const activeBtn = page.locator('.mode-btn.active');
-    await expect(activeBtn).toHaveText('Auto');
+    await expect(activeBtn).toHaveText('YOLO');
   });
 
   test('can create session with plan mode', async ({ page }) => {
@@ -454,8 +454,8 @@ test.describe('New Session - Mode Selection', () => {
     // Fill in required prompt field
     await page.fill('textarea[id="prompt"]', 'Test with yolo mode');
 
-    // Select Auto (yolo) mode
-    await page.click('button:has-text("Auto")');
+    // Select YOLO mode
+    await page.click('button:has-text("YOLO")');
 
     // Submit the form
     await page.click('button:has-text("Start Session")');
@@ -478,8 +478,8 @@ test.describe('New Session - Mode Selection', () => {
   test('can switch between modes', async ({ page }) => {
     await page.goto(`/projects/${project.id}/sessions/new`);
 
-    // Verify Auto is default
-    await expect(page.locator('.mode-btn.active')).toHaveText('Auto');
+    // Verify YOLO is default
+    await expect(page.locator('.mode-btn.active')).toHaveText('YOLO');
 
     // Click Plan mode and verify it becomes active
     await page.click('.mode-btn:has-text("Plan")');
@@ -489,9 +489,9 @@ test.describe('New Session - Mode Selection', () => {
     await page.click('.mode-btn:has-text("Standard")');
     await expect(page.locator('.mode-btn.active')).toHaveText('Standard');
 
-    // Click Auto mode and verify it becomes active
-    await page.click('.mode-btn:has-text("Auto")');
-    await expect(page.locator('.mode-btn.active')).toHaveText('Auto');
+    // Click YOLO mode and verify it becomes active
+    await page.click('.mode-btn:has-text("YOLO")');
+    await expect(page.locator('.mode-btn.active')).toHaveText('YOLO');
   });
 });
 
@@ -523,7 +523,7 @@ test.describe('Conversation - Mode Switching', () => {
     await expect(page.locator('.mode-switcher')).toBeVisible();
     await expect(page.locator('.mode-switcher button:has-text("Plan")')).toBeVisible();
     await expect(page.locator('.mode-switcher button:has-text("Standard")')).toBeVisible();
-    await expect(page.locator('.mode-switcher button:has-text("Auto")')).toBeVisible();
+    await expect(page.locator('.mode-switcher button:has-text("YOLO")')).toBeVisible();
   });
 
   test('mode switcher shows current session mode', async ({ page }) => {
@@ -557,14 +557,14 @@ test.describe('Conversation - Mode Switching', () => {
     // Verify Standard is active
     await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Standard');
 
-    // Click Auto to switch to yolo mode
-    await page.click('.mode-switcher button:has-text("Auto")');
+    // Click YOLO to switch to yolo mode
+    await page.click('.mode-switcher button:has-text("YOLO")');
 
     // Wait for mode to update
     await page.waitForTimeout(500);
 
-    // Verify Auto is now active
-    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Auto');
+    // Verify YOLO is now active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('YOLO');
 
     // Verify via API
     const updatedSession = await getSession(session.id);
@@ -583,8 +583,8 @@ test.describe('Conversation - Mode Switching', () => {
     // Wait for session to be in waiting state
     await waitForSessionStatus(page, session.id, 'waiting', 15000);
 
-    // Verify Auto is active
-    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('Auto');
+    // Verify YOLO is active
+    await expect(page.locator('.mode-switcher .mode-btn.active')).toHaveText('YOLO');
 
     // Click Plan to switch to plan mode
     await page.click('.mode-switcher button:has-text("Plan")');


### PR DESCRIPTION
## Summary

- **Fix reactivity bug**: Mode selector in ConversationTab wasn't visually updating when clicked because `updateSessionMode` in the store was directly mutating `currentSession.mode` instead of creating a new object reference. Vue's reactivity didn't detect the change properly.
- **Rename "Auto" to "YOLO"**: Changed the mode label from "Auto" to "YOLO" in both NewSessionView and ConversationTab
- **Add comprehensive tests**: Added sessions store unit tests covering the reactivity fix and other store actions

## Test plan

- [ ] Verify mode selector in ConversationTab highlights correctly when clicking different modes
- [ ] Verify mode actually changes on the backend when switching
- [ ] Verify NewSessionView mode selector still works correctly
- [ ] Verify "YOLO" label appears instead of "Auto"
- [ ] Run `npm test` in packages/web to verify new unit tests pass
- [ ] Run e2e tests to verify mode selection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)