### PR TITLE
fix: Work log association not happening at end of turn

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -69,10 +69,48 @@ async function* mockQuery({ prompt }) {
   // Small delay to simulate processing
   await new Promise((resolve) => setTimeout(resolve, 100));
 
+  // Simulate thinking (creates a work log)
+  yield {
+    type: 'stream_event',
+    event: {
+      type: 'content_block_delta',
+      delta: { type: 'thinking_delta', thinking: 'Analyzing the request...' },
+    },
+  };
+  yield {
+    type: 'stream_event',
+    event: { type: 'content_block_stop' },
+  };
+
+  // Simulate tool use (creates work logs for input)
+  const toolUseId = 'mock-tool-' + Date.now();
+  yield {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'Bash',
+          input: { command: 'echo "mock command"' },
+        },
+      ],
+    },
+  };
+
+  // Simulate tool result (creates work log for output)
+  yield {
+    type: 'tool_result',
+    tool_name: 'Bash',
+    content: 'mock command output',
+  };
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
   // Generate a mock response based on the user's message
   const responseText = `Mock response to: "${prompt}"`;
 
-  // Yield assistant message
+  // Yield assistant message with text
   yield {
     type: 'assistant',
     message: {

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -651,8 +651,9 @@ async function handleStreamEvent(sessionId, event) {
           sessions.update(sessionId, { costUsd: event.total_cost_usd });
         }
       }
-      // Clear message tracking when session completes
-      lastMessageIds.delete(sessionId);
+      // Note: Don't clear lastMessageIds here - let the post-loop association code handle it.
+      // Clearing here was causing work logs to never be associated because the 'result' event
+      // arrives before the loop ends, deleting the messageId before association can happen.
       break;
     }
   }

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -168,7 +168,32 @@ export const useSessionsStore = defineStore('sessions', {
       this.error = null;
       try {
         const grouped = await api.getSessionWorkLogs(sessionId);
-        this.workLogs = grouped;
+
+        // Merge strategy: Use fetched data as base, but preserve any _unassociated
+        // logs that arrived via WebSocket and aren't yet in the fetched data.
+        // This prevents race conditions where logs arrive during the fetch.
+
+        // Build a set of all log IDs from the fetched data
+        const fetchedLogIds = new Set();
+        for (const messageId of Object.keys(grouped)) {
+          for (const log of grouped[messageId] || []) {
+            fetchedLogIds.add(log.id);
+          }
+        }
+
+        // Get existing unassociated logs that aren't in the fetched data
+        // (these are logs that arrived via WebSocket during the fetch)
+        const existingUnassociated = this.workLogs['_unassociated'] || [];
+        const newUnassociatedLogs = existingUnassociated.filter(
+          log => !fetchedLogIds.has(log.id)
+        );
+
+        // Merge: use fetched data, but append any truly new unassociated logs
+        const fetchedUnassociated = grouped['_unassociated'] || [];
+        this.workLogs = {
+          ...grouped,
+          '_unassociated': [...fetchedUnassociated, ...newUnassociatedLogs],
+        };
       } catch (err) {
         this.error = err.message;
       }

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -190,5 +190,97 @@ describe('Sessions Store', () => {
       expect(store.workLogs['_unassociated']).toEqual([]);
       expect(store.workLogs['msg-1']).toEqual([log1, log2]);
     });
+
+    describe('fetchWorkLogs merge behavior', () => {
+      it('merges fetched work logs with existing unassociated logs', async () => {
+        const store = useSessionsStore();
+
+        // Simulate logs that arrived via WebSocket (before fetch)
+        const wsLog = { id: 'ws-log-1', content: 'arrived via websocket' };
+        store.addWorkLog(wsLog);
+
+        expect(store.workLogs['_unassociated']).toEqual([wsLog]);
+
+        // Mock API returning different logs (already associated in DB)
+        const fetchedLog = { id: 'db-log-1', content: 'from database' };
+        api.getSessionWorkLogs.mockResolvedValue({
+          'msg-1': [fetchedLog],
+          '_unassociated': [],
+        });
+
+        await store.fetchWorkLogs('session-1');
+
+        // WebSocket log should be preserved since it's not in fetched data
+        expect(store.workLogs['_unassociated']).toEqual([wsLog]);
+        // Fetched associated logs should be present
+        expect(store.workLogs['msg-1']).toEqual([fetchedLog]);
+      });
+
+      it('removes unassociated logs that are now associated in fetched data', async () => {
+        const store = useSessionsStore();
+
+        // Simulate log that arrived via WebSocket as unassociated
+        const log = { id: 'log-1', content: 'test log' };
+        store.addWorkLog(log);
+
+        expect(store.workLogs['_unassociated']).toEqual([log]);
+
+        // Mock API returning the same log but now associated with a message
+        api.getSessionWorkLogs.mockResolvedValue({
+          'msg-1': [log],
+          '_unassociated': [],
+        });
+
+        await store.fetchWorkLogs('session-1');
+
+        // Log should be removed from _unassociated since it's in fetched data
+        expect(store.workLogs['_unassociated']).toEqual([]);
+        // Log should be under the message ID
+        expect(store.workLogs['msg-1']).toEqual([log]);
+      });
+
+      it('preserves new WebSocket logs that arrived during fetch', async () => {
+        const store = useSessionsStore();
+
+        // Simulate logs in the store (some old, one new)
+        const oldLog = { id: 'old-log', content: 'old log' };
+        const newLog = { id: 'new-log', content: 'arrived during fetch' };
+        store.workLogs = { '_unassociated': [oldLog, newLog] };
+
+        // Mock API returning the old log as associated (but not the new one)
+        api.getSessionWorkLogs.mockResolvedValue({
+          'msg-1': [oldLog],
+          '_unassociated': [],
+        });
+
+        await store.fetchWorkLogs('session-1');
+
+        // New log should be preserved in _unassociated
+        expect(store.workLogs['_unassociated']).toEqual([newLog]);
+        // Old log should be under the message ID
+        expect(store.workLogs['msg-1']).toEqual([oldLog]);
+      });
+
+      it('combines fetched unassociated with new WebSocket unassociated', async () => {
+        const store = useSessionsStore();
+
+        // Simulate WebSocket log
+        const wsLog = { id: 'ws-log', content: 'from websocket' };
+        store.addWorkLog(wsLog);
+
+        // Mock API returning some unassociated logs from DB
+        const dbLog = { id: 'db-log', content: 'from database' };
+        api.getSessionWorkLogs.mockResolvedValue({
+          '_unassociated': [dbLog],
+        });
+
+        await store.fetchWorkLogs('session-1');
+
+        // Both logs should be in _unassociated
+        expect(store.workLogs['_unassociated']).toHaveLength(2);
+        expect(store.workLogs['_unassociated']).toContainEqual(dbLog);
+        expect(store.workLogs['_unassociated']).toContainEqual(wsLog);
+      });
+    });
   });
 });

