### PR TITLE
Add PR status indicators to session list cards

### DIFF
--- a/packages/server/src/services/ghService.js
+++ b/packages/server/src/services/ghService.js
@@ -38,10 +38,11 @@ export async function getPrInfo(prUrl) {
   if (!(await isGhAvailable())) return null;
 
   try {
-    const { stdout } = await execAsync(
-      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft,statusCheckRollup`
+    // First fetch basic PR info (this should always work)
+    const { stdout: basicStdout } = await execAsync(
+      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft`
     );
-    const data = JSON.parse(stdout);
+    const data = JSON.parse(basicStdout);
 
     // Determine PR state
     let state = data.state.toLowerCase();
@@ -52,30 +53,40 @@ export async function getPrInfo(prUrl) {
     // mergeable can be: 'MERGEABLE', 'CONFLICTING', 'UNKNOWN'
     const hasMergeConflicts = data.mergeable === 'CONFLICTING';
 
-    // Process CI checks
-    const checks = data.statusCheckRollup || [];
+    // Try to fetch CI status separately (may fail due to token permissions)
     let ciStatus = null;
     let ciFailures = [];
 
-    if (checks.length > 0) {
-      // Get failed checks with their names
-      const failedChecks = checks.filter(
-        (c) => c.conclusion === 'FAILURE' || c.conclusion === 'TIMED_OUT'
+    try {
+      const { stdout: ciStdout } = await execAsync(
+        `gh pr view "${prUrl}" --json statusCheckRollup`
       );
-      ciFailures = failedChecks.map((c) => c.name || c.context || 'Unknown check');
+      const ciData = JSON.parse(ciStdout);
+      const checks = ciData.statusCheckRollup || [];
 
-      // Determine overall CI status
-      const hasPending = checks.some(
-        (c) => c.status === 'IN_PROGRESS' || c.status === 'QUEUED' || c.status === 'PENDING'
-      );
+      if (checks.length > 0) {
+        // Get failed checks with their names
+        const failedChecks = checks.filter(
+          (c) => c.conclusion === 'FAILURE' || c.conclusion === 'TIMED_OUT'
+        );
+        ciFailures = failedChecks.map((c) => c.name || c.context || 'Unknown check');
 
-      if (failedChecks.length > 0) {
-        ciStatus = 'failure';
-      } else if (hasPending) {
-        ciStatus = 'pending';
-      } else {
-        ciStatus = 'success';
+        // Determine overall CI status
+        const hasPending = checks.some(
+          (c) => c.status === 'IN_PROGRESS' || c.status === 'QUEUED' || c.status === 'PENDING'
+        );
+
+        if (failedChecks.length > 0) {
+          ciStatus = 'failure';
+        } else if (hasPending) {
+          ciStatus = 'pending';
+        } else {
+          ciStatus = 'success';
+        }
       }
+    } catch (ciError) {
+      // CI status unavailable (likely token permissions) - continue without it
+      console.warn('[ghService] CI status unavailable:', ciError.message);
     }
 
     return {

--- a/packages/server/src/services/ghService.test.js
+++ b/packages/server/src/services/ghService.test.js
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+// Mock child_process exec
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+}));
+
+// Import after mocking
+import { isGhAvailable, getPrInfo, resetGhAvailableCache } from './ghService.js';
+
+const execAsync = promisify(exec);
+
+describe('ghService', () => {
+  beforeEach(() => {
+    resetGhAvailableCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isGhAvailable', () => {
+    it('returns true when gh is installed and authenticated', async () => {
+      exec.mockImplementation((cmd, callback) => {
+        callback(null, { stdout: 'gh version 2.0.0', stderr: '' });
+      });
+
+      const result = await isGhAvailable();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when gh is not installed', async () => {
+      exec.mockImplementation((cmd, callback) => {
+        callback(new Error('command not found: gh'), null);
+      });
+
+      const result = await isGhAvailable();
+      expect(result).toBe(false);
+    });
+
+    it('caches the result', async () => {
+      exec.mockImplementation((cmd, callback) => {
+        callback(null, { stdout: 'ok', stderr: '' });
+      });
+
+      await isGhAvailable();
+      await isGhAvailable();
+      await isGhAvailable();
+
+      // Should only call exec twice (version + auth), not 6 times
+      expect(exec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getPrInfo', () => {
+    beforeEach(() => {
+      // Setup gh as available by default
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        // First two calls are for isGhAvailable check
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        // Handle PR view commands
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              statusCheckRollup: [
+                { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+                { name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+              ],
+            }),
+            stderr: '',
+          });
+        }
+      });
+    });
+
+    it('returns null when gh is not available', async () => {
+      exec.mockImplementation((cmd, callback) => {
+        callback(new Error('command not found'), null);
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result).toBe(null);
+    });
+
+    it('returns PR info with open state', async () => {
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+
+      expect(result).toEqual({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
+    });
+
+    it('returns merged state when mergedAt is set', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'MERGED',
+              mergedAt: '2024-01-15T10:00:00Z',
+              mergeable: 'UNKNOWN',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, { stdout: JSON.stringify({ statusCheckRollup: [] }), stderr: '' });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.state).toBe('merged');
+      expect(result.merged).toBe(true);
+    });
+
+    it('returns draft state when isDraft is true', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: true,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, { stdout: JSON.stringify({ statusCheckRollup: [] }), stderr: '' });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.state).toBe('draft');
+    });
+
+    it('detects merge conflicts', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'CONFLICTING',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, { stdout: JSON.stringify({ statusCheckRollup: [] }), stderr: '' });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.hasMergeConflicts).toBe(true);
+    });
+
+    it('detects CI failures', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              statusCheckRollup: [
+                { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+                { name: 'lint', status: 'COMPLETED', conclusion: 'FAILURE' },
+                { name: 'test', status: 'COMPLETED', conclusion: 'TIMED_OUT' },
+              ],
+            }),
+            stderr: '',
+          });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.ciStatus).toBe('failure');
+      expect(result.ciFailures).toEqual(['lint', 'test']);
+    });
+
+    it('detects pending CI checks', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              statusCheckRollup: [
+                { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+                { name: 'test', status: 'IN_PROGRESS', conclusion: null },
+              ],
+            }),
+            stderr: '',
+          });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.ciStatus).toBe('pending');
+    });
+
+    it('continues without CI data when statusCheckRollup fails (permissions error)', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(
+            new Error('Resource not accessible by personal access token'),
+            null
+          );
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+
+      // Should still return basic PR info
+      expect(result).not.toBe(null);
+      expect(result.state).toBe('open');
+      expect(result.merged).toBe(false);
+      expect(result.hasMergeConflicts).toBe(false);
+
+      // CI status should be null (unavailable)
+      expect(result.ciStatus).toBe(null);
+      expect(result.ciFailures).toEqual([]);
+    });
+
+    it('returns null when basic PR info fetch fails', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(new Error('Could not resolve to a PullRequest'), null);
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/999999');
+      expect(result).toBe(null);
+    });
+
+    it('handles empty statusCheckRollup array', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, { stdout: JSON.stringify({ statusCheckRollup: [] }), stderr: '' });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.ciStatus).toBe(null);
+      expect(result.ciFailures).toEqual([]);
+    });
+  });
+});

