### PR TITLE
Improve new session view layout and git options order

### DIFF
--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -64,9 +64,9 @@
         <label class="form-label">Git Options</label>
         <div class="quick-git-options">
           <label class="radio-option">
-            <input type="radio" v-model="quickGitMode" value="" />
-            <span class="radio-label">Use current branch</span>
-            <span class="radio-help">{{ gitStatus.currentBranch }}</span>
+            <input type="radio" v-model="quickGitMode" value="worktree" />
+            <span class="radio-label">Create isolated worktree</span>
+            <span class="radio-help">Separate working directory for this session</span>
           </label>
           <label class="radio-option">
             <input type="radio" v-model="quickGitMode" value="branch" />
@@ -74,9 +74,9 @@
             <span class="radio-help">Work in the project directory</span>
           </label>
           <label class="radio-option">
-            <input type="radio" v-model="quickGitMode" value="worktree" />
-            <span class="radio-label">Create isolated worktree</span>
-            <span class="radio-help">Separate working directory for this session</span>
+            <input type="radio" v-model="quickGitMode" value="" />
+            <span class="radio-label">Use current branch</span>
+            <span class="radio-help">{{ gitStatus.currentBranch }}</span>
           </label>
         </div>
 
@@ -227,7 +227,7 @@ h1 {
 }
 
 .form {
-  max-width: 600px;
+  width: 100%;
 }
 
 .form-help {


### PR DESCRIPTION
## Summary
- Make the new session form take up all available width instead of being constrained to 600px
- Reorder git options to show "Create isolated worktree" as the first option (recommended workflow)

## Test plan
- [ ] Navigate to new session view and verify form takes full container width
- [ ] Verify git options are displayed in order: worktree → new branch → current branch
- [ ] Verify "Create isolated worktree" is selected by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)