### PR TITLE
fix: Base new worktree branches on origin's default branch instead of HEAD

### DIFF
--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -16,11 +16,25 @@ async function git(directory, command) {
 
 /**
  * Get the default branch from origin remote
- * Tries origin/main first, then origin/master as fallback
+ * Uses GitHub CLI if available, falls back to git commands
  * @param {string} directory
  * @returns {Promise<string>}
  */
 async function getOriginDefaultBranch(directory) {
+  // Try GitHub CLI first - most accurate method
+  try {
+    const { stdout } = await execAsync(
+      'gh repo view --json defaultBranchRef --jq ".defaultBranchRef.name"',
+      { cwd: directory }
+    );
+    const branch = stdout.trim();
+    if (branch) {
+      return `origin/${branch}`;
+    }
+  } catch {
+    // gh CLI not available or failed, fall back to git commands
+  }
+
   // Try to get the default branch from the remote HEAD
   try {
     const ref = await git(directory, 'symbolic-ref refs/remotes/origin/HEAD');

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -15,6 +15,29 @@ async function git(directory, command) {
 }
 
 /**
+ * Get the default branch from origin remote
+ * Tries origin/main first, then origin/master as fallback
+ * @param {string} directory
+ * @returns {Promise<string>}
+ */
+async function getOriginDefaultBranch(directory) {
+  // Try to get the default branch from the remote HEAD
+  try {
+    const ref = await git(directory, 'symbolic-ref refs/remotes/origin/HEAD');
+    // Returns something like "refs/remotes/origin/main"
+    return ref.replace('refs/remotes/', '');
+  } catch {
+    // Fallback: check if origin/main exists, otherwise use origin/master
+    try {
+      await git(directory, 'rev-parse --verify origin/main');
+      return 'origin/main';
+    } catch {
+      return 'origin/master';
+    }
+  }
+}
+
+/**
  * Check if a directory is a git repository
  * @param {string} directory
  * @returns {Promise<boolean>}
@@ -92,7 +115,12 @@ export async function getCurrentBranch(directory) {
  * @returns {Promise<{path: string, branch: string}>}
  */
 export async function createWorktree(directory, branch, path) {
-  await git(directory, `worktree add "${path}" -b "${branch}"`);
+  // Fetch latest from origin to ensure we have up-to-date default branch
+  await git(directory, 'fetch origin');
+  // Get the default branch from origin (main or master)
+  const defaultBranch = await getOriginDefaultBranch(directory);
+  // Base new branch on origin's default branch to avoid including unrelated commits from HEAD
+  await git(directory, `worktree add "${path}" -b "${branch}" ${defaultBranch}`);
   return { path, branch };
 }
 
@@ -171,11 +199,16 @@ export async function checkoutBranch(directory, branch) {
  * @returns {Promise<{path: string, branch: string}>}
  */
 export async function createWorktreeForBranch(directory, branch, worktreePath) {
+  // Fetch latest from origin to ensure we have up-to-date default branch
+  await git(directory, 'fetch origin');
   const exists = await branchExists(directory, branch);
   if (exists) {
     await git(directory, `worktree add "${worktreePath}" "${branch}"`);
   } else {
-    await git(directory, `worktree add -b "${branch}" "${worktreePath}"`);
+    // Get the default branch from origin (main or master)
+    const defaultBranch = await getOriginDefaultBranch(directory);
+    // Base new branch on origin's default branch to avoid including unrelated commits from HEAD
+    await git(directory, `worktree add -b "${branch}" "${worktreePath}" ${defaultBranch}`);
   }
   return { path: worktreePath, branch };
 }

--- a/packages/server/src/services/gitService.test.js
+++ b/packages/server/src/services/gitService.test.js
@@ -14,8 +14,13 @@ import {
 
 describe('gitService', () => {
   let testDir;
+  let bareRepoDir;
 
   beforeEach(async () => {
+    // Create a bare repo to serve as "origin"
+    bareRepoDir = await mkdtemp(join(tmpdir(), 'git-bare-'));
+    execSync('git init --bare', { cwd: bareRepoDir });
+
     // Create a temporary directory with a git repo
     testDir = await mkdtemp(join(tmpdir(), 'git-test-'));
     execSync('git init', { cwd: testDir });
@@ -25,11 +30,16 @@ describe('gitService', () => {
     await writeFile(join(testDir, 'README.md'), '# Test');
     execSync('git add .', { cwd: testDir });
     execSync('git commit -m "Initial commit"', { cwd: testDir });
+
+    // Add the bare repo as origin and push
+    execSync(`git remote add origin "${bareRepoDir}"`, { cwd: testDir });
+    execSync('git push -u origin HEAD', { cwd: testDir });
   });
 
   afterEach(async () => {
-    // Clean up temporary directory
+    // Clean up temporary directories
     await rm(testDir, { recursive: true, force: true });
+    await rm(bareRepoDir, { recursive: true, force: true });
   });
 
   describe('branchExists', () => {


### PR DESCRIPTION
## Summary

- Fix bug where new session worktree branches were created from HEAD instead of the remote's default branch
- This caused unrelated commits to leak into new branches when the main repo was checked out to a feature branch
- Add `getOriginDefaultBranch()` helper to dynamically detect `origin/main` or `origin/master`
- Update `createWorktree()` and `createWorktreeForBranch()` to fetch from origin and base new branches on the default remote branch

## Test plan

- [x] All 407 existing tests pass
- [x] Updated gitService tests to use a bare repo as mock origin
- [ ] Manual verification: Create a new session while main repo is on a feature branch - new worktree should only have commits from origin/main

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)