### PR TITLE
Add periodic PR status polling and Changes tab file count badge

### DIFF
--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -17,6 +17,7 @@ export class ProjectRepository extends BaseRepository {
       systemPrompt: row.system_prompt,
       onSessionCreated: row.on_session_created,
       onSessionDeleted: row.on_session_deleted,
+      prPollInterval: row.pr_poll_interval,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -25,13 +26,13 @@ export class ProjectRepository extends BaseRepository {
   create(name, workingDirectory, systemPrompt = null, options = {}) {
     const id = databaseManager.generateId();
     const now = Date.now();
-    const { onSessionCreated = null, onSessionDeleted = null } = options;
+    const { onSessionCreated = null, onSessionDeleted = null, prPollInterval = 60000 } = options;
     this.db
       .prepare(
-        `INSERT INTO projects (id, name, working_directory, system_prompt, on_session_created, on_session_deleted, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO projects (id, name, working_directory, system_prompt, on_session_created, on_session_deleted, pr_poll_interval, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
-      .run(id, name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, now, now);
+      .run(id, name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, prPollInterval, now, now);
     return this.getById(id);
   }
 
@@ -63,6 +64,10 @@ export class ProjectRepository extends BaseRepository {
     if (data.onSessionDeleted !== undefined) {
       updates.push('on_session_deleted = ?');
       values.push(data.onSessionDeleted);
+    }
+    if (data.prPollInterval !== undefined) {
+      updates.push('pr_poll_interval = ?');
+      values.push(data.prPollInterval);
     }
 
     if (updates.length === 0) return this.getById(id);

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -55,6 +55,20 @@ describe('ProjectRepository', () => {
       expect(project.onSessionCreated).toBeNull();
       expect(project.onSessionDeleted).toBeNull();
     });
+
+    it('creates project with default prPollInterval of 60000', () => {
+      const project = repo.create('Test Project', '/tmp/test');
+
+      expect(project.prPollInterval).toBe(60000);
+    });
+
+    it('creates project with custom prPollInterval', () => {
+      const project = repo.create('Test Project', '/tmp/test', null, {
+        prPollInterval: 30000,
+      });
+
+      expect(project.prPollInterval).toBe(30000);
+    });
   });
 
   describe('getById', () => {
@@ -181,6 +195,17 @@ describe('ProjectRepository', () => {
 
       expect(updated.onSessionCreated).toBeNull();
       expect(updated.onSessionDeleted).toBeNull();
+    });
+
+    it('updates prPollInterval', () => {
+      const project = repo.create('Test', '/tmp/test');
+      expect(project.prPollInterval).toBe(60000);
+
+      const updated = repo.update(project.id, {
+        prPollInterval: 120000,
+      });
+
+      expect(updated.prPollInterval).toBe(120000);
     });
   });
 

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -4,6 +4,7 @@ import { createApp } from './app.js';
 import { initDatabase } from './database.js';
 import { initWebSocket } from './websocket.js';
 import { DEFAULT_SERVER_PORT } from '@claudetools/shared';
+import * as prStatusService from './services/prStatusService.js';
 
 const { values } = parseArgs({
   options: {
@@ -39,6 +40,28 @@ const server = createServer(app);
 
 // Initialize WebSocket for app
 initWebSocket(server);
+
+// Start PR status polling service
+prStatusService.start();
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, shutting down gracefully');
+  prStatusService.stop();
+  server.close(() => {
+    console.log('Server closed');
+    process.exit(0);
+  });
+});
+
+process.on('SIGINT', () => {
+  console.log('SIGINT received, shutting down gracefully');
+  prStatusService.stop();
+  server.close(() => {
+    console.log('Server closed');
+    process.exit(0);
+  });
+});
 
 // Start server on all interfaces
 server.listen(port, '0.0.0.0', () => {

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS projects (
   system_prompt TEXT,
   on_session_created TEXT,
   on_session_deleted TEXT,
+  pr_poll_interval INTEGER NOT NULL DEFAULT 60000,  -- PR status poll interval in ms (default 1 minute)
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/server/src/services/prStatusService.js
+++ b/packages/server/src/services/prStatusService.js
@@ -1,0 +1,170 @@
+import { sessions, sessionSummaries } from '../database.js';
+import { webSocketManager, broadcastToSession } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import * as ghService from './ghService.js';
+
+// Default polling interval in milliseconds (1 minute)
+const DEFAULT_POLL_INTERVAL_MS = 60000;
+
+// PR states that don't need further polling (PR is done)
+const FINAL_PR_STATES = ['merged', 'closed'];
+
+// Session states that should have their PRs polled (allowlist for future-proofing)
+// When 'archived' is added, it won't be in this list
+const ACTIVE_SESSION_STATES = ['running', 'waiting'];
+
+// Polling interval handle
+let pollIntervalId = null;
+
+/**
+ * Start the PR status polling service
+ */
+export function start() {
+  if (pollIntervalId) {
+    console.log('[PrStatusService] Already running');
+    return;
+  }
+
+  console.log('[PrStatusService] Starting PR status polling');
+  pollIntervalId = setInterval(pollLoop, DEFAULT_POLL_INTERVAL_MS);
+
+  // Run immediately on start
+  pollLoop();
+}
+
+/**
+ * Stop the PR status polling service
+ */
+export function stop() {
+  if (pollIntervalId) {
+    clearInterval(pollIntervalId);
+    pollIntervalId = null;
+    console.log('[PrStatusService] Stopped PR status polling');
+  }
+}
+
+/**
+ * Get all sessions with PRs that should be checked
+ * @returns {Array<{sessionId: string, prUrl: string}>}
+ */
+export function getSessionsToCheck() {
+  const subscriptions = webSocketManager.getSessionSubscriptions();
+  const result = [];
+
+  for (const sessionId of subscriptions.keys()) {
+    // Check if there are active subscribers
+    const subscribers = subscriptions.get(sessionId);
+    if (!subscribers || subscribers.size === 0) continue;
+
+    const session = sessions.getById(sessionId);
+
+    // Skip if session not found
+    if (!session) continue;
+
+    // Skip if no PR URL
+    if (!session.prUrl) continue;
+
+    // Skip if session is not in an active state (future-proofs for 'archived')
+    if (!ACTIVE_SESSION_STATES.includes(session.status)) continue;
+
+    // Skip if PR is in a final state (merged/closed)
+    const summary = sessionSummaries.getBySessionId(sessionId);
+    if (summary?.prState && FINAL_PR_STATES.includes(summary.prState)) continue;
+
+    result.push({ sessionId, prUrl: session.prUrl });
+  }
+
+  return result;
+}
+
+/**
+ * Normalize boolean values for comparison (handles null/undefined/false equivalence)
+ * SQLite stores booleans as 0/1, and the repository maps 0 to null in some cases.
+ * This ensures null, undefined, and false are all treated as equivalent.
+ * @param {boolean|null|undefined} value
+ * @returns {boolean}
+ */
+function normalizeBool(value) {
+  return Boolean(value);
+}
+
+/**
+ * Check and update PR status for a single session
+ * @param {string} sessionId
+ * @param {string} prUrl
+ * @returns {Promise<boolean>} Whether status was updated
+ */
+export async function checkPrStatus(sessionId, prUrl) {
+  try {
+    const prInfo = await ghService.getPrInfo(prUrl);
+    if (!prInfo) return false;
+
+    const currentSummary = sessionSummaries.getBySessionId(sessionId);
+
+    // Check if anything changed
+    // Note: Use normalizeBool for boolean fields because SQLite stores 0/1 and
+    // the repository maps 0 to null, so we need to treat null/false as equivalent
+    const hasChanged =
+      currentSummary?.prState !== prInfo.state ||
+      normalizeBool(currentSummary?.prMerged) !== normalizeBool(prInfo.merged) ||
+      normalizeBool(currentSummary?.hasMergeConflicts) !== normalizeBool(prInfo.hasMergeConflicts) ||
+      currentSummary?.ciStatus !== prInfo.ciStatus ||
+      JSON.stringify(currentSummary?.ciFailures || []) !== JSON.stringify(prInfo.ciFailures || []);
+
+    if (!hasChanged) return false;
+
+    // Build update data
+    const updateData = {
+      prState: prInfo.state,
+      prMerged: prInfo.merged,
+      hasMergeConflicts: prInfo.hasMergeConflicts,
+      ciStatus: prInfo.ciStatus,
+      ciFailures: prInfo.ciFailures,
+    };
+
+    // If no summary exists, provide required fields for creation
+    if (!currentSummary) {
+      updateData.shortSummary = 'PR status pending summary generation';
+      updateData.fullSummary = 'Summary will be generated when session activity occurs.';
+    }
+
+    // Update database
+    const updatedSummary = sessionSummaries.upsert(sessionId, updateData);
+
+    // Broadcast change
+    broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_SUMMARY_UPDATED, {
+      sessionId,
+      summary: updatedSummary,
+    });
+
+    console.log(`[PrStatusService] Updated PR status for session ${sessionId}: ${prInfo.state}`);
+    return true;
+  } catch (error) {
+    console.error(`[PrStatusService] Error checking PR for session ${sessionId}:`, error.message);
+    return false;
+  }
+}
+
+/**
+ * Main polling loop - called every interval
+ */
+async function pollLoop() {
+  const sessionsToCheck = getSessionsToCheck();
+
+  if (sessionsToCheck.length === 0) return;
+
+  console.log(`[PrStatusService] Checking ${sessionsToCheck.length} session(s) with PRs`);
+
+  // Check sequentially to avoid hammering GitHub API
+  for (const { sessionId, prUrl } of sessionsToCheck) {
+    await checkPrStatus(sessionId, prUrl);
+  }
+}
+
+// Export for testing
+export {
+  DEFAULT_POLL_INTERVAL_MS,
+  FINAL_PR_STATES,
+  ACTIVE_SESSION_STATES,
+  pollLoop,
+};

--- a/packages/server/src/services/prStatusService.test.js
+++ b/packages/server/src/services/prStatusService.test.js
@@ -1,0 +1,438 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { projects, sessions, sessionSummaries } from '../database.js';
+
+// Mock the websocket module
+vi.mock('../websocket.js', () => ({
+  webSocketManager: {
+    getSessionSubscriptions: vi.fn(() => new Map()),
+  },
+  broadcastToSession: vi.fn(),
+}));
+
+// Mock ghService
+vi.mock('./ghService.js', () => ({
+  getPrInfo: vi.fn(),
+}));
+
+// Import after mock setup
+import * as prStatusService from './prStatusService.js';
+import { webSocketManager, broadcastToSession } from '../websocket.js';
+import * as ghService from './ghService.js';
+import {
+  DEFAULT_POLL_INTERVAL_MS,
+  FINAL_PR_STATES,
+  ACTIVE_SESSION_STATES,
+  getSessionsToCheck,
+  checkPrStatus,
+} from './prStatusService.js';
+
+describe('prStatusService', () => {
+  let projectId;
+  let sessionId;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create test project and session with PR URL
+    const project = projects.create('Test Project', '/tmp/test');
+    projectId = project.id;
+
+    const session = sessions.create(projectId, 'Test Session', 'Initial prompt', 'standard');
+    sessionId = session.id;
+  });
+
+  afterEach(() => {
+    prStatusService.stop();
+  });
+
+  describe('constants', () => {
+    it('has a 60 second default poll interval', () => {
+      expect(DEFAULT_POLL_INTERVAL_MS).toBe(60000);
+    });
+
+    it('has merged and closed as final PR states', () => {
+      expect(FINAL_PR_STATES).toEqual(['merged', 'closed']);
+    });
+
+    it('has running and waiting as active session states', () => {
+      expect(ACTIVE_SESSION_STATES).toEqual(['running', 'waiting']);
+    });
+  });
+
+  describe('getSessionsToCheck', () => {
+    it('returns empty array when no subscriptions', () => {
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('returns sessions with PRs that have subscribers', () => {
+      // Update session to have PR URL and be in waiting state
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Mock subscription with active subscriber
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([{ sessionId, prUrl: 'https://github.com/org/repo/pull/123' }]);
+    });
+
+    it('excludes sessions without PR URLs', () => {
+      // Session has no PR URL
+      sessions.update(sessionId, { status: 'waiting' });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('excludes sessions not in active states (completed)', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'completed' });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('excludes sessions not in active states (stopped)', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'stopped' });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('excludes sessions not in active states (error)', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'error' });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('includes sessions in running state', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'running' });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
+    });
+
+    it('includes sessions in waiting state', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
+    });
+
+    it('excludes sessions with merged PRs', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Create summary with merged PR
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'merged',
+      });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('excludes sessions with closed PRs', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Create summary with closed PR
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'closed',
+      });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('includes sessions with open PRs', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Create summary with open PR
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'open',
+      });
+
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes subscriptions with no active subscribers', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Mock subscription with empty set
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set());
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('checkPrStatus', () => {
+    const prUrl = 'https://github.com/org/repo/pull/123';
+
+    beforeEach(() => {
+      sessions.update(sessionId, { prUrl, status: 'waiting' });
+    });
+
+    it('returns false when ghService returns null', async () => {
+      ghService.getPrInfo.mockResolvedValue(null);
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(false);
+      expect(broadcastToSession).not.toHaveBeenCalled();
+    });
+
+    it('returns false when status unchanged', async () => {
+      // Create existing summary
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'open',
+        prMerged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
+
+      // Mock same status from GitHub
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(false);
+      expect(broadcastToSession).not.toHaveBeenCalled();
+    });
+
+    it('updates DB and broadcasts when PR state changes', async () => {
+      // Create existing summary with open PR
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'open',
+        prMerged: false,
+      });
+
+      // Mock merged status from GitHub
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'merged',
+        merged: true,
+        hasMergeConflicts: false,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(true);
+
+      // Check DB was updated
+      const summary = sessionSummaries.getBySessionId(sessionId);
+      expect(summary.prState).toBe('merged');
+      expect(summary.prMerged).toBe(true);
+
+      // Check broadcast was called
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        sessionId,
+        'session:summary_updated',
+        expect.objectContaining({
+          sessionId,
+          summary: expect.objectContaining({
+            prState: 'merged',
+          }),
+        })
+      );
+    });
+
+    it('updates when CI status changes', async () => {
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'open',
+        ciStatus: 'pending',
+      });
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(true);
+
+      const summary = sessionSummaries.getBySessionId(sessionId);
+      expect(summary.ciStatus).toBe('success');
+    });
+
+    it('updates when merge conflicts appear', async () => {
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'open',
+        hasMergeConflicts: false,
+      });
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: true,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(true);
+
+      const summary = sessionSummaries.getBySessionId(sessionId);
+      expect(summary.hasMergeConflicts).toBe(true);
+    });
+
+    it('updates when CI failures change', async () => {
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Test',
+        fullSummary: 'Test summary',
+        prState: 'open',
+        ciStatus: 'failure',
+        ciFailures: ['test-1'],
+      });
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'failure',
+        ciFailures: ['test-1', 'test-2'],
+      });
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(true);
+
+      const summary = sessionSummaries.getBySessionId(sessionId);
+      expect(summary.ciFailures).toEqual(['test-1', 'test-2']);
+    });
+
+    it('handles errors gracefully', async () => {
+      ghService.getPrInfo.mockRejectedValue(new Error('API error'));
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(false);
+      expect(broadcastToSession).not.toHaveBeenCalled();
+    });
+
+    it('creates summary if none exists and status changes', async () => {
+      // No existing summary
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'pending',
+        ciFailures: [],
+      });
+
+      const result = await checkPrStatus(sessionId, prUrl);
+      expect(result).toBe(true);
+
+      const summary = sessionSummaries.getBySessionId(sessionId);
+      expect(summary.prState).toBe('open');
+    });
+  });
+
+  describe('polling lifecycle', () => {
+    it('start() begins polling', () => {
+      vi.useFakeTimers();
+
+      prStatusService.start();
+
+      // Verify interval is set (by advancing time and checking if pollLoop would be called)
+      expect(() => vi.advanceTimersByTime(DEFAULT_POLL_INTERVAL_MS)).not.toThrow();
+
+      vi.useRealTimers();
+    });
+
+    it('stop() clears interval', () => {
+      vi.useFakeTimers();
+
+      prStatusService.start();
+      prStatusService.stop();
+
+      // Should not throw or cause issues when advancing time
+      expect(() => vi.advanceTimersByTime(DEFAULT_POLL_INTERVAL_MS * 5)).not.toThrow();
+
+      vi.useRealTimers();
+    });
+
+    it('start() is idempotent', () => {
+      prStatusService.start();
+      prStatusService.start(); // Should not throw or create multiple intervals
+      prStatusService.stop();
+    });
+  });
+
+  describe('future-proofing for archived state', () => {
+    it('would exclude archived sessions (if state existed)', () => {
+      // This test documents the intended behavior when 'archived' is added
+      // Currently we can't actually set status to 'archived' due to CHECK constraint
+      // But the logic should work because 'archived' is not in ACTIVE_SESSION_STATES
+
+      expect(ACTIVE_SESSION_STATES).not.toContain('archived');
+
+      // If a session somehow had status 'archived', it would be excluded
+      // because !ACTIVE_SESSION_STATES.includes('archived') === true
+    });
+  });
+});

--- a/packages/shared/src/contracts/projects.js
+++ b/packages/shared/src/contracts/projects.js
@@ -6,6 +6,7 @@ export const CreateProjectRequest = z.object({
   systemPrompt: z.string().optional(),
   onSessionCreated: z.string().nullable().optional(),
   onSessionDeleted: z.string().nullable().optional(),
+  prPollInterval: z.number().int().min(10000).optional(), // Min 10 seconds
 });
 
 export const UpdateProjectRequest = z.object({
@@ -14,6 +15,7 @@ export const UpdateProjectRequest = z.object({
   systemPrompt: z.string().nullable().optional(),
   onSessionCreated: z.string().nullable().optional(),
   onSessionDeleted: z.string().nullable().optional(),
+  prPollInterval: z.number().int().min(10000).optional(), // Min 10 seconds
 });
 
 export const ProjectResponse = z.object({
@@ -23,6 +25,7 @@ export const ProjectResponse = z.object({
   systemPrompt: z.string().nullable(),
   onSessionCreated: z.string().nullable(),
   onSessionDeleted: z.string().nullable(),
+  prPollInterval: z.number().int(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -289,4 +289,92 @@ describe('ChangesTab', () => {
 
     expect(wrapper.text()).toContain('No git changes to show');
   });
+
+  describe('fileCount', () => {
+    it('computes fileCount as sum of all file types', async () => {
+      const stagedDiff = [
+        'diff --git a/staged1.js b/staged1.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/staged1.js',
+        '+++ b/staged1.js',
+        '@@ -1,2 +1,3 @@',
+        ' const x = 1;',
+        '+const y = 2;',
+      ].join('\n');
+
+      const unstagedDiff = [
+        'diff --git a/unstaged1.js b/unstaged1.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/unstaged1.js',
+        '+++ b/unstaged1.js',
+        '@@ -1,2 +1,3 @@',
+        ' const a = 1;',
+        '+const b = 2;',
+        'diff --git a/unstaged2.js b/unstaged2.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/unstaged2.js',
+        '+++ b/unstaged2.js',
+        '@@ -1,2 +1,3 @@',
+        ' const c = 1;',
+        '+const d = 2;',
+      ].join('\n');
+
+      const untrackedDiff = [
+        'diff --git a/new.js b/new.js',
+        'new file mode 100644',
+        '--- /dev/null',
+        '+++ b/new.js',
+        '@@ -0,0 +1 @@',
+        '+console.log("new");',
+      ].join('\n');
+
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiff,
+        unstaged: unstagedDiff,
+        untracked: untrackedDiff,
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // 1 staged + 2 unstaged + 1 untracked = 4
+      expect(wrapper.vm.fileCount).toBe(4);
+    });
+
+    it('returns 1 when single staged file', async () => {
+      const stagedDiff = [
+        'diff --git a/file.js b/file.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/file.js',
+        '+++ b/file.js',
+        '@@ -1,2 +1,3 @@',
+        ' const x = 1;',
+        '+const y = 2;',
+      ].join('\n');
+
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiff,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.fileCount).toBe(1);
+    });
+
+    it('returns 0 when no changes', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.fileCount).toBe(0);
+    });
+  });
 });

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { api } from '../api/ApiClient.js';
 import { parseDiff } from '../utils/diffParser.js';
 import DiffViewer from './DiffViewer.vue';
@@ -47,6 +47,8 @@ import DiffViewer from './DiffViewer.vue';
 const props = defineProps({
   sessionId: { type: String, required: true },
 });
+
+const emit = defineEmits(['update:fileCount']);
 
 const staged = ref('');
 const unstaged = ref('');
@@ -63,6 +65,12 @@ const stagedFiles = computed(() => parseDiff(staged.value));
 const unstagedFiles = computed(() => parseDiff(unstaged.value));
 const untrackedFiles = computed(() => parseDiff(untracked.value));
 const hasChanges = computed(() => staged.value || unstaged.value || untracked.value);
+const fileCount = computed(
+  () => stagedFiles.value.length + unstagedFiles.value.length + untrackedFiles.value.length
+);
+
+// Emit file count whenever it changes
+watch(fileCount, (count) => emit('update:fileCount', count), { immediate: true });
 
 function toggleAllFiles() {
   if (allExpanded.value) {
@@ -108,6 +116,7 @@ defineExpose({
   stagedFiles,
   unstagedFiles,
   untrackedFiles,
+  fileCount,
 });
 </script>
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -77,7 +77,7 @@
       <div class="tab-content">
         <SummaryTab v-if="activeTab === 'summary'" :session-id="route.params.id" />
         <ConversationTab v-else-if="activeTab === 'conversation'" :session-id="route.params.id" />
-        <ChangesTab v-else-if="activeTab === 'changes'" :session-id="route.params.id" />
+        <ChangesTab v-else-if="activeTab === 'changes'" :session-id="route.params.id" @update:file-count="changesFileCount = $event" />
         <CanvasTab v-else-if="activeTab === 'canvas'" :session-id="route.params.id" />
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
       </div>
@@ -114,14 +114,15 @@ const uiStore = useUiStore();
 const sessionId = route.params.id;
 
 const activeTab = computed(() => route.params.tab || 'conversation');
+const changesFileCount = ref(0);
 
-const tabs = [
+const tabs = computed(() => [
   { id: 'summary', label: 'Summary' },
   { id: 'conversation', label: 'Conversation' },
-  { id: 'changes', label: 'Changes' },
+  { id: 'changes', label: changesFileCount.value > 0 ? `Changes (${changesFileCount.value})` : 'Changes' },
   { id: 'canvas', label: 'Canvas' },
   { id: 'notes', label: 'Notes' }
-];
+]);
 
 function navigateToTab(tabId) {
   router.push(`/sessions/${route.params.id}/${tabId}`);


### PR DESCRIPTION
## Summary
- Add prStatusService that periodically polls GitHub for PR status updates
- Only checks sessions with active WebSocket subscribers in running/waiting state
- Skip PRs in final states (merged/closed) to avoid unnecessary API calls
- Future-proofs for 'archived' session state using allowlist pattern
- Add configurable pr_poll_interval setting to projects table (default 60s)
- Show file count badge on Changes tab: "Changes (3)"

## Changes
| File | Purpose |
|------|---------|
| `schema.sql` | Add `pr_poll_interval` column |
| `ProjectRepository.js` | Handle new field |
| `contracts/projects.js` | Add to Zod schema |
| `prStatusService.js` | **New** - Main polling service |
| `prStatusService.test.js` | **New** - 27 tests |
| `index.js` | Start service on boot + graceful shutdown |
| `ChangesTab.vue` | Emit file count |
| `SessionDetailView.vue` | Show count in tab label |

## Test plan
- [x] prStatusService tests pass (27 tests)
- [x] Server tests pass (493/494 - 1 pre-existing failure)
- [x] Web tests pass (289/290 - 1 pre-existing failure)
- [ ] Manual testing: View session with PR, verify status updates after CI completes
- [ ] Manual testing: View Changes tab, verify file count badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)