### PR TITLE
feat: Add file upload to canvas

### DIFF
--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -224,6 +224,33 @@ export class ApiClient {
   }
 
   /**
+   * Upload a file to the canvas
+   * @param {string} sessionId - Session ID
+   * @param {File} file - File to upload
+   * @param {string|null} label - Optional label for the canvas item
+   * @returns {Promise<Object>}
+   */
+  async uploadCanvasItem(sessionId, file, label = null) {
+    const formData = new FormData();
+    formData.append('file', file);
+    if (label) {
+      formData.append('label', label);
+    }
+
+    const response = await fetch(`${this.#baseUrl}/sessions/${sessionId}/canvas`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || `HTTP ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
    * Delete a canvas item
    * @param {string} sessionId - Session ID
    * @param {string} itemId - Canvas item ID

--- a/packages/web/src/api/ApiClient.test.js
+++ b/packages/web/src/api/ApiClient.test.js
@@ -243,6 +243,70 @@ describe('ApiClient', () => {
       });
     });
 
+    describe('uploadCanvasItem', () => {
+      it('uploads file to canvas', async () => {
+        const mockItem = { id: 'item-1', type: 'image', mimeType: 'image/png' };
+        mockFetch.mockReturnValue(mockResponse(mockItem));
+
+        const file = new File(['test content'], 'test.png', { type: 'image/png' });
+        const result = await client.uploadCanvasItem('sess-123', file);
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/sessions/sess-123/canvas', expect.objectContaining({
+          method: 'POST',
+        }));
+        // Check that FormData was used (not JSON)
+        const callArgs = mockFetch.mock.calls[0];
+        expect(callArgs[1].body).toBeInstanceOf(FormData);
+        expect(result).toEqual(mockItem);
+      });
+
+      it('includes label in FormData when provided', async () => {
+        mockFetch.mockReturnValue(mockResponse({ id: 'item-1' }));
+
+        const file = new File(['test'], 'doc.pdf', { type: 'application/pdf' });
+        await client.uploadCanvasItem('sess-123', file, 'My Document');
+
+        const callArgs = mockFetch.mock.calls[0];
+        const formData = callArgs[1].body;
+        expect(formData.get('file')).toBeInstanceOf(File);
+        expect(formData.get('label')).toBe('My Document');
+      });
+
+      it('does not include label in FormData when not provided', async () => {
+        mockFetch.mockReturnValue(mockResponse({ id: 'item-1' }));
+
+        const file = new File(['test'], 'image.jpg', { type: 'image/jpeg' });
+        await client.uploadCanvasItem('sess-123', file);
+
+        const callArgs = mockFetch.mock.calls[0];
+        const formData = callArgs[1].body;
+        expect(formData.get('file')).toBeInstanceOf(File);
+        expect(formData.get('label')).toBeNull();
+      });
+
+      it('throws error on upload failure', async () => {
+        mockFetch.mockReturnValue(Promise.resolve({
+          ok: false,
+          status: 413,
+          json: () => Promise.resolve({ error: 'File too large' }),
+        }));
+
+        const file = new File(['large content'], 'big.zip', { type: 'application/zip' });
+        await expect(client.uploadCanvasItem('sess-123', file)).rejects.toThrow('File too large');
+      });
+
+      it('throws HTTP status error when no error message in response', async () => {
+        mockFetch.mockReturnValue(Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.reject(new Error('Parse error')),
+        }));
+
+        const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+        await expect(client.uploadCanvasItem('sess-123', file)).rejects.toThrow('HTTP 500');
+      });
+    });
+
     describe('deleteCanvasItem', () => {
       it('deletes canvas item', async () => {
         mockFetch.mockReturnValue(mockResponse(null, { status: 204 }));

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -1,12 +1,33 @@
 <template>
-  <div class="canvas-tab">
-    <div v-if="canvasStore.loading" class="loading-state">
+  <div
+    class="canvas-tab"
+    :class="{ 'drag-over': isDragOver }"
+    @dragover.prevent="handleDragOver"
+    @dragleave="handleDragLeave"
+    @drop.prevent="handleDrop"
+  >
+    <!-- Upload header -->
+    <div class="canvas-header">
+      <button class="btn btn-primary" @click="triggerFileInput" :disabled="uploading">
+        {{ uploading ? 'Uploading...' : 'Upload File' }}
+      </button>
+      <input
+        type="file"
+        ref="fileInput"
+        @change="handleFileSelect"
+        hidden
+      />
+      <span v-if="isDragOver" class="drag-hint">Drop file to upload</span>
+    </div>
+
+    <div v-if="canvasStore.loading && !uploading" class="loading-state">
       <span class="loading-spinner"></span>
       Loading canvas items...
     </div>
 
     <div v-else-if="canvasStore.items.length === 0" class="empty-state">
-      <p>No canvas items yet. Claude can add images, markdown, and JSON to the canvas.</p>
+      <p>No canvas items yet. Upload a file or drag and drop here.</p>
+      <p class="empty-state-hint">Claude can also add images, markdown, and JSON to the canvas.</p>
     </div>
 
     <div v-else class="canvas-grid">
@@ -61,6 +82,8 @@ import { useCanvasStore } from '../stores/canvas.js';
 import { useUiStore } from '../stores/ui.js';
 import MarkdownViewer from './MarkdownViewer.vue';
 
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
 const props = defineProps({
   sessionId: { type: String, required: true },
 });
@@ -68,6 +91,9 @@ const props = defineProps({
 const canvasStore = useCanvasStore();
 const uiStore = useUiStore();
 const previewMode = ref({});
+const fileInput = ref(null);
+const isDragOver = ref(false);
+const uploading = ref(false);
 
 // Initialize preview mode to true (preview by default) for markdown items
 watch(
@@ -94,6 +120,56 @@ function formatJson(data) {
   }
 }
 
+function triggerFileInput() {
+  fileInput.value?.click();
+}
+
+function handleDragOver(event) {
+  isDragOver.value = true;
+}
+
+function handleDragLeave(event) {
+  // Only set to false if we're leaving the canvas-tab element
+  if (!event.currentTarget.contains(event.relatedTarget)) {
+    isDragOver.value = false;
+  }
+}
+
+async function handleDrop(event) {
+  isDragOver.value = false;
+  const files = event.dataTransfer?.files;
+  if (files && files.length > 0) {
+    await uploadFile(files[0]);
+  }
+}
+
+async function handleFileSelect(event) {
+  const files = event.target.files;
+  if (files && files.length > 0) {
+    await uploadFile(files[0]);
+  }
+  // Reset file input so same file can be selected again
+  event.target.value = '';
+}
+
+async function uploadFile(file) {
+  // Check file size
+  if (file.size > MAX_FILE_SIZE) {
+    uiStore.error(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`);
+    return;
+  }
+
+  uploading.value = true;
+  try {
+    await canvasStore.uploadItem(props.sessionId, file, file.name);
+    uiStore.success(`Uploaded ${file.name}`);
+  } catch (err) {
+    uiStore.error(`Upload failed: ${err.message}`);
+  } finally {
+    uploading.value = false;
+  }
+}
+
 async function handleDelete(itemId) {
   if (!confirm('Delete this canvas item?')) return;
 
@@ -109,6 +185,26 @@ async function handleDelete(itemId) {
 <style scoped>
 .canvas-tab {
   padding: 1rem 0;
+  min-height: 200px;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.canvas-tab.drag-over {
+  background-color: rgba(88, 166, 255, 0.1);
+  border: 2px dashed var(--color-primary);
+  border-radius: var(--border-radius);
+}
+
+.canvas-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.drag-hint {
+  color: var(--color-primary);
+  font-weight: 500;
 }
 
 .loading-state {
@@ -123,6 +219,12 @@ async function handleDelete(itemId) {
   text-align: center;
   padding: 2rem;
   color: var(--color-text-soft);
+}
+
+.empty-state-hint {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  opacity: 0.8;
 }
 
 .canvas-grid {

--- a/packages/web/src/stores/canvas.js
+++ b/packages/web/src/stores/canvas.js
@@ -32,6 +32,21 @@ export const useCanvasStore = defineStore('canvas', {
       }
     },
 
+    async uploadItem(sessionId, file, label = null) {
+      this.loading = true;
+      this.error = null;
+      try {
+        const item = await api.uploadCanvasItem(sessionId, file, label);
+        this.items.unshift(item);
+        return item;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      } finally {
+        this.loading = false;
+      }
+    },
+
     addItem(item) {
       this.items.unshift(item);
     },

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -383,8 +383,8 @@ test.describe('Canvas Management', () => {
     // Empty state should be gone
     await expect(page.getByText('No canvas items yet')).not.toBeVisible();
 
-    // Verify the label is displayed (filename)
-    await expect(page.getByText('test-image.png')).toBeVisible();
+    // Verify the label is displayed (filename) - use specific selector to avoid matching toast
+    await expect(page.locator('.canvas-item-label').getByText('test-image.png')).toBeVisible();
 
     // Verify via API
     const items = await getCanvasItems(session.id);

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -18,9 +18,12 @@ test.describe('Canvas Management', () => {
     await cleanupAll();
   });
 
-  test('displays empty canvas state', async ({ page }) => {
+  test('displays empty canvas state with upload option', async ({ page }) => {
     await page.goto(`/sessions/${session.id}/canvas`);
+    // Empty state message should be visible
     await expect(page.getByText('No canvas items yet')).toBeVisible();
+    // Upload button should be present
+    await expect(page.getByRole('button', { name: 'Upload File' })).toBeVisible();
   });
 
   test('displays canvas items', async ({ page }) => {
@@ -343,5 +346,51 @@ test.describe('Canvas Management', () => {
         fs.unlinkSync(testFilePath);
       }
     }
+  });
+
+  test('can upload an image file via file input', async ({ page }) => {
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Initially empty
+    await expect(page.getByText('No canvas items yet')).toBeVisible();
+
+    // Get the file input (hidden but accessible)
+    const fileInput = page.locator('input[type="file"]');
+
+    // Create a minimal valid PNG (1x1 pixel transparent)
+    const pngBuffer = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+      0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+      0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, // IDAT chunk
+      0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+      0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, // IEND chunk
+      0x42, 0x60, 0x82,
+    ]);
+
+    // Upload the image file
+    await fileInput.setInputFiles({
+      name: 'test-image.png',
+      mimeType: 'image/png',
+      buffer: pngBuffer,
+    });
+
+    // Wait for upload to complete - look for the image type indicator
+    await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible({ timeout: 10000 });
+
+    // Empty state should be gone
+    await expect(page.getByText('No canvas items yet')).not.toBeVisible();
+
+    // Verify the label is displayed (filename)
+    await expect(page.getByText('test-image.png')).toBeVisible();
+
+    // Verify via API
+    const items = await getCanvasItems(session.id);
+    expect(items.length).toBe(1);
+    expect(items[0].type).toBe('image');
+    expect(items[0].mimeType).toBe('image/png');
+    expect(items[0].label).toBe('test-image.png');
   });
 });


### PR DESCRIPTION
## Summary

- Add **Upload File** button to the canvas tab header
- Add **drag-and-drop** support for uploading files to the canvas area
- Support any file type (images, documents, etc.)
- 10MB file size limit (since multer uses memory storage on the backend)
- Visual feedback during drag-over with dashed border and hint text

## Changes

- `packages/web/src/api/ApiClient.js` - New `uploadCanvasItem()` method using FormData
- `packages/web/src/stores/canvas.js` - New `uploadItem()` action
- `packages/web/src/components/CanvasTab.vue` - Upload UI with button and drag-drop
- `packages/web/src/api/ApiClient.test.js` - Unit tests for upload method
- `tests/e2e/canvas.spec.ts` - E2E tests for upload functionality

## Test plan

- [ ] Upload an image file via button and verify it displays correctly
- [ ] Upload a text file and verify label is shown
- [ ] Drag and drop a file onto the canvas area
- [ ] Verify file size limit error for files > 10MB
- [ ] Test in different browsers (Chrome, Firefox, Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)