--- a/tests/e2e/work-logs.spec.ts
+++ b/tests/e2e/work-logs.spec.ts
@@ -6,7 +6,24 @@ import {
   cleanupAll,
   getSessionWorkLogs,
   updateSessionStatus,
+  getSessionMessages,
+  getSession,
 } from './helpers';
+
+const API_URL = process.env.API_URL || 'http://localhost:5000';
+
+// Helper to wait for session to reach a specific status
+async function waitForSessionStatus(sessionId: string, targetStatus: string, timeoutMs = 10000) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeoutMs) {
+    const session = await getSession(sessionId);
+    if (session?.status === targetStatus) {
+      return session;
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error(`Session did not reach status '${targetStatus}' within ${timeoutMs}ms`);
+}
 
 test.describe('Work Logs API', () => {
   let project: any;
@@ -59,7 +76,7 @@ test.describe('Work Logs API', () => {
     await updateSessionStatus(session.id, 'running');
 
     // Verify status was updated (fetch session to check)
-    const response = await fetch(`${process.env.API_URL || 'http://localhost:5000'}/api/sessions/${session.id}`);
+    const response = await fetch(`${API_URL}/api/sessions/${session.id}`);
     const updated = await response.json();
     expect(updated.status).toBe('running');
   });
@@ -85,5 +102,92 @@ test.describe('Work Logs API', () => {
     expect(workLogs._unassociated).toBeDefined();
     expect(workLogs._unassociated.length).toBe(1);
     expect(workLogs._unassociated[0].content).toBe('Thinking while running');
+  });
+});
+
+test.describe('Work Log Association', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Work Log Association Test', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('work logs are associated with messages after session turn completes', async () => {
+    // Create a session - this triggers the mock query which creates work logs
+    const session = await seedSession(project.id, {
+      prompt: 'Test work log association',
+      name: 'Association Test',
+    });
+
+    // Wait for session to complete its first turn (status becomes 'waiting')
+    await waitForSessionStatus(session.id, 'waiting', 15000);
+
+    // Get messages - should have the assistant response
+    const messages = await getSessionMessages(session.id);
+    const assistantMessages = messages.filter((m: any) => m.role === 'assistant');
+    expect(assistantMessages.length).toBeGreaterThan(0);
+
+    // Get work logs
+    const workLogs = await getSessionWorkLogs(session.id);
+
+    // Work logs should be associated with the assistant message, not unassociated
+    // The mock query creates: 1 thinking, 1 tool_input, 1 tool_output = 3 work logs
+    const lastAssistantMessage = assistantMessages[assistantMessages.length - 1];
+    const associatedLogs = workLogs[lastAssistantMessage.id] || [];
+    const unassociatedLogs = workLogs._unassociated || [];
+
+    // All work logs should be associated (not in _unassociated)
+    expect(unassociatedLogs.length).toBe(0);
+    expect(associatedLogs.length).toBeGreaterThan(0);
+
+    // Verify the types of work logs created by the mock
+    const types = associatedLogs.map((log: any) => log.type);
+    expect(types).toContain('thinking');
+    expect(types).toContain('tool_input');
+    expect(types).toContain('tool_output');
+  });
+
+  test('work logs from multiple turns are each associated with their respective messages', async () => {
+    // Create initial session
+    const session = await seedSession(project.id, {
+      prompt: 'First message',
+      name: 'Multi-turn Test',
+    });
+
+    // Wait for first turn to complete
+    await waitForSessionStatus(session.id, 'waiting', 15000);
+
+    // Send follow-up message
+    const response = await fetch(`${API_URL}/api/sessions/${session.id}/message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'Second message' }),
+    });
+    expect(response.ok).toBe(true);
+
+    // Wait for second turn to complete
+    await waitForSessionStatus(session.id, 'waiting', 15000);
+
+    // Get all messages and work logs
+    const messages = await getSessionMessages(session.id);
+    const workLogs = await getSessionWorkLogs(session.id);
+
+    // Should have multiple assistant messages (one per turn)
+    const assistantMessages = messages.filter((m: any) => m.role === 'assistant');
+    expect(assistantMessages.length).toBeGreaterThanOrEqual(2);
+
+    // Each assistant message should have associated work logs
+    for (const msg of assistantMessages) {
+      const msgWorkLogs = workLogs[msg.id] || [];
+      expect(msgWorkLogs.length).toBeGreaterThan(0);
+    }
+
+    // No work logs should be left unassociated
+    expect(workLogs._unassociated?.length || 0).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Fixed bug where work logs were never being associated with messages at the end of a turn
- Fixed race condition in frontend store where WebSocket-delivered logs could be lost during polling

## Root Cause

The `'result'` event handler in `sessionManager.js` was calling `lastMessageIds.delete(sessionId)` inside the for-await loop, which cleared the message ID **before** the post-loop association code could run. This meant work logs were never associated with their messages, causing them to accumulate in the "Claude is working" panel indefinitely.

## Changes

### Server-side (`packages/server/src/services/sessionManager.js`)
- Removed the premature `lastMessageIds.delete(sessionId)` from the `'result'` event handler
- The post-loop code now correctly handles cleanup after association

### Frontend (`packages/web/src/stores/sessions.js`)
- Improved `fetchWorkLogs` to merge fetched data with existing unassociated logs
- Prevents race conditions where logs arriving via WebSocket during a fetch could be lost

### Tests (`packages/web/src/stores/sessions.test.js`)
- Added comprehensive tests for the `fetchWorkLogs` merge behavior

## Test plan

- [x] All existing unit tests pass
- [x] New tests for fetchWorkLogs merge behavior pass
- [ ] Manual testing: Start a session, watch work logs appear during "Claude is working", verify they move to the completed message when the turn ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)