### PR TITLE
Fix canvas view file version numbering to show latest as highest

### DIFF
--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -91,7 +91,8 @@ describe('CanvasFileViewer', () => {
 
     it('displays current version number', () => {
       const wrapper = mountComponent({ versions: baseVersions });
-      expect(wrapper.find('.version-dropdown summary').text()).toContain('v1');
+      // Current item is at index 0, so version number is versions.length - 0 = 2
+      expect(wrapper.find('.version-dropdown summary').text()).toContain('v2');
     });
 
     it('lists all versions in dropdown', () => {
@@ -112,9 +113,10 @@ describe('CanvasFileViewer', () => {
       const versionItems = wrapper.findAll('.version-list li');
 
       // Verify each version item exists and shows correct info
+      // Newest version (index 0) should have highest version number
       expect(versionItems.length).toBe(2);
-      expect(versionItems[0].text()).toContain('v1');
-      expect(versionItems[1].text()).toContain('v2');
+      expect(versionItems[0].text()).toContain('v2');
+      expect(versionItems[1].text()).toContain('v1');
     });
   });
 

--- a/packages/web/src/components/CanvasFileViewer.vue
+++ b/packages/web/src/components/CanvasFileViewer.vue
@@ -21,7 +21,7 @@
           class="version-dropdown"
         >
           <summary class="version-badge">
-            v{{ currentVersionIndex + 1 }}
+            v{{ versions.length - currentVersionIndex }}
             <span class="dropdown-arrow">&#9662;</span>
           </summary>
           <ul class="version-list">
@@ -31,7 +31,7 @@
               :class="{ active: v.id === item.id }"
               @click="selectVersion(v.id)"
             >
-              <span class="version-number">v{{ index + 1 }}</span>
+              <span class="version-number">v{{ versions.length - index }}</span>
               <span class="version-time">{{ formatRelativeTime(v.createdAt) }}</span>
               <span v-if="v.id === item.id" class="version-current">(current)</span>
             </li>

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -527,10 +527,10 @@ test.describe('Canvas Management', () => {
     // Single group, should show viewer directly
     await expect(page.locator('.viewer-filename')).toContainText('doc.txt');
 
-    // Should show version dropdown with v1 (newest)
+    // Should show version dropdown with v2 (newest has highest version number)
     const versionDropdown = page.locator('.version-dropdown');
     await expect(versionDropdown).toBeVisible();
-    await expect(versionDropdown.locator('summary')).toContainText('v1');
+    await expect(versionDropdown.locator('summary')).toContainText('v2');
 
     // Content should be latest version
     await expect(page.locator('.viewer-text')).toContainText('Version 2 content');
@@ -541,7 +541,7 @@ test.describe('Canvas Management', () => {
 
     // Content should now be older version
     await expect(page.locator('.viewer-text')).toContainText('Version 1 content');
-    await expect(versionDropdown.locator('summary')).toContainText('v2');
+    await expect(versionDropdown.locator('summary')).toContainText('v1');
   });
 
   test('delete all versions: removes entire file group', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fixed backwards version numbering in canvas file viewer where newest version was displayed as v1
- Changed calculation from `index + 1` to `versions.length - index` so oldest version is v1 and newest has highest number
- Updated tests to reflect correct version ordering behavior

## Test plan
- [x] Run `npm test -- CanvasFileViewer` - all 27 tests pass
- [ ] Manually verify in canvas view that newest file version shows highest version number
- [ ] Verify version dropdown lists versions with newest having highest number

🤖 Generated with [Claude Code](https://claude.com/claude-code)