### PR TITLE
Remove Active Sessions heading from global session list

### DIFF
--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -3,7 +3,6 @@
     <div class="page-header">
       <div>
         <router-link to="/" class="back-link">&larr; Projects</router-link>
-        <h1>Active Sessions</h1>
         <p class="page-description">Sessions that are running or waiting for input</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Removes the redundant `<h1>Active Sessions</h1>` heading from the global sessions list view
- The page context is already provided by navigation and the description text

## Test plan
- [ ] Navigate to the Sessions page from the top nav
- [ ] Verify the "Active Sessions" heading is no longer displayed
- [ ] Verify the description "Sessions that are running or waiting for input" is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)