--- a/packages/server/src/services/ghService.test.js
+++ b/packages/server/src/services/ghService.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { exec } from 'child_process';
-import { promisify } from 'util';
 
 // Mock child_process exec
 vi.mock('child_process', () => ({
@@ -9,8 +8,6 @@ vi.mock('child_process', () => ({
 
 // Import after mocking
 import { isGhAvailable, getPrInfo, resetGhAvailableCache } from './ghService.js';
-
-const execAsync = promisify(exec);
 
 describe('ghService', () => {
   beforeEach(() => {

--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -288,4 +288,190 @@ describe('SessionCard', () => {
       });
     });
   });
+
+  describe('PR status indicators', () => {
+    describe('PR state badge', () => {
+      it('shows merged badge when prState is merged', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', prState: 'merged' },
+        });
+        const badge = wrapper.find('.pr-state-badge');
+        expect(badge.exists()).toBe(true);
+        expect(badge.text()).toBe('Merged');
+        expect(badge.classes()).toContain('pr-state-merged');
+      });
+
+      it('shows open badge when prState is open', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', prState: 'open' },
+        });
+        const badge = wrapper.find('.pr-state-badge');
+        expect(badge.exists()).toBe(true);
+        expect(badge.text()).toBe('Open');
+        expect(badge.classes()).toContain('pr-state-open');
+      });
+
+      it('shows closed badge when prState is closed', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', prState: 'closed' },
+        });
+        const badge = wrapper.find('.pr-state-badge');
+        expect(badge.exists()).toBe(true);
+        expect(badge.text()).toBe('Closed');
+        expect(badge.classes()).toContain('pr-state-closed');
+      });
+
+      it('shows draft badge when prState is draft', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', prState: 'draft' },
+        });
+        const badge = wrapper.find('.pr-state-badge');
+        expect(badge.exists()).toBe(true);
+        expect(badge.text()).toBe('Draft');
+        expect(badge.classes()).toContain('pr-state-draft');
+      });
+
+      it('does not show PR state badge when prState is not present', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test' },
+        });
+        expect(wrapper.find('.pr-state-badge').exists()).toBe(false);
+      });
+
+      it('does not show PR state badge when summary is null', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: null,
+        });
+        expect(wrapper.find('.pr-state-badge').exists()).toBe(false);
+      });
+    });
+
+    describe('merge conflict indicator', () => {
+      it('shows conflict indicator when hasMergeConflicts is true', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', hasMergeConflicts: true },
+        });
+        const indicator = wrapper.find('.conflict-indicator');
+        expect(indicator.exists()).toBe(true);
+        expect(indicator.attributes('title')).toBe('Merge conflicts detected');
+      });
+
+      it('does not show conflict indicator when hasMergeConflicts is false', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', hasMergeConflicts: false },
+        });
+        expect(wrapper.find('.conflict-indicator').exists()).toBe(false);
+      });
+
+      it('does not show conflict indicator when hasMergeConflicts is not present', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test' },
+        });
+        expect(wrapper.find('.conflict-indicator').exists()).toBe(false);
+      });
+    });
+
+    describe('CI status indicator', () => {
+      it('shows success indicator when ciStatus is success', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', ciStatus: 'success' },
+        });
+        const indicator = wrapper.find('.ci-indicator');
+        expect(indicator.exists()).toBe(true);
+        expect(indicator.text()).toBe('✓');
+        expect(indicator.classes()).toContain('ci-success');
+        expect(indicator.attributes('title')).toBe('CI passing');
+      });
+
+      it('shows failure indicator when ciStatus is failure', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', ciStatus: 'failure' },
+        });
+        const indicator = wrapper.find('.ci-indicator');
+        expect(indicator.exists()).toBe(true);
+        expect(indicator.text()).toBe('✗');
+        expect(indicator.classes()).toContain('ci-failure');
+        expect(indicator.attributes('title')).toBe('CI failing');
+      });
+
+      it('shows pending indicator when ciStatus is pending', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', ciStatus: 'pending' },
+        });
+        const indicator = wrapper.find('.ci-indicator');
+        expect(indicator.exists()).toBe(true);
+        expect(indicator.text()).toBe('○');
+        expect(indicator.classes()).toContain('ci-pending');
+        expect(indicator.attributes('title')).toBe('CI pending');
+      });
+
+      it('does not show CI indicator when ciStatus is not present', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test' },
+        });
+        expect(wrapper.find('.ci-indicator').exists()).toBe(false);
+      });
+
+      it('does not show CI indicator when ciStatus is null', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: { shortSummary: 'Test', ciStatus: null },
+        });
+        expect(wrapper.find('.ci-indicator').exists()).toBe(false);
+      });
+    });
+
+    describe('graceful degradation', () => {
+      it('shows all indicators when all data is present', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: {
+            shortSummary: 'Test',
+            prState: 'open',
+            hasMergeConflicts: true,
+            ciStatus: 'failure',
+          },
+        });
+        expect(wrapper.find('.pr-state-badge').exists()).toBe(true);
+        expect(wrapper.find('.conflict-indicator').exists()).toBe(true);
+        expect(wrapper.find('.ci-indicator').exists()).toBe(true);
+      });
+
+      it('shows no indicators when summary is missing', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+        });
+        expect(wrapper.find('.pr-state-badge').exists()).toBe(false);
+        expect(wrapper.find('.conflict-indicator').exists()).toBe(false);
+        expect(wrapper.find('.ci-indicator').exists()).toBe(false);
+      });
+
+      it('shows only available indicators (partial data)', () => {
+        const wrapper = mountComponent({
+          session: { ...baseSession, prUrl: 'https://github.com/org/repo/pull/123' },
+          summary: {
+            shortSummary: 'Test',
+            prState: 'open',
+            // No hasMergeConflicts or ciStatus
+          },
+        });
+        expect(wrapper.find('.pr-state-badge').exists()).toBe(true);
+        expect(wrapper.find('.conflict-indicator').exists()).toBe(false);
+        expect(wrapper.find('.ci-indicator').exists()).toBe(false);
+      });
+    });
+  });
 });

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -20,6 +20,18 @@
             </svg>
             {{ extractPrNumber(session.prUrl) }}
           </a>
