### PR TITLE
Fix start-server.sh killing main server from worktrees

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -96,9 +96,10 @@ fi
 # Auto-kill any process on port 5000 if that's our target port
 #
 # Kill existing process on port 5000 to avoid conflicts when restarting.
-# Only applies when the script needs port 5000 specifically.
+# Only applies when running from the MAIN repo (not a worktree).
+# Worktrees should never kill port 5000 as that belongs to the main repo.
 # -----------------------------------------------------------------------------
-if [ "$SELECTED_PORT" == "5000" ]; then
+if [ "$SELECTED_PORT" == "5000" ] && ! is_worktree; then
     PID_5000=$(lsof -t -i:5000 2>/dev/null)
     if [ -n "$PID_5000" ]; then
         echo "Killing existing process $PID_5000 on port 5000..."


### PR DESCRIPTION
## Summary
- Fixes a bug where running `start-server.sh` from a git worktree would kill the main repository's server on port 5000
- The issue occurred when `PORT=5000` was set in the environment, which bypassed worktree detection before reaching the auto-kill logic
- Now the auto-kill for port 5000 only executes when running from the main repo (not a worktree)

## Test plan
- [ ] Run `start-server.sh` from main repo - should still auto-kill existing process on port 5000
- [ ] Run `start-server.sh` from a worktree with `PORT=5000` set - should fail gracefully with "Port 5000 is already in use" instead of killing the main server
- [ ] Run `start-server.sh` from a worktree without PORT set - should auto-assign port 5001+

🤖 Generated with [Claude Code](https://claude.com/claude-code)