### PR TITLE
Add changes indicator dot to Changes tab

### DIFF
--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -28,6 +28,7 @@ vi.mock('../composables/useWebSocket.js', () => ({
     onCanvasRemove: vi.fn(() => vi.fn()),
     onTodosUpdate: vi.fn(() => vi.fn()),
     onSessionUpdate: vi.fn(() => vi.fn()),
+    onSummaryUpdate: vi.fn(() => vi.fn()),
   })),
 }));
 
@@ -53,6 +54,17 @@ vi.mock('../stores/ui.js', () => ({
     success: vi.fn(),
     error: vi.fn(),
   })),
+}));
+
+// Mock the API - use object reference so value can be changed between tests
+let mockChangesResult = { staged: '', unstaged: '', untracked: '' };
+const mockGetSessionChanges = vi.fn(() => Promise.resolve(mockChangesResult));
+const mockGetSessionSummary = vi.fn(() => Promise.resolve(null));
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getSessionChanges: (...args) => mockGetSessionChanges(...args),
+    getSessionSummary: (...args) => mockGetSessionSummary(...args),
+  },
 }));
 
 // Mock child components to avoid their internal dependencies
@@ -87,6 +99,23 @@ describe('SessionDetailView', () => {
     mockRouteParams.id = 'test-session-id';
     mockRouteParams.tab = 'conversation';
 
+    // Reset API mocks with default returns
+    mockChangesResult = { staged: '', unstaged: '', untracked: '' };
+
+    // Reset useSessionSubscription to default mock
+    useSessionSubscription.mockImplementation(() => ({
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      onStatus: vi.fn(() => vi.fn()),
+      onMessage: vi.fn(() => vi.fn()),
+      onError: vi.fn(() => vi.fn()),
+      onCanvasAdd: vi.fn(() => vi.fn()),
+      onCanvasRemove: vi.fn(() => vi.fn()),
+      onTodosUpdate: vi.fn(() => vi.fn()),
+      onSessionUpdate: vi.fn(() => vi.fn()),
+      onSummaryUpdate: vi.fn(() => vi.fn()),
+    }));
+
     mockSessionsStore = {
       loading: false,
       currentSession: {
@@ -100,6 +129,7 @@ describe('SessionDetailView', () => {
       },
       fetchSession: vi.fn(),
       fetchMessages: vi.fn(),
+      fetchWorkLogs: vi.fn(),
       deleteSession: vi.fn(),
       updateSessionStatus: vi.fn(),
       addMessage: vi.fn(),
@@ -209,7 +239,7 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      expect(wrapper.find('.session-mode').text()).toBe('standard');
+      expect(wrapper.find('.session-mode').text()).toBe('Standard');
     });
 
     it('shows PR link when prUrl is set', async () => {
@@ -311,6 +341,7 @@ describe('SessionDetailView', () => {
         onCanvasRemove: vi.fn(() => vi.fn()),
         onTodosUpdate: vi.fn(() => vi.fn()),
         onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
       }));
 
       const wrapper = mountComponent();
@@ -331,5 +362,93 @@ describe('SessionDetailView', () => {
         'completed'
       );
     });
+  });
+
+  describe('changes indicator', () => {
+    it('does not show changes indicator when hasChanges is false', async () => {
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // With default empty changes, indicator should not be visible
+      expect(wrapper.find('.changes-indicator').exists()).toBe(false);
+    });
+
+    it('checks for changes on mount', async () => {
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(mockGetSessionChanges).toHaveBeenCalledWith('test-session-id');
+    });
+
+    it('checks for changes when status changes to waiting', async () => {
+      let capturedOnStatusCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn((callback) => {
+          capturedOnStatusCallback = callback;
+          return vi.fn();
+        }),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Clear initial call
+      mockGetSessionChanges.mockClear();
+
+      // Trigger status change to 'waiting'
+      if (capturedOnStatusCallback) {
+        capturedOnStatusCallback('waiting');
+      }
+      await flushPromises();
+
+      expect(mockGetSessionChanges).toHaveBeenCalledWith('test-session-id');
+    });
+
+    it('checks for changes when status changes to completed', async () => {
+      let capturedOnStatusCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn((callback) => {
+          capturedOnStatusCallback = callback;
+          return vi.fn();
+        }),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Clear initial call
+      mockGetSessionChanges.mockClear();
+
+      // Trigger status change to 'completed'
+      if (capturedOnStatusCallback) {
+        capturedOnStatusCallback('completed');
+      }
+      await flushPromises();
+
+      expect(mockGetSessionChanges).toHaveBeenCalledWith('test-session-id');
+    });
+
   });
 });

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -61,6 +61,11 @@
             :class="['tab', { active: activeTab === tab.id }]"
           >
             {{ tab.label }}
+            <span
+              v-if="tab.id === 'changes' && hasChanges"
+              class="changes-indicator"
+              title="Uncommitted changes"
+            ></span>
           </router-link>
         </div>
 
@@ -68,7 +73,7 @@
         <div class="tabs-mobile">
           <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
             <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
-              {{ tab.label }}
+              {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' •' : '' }}
             </option>
           </select>
         </div>
@@ -134,6 +139,19 @@ let cleanups = [];
 const pollIntervalId = ref(null);
 const showDeleteConfirm = ref(false);
 const summary = ref(null);
+const hasChanges = ref(false);
+
+// Check for file system changes (staged, unstaged, untracked)
+async function checkForChanges() {
+  if (!sessionId) return;
+  try {
+    const changes = await api.getSessionChanges(sessionId);
+    hasChanges.value = !!(changes.staged || changes.unstaged || changes.untracked);
+  } catch (error) {
+    // Silently fail - changes indicator is not critical
+    console.error('Failed to check for changes:', error);
+  }
+}
 
 // Poll for updates while session is actively processing (fallback for race conditions)
 function startPolling() {
@@ -190,6 +208,9 @@ onMounted(async () => {
     // Ignore errors - summary may not exist yet
   });
 
+  // Check for file system changes initially
+  checkForChanges();
+
   // Start polling if session is actively processing (handles race condition where session
   // completes before WebSocket subscription is established)
   const status = sessionsStore.currentSession?.status;
@@ -205,6 +226,10 @@ onMounted(async () => {
         startPolling();
       } else {
         stopPolling();
+        // Check for changes when session becomes idle (after conversation returns)
+        if (status === 'waiting' || status === 'completed') {
+          checkForChanges();
+        }
       }
     })
   );
@@ -352,5 +377,15 @@ async function handleDelete() {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+}
+
+.changes-indicator {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-warning, #d29922);
+  border-radius: 50%;
+  margin-left: 4px;
+  vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
## Summary

- Added a visual indicator dot to the Changes tab that shows when there are uncommitted file system changes
- The indicator appears when there are staged, unstaged, or untracked changes
- Refreshes automatically after every conversation return (when status becomes 'waiting' or 'completed')
- Also displays in the mobile dropdown with a bullet character (•)

## Test plan

- [ ] Verify the dot appears on the Changes tab when there are uncommitted changes
- [ ] Verify the dot disappears when all changes are committed or reverted
- [ ] Verify the dot updates after Claude makes file modifications and the session becomes idle
- [ ] Verify the mobile dropdown shows the bullet indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)