+          <span v-if="summary?.prState" :class="['pr-state-badge', `pr-state-${summary.prState}`]">
+            {{ formatPrState(summary.prState) }}
+          </span>
+          <span v-if="summary?.hasMergeConflicts" class="conflict-indicator" title="Merge conflicts detected">
+            <svg viewBox="0 0 16 16" fill="currentColor" class="conflict-icon">
+              <path d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z"/>
+              <path d="M7.25 4.5a.75.75 0 011.5 0v3.25a.75.75 0 01-1.5 0V4.5zM8 10a1 1 0 100 2 1 1 0 000-2z"/>
+            </svg>
+          </span>
+          <span v-if="summary?.ciStatus" :class="['ci-indicator', `ci-${summary.ciStatus}`]" :title="ciStatusTitle">
+            {{ ciStatusIcon }}
+          </span>
         </p>
         <p v-if="showProject && session.projectName" class="session-project">
           <span class="project-name">{{ session.projectName }}</span>
@@ -89,10 +101,38 @@ const dateToShow = computed(() => {
   return props.showProject ? props.session.updatedAt : props.session.createdAt;
 });
 
+const ciStatusIcon = computed(() => {
+  const icons = {
+    success: '✓',
+    failure: '✗',
+    pending: '○',
+  };
+  return icons[props.summary?.ciStatus] || '';
+});
+
+const ciStatusTitle = computed(() => {
+  const titles = {
+    success: 'CI passing',
+    failure: 'CI failing',
+    pending: 'CI pending',
+  };
+  return titles[props.summary?.ciStatus] || '';
+});
+
 function extractPrNumber(url) {
   if (!url) return 'PR';
   const match = url.match(/\/pull\/(\d+)/);
   return match ? `PR ${match[1]}` : 'PR';
+}
+
+function formatPrState(state) {
+  const labels = {
+    merged: 'Merged',
+    open: 'Open',
+    closed: 'Closed',
+    draft: 'Draft',
+  };
+  return labels[state] || state;
 }
 </script>
 
