### PR TITLE
fix: Consolidate work log display and defer association to end of turn

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -5,8 +5,8 @@ import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT, DEFAULT_SYSTEM_PROMPT } from '@c
 import { updateTodos } from './todoStore.js';
 import * as summaryService from './summaryService.js';
 
-/** @type {Map<string, string|null>} Track current message ID for work log association */
-const currentMessageIds = new Map();
+/** @type {Map<string, string|null>} Track last message ID for end-of-turn work log association */
+const lastMessageIds = new Map();
 
 /** @type {Map<string, string>} Accumulate thinking content per session */
 const thinkingAccumulators = new Map();
@@ -269,9 +269,6 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
-  // Reset message tracking for this turn - ensures work logs start as unassociated
-  currentMessageIds.set(sessionId, null);
-
   try {
     // Get session for settings
     const session = sessions.getById(sessionId);
@@ -307,6 +304,13 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
       if (controller.signal.aborted) break;
 
       await handleStreamEvent(sessionId, event);
+    }
+
+    // Associate work logs with the last message now that the turn is complete
+    const lastMessageId = lastMessageIds.get(sessionId);
+    if (lastMessageId) {
+      associateAndBroadcastWorkLogs(sessionId, lastMessageId);
+      lastMessageIds.delete(sessionId);
     }
 
     // Session ready for follow-up - set to waiting instead of completed
