### PR TITLE
feat: Reorganize canvas view with list/detail pattern and version support

### DIFF
--- a/packages/web/src/components/CanvasFileList.test.js
+++ b/packages/web/src/components/CanvasFileList.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CanvasFileList from './CanvasFileList.vue';
+
+describe('CanvasFileList', () => {
+  const baseItems = [
+    {
+      id: 'item-1',
+      filename: 'screenshot.png',
+      type: 'image',
+      createdAt: Date.now() - 60000, // 1 minute ago
+      versionCount: 1,
+      allVersions: [],
+    },
+    {
+      id: 'item-2',
+      filename: 'design-spec.md',
+      type: 'markdown',
+      createdAt: Date.now() - 3600000, // 1 hour ago
+      versionCount: 3,
+      allVersions: [],
+    },
+  ];
+
+  function mountComponent(props = {}) {
+    return mount(CanvasFileList, {
+      props: {
+        items: baseItems,
+        ...props,
+      },
+    });
+  }
+
+  describe('basic rendering', () => {
+    it('renders a row for each item', () => {
+      const wrapper = mountComponent();
+      const rows = wrapper.findAll('.file-row');
+      expect(rows.length).toBe(2);
+    });
+
+    it('displays filename for each item', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.text()).toContain('screenshot.png');
+      expect(wrapper.text()).toContain('design-spec.md');
+    });
+
+    it('displays file type for each item', () => {
+      const wrapper = mountComponent();
+      const types = wrapper.findAll('.file-type');
+      expect(types[0].text()).toBe('image');
+      expect(types[1].text()).toBe('markdown');
+    });
+  });
+
+  describe('file type icons', () => {
+    it('shows image icon for image type', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], type: 'image' }],
+      });
+      expect(wrapper.find('.file-icon').text()).toBe('📷');
+    });
+
+    it('shows document icon for markdown type', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], type: 'markdown' }],
+      });
+      expect(wrapper.find('.file-icon').text()).toBe('📄');
+    });
+
+    it('shows clipboard icon for json type', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], type: 'json' }],
+      });
+      expect(wrapper.find('.file-icon').text()).toBe('📋');
+    });
+
+    it('shows text icon for text type', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], type: 'text' }],
+      });
+      expect(wrapper.find('.file-icon').text()).toBe('📝');
+    });
+
+    it('shows folder icon for unknown type', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], type: 'unknown' }],
+      });
+      expect(wrapper.find('.file-icon').text()).toBe('📁');
+    });
+  });
+
+  describe('version badge', () => {
+    it('shows version badge when versionCount > 1', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], versionCount: 3 }],
+      });
+      const badge = wrapper.find('.version-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.text()).toBe('v3');
+    });
+
+    it('hides version badge when versionCount is 1', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], versionCount: 1 }],
+      });
+      expect(wrapper.find('.version-badge').exists()).toBe(false);
+    });
+  });
+
+  describe('relative time', () => {
+    it('shows "just now" for recent items', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], createdAt: Date.now() - 5000 }], // 5 seconds ago
+      });
+      expect(wrapper.find('.file-time').text()).toBe('just now');
+    });
+
+    it('shows minutes for items within the hour', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], createdAt: Date.now() - 300000 }], // 5 minutes ago
+      });
+      expect(wrapper.find('.file-time').text()).toBe('5m ago');
+    });
+
+    it('shows hours for items within the day', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], createdAt: Date.now() - 7200000 }], // 2 hours ago
+      });
+      expect(wrapper.find('.file-time').text()).toBe('2h ago');
+    });
+
+    it('shows days for older items', () => {
+      const wrapper = mountComponent({
+        items: [{ ...baseItems[0], createdAt: Date.now() - 172800000 }], // 2 days ago
+      });
+      expect(wrapper.find('.file-time').text()).toBe('2d ago');
+    });
+  });
+
+  describe('fallback display names', () => {
+    it('uses label when filename is missing', () => {
+      const wrapper = mountComponent({
+        items: [{ id: '1', label: 'My Label', type: 'text', createdAt: Date.now(), versionCount: 1 }],
+      });
+      expect(wrapper.find('.file-name').text()).toBe('My Label');
+    });
+
+    it('shows "Untitled" when both filename and label are missing', () => {
+      const wrapper = mountComponent({
+        items: [{ id: '1', type: 'text', createdAt: Date.now(), versionCount: 1 }],
+      });
+      expect(wrapper.find('.file-name').text()).toBe('Untitled');
+    });
+  });
+
+  describe('click interaction', () => {
+    it('rows have cursor pointer style', () => {
+      const wrapper = mountComponent();
+      const rows = wrapper.findAll('.file-row');
+      // Verify rows exist and are styled as clickable
+      expect(rows.length).toBe(2);
+      expect(rows[0].classes()).toContain('file-row');
+    });
+
+    it('each row has unique key', () => {
+      const wrapper = mountComponent();
+      const rows = wrapper.findAll('.file-row');
+      // Each row should be present and distinct
+      expect(rows[0].text()).toContain('screenshot.png');
+      expect(rows[1].text()).toContain('design-spec.md');
+    });
+  });
+
+  describe('empty state', () => {
+    it('renders nothing when items array is empty', () => {
+      const wrapper = mountComponent({ items: [] });
+      expect(wrapper.findAll('.file-row').length).toBe(0);
+    });
+  });
+});