@@ -164,6 +204,75 @@ function extractPrNumber(url) {
 .pr-icon {
   width: 12px;
   height: 12px;
+}
+
+/* PR State Badges */
+.pr-state-badge {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.625rem;
+  font-weight: 500;
+  border-radius: 3px;
+  text-transform: capitalize;
+}
+
+.pr-state-merged {
+  background: rgba(130, 80, 223, 0.15);
+  color: #8250df;
+}
+
+.pr-state-open {
+  background: rgba(46, 160, 67, 0.15);
+  color: #2ea043;
+}
+
+.pr-state-closed {
+  background: rgba(110, 119, 129, 0.15);
+  color: #6e7781;
+}
+
+.pr-state-draft {
+  background: rgba(210, 153, 34, 0.15);
+  color: #9a6700;
+}
+
+/* Merge Conflict Indicator */
+.conflict-indicator {
+  display: inline-flex;
+  align-items: center;
+  color: #cf222e;
+}
+
+.conflict-icon {
+  width: 12px;
+  height: 12px;
+}
+
+/* CI Status Indicators */
+.ci-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  border-radius: 50%;
+}
+
+.ci-success {
+  background: rgba(46, 160, 67, 0.15);
+  color: #2ea043;
+}
+
+.ci-failure {
+  background: rgba(207, 34, 46, 0.15);
+  color: #cf222e;
+}
+
+.ci-pending {
+  background: rgba(210, 153, 34, 0.15);
+  color: #9a6700;
 }
 
 .session-project {


### PR DESCRIPTION
## Summary

- Fixes missing PR status indicators that were only visible in the Summary tab
- Adds PR state, CI status, and merge conflict indicators to SessionCard (session list view)
- Fixes ghService.js to gracefully handle GitHub token permission failures

## Changes

| File | Changes |
|------|---------|
| `ghService.js` | Split API calls so basic PR info works even when CI status permissions fail |
| `SessionCard.vue` | Added PR state badge, merge conflict icon, and CI status indicator |

## What's shown in session list now

| Indicator | Appearance |
|-----------|------------|
| **PR State** | `Merged` (purple), `Open` (green), `Closed` (gray), `Draft` (yellow) |
| **Merge Conflicts** | ⚠️ warning icon |
| **CI Status** | ✓ (green), ✗ (red), ○ (yellow) |

All indicators use silent graceful degradation - only appear when data is available.

## Test plan

- [x] Build passes
- [x] All tests pass (158 web + 407 server)
- [ ] Verify PR state badge appears for sessions with PRs
- [ ] Verify merge conflict indicator shows when conflicts exist
- [ ] Verify CI status shows when available
- [ ] Verify graceful degradation when data unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)