### PR TITLE
Simplify start-server.sh with strict port 5000 protection

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -4,32 +4,30 @@
 # start-server.sh - Start the claudetools.io development server
 # =============================================================================
 #
-# This script supports running multiple concurrent server instances, which is
-# needed when working with git worktrees. Each worktree can have its own
-# running server on a different port.
+# This script supports running multiple concurrent server instances for
+# git worktree-based development. Each worktree gets its own server port.
 #
-# PORT ASSIGNMENT LOGIC:
-#   - Main repository (.git is a directory): Uses port 5000
+# PORT ASSIGNMENT:
+#   - Main repository (.git is a directory): Always uses port 5000
 #   - Git worktree (.git is a file):         Auto-assigns next available port (5001+)
-#   - PORT env var set:                      Uses that port (overrides auto-detection)
 #
-# WHY THIS MATTERS:
-#   When using git worktrees, each worktree is a separate working directory
-#   that shares the same git history. To work on multiple features simultaneously,
-#   each worktree needs its own server instance on a different port.
+# PROTECTION:
+#   Port 5000 is PROTECTED and will never be killed by worktrees.
+#   This ensures the main development server remains stable.
 #
 # PORT DISCOVERY:
 #   The selected port is written to .server-port so other tools (like Playwright)
 #   can discover which port this instance is using.
 #
 # USAGE:
-#   ./scripts/start-server.sh           # Auto-detect port based on repo type
+#   ./scripts/start-server.sh           # Start server (auto-detect port)
 #   ./scripts/start-server.sh --force   # Kill existing process on target port first
-#   PORT=5005 ./scripts/start-server.sh # Use explicit port
 #
 # =============================================================================
 
 PORT_FILE=".server-port"
+MAIN_PORT=5000
+WORKTREE_PORT_START=5001
 
 # -----------------------------------------------------------------------------
 # Detect if we're in a git worktree
@@ -56,76 +54,64 @@ find_available_port() {
 }
 
 # -----------------------------------------------------------------------------
-# Determine which port to use
-#
-# Priority:
-#   1. PORT env var (explicit override)
-#   2. Auto-detect based on worktree status:
-#      - Worktree: find next available port starting at 5001
-#      - Main repo: use default port 5000
+# Determine which port to use based on worktree status
 # -----------------------------------------------------------------------------
-if [ -n "$PORT" ]; then
-    # Explicit PORT env var takes precedence
-    SELECTED_PORT=$PORT
-elif is_worktree; then
+if is_worktree; then
     # Worktree: find next available port starting at 5001
     # This ensures worktrees don't conflict with the main repo (port 5000)
     # or with each other
-    SELECTED_PORT=$(find_available_port 5001)
+    SELECTED_PORT=$(find_available_port $WORKTREE_PORT_START)
 else
-    # Main repo: use default port 5000
-    SELECTED_PORT=5000
+    # Main repo: always use port 5000
+    SELECTED_PORT=$MAIN_PORT
 fi
 
 # -----------------------------------------------------------------------------
 # Handle --force flag
 #
-# If --force is passed, kill any existing process on the target port.
-# This is opt-in to prevent accidentally killing other instances.
+# Allows killing an existing process on the target port.
+# IMPORTANT: Worktrees can NEVER kill port 5000 - this protects the main server.
 # -----------------------------------------------------------------------------
 if [[ "$1" == "--force" ]]; then
+    if is_worktree && [ "$SELECTED_PORT" == "$MAIN_PORT" ]; then
+        # This should never happen due to port assignment logic, but double-check
+        echo "Error: Worktrees cannot kill the main server on port $MAIN_PORT"
+        exit 1
+    fi
+
     PID=$(lsof -t -i:${SELECTED_PORT} 2>/dev/null)
     if [ -n "$PID" ]; then
-        echo "Stopping process $PID on port ${SELECTED_PORT}..."
+        if [ "$SELECTED_PORT" == "$MAIN_PORT" ]; then
+            echo "Restarting main server (killing process $PID on port $MAIN_PORT)..."
+        else
+            echo "Stopping process $PID on port ${SELECTED_PORT}..."
+        fi
         kill -9 $PID 2>/dev/null
         sleep 1
     fi
 fi
 
 # -----------------------------------------------------------------------------
-# Auto-kill any process on port 5000 if that's our target port
-#
-# Kill existing process on port 5000 to avoid conflicts when restarting.
-# Only applies when running from the MAIN repo (not a worktree).
-# Worktrees should never kill port 5000 as that belongs to the main repo.
-# -----------------------------------------------------------------------------
-if [ "$SELECTED_PORT" == "5000" ] && ! is_worktree; then
-    PID_5000=$(lsof -t -i:5000 2>/dev/null)
-    if [ -n "$PID_5000" ]; then
-        echo "Killing existing process $PID_5000 on port 5000..."
-        kill $PID_5000 2>/dev/null
-        sleep 1
-    fi
-fi
-
-# -----------------------------------------------------------------------------
 # Check if port is available
-#
-# For the main repo or explicit PORT, fail if the port is already in use.
-# This prevents accidentally running duplicate instances on the same port.
 # -----------------------------------------------------------------------------
 if lsof -i:${SELECTED_PORT} >/dev/null 2>&1; then
-    echo "Error: Port ${SELECTED_PORT} is already in use"
-    echo "Use --force to kill the existing process"
-    exit 1
+    if is_worktree; then
+        # Worktree port collision - find another port
+        echo "Port ${SELECTED_PORT} is in use, finding another..."
+        SELECTED_PORT=$(find_available_port $((SELECTED_PORT + 1)))
+    else
+        # Main repo - port 5000 is in use
+        echo "Error: Port $MAIN_PORT is already in use"
+        echo "Use --force to restart the main server"
+        exit 1
+    fi
 fi
 
 # -----------------------------------------------------------------------------
 # Write port to file for tool discovery
 #
 # Other tools (like playwright.config.ts) read this file to know which
-# port the server is running on. This enables automatic port discovery
-# without requiring manual configuration.
+# port the server is running on.
 # -----------------------------------------------------------------------------
 echo "$SELECTED_PORT" > "$PORT_FILE"
 


### PR DESCRIPTION
## Summary

- Removes `PORT` env var override - port assignment is now deterministic based on worktree status
- Main repo always uses port 5000, worktrees auto-assign ports starting at 5001
- Port 5000 is now protected and can never be killed by worktrees
- Worktrees automatically find the next available port on collision (no manual intervention needed)

## Changes

| Before | After |
|--------|-------|
| `PORT` env var could override port | Port determined solely by worktree status |
| Auto-kill on port 5000 from main repo | Requires explicit `--force` flag |
| `--force` could kill any port | Worktrees can only kill worktree ports (5001+) |

## Test plan

- [ ] Run from main repo: should use port 5000
- [ ] Run from main repo with port 5000 in use: should fail with message to use `--force`
- [ ] Run from main repo with `--force`: should restart server on port 5000
- [ ] Run from worktree: should auto-assign port 5001+
- [ ] Run from worktree with port collision: should automatically find next available port
- [ ] Verify worktree cannot kill port 5000 (even with `--force`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)