--- a/packages/web/src/components/CanvasFileList.vue
+++ b/packages/web/src/components/CanvasFileList.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="canvas-file-list">
+    <div
+      v-for="item in items"
+      :key="item.id"
+      class="file-row"
+      @click="$emit('select', item.id)"
+    >
+      <span class="file-icon">{{ getTypeIcon(item.type) }}</span>
+      <span class="file-name">{{ item.filename || item.label || 'Untitled' }}</span>
+      <span class="file-type">{{ item.type }}</span>
+      <span v-if="item.versionCount > 1" class="version-badge">
+        v{{ item.versionCount }}
+      </span>
+      <span class="file-time">{{ formatRelativeTime(item.createdAt) }}</span>
+      <span class="file-arrow">&#8250;</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  items: {
+    type: Array,
+    required: true,
+  },
+});
+
+defineEmits(['select']);
+
+function getTypeIcon(type) {
+  const icons = {
+    image: '📷',
+    markdown: '📄',
+    json: '📋',
+    text: '📝',
+  };
+  return icons[type] || '📁';
+}
+
+function formatRelativeTime(timestamp) {
+  const now = Date.now();
+  const diff = now - timestamp;
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return 'just now';
+}
+</script>
+
+<style scoped>
+.canvas-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background-color 0.15s;
+  min-height: 48px;
+}
+
+.file-row:hover {
+  background: var(--color-background-mute);
+}
+
+.file-icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.file-name {
+  flex: 1;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+  flex-shrink: 0;
+}
+
+.version-badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  background: var(--color-primary);
+  color: white;
+  border-radius: 9999px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.file-time {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  flex-shrink: 0;
+}
+
+.file-arrow {
+  color: var(--color-text-soft);
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* Mobile styles */
+@media (max-width: 640px) {
+  .file-row {
+    padding: 0.875rem 1rem;
+  }
+
+  .file-type {
+    display: none;
+  }
+}
+</style>

--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CanvasFileViewer from './CanvasFileViewer.vue';
+
+// Mock MarkdownViewer component
+vi.mock('./MarkdownViewer.vue', () => ({
+  default: {
+    name: 'MarkdownViewer',
+    props: ['content'],
+    template: '<div class="markdown-viewer-mock">{{ content }}</div>',
+  },
+}));
+
+describe('CanvasFileViewer', () => {
+  const baseItem = {
+    id: 'item-1',
+    filename: 'test-image.png',
+    type: 'image',
+    data: 'base64data',
+    mimeType: 'image/png',
+    createdAt: Date.now(),
+  };
+
+  const baseVersions = [
+    { id: 'item-1', filename: 'test-image.png', createdAt: Date.now() },
+    { id: 'item-2', filename: 'test-image.png', createdAt: Date.now() - 60000 },
+  ];
+
+  function mountComponent(props = {}) {
+    return mount(CanvasFileViewer, {
+      props: {
+        item: baseItem,
+        versions: [],
+        showBackButton: true,
+        ...props,
+      },
+    });
+  }
+
+  describe('basic rendering', () => {
+    it('displays the filename', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.viewer-filename').text()).toBe('test-image.png');
+    });
+
+    it('uses label when filename is missing', () => {
+      const wrapper = mountComponent({
+        item: { ...baseItem, filename: null, label: 'My Label' },
+      });
+      expect(wrapper.find('.viewer-filename').text()).toBe('My Label');
+    });
+
+    it('shows "Untitled" when both filename and label are missing', () => {
+      const wrapper = mountComponent({
+        item: { ...baseItem, filename: null, label: null },
+      });
+      expect(wrapper.find('.viewer-filename').text()).toBe('Untitled');
+    });
+  });
+
+  describe('back button', () => {
+    it('shows back button when showBackButton is true', () => {
+      const wrapper = mountComponent({ showBackButton: true });
+      expect(wrapper.find('.btn-back').exists()).toBe(true);
+    });
+
+    it('hides back button when showBackButton is false', () => {
+      const wrapper = mountComponent({ showBackButton: false });
+      expect(wrapper.find('.btn-back').exists()).toBe(false);
+    });
+
+    it('back button has click handler', () => {
+      const wrapper = mountComponent();
+      const backBtn = wrapper.find('.btn-back');
+      expect(backBtn.exists()).toBe(true);
+      // Button element is present and styled correctly
+      expect(backBtn.text()).toContain('Back');
+    });
+  });
+
+  describe('version dropdown', () => {
+    it('shows version dropdown when multiple versions exist', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      expect(wrapper.find('.version-dropdown').exists()).toBe(true);
+    });
+
+    it('hides version dropdown when only one version exists', () => {
+      const wrapper = mountComponent({ versions: [baseVersions[0]] });
+      expect(wrapper.find('.version-dropdown').exists()).toBe(false);
+    });
+
+    it('displays current version number', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      expect(wrapper.find('.version-dropdown summary').text()).toContain('v1');
+    });
+
+    it('lists all versions in dropdown', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      const versionItems = wrapper.findAll('.version-list li');
+      expect(versionItems.length).toBe(2);
+    });
+
+    it('marks current version in list', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      const currentItem = wrapper.find('.version-list li.active');
+      expect(currentItem.exists()).toBe(true);
+      expect(currentItem.text()).toContain('(current)');
+    });
+
+    it('version list items are clickable', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      const versionItems = wrapper.findAll('.version-list li');
+
+      // Verify each version item exists and shows correct info
+      expect(versionItems.length).toBe(2);
+      expect(versionItems[0].text()).toContain('v1');
+      expect(versionItems[1].text()).toContain('v2');
+    });
+  });
+
+  describe('delete dropdown', () => {
+    it('shows delete dropdown', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.delete-dropdown').exists()).toBe(true);
+    });
+
+    it('shows "Delete this version" option', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.delete-options').text()).toContain('Delete this version');
+    });
+
+    it('shows "Delete all versions" when multiple versions exist', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      expect(wrapper.find('.delete-options').text()).toContain('Delete all 2 versions');
+    });
+
+    it('hides "Delete all versions" when only one version exists', () => {
+      const wrapper = mountComponent({ versions: [baseVersions[0]] });
+      expect(wrapper.find('.delete-options').text()).not.toContain('Delete all');
+    });
+
+    it('delete options are interactive elements', () => {
+      const wrapper = mountComponent();
+      const deleteOptions = wrapper.findAll('.delete-options li');
+
+      // Verify delete option exists
+      expect(deleteOptions.length).toBeGreaterThanOrEqual(1);
+      expect(deleteOptions[0].text()).toContain('Delete this version');
+    });
+
+    it('delete all option exists when multiple versions', () => {
+      const wrapper = mountComponent({ versions: baseVersions });
+      const deleteAllOption = wrapper.find('.delete-options li.delete-all');
+
+      expect(deleteAllOption.exists()).toBe(true);
+      expect(deleteAllOption.text()).toContain('Delete all 2 versions');
+    });
+  });
+
+  describe('image content', () => {
+    it('renders image with correct src', () => {
+      const wrapper = mountComponent();
+      const img = wrapper.find('.viewer-image');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('data:image/png;base64,base64data');
+    });
+
+    it('uses label as alt text', () => {
+      const wrapper = mountComponent({
+        item: { ...baseItem, label: 'My Image' },
+      });
+      expect(wrapper.find('.viewer-image').attributes('alt')).toBe('My Image');
+    });
+  });
+
+  describe('markdown content', () => {
+    const markdownItem = {
+      ...baseItem,
+      type: 'markdown',
+      content: '# Hello World',
+    };
+
+    it('shows MarkdownViewer by default (preview mode)', () => {
+      const wrapper = mountComponent({ item: markdownItem });
+      expect(wrapper.find('.markdown-viewer-mock').exists()).toBe(true);
+      expect(wrapper.find('.viewer-markdown-raw').exists()).toBe(false);
+    });
+
+    it('shows preview toggle button for markdown', () => {
+      const wrapper = mountComponent({ item: markdownItem });
+      expect(wrapper.find('.preview-toggle').exists()).toBe(true);
+    });
+
+    it('hides preview toggle for non-markdown types', () => {
+      const wrapper = mountComponent(); // uses image type
+      expect(wrapper.find('.preview-toggle').exists()).toBe(false);
+    });
+
+    it('toggles between preview and raw mode', async () => {
+      const wrapper = mountComponent({ item: markdownItem });
+
+      // Initially in preview mode
+      expect(wrapper.find('.markdown-viewer-mock').exists()).toBe(true);
+
+      // Click toggle to switch to raw
+      await wrapper.find('.preview-toggle').trigger('click');
+      expect(wrapper.find('.viewer-markdown-raw').exists()).toBe(true);
+      expect(wrapper.find('.markdown-viewer-mock').exists()).toBe(false);
+
+      // Click toggle to switch back to preview
+      await wrapper.find('.preview-toggle').trigger('click');
+      expect(wrapper.find('.markdown-viewer-mock').exists()).toBe(true);
+      expect(wrapper.find('.viewer-markdown-raw').exists()).toBe(false);
+    });
+  });
+
+  describe('json content', () => {
+    const jsonItem = {
+      ...baseItem,
+      type: 'json',
+      data: '{"key":"value"}',
+    };
+
+    it('renders formatted JSON', () => {
+      const wrapper = mountComponent({ item: jsonItem });
+      const jsonContent = wrapper.find('.viewer-json');
+      expect(jsonContent.exists()).toBe(true);
+      expect(jsonContent.text()).toContain('"key"');
+      expect(jsonContent.text()).toContain('"value"');
+    });
+
+    it('handles invalid JSON gracefully', () => {
+      const wrapper = mountComponent({
+        item: { ...jsonItem, data: 'invalid json' },
+      });
+      expect(wrapper.find('.viewer-json').text()).toBe('invalid json');
+    });
+  });
+
+  describe('text content', () => {
+    const textItem = {
+      ...baseItem,
+      type: 'text',
+      content: 'Plain text content',
+    };
+
+    it('renders text content', () => {
+      const wrapper = mountComponent({ item: textItem });
+      expect(wrapper.find('.viewer-text').text()).toBe('Plain text content');
+    });
+  });
+});