@@ -358,9 +362,6 @@ export async function continueSession(sessionId, content, workingDirectory, syst
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
-  // Reset message tracking for this turn - ensures work logs start as unassociated
-  currentMessageIds.set(sessionId, null);
-
   try {
     // Store the user message
     const message = messages.create(sessionId, 'user', content);
@@ -396,6 +397,13 @@ export async function continueSession(sessionId, content, workingDirectory, syst
       if (controller.signal.aborted) break;
 
       await handleStreamEvent(sessionId, event);
+    }
+
+    // Associate work logs with the last message now that the turn is complete
+    const lastMessageId = lastMessageIds.get(sessionId);
+    if (lastMessageId) {
+      associateAndBroadcastWorkLogs(sessionId, lastMessageId);
+      lastMessageIds.delete(sessionId);
     }
 
     // Session ready for more follow-ups
@@ -467,19 +475,37 @@ export function cleanupActiveSession(sessionId) {
 
 /**
  * Create and broadcast a work log entry
+ * Work logs are always created as unassociated during the turn,
+ * then associated with the message when the turn completes.
  * @param {string} sessionId
  * @param {string} type - 'thinking', 'tool_input', or 'tool_output'
  * @param {string} content
  * @param {string|null} toolName
  */
 function createWorkLog(sessionId, type, content, toolName = null) {
-  const messageId = currentMessageIds.get(sessionId) || null;
-  const log = workLogs.create(sessionId, type, content, messageId, toolName);
+  // Always create as unassociated - will be associated at end of turn
+  const log = workLogs.create(sessionId, type, content, null, toolName);
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_WORK_LOG, {
     sessionId,
     log
   });
   return log;
+}
+
+/**
+ * Associate pending work logs with a message and broadcast the event
+ * @param {string} sessionId
+ * @param {string} messageId
+ */
+function associateAndBroadcastWorkLogs(sessionId, messageId) {
+  const associatedCount = workLogs.associatePendingLogs(sessionId, messageId);
+  if (associatedCount > 0) {
+    broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_WORK_LOGS_ASSOCIATED, {
+      sessionId,
+      messageId,
+    });
+  }
+  return associatedCount;
 }
 
 /**
@@ -497,7 +523,7 @@ async function handleStreamEvent(sessionId, event) {
           model: event.model,
         });
         // Reset message tracking for new session
-        currentMessageIds.set(sessionId, null);
+        lastMessageIds.delete(sessionId);
       }
       break;
     }
@@ -516,13 +542,10 @@ async function handleStreamEvent(sessionId, event) {
         const toolUse = toolUseBlocks.length > 0 ? toolUseBlocks : null;
         const message = messages.create(sessionId, 'assistant', textContent, toolUse);
 
-        // Update current message ID for work log association
-        currentMessageIds.set(sessionId, message.id);
+        // Track the message ID for end-of-turn work log association
+        lastMessageIds.set(sessionId, message.id);
 
-        // Associate any pending work logs with this message
-        const associatedCount = workLogs.associatePendingLogs(sessionId, message.id);
-
-        // Broadcast message first
+        // Broadcast message
         broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, { message });
 
         // Check for TodoWrite tool and update todos
@@ -531,14 +554,6 @@ async function handleStreamEvent(sessionId, event) {
           if (todoWrite?.input?.todos) {
             updateTodos(sessionId, todoWrite.input.todos);
           }
-        }
-
-        // Notify client to re-associate work logs in their state
-        if (associatedCount > 0) {
-          broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_WORK_LOGS_ASSOCIATED, {
-            sessionId,
-            messageId: message.id,
-          });
         }
 
         // Trigger debounced summary generation on new message
@@ -636,7 +651,7 @@ async function handleStreamEvent(sessionId, event) {
         }
       }
       // Clear message tracking when session completes
-      currentMessageIds.delete(sessionId);
+      lastMessageIds.delete(sessionId);
       break;
     }
   }

--- a/packages/server/test/work-logs.test.js
+++ b/packages/server/test/work-logs.test.js
@@ -135,6 +135,98 @@ describe('Work Logs API', () => {
     });
   });
 
+  describe('End-of-turn work log association', () => {
+    // These tests document the expected behavior where work logs are:
+    // 1. Created as unassociated during the turn (shown in LiveWorkLogPanel)
+    // 2. Associated with the message at the END of the turn (moved to WorkLogPanel)
+
+    it('work logs created with null messageId are unassociated', () => {
+      // During a turn, work logs are created without a messageId
+      workLogs.create(session.id, 'thinking', 'First thought', null);
+      workLogs.create(session.id, 'tool_input', '{"command": "ls"}', null, 'Bash');
+      workLogs.create(session.id, 'tool_output', 'file1.txt\nfile2.txt', null, 'Bash');
+
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+
+      // All logs should be in _unassociated
+      expect(grouped['_unassociated']).toBeDefined();
+      expect(grouped['_unassociated'].length).toBe(3);
+    });
+
+    it('unassociated logs remain visible until associated', () => {
+      // Create unassociated logs (simulating work during turn)
+      workLogs.create(session.id, 'thinking', 'Analyzing request');
+      workLogs.create(session.id, 'tool_input', 'Some tool input');
+
+      // Before association, logs should be in _unassociated
+      let grouped = workLogs.getBySessionIdGrouped(session.id);
+      expect(grouped['_unassociated'].length).toBe(2);
+
+      // Create a message (this happens during the turn)
+      const message = messages.create(session.id, 'assistant', 'Response');
+
+      // Logs are STILL unassociated (association happens at end of turn)
+      grouped = workLogs.getBySessionIdGrouped(session.id);
+      expect(grouped['_unassociated'].length).toBe(2);
+      expect(grouped[message.id]).toBeUndefined();
+
+      // Now associate logs (this happens at end of turn)
+      const count = workLogs.associatePendingLogs(session.id, message.id);
+      expect(count).toBe(2);
+
+      // After association, logs move to the message
+      grouped = workLogs.getBySessionIdGrouped(session.id);
+      expect(grouped['_unassociated']).toBeUndefined();
+      expect(grouped[message.id].length).toBe(2);
+    });
+
+    it('multiple logs can be associated in a single call', () => {
+      // Simulate a full turn with multiple work log entries
+      workLogs.create(session.id, 'thinking', 'Let me analyze this');
+      workLogs.create(session.id, 'tool_input', '{"pattern": "*.js"}', null, 'Glob');
+      workLogs.create(session.id, 'tool_output', 'src/index.js\nsrc/app.js', null, 'Glob');
+      workLogs.create(session.id, 'thinking', 'Found the files, now reading');
+      workLogs.create(session.id, 'tool_input', '{"path": "src/index.js"}', null, 'Read');
+      workLogs.create(session.id, 'tool_output', 'console.log("Hello");', null, 'Read');
+
+      const message = messages.create(session.id, 'assistant', 'I found 2 JS files.');
+
+      // All 6 logs should be associated
+      const count = workLogs.associatePendingLogs(session.id, message.id);
+      expect(count).toBe(6);
+
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+      expect(grouped[message.id].length).toBe(6);
+    });
+
+    it('returns 0 when no logs to associate', () => {
+      const message = messages.create(session.id, 'assistant', 'Quick response');
+
+      // No unassociated logs exist
+      const count = workLogs.associatePendingLogs(session.id, message.id);
+      expect(count).toBe(0);
+    });
+
+    it('only associates logs for the correct session', () => {
+      // Create a second session
+      const session2 = sessions.create(project.id, 'Session 2', 'Prompt 2', 'standard');
+
+      // Create logs in both sessions
+      workLogs.create(session.id, 'thinking', 'Session 1 thought');
+      workLogs.create(session2.id, 'thinking', 'Session 2 thought');
+
+      const message = messages.create(session.id, 'assistant', 'Response');
+
+      // Associate only session 1 logs
+      const count = workLogs.associatePendingLogs(session.id, message.id);
+      expect(count).toBe(1);
+
+      // Session 2 logs should still be unassociated
+      const grouped2 = workLogs.getBySessionIdGrouped(session2.id);
+      expect(grouped2['_unassociated'].length).toBe(1);
+    });
+  });
+
   describe('Session status update for polling', () => {
     it('can update session status', () => {
       // This tests that status can be updated, which is needed for the

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -2,7 +2,7 @@
   <div class="conversation-tab">
     <div class="messages" ref="messagesContainer">
       <div
-        v-for="(message, index) in sessionsStore.messages"
+        v-for="message in sessionsStore.messages"
         :key="message.id"
         :class="['message', `message-${message.role}`]"
       >

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -20,28 +20,10 @@
             <pre>{{ JSON.stringify(tool.input, null, 2) }}</pre>
           </details>
         </div>
-        <!-- Work Log Panel for assistant messages -->
+        <!-- Work Log Panel for assistant messages (collapsed by default) -->
         <WorkLogPanel
           v-if="message.role === 'assistant'"
           :work-logs="sessionsStore.getWorkLogsForMessage(message.id)"
-          :is-latest-message="index === sessionsStore.messages.length - 1"
-        />
-      </div>
-
-      <!-- Streaming thinking indicator -->
-      <div v-if="sessionsStore.partialThinking" class="message message-assistant message-streaming">
-        <div class="message-header">
-          <span class="message-role">assistant</span>
-          <span class="streaming-indicator">
-            <span class="dot"></span>
-            <span class="dot"></span>
-            <span class="dot"></span>
-          </span>
-        </div>
-        <WorkLogPanel
-          :work-logs="[]"
-          :partial-thinking="sessionsStore.partialThinking"
-          :is-latest-message="true"
         />
       </div>
 

--- a/packages/web/src/components/WorkLogPanel.test.js
+++ b/packages/web/src/components/WorkLogPanel.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import WorkLogPanel from './WorkLogPanel.vue';
+
+// Stub child components
+const ThinkingBlockStub = {
+  name: 'ThinkingBlock',
+  template: '<div class="thinking-block-stub">{{ content }}</div>',
+  props: ['content', 'timestamp', 'streaming'],
+};
+
+const CommandBlockStub = {
+  name: 'CommandBlock',
+  template: '<div class="command-block-stub">{{ log.content }}</div>',
+  props: ['log'],
+};
+
+describe('WorkLogPanel', () => {
+  function mountComponent(props = {}) {
+    return mount(WorkLogPanel, {
+      props,
+      global: {
+        stubs: {
+          ThinkingBlock: ThinkingBlockStub,
+          CommandBlock: CommandBlockStub,
+        },
+      },
+    });
+  }
+
+  function createWorkLog(id, type = 'tool_input') {
+    return {
+      id,
+      type,
+      toolName: 'Bash',
+      content: `Log content ${id}`,
+      timestamp: Date.now(),
+    };
+  }
+
+  describe('rendering', () => {
+    it('does not render when workLogs is empty', () => {
+      const wrapper = mountComponent({ workLogs: [] });
+      expect(wrapper.find('.work-log-panel').exists()).toBe(false);
+    });
+
+    it('renders when workLogs has content', () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+      expect(wrapper.find('.work-log-panel').exists()).toBe(true);
+    });
+
+    it('displays correct item count', () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1), createWorkLog(2), createWorkLog(3)],
+      });
+      expect(wrapper.find('.work-log-count').text()).toBe('(3)');
+    });
+
+    it('renders ThinkingBlock for thinking logs', () => {
+      const wrapper = mountComponent({
+        workLogs: [{ id: 1, type: 'thinking', content: 'Thinking content', timestamp: Date.now() }],
+      });
+
+      const thinkingBlock = wrapper.findComponent({ name: 'ThinkingBlock' });
+      expect(thinkingBlock.exists()).toBe(true);
+      expect(thinkingBlock.props('content')).toBe('Thinking content');
+    });
+
+    it('renders CommandBlock for non-thinking logs', () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      const commandBlock = wrapper.findComponent({ name: 'CommandBlock' });
+      expect(commandBlock.exists()).toBe(true);
+    });
+  });
+
+  describe('collapsed by default behavior', () => {
+    it('starts collapsed by default', () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      const details = wrapper.find('details');
+      expect(details.exists()).toBe(true);
+      // details element should NOT have open attribute
+      expect(details.attributes('open')).toBeUndefined();
+    });
+
+    it('chevron is not in expanded state initially', () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      const chevron = wrapper.find('.work-log-chevron');
+      expect(chevron.classes()).not.toContain('expanded');
+    });
+
+    it('work-log-content is not visible when collapsed', () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      // When details is closed, content should not be visible
+      // (browser handles this via details/summary behavior)
+      const details = wrapper.find('details');
+      expect(details.attributes('open')).toBeUndefined();
+    });
+  });
+
+  describe('toggle behavior', () => {
+    it('expands when details is toggled open', async () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      const details = wrapper.find('details');
+      const detailsEl = details.element;
+
+      // Simulate opening the details element
+      detailsEl.open = true;
+      await details.trigger('toggle');
+
+      // After toggle, chevron should be expanded
+      const chevron = wrapper.find('.work-log-chevron');
+      expect(chevron.classes()).toContain('expanded');
+    });
+
+    it('collapses when details is toggled closed', async () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      const details = wrapper.find('details');
+      const detailsEl = details.element;
+
+      // First expand
+      detailsEl.open = true;
+      await details.trigger('toggle');
+      expect(wrapper.find('.work-log-chevron').classes()).toContain('expanded');
+
+      // Then collapse
+      detailsEl.open = false;
+      await details.trigger('toggle');
+      expect(wrapper.find('.work-log-chevron').classes()).not.toContain('expanded');
+    });
+  });
+
+  describe('multiple work logs', () => {
+    it('renders all work logs', () => {
+      const wrapper = mountComponent({
+        workLogs: [
+          createWorkLog(1),
+          createWorkLog(2),
+          { id: 3, type: 'thinking', content: 'A thought', timestamp: Date.now() },
+        ],
+      });
+
+      const items = wrapper.findAll('.work-log-item');
+      expect(items.length).toBe(3);
+    });
+
+    it('renders mixed thinking and command blocks correctly', () => {
+      const wrapper = mountComponent({
+        workLogs: [
+          { id: 1, type: 'thinking', content: 'Thought 1', timestamp: Date.now() },
+          createWorkLog(2),
+          { id: 3, type: 'thinking', content: 'Thought 2', timestamp: Date.now() },
+        ],
+      });
+
+      const thinkingBlocks = wrapper.findAllComponents({ name: 'ThinkingBlock' });
+      const commandBlocks = wrapper.findAllComponents({ name: 'CommandBlock' });
+
+      expect(thinkingBlocks.length).toBe(2);
+      expect(commandBlocks.length).toBe(1);
+    });
+  });
+
+  describe('stays collapsed when logs are added', () => {
+    it('remains collapsed when workLogs prop is updated', async () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      // Initially collapsed
+      expect(wrapper.find('details').attributes('open')).toBeUndefined();
+
+      // Add more logs
+      await wrapper.setProps({
+        workLogs: [createWorkLog(1), createWorkLog(2), createWorkLog(3)],
+      });
+
+      // Should still be collapsed
+      expect(wrapper.find('details').attributes('open')).toBeUndefined();
+      expect(wrapper.find('.work-log-chevron').classes()).not.toContain('expanded');
+    });
+
+    it('count updates when logs are added but remains collapsed', async () => {
+      const wrapper = mountComponent({
+        workLogs: [createWorkLog(1)],
+      });
+
+      expect(wrapper.find('.work-log-count').text()).toBe('(1)');
+
+      await wrapper.setProps({
+        workLogs: [createWorkLog(1), createWorkLog(2)],
+      });
+
+      // Count updated
+      expect(wrapper.find('.work-log-count').text()).toBe('(2)');
+      // But still collapsed
+      expect(wrapper.find('details').attributes('open')).toBeUndefined();
+    });
+  });
+});

--- a/packages/web/src/components/WorkLogPanel.vue
+++ b/packages/web/src/components/WorkLogPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="workLogs?.length || partialThinking" class="work-log-panel">
+  <div v-if="workLogs?.length" class="work-log-panel">
     <details :open="isExpanded" ref="detailsRef" @toggle="handleToggle">
       <summary class="work-log-header">
         <span class="work-log-icon">
@@ -9,11 +9,6 @@
         </span>
         <span class="work-log-title">Work Log</span>
         <span class="work-log-count">({{ totalCount }})</span>
-        <span v-if="partialThinking" class="streaming-indicator">
-          <span class="dot"></span>
-          <span class="dot"></span>
-          <span class="dot"></span>
-        </span>
         <span class="work-log-chevron" :class="{ expanded: isExpanded }">
           <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="9 18 15 12 9 6"/>
@@ -21,14 +16,9 @@
         </span>
       </summary>
       <div class="work-log-content">
-        <!-- Existing work logs -->
         <div v-for="log in workLogs" :key="log.id" class="work-log-item">
           <ThinkingBlock v-if="log.type === 'thinking'" :content="log.content" :timestamp="log.timestamp" />
           <CommandBlock v-else :log="log" />
-        </div>
-        <!-- Streaming partial thinking -->
-        <div v-if="partialThinking" class="work-log-item work-log-streaming">
-          <ThinkingBlock :content="partialThinking" :streaming="true" />
         </div>
       </div>
     </details>
@@ -36,45 +26,23 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue';
+import { ref, computed } from 'vue';
 import ThinkingBlock from './ThinkingBlock.vue';
 import CommandBlock from './CommandBlock.vue';
 
 const props = defineProps({
   workLogs: { type: Array, default: () => [] },
-  isLatestMessage: { type: Boolean, default: false },
-  partialThinking: { type: String, default: null },
 });
 
 const detailsRef = ref(null);
-const manuallyToggled = ref(false);
-const isExpanded = ref(!!props.partialThinking);
+// Work logs in completed messages should always start collapsed
+const isExpanded = ref(false);
 
-// Total count includes work logs + 1 if partial thinking is present
 const totalCount = computed(() => {
-  return (props.workLogs?.length || 0) + (props.partialThinking ? 1 : 0);
-});
-
-// Watch for new work logs to expand panel for latest message
-watch(() => props.workLogs?.length, (newLen, oldLen) => {
-  if (props.isLatestMessage && newLen > (oldLen || 0)) {
-    isExpanded.value = true;
-  }
-});
-
-// Watch for partial thinking to auto-expand/collapse
-watch(() => props.partialThinking, (newVal, oldVal) => {
-  if (newVal && !manuallyToggled.value) {
-    // Expand when streaming starts
-    isExpanded.value = true;
-  } else if (!newVal && oldVal && !manuallyToggled.value) {
-    // Collapse when streaming finishes
-    isExpanded.value = false;
-  }
+  return props.workLogs?.length || 0;
 });
 
 function handleToggle(event) {
-  manuallyToggled.value = true;
   isExpanded.value = event.target.open;
 }
 </script>
@@ -139,57 +107,6 @@ function handleToggle(event) {
 }
 
 .work-log-item {
-  animation: fadeIn 0.2s ease;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.work-log-streaming {
-  border-left: 2px solid var(--color-primary);
-  padding-left: 0.5rem;
-}
-
-/* Streaming indicator animation */
-.streaming-indicator {
-  display: flex;
-  gap: 0.15rem;
-  align-items: center;
-  margin-left: 0.5rem;
-}
-
-.streaming-indicator .dot {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background-color: var(--color-primary);
-  animation: pulse 1.4s ease-in-out infinite;
-}
-
-.streaming-indicator .dot:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.streaming-indicator .dot:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes pulse {
-  0%, 80%, 100% {
-    opacity: 0.3;
-    transform: scale(0.8);
-  }
-  40% {
-    opacity: 1;
-    transform: scale(1);
-  }
+  /* No animation needed for collapsed work logs */
 }
 </style>


### PR DESCRIPTION
## Summary

- **Fixed confusing work log display behavior** - Work logs were appearing in multiple places (inside messages AND below the conversation), causing confusion
- **Work logs now consistently show below the conversation** while Claude is working via `LiveWorkLogPanel`
- **Deferred work log association to end of turn** - Work logs are no longer associated with messages immediately on creation, but at the end of the turn when Claude finishes
- **Work logs in completed messages are now collapsed by default** - Keeps the conversation clean while still allowing users to expand and review

## Test plan

- [x] Verify work logs appear in `LiveWorkLogPanel` below the conversation while Claude is working
- [x] Verify work logs move to `WorkLogPanel` inside the message when the turn completes
- [x] Verify `WorkLogPanel` starts collapsed by default
- [x] Verify clicking the work log header expands/collapses the panel
- [x] All existing tests pass (412 server tests, 172 web tests)
- [x] New tests added for `WorkLogPanel` component (14 tests)
- [x] New tests added for end-of-turn work log association (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)