### PR TITLE
Fix scroll snap-back issue when Claude is working

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -227,9 +227,9 @@ onMounted(async () => {
   });
 
   // Subscribe to work log updates
+  // Note: Work logs are displayed in LiveWorkLogPanel which has its own scroll management
   unsubWorkLog = onWorkLog((log) => {
     sessionsStore.addWorkLog(log);
-    scrollToBottom();
   });
 
   // Subscribe to work log association events (re-associate _unassociated logs)
@@ -238,13 +238,13 @@ onMounted(async () => {
   });
 
   // Subscribe to partial thinking updates for streaming display
+  // Note: Partial thinking is displayed in LiveWorkLogPanel which has its own scroll management
   unsubThinkingPartial = onThinkingPartial((thinking) => {
     if (thinking === null) {
       sessionsStore.clearPartialThinking();
     } else {
       sessionsStore.setPartialThinking(thinking);
     }
-    scrollToBottom();
   });
 
   // Fetch initial work logs
@@ -396,6 +396,7 @@ async function handleModeChange(newMode) {
   max-height: 500px;
   padding: 1rem 0;
   position: relative;
+  overflow-anchor: none; /* Prevent browser scroll anchoring issues during streaming */
 }
 
 .message {


### PR DESCRIPTION
## Summary

- Remove unnecessary `scrollToBottom()` calls from `onWorkLog` and `onThinkingPartial` handlers in ConversationTab.vue
- These handlers were scrolling the messages container, but the content they update is displayed in `LiveWorkLogPanel` which has its own scroll management
- Add `overflow-anchor: none` CSS property to prevent browser scroll anchoring interference

## Problem

When Claude Code is working and the user tries to scroll the page to see the Stop button, the screen snaps back up because:
1. Work log and thinking updates were triggering `scrollToBottom()` on the wrong container
2. This caused layout thrashing and browser scroll anchoring conflicts

## Test plan

- [ ] Start a new session with Claude working
- [ ] Scroll the page down to see the Stop button
- [ ] Verify the page no longer snaps back as Claude streams work logs/thinking
- [ ] Verify messages still auto-scroll when a new message streams in
- [ ] Verify LiveWorkLogPanel still auto-scrolls its own content

🤖 Generated with [Claude Code](https://claude.com/claude-code)