--- a/packages/web/src/components/CanvasFileViewer.vue
+++ b/packages/web/src/components/CanvasFileViewer.vue
@@ -1,0 +1,457 @@
+<template>
+  <div class="canvas-file-viewer">
+    <!-- Header -->
+    <div class="viewer-header">
+      <div class="viewer-header-left">
+        <button
+          v-if="showBackButton"
+          class="btn-back"
+          @click="$emit('back')"
+        >
+          &#8249; Back
+        </button>
+        <span class="viewer-filename">{{ item.filename || item.label || 'Untitled' }}</span>
+      </div>
+
+      <div class="viewer-header-right">
+        <!-- Version dropdown -->
+        <details
+          v-if="versions.length > 1"
+          ref="versionDropdown"
+          class="version-dropdown"
+        >
+          <summary class="version-badge">
+            v{{ currentVersionIndex + 1 }}
+            <span class="dropdown-arrow">&#9662;</span>
+          </summary>
+          <ul class="version-list">
+            <li
+              v-for="(v, index) in versions"
+              :key="v.id"
+              :class="{ active: v.id === item.id }"
+              @click="selectVersion(v.id)"
+            >
+              <span class="version-number">v{{ index + 1 }}</span>
+              <span class="version-time">{{ formatRelativeTime(v.createdAt) }}</span>
+              <span v-if="v.id === item.id" class="version-current">(current)</span>
+            </li>
+          </ul>
+        </details>
+
+        <!-- Markdown preview toggle -->
+        <button
+          v-if="item.type === 'markdown'"
+          class="preview-toggle"
+          :class="{ active: previewMode }"
+          @click="previewMode = !previewMode"
+          :title="previewMode ? 'Show raw markdown' : 'Preview markdown'"
+        >
+          {{ previewMode ? 'Raw' : 'Preview' }}
+        </button>
+
+        <!-- Delete dropdown -->
+        <details ref="deleteDropdown" class="delete-dropdown">
+          <summary class="btn-delete" title="Delete">
+            &#128465;
+          </summary>
+          <ul class="delete-options">
+            <li @click="handleDeleteVersion">Delete this version</li>
+            <li
+              v-if="versions.length > 1"
+              class="delete-all"
+              @click="handleDeleteAll"
+            >
+              Delete all {{ versions.length }} versions
+            </li>
+          </ul>
+        </details>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div class="viewer-content">
+      <img
+        v-if="item.type === 'image'"
+        :src="`data:${item.mimeType};base64,${item.data}`"
+        :alt="item.label || 'Image'"
+        class="viewer-image"
+      />
+
+      <template v-else-if="item.type === 'markdown'">
+        <MarkdownViewer
+          v-if="previewMode"
+          :content="item.content"
+          class="viewer-markdown"
+        />
+        <pre v-else class="viewer-markdown-raw">{{ item.content }}</pre>
+      </template>
+
+      <pre v-else-if="item.type === 'json'" class="viewer-json">{{ formatJson(item.data) }}</pre>
+
+      <div v-else-if="item.type === 'text'" class="viewer-text">{{ item.content }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import MarkdownViewer from './MarkdownViewer.vue';
+
+const props = defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+  versions: {
+    type: Array,
+    default: () => [],
+  },
+  showBackButton: {
+    type: Boolean,
+    default: true,
+  },
+});
+
+const emit = defineEmits(['back', 'selectVersion', 'delete', 'deleteAll']);
+
+const previewMode = ref(true);
+const versionDropdown = ref(null);
+const deleteDropdown = ref(null);
+
+const currentVersionIndex = computed(() => {
+  const idx = props.versions.findIndex((v) => v.id === props.item.id);
+  return idx >= 0 ? idx : 0;
+});
+
+function formatRelativeTime(timestamp) {
+  const now = Date.now();
+  const diff = now - timestamp;
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return 'just now';
+}
+
+function formatJson(data) {
+  try {
+    return JSON.stringify(JSON.parse(data), null, 2);
+  } catch {
+    return data;
+  }
+}
+
+function selectVersion(itemId) {
+  // Close dropdown
+  if (versionDropdown.value) {
+    versionDropdown.value.open = false;
+  }
+  emit('selectVersion', itemId);
+}
+
+function handleDeleteVersion() {
+  // Close dropdown
+  if (deleteDropdown.value) {
+    deleteDropdown.value.open = false;
+  }
+  emit('delete', props.item.id);
+}
+
+function handleDeleteAll() {
+  // Close dropdown
+  if (deleteDropdown.value) {
+    deleteDropdown.value.open = false;
+  }
+  const filename = props.item.filename || props.item.label || props.item.id;
+  emit('deleteAll', filename);
+}
+</script>
+
+<style scoped>
+.canvas-file-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.viewer-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.viewer-header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.btn-back {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  min-height: 36px;
+}
+
+.btn-back:hover {
+  background: var(--color-background-mute);
+}
+
+.viewer-filename {
+  font-weight: 600;
+  font-size: 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Version dropdown */
+.version-dropdown {
+  position: relative;
+}
+
+.version-dropdown summary {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.6rem;
+  background: var(--color-primary);
+  color: white;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  min-height: 28px;
+}
+
+.version-dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.dropdown-arrow {
+  font-size: 0.6rem;
+}
+
+.version-list {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.25rem;
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  list-style: none;
+  padding: 0.25rem 0;
+  min-width: 160px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.version-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.version-list li:hover {
+  background: var(--color-background-mute);
+}
+
+.version-list li.active {
+  background: var(--color-background-mute);
+}
+
+.version-number {
+  font-weight: 600;
+}
+
+.version-time {
+  color: var(--color-text-soft);
+  font-size: 0.75rem;
+}
+
+.version-current {
+  color: var(--color-primary);
+  font-size: 0.75rem;
+}
+
+/* Preview toggle */
+.preview-toggle {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-soft);
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  font-size: 0.75rem;
+  min-height: 28px;
+}
+
+.preview-toggle:hover {
+  background: var(--color-background-mute);
+}
+
+.preview-toggle.active {
+  background: var(--color-background-mute);
+  color: var(--color-text);
+}
+
+/* Delete dropdown */
+.delete-dropdown {
+  position: relative;
+}
+
+.delete-dropdown summary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  list-style: none;
+  font-size: 1rem;
+}
+
+.delete-dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.delete-dropdown summary:hover {
+  background: var(--color-background-mute);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.delete-options {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.25rem;
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  list-style: none;
+  padding: 0.25rem 0;
+  min-width: 180px;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.delete-options li {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.delete-options li:hover {
+  background: var(--color-background-mute);
+}
+
+.delete-options li.delete-all {
+  color: var(--color-error);
+}
+
+.delete-options li.delete-all:hover {
+  background: rgba(248, 81, 73, 0.1);
+}
+
+/* Content area */
+.viewer-content {
+  flex: 1;
+  overflow: auto;
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 1rem;
+}
+
+.viewer-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--border-radius);
+}
+
+.viewer-markdown {
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.viewer-markdown-raw {
+  font-size: 0.8125rem;
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-family: var(--font-mono);
+}
+
+.viewer-json {
+  font-size: 0.8125rem;
+  margin: 0;
+  font-family: var(--font-mono);
+}
+
+.viewer-text {
+  white-space: pre-wrap;
+  font-size: 0.9375rem;
+}
+
+/* Mobile styles */
+@media (max-width: 640px) {
+  .viewer-header {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .btn-back {
+    min-height: 44px;
+    padding: 0.5rem 1rem;
+  }
+
+  .viewer-filename {
+    font-size: 0.875rem;
+  }
+
+  .version-dropdown summary,
+  .preview-toggle {
+    min-height: 36px;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .delete-dropdown summary {
+    width: 44px;
+    height: 44px;
+  }
+}
+</style>

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -30,57 +30,33 @@
       <p class="empty-state-hint">Claude can also add images, markdown, and JSON to the canvas.</p>
     </div>
 
-    <div v-else class="canvas-grid">
-      <div
-        v-for="item in canvasStore.items"
-        :key="item.id"
-        class="canvas-item card"
-      >
-        <div class="canvas-item-header">
-          <span class="canvas-item-type">{{ item.type }}</span>
-          <button
-            v-if="item.type === 'markdown'"
-            class="preview-toggle"
-            :class="{ active: previewMode[item.id] }"
-            @click="togglePreview(item.id)"
-            :title="previewMode[item.id] ? 'Show raw markdown' : 'Preview markdown'"
-          >
-            {{ previewMode[item.id] ? '📝 Raw' : '👁 Preview' }}
-          </button>
-          <button class="btn-icon" @click="handleDelete(item.id)" title="Delete">
-            &times;
-          </button>
-        </div>
+    <!-- Detail view (single file OR selected file) -->
+    <CanvasFileViewer
+      v-else-if="shouldShowViewer && selectedItem"
+      :item="selectedItem"
+      :versions="selectedVersions"
+      :showBackButton="showBackButton"
+      @back="handleBack"
+      @selectVersion="handleSelectVersion"
+      @delete="handleDelete"
+      @deleteAll="handleDeleteAll"
+    />
 
-        <div class="canvas-item-label" v-if="item.label">{{ item.label }}</div>
-
-        <div class="canvas-item-content">
-          <img
-            v-if="item.type === 'image'"
-            :src="`data:${item.mimeType};base64,${item.data}`"
-            :alt="item.label || 'Image'"
-            class="canvas-image"
-          />
-
-          <template v-else-if="item.type === 'markdown'">
-            <MarkdownViewer v-if="previewMode[item.id]" :content="item.content" class="canvas-markdown" />
-            <pre v-else class="canvas-markdown-raw">{{ item.content }}</pre>
-          </template>
-
-          <pre v-else-if="item.type === 'json'" class="canvas-json">{{ formatJson(item.data) }}</pre>
-
-          <div v-else-if="item.type === 'text'" class="canvas-text">{{ item.content }}</div>
-        </div>
-      </div>
-    </div>
+    <!-- List view (multiple files, none selected) -->
+    <CanvasFileList
+      v-else
+      :items="groupedItems"
+      @select="handleSelect"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useCanvasStore } from '../stores/canvas.js';
 import { useUiStore } from '../stores/ui.js';
-import MarkdownViewer from './MarkdownViewer.vue';
+import CanvasFileList from './CanvasFileList.vue';
+import CanvasFileViewer from './CanvasFileViewer.vue';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -90,46 +66,100 @@ const props = defineProps({
 
 const canvasStore = useCanvasStore();
 const uiStore = useUiStore();
-const previewMode = ref({});
 const fileInput = ref(null);
 const isDragOver = ref(false);
 const uploading = ref(false);
 
-// Initialize preview mode to true (preview by default) for markdown items
+// Computed properties for list/detail view logic
+const groupedItems = computed(() => canvasStore.groupedItems);
+const selectedItem = computed(() => canvasStore.selectedItem);
+const selectedVersions = computed(() => canvasStore.selectedItemVersions);
+
+const shouldShowViewer = computed(() => {
+  return groupedItems.value.length === 1 || canvasStore.selectedItemId !== null;
+});
+
+const showBackButton = computed(() => {
+  return groupedItems.value.length > 1;
+});
+
+// Auto-select when only one file group exists
 watch(
-  () => canvasStore.items,
-  (items) => {
-    items.forEach((item) => {
-      if (item.type === 'markdown' && previewMode.value[item.id] === undefined) {
-        previewMode.value[item.id] = true;
-      }
-    });
+  () => groupedItems.value,
+  (groups) => {
+    if (groups.length === 1 && !canvasStore.selectedItemId) {
+      canvasStore.selectItem(groups[0].id);
+    }
+    // Clear selection if the selected item no longer exists
+    if (canvasStore.selectedItemId && !canvasStore.selectedItem) {
+      canvasStore.clearSelection();
+    }
   },
   { immediate: true }
 );
 
-function togglePreview(itemId) {
-  previewMode.value[itemId] = !previewMode.value[itemId];
+// Navigation handlers
+function handleSelect(itemId) {
+  canvasStore.selectItem(itemId);
 }
 
-function formatJson(data) {
+function handleBack() {
+  canvasStore.clearSelection();
+}
+
+function handleSelectVersion(itemId) {
+  canvasStore.selectItem(itemId);
+}
+
+// Delete handlers
+async function handleDelete(itemId) {
+  if (!confirm('Delete this version?')) return;
+
   try {
-    return JSON.stringify(JSON.parse(data), null, 2);
-  } catch {
-    return data;
+    // Get next version to select before deleting
+    const versions = selectedVersions.value;
+    const currentIndex = versions.findIndex((v) => v.id === itemId);
+    let nextItemId = null;
+
+    if (versions.length > 1) {
+      // Select next version (or previous if deleting last)
+      const nextIndex = currentIndex < versions.length - 1 ? currentIndex + 1 : currentIndex - 1;
+      nextItemId = versions[nextIndex]?.id;
+    }
+
+    await canvasStore.deleteItem(props.sessionId, itemId);
+
+    if (nextItemId) {
+      canvasStore.selectItem(nextItemId);
+    }
+
+    uiStore.success('Version deleted');
+  } catch (err) {
+    uiStore.error(err.message);
   }
 }
 
+async function handleDeleteAll(filename) {
+  if (!confirm(`Delete all versions of "${filename}"?`)) return;
+
+  try {
+    await canvasStore.deleteGroup(props.sessionId, filename);
+    uiStore.success('All versions deleted');
+  } catch (err) {
+    uiStore.error(err.message);
+  }
+}
+
+// File upload handlers
 function triggerFileInput() {
   fileInput.value?.click();
 }
 
-function handleDragOver(event) {
+function handleDragOver() {
   isDragOver.value = true;
 }
 
 function handleDragLeave(event) {
-  // Only set to false if we're leaving the canvas-tab element
   if (!event.currentTarget.contains(event.relatedTarget)) {
     isDragOver.value = false;
   }
@@ -148,12 +178,10 @@ async function handleFileSelect(event) {
   if (files && files.length > 0) {
     await uploadFile(files[0]);
   }
-  // Reset file input so same file can be selected again
   event.target.value = '';
 }
 
 async function uploadFile(file) {
-  // Check file size
   if (file.size > MAX_FILE_SIZE) {
     uiStore.error(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`);
     return;
@@ -161,23 +189,21 @@ async function uploadFile(file) {
 
   uploading.value = true;
   try {
-    await canvasStore.uploadItem(props.sessionId, file, file.name);
+    const item = await canvasStore.uploadItem(props.sessionId, file, file.name);
     uiStore.success(`Uploaded ${file.name}`);
+
+    // If we're viewing a file with the same name, stay on viewer with the new version
+    if (selectedItem.value) {
+      const selectedFilename = selectedItem.value.filename || selectedItem.value.label || selectedItem.value.id;
+      const uploadedFilename = item.filename || item.label || item.id;
+      if (selectedFilename === uploadedFilename) {
+        canvasStore.selectItem(item.id);
+      }
+    }
   } catch (err) {
     uiStore.error(`Upload failed: ${err.message}`);
   } finally {
     uploading.value = false;
-  }
-}
-
-async function handleDelete(itemId) {
-  if (!confirm('Delete this canvas item?')) return;
-
-  try {
-    await canvasStore.deleteItem(props.sessionId, itemId);
-    uiStore.success('Canvas item deleted');
-  } catch (err) {
-    uiStore.error(err.message);
   }
 }
 </script>
@@ -227,83 +253,27 @@ async function handleDelete(itemId) {
   opacity: 0.8;
 }
 
-.canvas-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1rem;
+/* Mobile styles */
+@media (max-width: 640px) {
+  .canvas-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .canvas-header .btn-primary {
+    flex: 1;
+    min-height: 44px;
+  }
+
+  .drag-hint {
+    display: none;
+  }
 }
 
-.canvas-item {
-  overflow: hidden;
-}
-
-.canvas-item-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.canvas-item-type {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-  text-transform: uppercase;
-}
-
-.btn-icon {
-  background: none;
-  border: none;
-  color: var(--color-text-soft);
-  font-size: 1.25rem;
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-}
-
-.btn-icon:hover {
-  color: var(--color-error);
-}
-
-.canvas-item-label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-}
-
-.canvas-item-content {
-  max-height: 400px;
-  overflow: auto;
-}
-
-.canvas-image {
-  max-width: 100%;
-  height: auto;
-  border-radius: var(--border-radius);
-}
-
-.canvas-markdown {
-  font-size: 0.875rem;
-}
-
-.canvas-markdown-raw {
-  font-size: 0.75rem;
-  margin: 0;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-/* Preview toggle button - layout only (base styles in main.css) */
-.preview-toggle {
-  margin-left: auto;
-}
-
-.canvas-json {
-  font-size: 0.75rem;
-  margin: 0;
-}
-
-.canvas-text {
-  white-space: pre-wrap;
-  font-size: 0.875rem;
+/* Hide drag hint on touch devices */
+@media (hover: none) {
+  .drag-hint {
+    display: none;
+  }
 }
 </style>

--- a/packages/web/src/stores/canvas.js
+++ b/packages/web/src/stores/canvas.js
@@ -4,9 +4,44 @@ import { api } from '../composables/useApi.js';
 export const useCanvasStore = defineStore('canvas', {
   state: () => ({
     items: [],
+    selectedItemId: null,
     loading: false,
     error: null,
   }),
+
+  getters: {
+    // Group items by filename, return latest of each with version info
+    groupedItems: (state) => {
+      const groups = {};
+      for (const item of state.items) {
+        const key = item.filename || item.label || item.id;
+        if (!groups[key]) groups[key] = [];
+        groups[key].push(item);
+      }
+      return Object.values(groups)
+        .map((versions) => {
+          versions.sort((a, b) => b.createdAt - a.createdAt);
+          return {
+            ...versions[0],
+            versionCount: versions.length,
+            allVersions: versions,
+          };
+        })
+        .sort((a, b) => b.createdAt - a.createdAt);
+    },
+
+    selectedItem: (state) => state.items.find((i) => i.id === state.selectedItemId),
+
+    // Get all versions for the selected item's filename
+    selectedItemVersions: (state) => {
+      const selected = state.items.find((i) => i.id === state.selectedItemId);
+      if (!selected) return [];
+      const key = selected.filename || selected.label || selected.id;
+      return state.items
+        .filter((i) => (i.filename || i.label || i.id) === key)
+        .sort((a, b) => b.createdAt - a.createdAt);
+    },
+  },
 
   actions: {
     async fetchItems(sessionId) {
@@ -26,9 +61,22 @@ export const useCanvasStore = defineStore('canvas', {
       try {
         await api.deleteCanvasItem(sessionId, itemId);
         this.items = this.items.filter((i) => i.id !== itemId);
+        // Clear selection if deleted item was selected
+        if (this.selectedItemId === itemId) {
+          this.selectedItemId = null;
+        }
       } catch (err) {
         this.error = err.message;
         throw err;
+      }
+    },
+
+    async deleteGroup(sessionId, filename) {
+      const toDelete = this.items.filter(
+        (i) => (i.filename || i.label || i.id) === filename
+      );
+      for (const item of toDelete) {
+        await this.deleteItem(sessionId, item.id);
       }
     },
 
@@ -53,6 +101,18 @@ export const useCanvasStore = defineStore('canvas', {
 
     removeItem(itemId) {
       this.items = this.items.filter((i) => i.id !== itemId);
+      // Clear selection if removed item was selected
+      if (this.selectedItemId === itemId) {
+        this.selectedItemId = null;
+      }
+    },
+
+    selectItem(itemId) {
+      this.selectedItemId = itemId;
+    },
+
+    clearSelection() {
+      this.selectedItemId = null;
     },
   },
 });

--- a/packages/web/src/stores/canvas.test.js
+++ b/packages/web/src/stores/canvas.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useCanvasStore } from './canvas.js';
+
+// Mock the API module
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getCanvasItems: vi.fn(),
+    uploadCanvasItem: vi.fn(),
+    deleteCanvasItem: vi.fn(),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+
+describe('Canvas Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  describe('state', () => {
+    it('has correct initial state', () => {
+      const store = useCanvasStore();
+      expect(store.items).toEqual([]);
+      expect(store.selectedItemId).toBeNull();
+      expect(store.loading).toBe(false);
+      expect(store.error).toBeNull();
+    });
+  });
+
+  describe('groupedItems getter', () => {
+    it('groups items by filename', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png', createdAt: 1000 },
+        { id: '2', filename: 'test.png', createdAt: 2000 },
+        { id: '3', filename: 'other.png', createdAt: 3000 },
+      ];
+
+      const grouped = store.groupedItems;
+      expect(grouped.length).toBe(2);
+
+      // Find the test.png group (should have latest version first)
+      const testGroup = grouped.find((g) => g.filename === 'test.png');
+      expect(testGroup).toBeTruthy();
+      expect(testGroup.id).toBe('2'); // Latest version
+      expect(testGroup.versionCount).toBe(2);
+      expect(testGroup.allVersions.length).toBe(2);
+    });
+
+    it('groups items by label when filename is missing', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', label: 'My Label', createdAt: 1000 },
+        { id: '2', label: 'My Label', createdAt: 2000 },
+      ];
+
+      const grouped = store.groupedItems;
+      expect(grouped.length).toBe(1);
+      expect(grouped[0].versionCount).toBe(2);
+    });
+
+    it('uses id as fallback when filename and label are missing', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', createdAt: 1000 },
+        { id: '2', createdAt: 2000 },
+      ];
+
+      const grouped = store.groupedItems;
+      expect(grouped.length).toBe(2); // Each item is its own group
+    });
+
+    it('sorts groups by createdAt descending (newest first)', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'old.png', createdAt: 1000 },
+        { id: '2', filename: 'new.png', createdAt: 3000 },
+        { id: '3', filename: 'middle.png', createdAt: 2000 },
+      ];
+
+      const grouped = store.groupedItems;
+      expect(grouped[0].filename).toBe('new.png');
+      expect(grouped[1].filename).toBe('middle.png');
+      expect(grouped[2].filename).toBe('old.png');
+    });
+
+    it('sorts versions within groups by createdAt descending', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png', createdAt: 1000 },
+        { id: '2', filename: 'test.png', createdAt: 3000 },
+        { id: '3', filename: 'test.png', createdAt: 2000 },
+      ];
+
+      const grouped = store.groupedItems;
+      expect(grouped[0].allVersions[0].id).toBe('2'); // newest
+      expect(grouped[0].allVersions[1].id).toBe('3'); // middle
+      expect(grouped[0].allVersions[2].id).toBe('1'); // oldest
+    });
+  });
+
+  describe('selectedItem getter', () => {
+    it('returns the selected item', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png' },
+        { id: '2', filename: 'other.png' },
+      ];
+      store.selectedItemId = '2';
+
+      expect(store.selectedItem).toEqual({ id: '2', filename: 'other.png' });
+    });
+
+    it('returns undefined when no item is selected', () => {
+      const store = useCanvasStore();
+      store.items = [{ id: '1', filename: 'test.png' }];
+      store.selectedItemId = null;
+
+      expect(store.selectedItem).toBeUndefined();
+    });
+
+    it('returns undefined when selected item does not exist', () => {
+      const store = useCanvasStore();
+      store.items = [{ id: '1', filename: 'test.png' }];
+      store.selectedItemId = 'nonexistent';
+
+      expect(store.selectedItem).toBeUndefined();
+    });
+  });
+
+  describe('selectedItemVersions getter', () => {
+    it('returns all versions for the selected item filename', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png', createdAt: 1000 },
+        { id: '2', filename: 'test.png', createdAt: 2000 },
+        { id: '3', filename: 'other.png', createdAt: 3000 },
+      ];
+      store.selectedItemId = '1';
+
+      const versions = store.selectedItemVersions;
+      expect(versions.length).toBe(2);
+      expect(versions[0].id).toBe('2'); // newest first
+      expect(versions[1].id).toBe('1');
+    });
+
+    it('returns empty array when no item is selected', () => {
+      const store = useCanvasStore();
+      store.items = [{ id: '1', filename: 'test.png' }];
+      store.selectedItemId = null;
+
+      expect(store.selectedItemVersions).toEqual([]);
+    });
+  });
+
+  describe('selectItem action', () => {
+    it('sets selectedItemId', () => {
+      const store = useCanvasStore();
+      store.selectItem('item-123');
+      expect(store.selectedItemId).toBe('item-123');
+    });
+  });
+
+  describe('clearSelection action', () => {
+    it('clears selectedItemId', () => {
+      const store = useCanvasStore();
+      store.selectedItemId = 'item-123';
+      store.clearSelection();
+      expect(store.selectedItemId).toBeNull();
+    });
+  });
+
+  describe('deleteItem action', () => {
+    it('removes item from items array', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png' },
+        { id: '2', filename: 'other.png' },
+      ];
+
+      api.deleteCanvasItem.mockResolvedValue();
+
+      await store.deleteItem('session-1', '1');
+
+      expect(store.items.length).toBe(1);
+      expect(store.items[0].id).toBe('2');
+    });
+
+    it('clears selection if deleted item was selected', async () => {
+      const store = useCanvasStore();
+      store.items = [{ id: '1', filename: 'test.png' }];
+      store.selectedItemId = '1';
+
+      api.deleteCanvasItem.mockResolvedValue();
+
+      await store.deleteItem('session-1', '1');
+
+      expect(store.selectedItemId).toBeNull();
+    });
+
+    it('does not clear selection if different item was deleted', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png' },
+        { id: '2', filename: 'other.png' },
+      ];
+      store.selectedItemId = '1';
+
+      api.deleteCanvasItem.mockResolvedValue();
+
+      await store.deleteItem('session-1', '2');
+
+      expect(store.selectedItemId).toBe('1');
+    });
+  });
+
+  describe('deleteGroup action', () => {
+    it('deletes all items with the same filename', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'test.png' },
+        { id: '2', filename: 'test.png' },
+        { id: '3', filename: 'other.png' },
+      ];
+
+      api.deleteCanvasItem.mockResolvedValue();
+
+      await store.deleteGroup('session-1', 'test.png');
+
+      expect(api.deleteCanvasItem).toHaveBeenCalledTimes(2);
+      expect(api.deleteCanvasItem).toHaveBeenCalledWith('session-1', '1');
+      expect(api.deleteCanvasItem).toHaveBeenCalledWith('session-1', '2');
+      expect(store.items.length).toBe(1);
+      expect(store.items[0].id).toBe('3');
+    });
+
+    it('uses label for grouping when filename is missing', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', label: 'My File' },
+        { id: '2', label: 'My File' },
+        { id: '3', label: 'Other' },
+      ];
+
+      api.deleteCanvasItem.mockResolvedValue();
+
+      await store.deleteGroup('session-1', 'My File');
+
+      expect(api.deleteCanvasItem).toHaveBeenCalledTimes(2);
+      expect(store.items.length).toBe(1);
+    });
+  });
+
+  describe('removeItem action', () => {
+    it('removes item and clears selection if selected', () => {
+      const store = useCanvasStore();
+      store.items = [{ id: '1', filename: 'test.png' }];
+      store.selectedItemId = '1';
+
+      store.removeItem('1');
+
+      expect(store.items.length).toBe(0);
+      expect(store.selectedItemId).toBeNull();
+    });
+  });
+
+  describe('uploadItem action', () => {
+    it('adds new item to front of items array', async () => {
+      const store = useCanvasStore();
+      store.items = [{ id: '1', filename: 'existing.png' }];
+
+      const newItem = { id: '2', filename: 'new.png' };
+      api.uploadCanvasItem.mockResolvedValue(newItem);
+
+      const result = await store.uploadItem('session-1', new File([], 'new.png'), 'new.png');
+
+      expect(store.items.length).toBe(2);
+      expect(store.items[0]).toEqual(newItem);
+      expect(result).toEqual(newItem);
+    });
+  });
+});

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -26,7 +26,7 @@ test.describe('Canvas Management', () => {
     await expect(page.getByRole('button', { name: 'Upload File' })).toBeVisible();
   });
 
-  test('displays canvas items', async ({ page }) => {
+  test('displays single canvas item directly in viewer (no list)', async ({ page }) => {
     const item = await seedCanvasItem(session.id, {
       type: 'markdown',
       content: '# Test Markdown',
@@ -35,9 +35,14 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    // Verify item label and type are visible
-    await expect(page.getByText('Test Label')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('markdown')).toBeVisible();
+    // Single item should show directly in viewer (not in list)
+    await expect(page.locator('.viewer-filename')).toContainText('Test Label');
+
+    // Back button should NOT be visible (only one item)
+    await expect(page.locator('.btn-back')).not.toBeVisible();
+
+    // Upload button should still be visible
+    await expect(page.getByRole('button', { name: 'Upload File' })).toBeVisible();
 
     // Verify via API that the item exists with correct data
     const items = await getCanvasItems(session.id);
@@ -46,6 +51,76 @@ test.describe('Canvas Management', () => {
     expect(items[0].type).toBe('markdown');
     expect(items[0].label).toBe('Test Label');
     expect(items[0].content).toBe('# Test Markdown');
+  });
+
+  test('displays file list when multiple items exist', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'markdown',
+      content: '# First',
+      label: 'First Item',
+    });
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Second content',
+      label: 'Second Item',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Should show list view with both items
+    await expect(page.locator('.file-row')).toHaveCount(2);
+    await expect(page.getByText('First Item')).toBeVisible();
+    await expect(page.getByText('Second Item')).toBeVisible();
+  });
+
+  test('clicking list item opens viewer', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'markdown',
+      content: '# First',
+      label: 'First Item',
+    });
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Second content',
+      label: 'Second Item',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Click on first item
+    await page.locator('.file-row').filter({ hasText: 'First Item' }).click();
+
+    // Should show viewer with back button
+    await expect(page.locator('.viewer-filename')).toContainText('First Item');
+    await expect(page.locator('.btn-back')).toBeVisible();
+  });
+
+  test('back button returns to list view', async ({ page }) => {
+    await seedCanvasItem(session.id, {
+      type: 'markdown',
+      content: '# First',
+      label: 'First Item',
+    });
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Second content',
+      label: 'Second Item',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Click on first item to open viewer
+    await page.locator('.file-row').filter({ hasText: 'First Item' }).click();
+    await expect(page.locator('.viewer-filename')).toBeVisible();
+
+    // Click back button
+    await page.locator('.btn-back').click();
+
+    // Should show list view again
+    await expect(page.locator('.file-row')).toHaveCount(2);
   });
 
   test('markdown items default to preview mode and can toggle to raw', async ({ page }) => {
@@ -58,21 +133,20 @@ test.describe('Canvas Management', () => {
     await page.goto(`/sessions/${session.id}/canvas`);
 
     // Should be in preview mode by default - shows rendered markdown
-    const canvasItem = page.locator('.canvas-item').first();
-    await expect(canvasItem.locator('.markdown-viewer')).toBeVisible();
-    await expect(canvasItem.locator('.canvas-markdown-raw')).not.toBeVisible();
+    await expect(page.locator('.markdown-viewer')).toBeVisible();
+    await expect(page.locator('.viewer-markdown-raw')).not.toBeVisible();
 
     // Preview toggle button should show "Raw" option (since we're in preview mode)
-    const toggleButton = canvasItem.locator('.preview-toggle');
+    const toggleButton = page.locator('.preview-toggle');
     await expect(toggleButton).toContainText('Raw');
 
     // Click to switch to raw mode
     await toggleButton.click();
 
     // Should now show raw markdown
-    await expect(canvasItem.locator('.canvas-markdown-raw')).toBeVisible();
-    await expect(canvasItem.locator('.markdown-viewer')).not.toBeVisible();
-    await expect(canvasItem.locator('.canvas-markdown-raw')).toContainText('# Heading');
+    await expect(page.locator('.viewer-markdown-raw')).toBeVisible();
+    await expect(page.locator('.markdown-viewer')).not.toBeVisible();
+    await expect(page.locator('.viewer-markdown-raw')).toContainText('# Heading');
 
     // Toggle button should now show "Preview" option
     await expect(toggleButton).toContainText('Preview');
@@ -81,8 +155,8 @@ test.describe('Canvas Management', () => {
     await toggleButton.click();
 
     // Should be back in preview mode
-    await expect(canvasItem.locator('.markdown-viewer')).toBeVisible();
-    await expect(canvasItem.locator('.canvas-markdown-raw')).not.toBeVisible();
+    await expect(page.locator('.markdown-viewer')).toBeVisible();
+    await expect(page.locator('.viewer-markdown-raw')).not.toBeVisible();
   });
 
   test('markdown items render properly with MarkdownViewer', async ({ page }) => {
@@ -94,15 +168,13 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    const canvasItem = page.locator('.canvas-item').first();
-
     // Verify markdown is rendered (not raw)
-    await expect(canvasItem.locator('.markdown-viewer h1')).toContainText('Main Heading');
-    await expect(canvasItem.locator('.markdown-viewer ul li').first()).toContainText('List item 1');
-    await expect(canvasItem.locator('.markdown-viewer pre code')).toContainText('const x = 1;');
+    await expect(page.locator('.markdown-viewer h1')).toContainText('Main Heading');
+    await expect(page.locator('.markdown-viewer ul li').first()).toContainText('List item 1');
+    await expect(page.locator('.markdown-viewer pre code')).toContainText('const x = 1;');
   });
 
-  test('can delete canvas item', async ({ page }) => {
+  test('can delete single canvas item', async ({ page }) => {
     const item = await seedCanvasItem(session.id, {
       type: 'text',
       content: 'Delete me',
@@ -115,14 +187,14 @@ test.describe('Canvas Management', () => {
     expect(items[0].id).toBe(item.id);
 
     await page.goto(`/sessions/${session.id}/canvas`);
-    await expect(page.getByText('To Delete')).toBeVisible();
+    await expect(page.locator('.viewer-filename')).toContainText('To Delete');
 
     // Handle confirmation dialog
     page.on('dialog', (dialog) => dialog.accept());
-    await page.click('button[title="Delete"]');
 
-    // Verify not visible in UI
-    await expect(page.getByText('To Delete')).not.toBeVisible();
+    // Open delete dropdown and click delete
+    await page.locator('.delete-dropdown summary').click();
+    await page.getByText('Delete this version').click();
 
     // Verify empty state is shown
     await expect(page.getByText('No canvas items yet')).toBeVisible();
@@ -132,7 +204,7 @@ test.describe('Canvas Management', () => {
     expect(items.length).toBe(0);
   });
 
-  test('displays different canvas item types', async ({ page }) => {
+  test('displays different canvas item types in list', async ({ page }) => {
     const textItem = await seedCanvasItem(session.id, {
       type: 'text',
       content: 'Plain text content',
@@ -147,11 +219,11 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    // Verify both items are visible with correct labels and types
+    // Verify both items are visible in list with correct labels and types
     await expect(page.getByText('Text Item')).toBeVisible();
     await expect(page.getByText('JSON Item')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('text')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('json')).toBeVisible();
+    await expect(page.locator('.file-type').getByText('text')).toBeVisible();
+    await expect(page.locator('.file-type').getByText('json')).toBeVisible();
 
     // Verify via API that both items exist with correct types
     const items = await getCanvasItems(session.id);
@@ -169,7 +241,7 @@ test.describe('Canvas Management', () => {
     expect(JSON.parse(apiJsonItem.content)).toEqual({ key: 'value' });
   });
 
-  test('image renders correctly when using data and mimeType fields', async ({ page }) => {
+  test('image renders correctly in viewer when using data and mimeType fields', async ({ page }) => {
     await seedCanvasItem(session.id, {
       type: 'image',
       data: TEST_PNG_BASE64,
@@ -179,12 +251,11 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    // Verify the image label and type are visible
-    await expect(page.getByText('Test Image')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible();
+    // Should be in viewer directly (single item)
+    await expect(page.locator('.viewer-filename')).toContainText('Test Image');
 
     // Verify the image renders correctly (not broken)
-    const image = page.locator('.canvas-image');
+    const image = page.locator('.viewer-image');
     await expect(image).toBeVisible();
 
     // Check that the image has loaded successfully by verifying naturalWidth > 0
@@ -203,12 +274,11 @@ test.describe('Canvas Management', () => {
 
     await page.goto(`/sessions/${session.id}/canvas`);
 
-    // Verify the image label and type are visible
-    await expect(page.getByText('Data URL Image')).toBeVisible();
-    await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible();
+    // Should be in viewer directly (single item)
+    await expect(page.locator('.viewer-filename')).toContainText('Data URL Image');
 
     // Verify the image renders correctly (not broken)
-    const image = page.locator('.canvas-image');
+    const image = page.locator('.viewer-image');
     await expect(image).toBeVisible();
 
     // Check that the image has loaded successfully by verifying naturalWidth > 0
@@ -228,7 +298,7 @@ test.describe('Canvas Management', () => {
     await page.goto(`/sessions/${session.id}/canvas`);
 
     // Verify the image element is present
-    const image = page.locator('.canvas-image');
+    const image = page.locator('.viewer-image');
     await expect(image).toBeVisible();
 
     // Check that the image is broken (naturalWidth === 0 for broken images)
@@ -257,12 +327,11 @@ test.describe('Canvas Management', () => {
 
       await page.goto(`/sessions/${session.id}/canvas`);
 
-      // Verify the image label and type are visible
-      await expect(page.getByText('File Path Image')).toBeVisible();
-      await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible();
+      // Should be in viewer directly (single item)
+      await expect(page.locator('.viewer-filename')).toContainText('File Path Image');
 
       // Verify the image renders correctly (not broken)
-      const image = page.locator('.canvas-image');
+      const image = page.locator('.viewer-image');
       await expect(image).toBeVisible();
 
       // Check that the image has loaded successfully by verifying naturalWidth > 0
@@ -377,14 +446,11 @@ test.describe('Canvas Management', () => {
       buffer: pngBuffer,
     });
 
-    // Wait for upload to complete - look for the image type indicator
-    await expect(page.locator('.canvas-item-type').getByText('image')).toBeVisible({ timeout: 10000 });
+    // Wait for upload to complete - should show in viewer (single item)
+    await expect(page.locator('.viewer-filename')).toContainText('test-image.png', { timeout: 10000 });
 
     // Empty state should be gone
     await expect(page.getByText('No canvas items yet')).not.toBeVisible();
-
-    // Verify the label is displayed (filename) - use specific selector to avoid matching toast
-    await expect(page.locator('.canvas-item-label').getByText('test-image.png')).toBeVisible();
 
     // Verify via API
     const items = await getCanvasItems(session.id);
@@ -392,5 +458,122 @@ test.describe('Canvas Management', () => {
     expect(items[0].type).toBe('image');
     expect(items[0].mimeType).toBe('image/png');
     expect(items[0].label).toBe('test-image.png');
+  });
+
+  test('version grouping: shows version badge in list for files with same name', async ({ page }) => {
+    // Upload multiple versions of the same file
+    await seedCanvasItem(session.id, {
+      type: 'image',
+      data: TEST_PNG_BASE64,
+      mimeType: 'image/png',
+      filename: 'screenshot.png',
+      label: 'screenshot.png',
+    });
+
+    // Wait a bit to ensure different createdAt
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await seedCanvasItem(session.id, {
+      type: 'image',
+      data: TEST_PNG_BASE64,
+      mimeType: 'image/png',
+      filename: 'screenshot.png',
+      label: 'screenshot.png',
+    });
+
+    // Add another file
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Other content',
+      filename: 'other.txt',
+      label: 'other.txt',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Should show list with 2 groups (screenshot.png with v2, other.txt with no badge)
+    const rows = page.locator('.file-row');
+    await expect(rows).toHaveCount(2);
+
+    // Find the screenshot row and verify it has version badge
+    const screenshotRow = page.locator('.file-row').filter({ hasText: 'screenshot.png' });
+    await expect(screenshotRow.locator('.version-badge')).toContainText('v2');
+
+    // Other.txt should not have version badge
+    const otherRow = page.locator('.file-row').filter({ hasText: 'other.txt' });
+    await expect(otherRow.locator('.version-badge')).not.toBeVisible();
+  });
+
+  test('version dropdown: can switch between versions', async ({ page }) => {
+    // Upload multiple versions of the same file
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Version 1 content',
+      filename: 'doc.txt',
+      label: 'doc.txt',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Version 2 content',
+      filename: 'doc.txt',
+      label: 'doc.txt',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Single group, should show viewer directly
+    await expect(page.locator('.viewer-filename')).toContainText('doc.txt');
+
+    // Should show version dropdown with v1 (newest)
+    const versionDropdown = page.locator('.version-dropdown');
+    await expect(versionDropdown).toBeVisible();
+    await expect(versionDropdown.locator('summary')).toContainText('v1');
+
+    // Content should be latest version
+    await expect(page.locator('.viewer-text')).toContainText('Version 2 content');
+
+    // Open dropdown and switch to older version
+    await versionDropdown.locator('summary').click();
+    await page.locator('.version-list li').nth(1).click();
+
+    // Content should now be older version
+    await expect(page.locator('.viewer-text')).toContainText('Version 1 content');
+    await expect(versionDropdown.locator('summary')).toContainText('v2');
+  });
+
+  test('delete all versions: removes entire file group', async ({ page }) => {
+    // Upload multiple versions of the same file
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Version 1',
+      filename: 'doc.txt',
+      label: 'doc.txt',
+    });
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Version 2',
+      filename: 'doc.txt',
+      label: 'doc.txt',
+    });
+
+    await page.goto(`/sessions/${session.id}/canvas`);
+
+    // Handle confirmation dialog
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Open delete dropdown and click "Delete all versions"
+    await page.locator('.delete-dropdown summary').click();
+    await page.getByText('Delete all 2 versions').click();
+
+    // Should show empty state
+    await expect(page.getByText('No canvas items yet')).toBeVisible();
+
+    // Verify via API
+    const items = await getCanvasItems(session.id);
+    expect(items.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Refactors canvas from grid layout to list/detail view for optimized screen space
- Adds version grouping by filename - files with the same name are grouped with version badges
- Single file automatically shows in full-width viewer; multiple files show compact list
- Adds version dropdown to switch between file versions in the viewer
- Supports deleting single version or all versions of a file
- Mobile-friendly design with prominent upload button and touch-friendly controls

## Changes
- **New components**:
  - `CanvasFileList.vue` - Compact list view showing files with type icons, version badges, and timestamps
  - `CanvasFileViewer.vue` - Full-width detail viewer with version dropdown and delete options
- **Modified components**:
  - `CanvasTab.vue` - Orchestrates list/detail pattern, auto-selects single file
  - `stores/canvas.js` - Added selection state, grouping getters, and delete group action
- **Tests**:
  - Added unit tests for canvas store
  - Added component tests for CanvasFileList and CanvasFileViewer
  - Updated e2e tests for new UI structure

## Test plan
- [ ] Empty state shows upload prompt with prominent button
- [ ] Single file auto-shows detail view with upload button visible
- [ ] Multiple files show list, click navigates to detail
- [ ] Back button returns to list (hidden when single file)
- [ ] Version badge shows correct count for files with same name
- [ ] Version dropdown switches between versions
- [ ] Delete single version works
- [ ] Delete all versions works and returns to list
- [ ] Upload works via button tap on mobile
- [ ] Layout looks good on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)