### PR TITLE
Fix PR CI status indicators not working

### DIFF
--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -135,4 +135,16 @@ export class SessionRepository extends BaseRepository {
 
     return this.getById(id);
   }
+
+  /**
+   * Get all sessions that have a PR URL set
+   * Used by prStatusService for polling CI status
+   * @returns {Array<Object>} Sessions with PR URLs
+   */
+  getSessionsWithPrUrls() {
+    const rows = this.db
+      .prepare('SELECT * FROM sessions WHERE pr_url IS NOT NULL ORDER BY updated_at DESC')
+      .all();
+    return this.mapAll(rows);
+  }
 }

--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -53,7 +53,9 @@ export class SessionRepository extends BaseRepository {
          WHERE project_id = ?
          ORDER BY
            CASE WHEN status = 'completed' THEN 1 ELSE 0 END,
-           updated_at DESC`
+           updated_at DESC,
+           created_at DESC,
+           rowid DESC`
       )
       .all(projectId);
     return this.mapAll(rows);
@@ -66,7 +68,7 @@ export class SessionRepository extends BaseRepository {
          FROM sessions s
          JOIN projects p ON s.project_id = p.id
          WHERE s.status IN ('starting', 'running', 'waiting')
-         ORDER BY s.updated_at DESC`
+         ORDER BY s.updated_at DESC, s.created_at DESC, s.rowid DESC`
       )
       .all();
     return rows.map(row => ({
@@ -143,7 +145,7 @@ export class SessionRepository extends BaseRepository {
    */
   getSessionsWithPrUrls() {
     const rows = this.db
-      .prepare('SELECT * FROM sessions WHERE pr_url IS NOT NULL ORDER BY updated_at DESC')
+      .prepare('SELECT * FROM sessions WHERE pr_url IS NOT NULL ORDER BY updated_at DESC, created_at DESC, rowid DESC')
       .all();
     return this.mapAll(rows);
   }

--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -389,4 +389,80 @@ describe('SessionRepository', () => {
       expect(repo.getById(session.id)).toBeNull();
     });
   });
+
+  describe('getSessionsWithPrUrls', () => {
+    it('returns empty array when no sessions have PR URLs', () => {
+      repo.create(projectId, 'Session 1', 'Prompt 1');
+      repo.create(projectId, 'Session 2', 'Prompt 2');
+
+      const result = repo.getSessionsWithPrUrls();
+      expect(result).toEqual([]);
+    });
+
+    it('returns only sessions that have PR URLs', () => {
+      const session1 = repo.create(projectId, 'Session 1', 'Prompt 1');
+      repo.create(projectId, 'Session 2', 'Prompt 2');
+      const session3 = repo.create(projectId, 'Session 3', 'Prompt 3');
+
+      // Set PR URL on session 1 and 3
+      repo.update(session1.id, { prUrl: 'https://github.com/org/repo/pull/1' });
+      repo.update(session3.id, { prUrl: 'https://github.com/org/repo/pull/3' });
+
+      const result = repo.getSessionsWithPrUrls();
+      expect(result).toHaveLength(2);
+      expect(result.map(s => s.id)).toContain(session1.id);
+      expect(result.map(s => s.id)).toContain(session3.id);
+    });
+
+    it('orders sessions by updated_at descending', () => {
+      const session1 = repo.create(projectId, 'Session 1', 'Prompt 1');
+      const session2 = repo.create(projectId, 'Session 2', 'Prompt 2');
+
+      // Set PR URLs
+      repo.update(session1.id, { prUrl: 'https://github.com/org/repo/pull/1' });
+      // Update session2 after session1 so it has a later updated_at
+      repo.update(session2.id, { prUrl: 'https://github.com/org/repo/pull/2' });
+
+      const result = repo.getSessionsWithPrUrls();
+      expect(result).toHaveLength(2);
+      // Session 2 should be first because it was updated more recently
+      expect(result[0].id).toBe(session2.id);
+      expect(result[1].id).toBe(session1.id);
+    });
+
+    it('includes sessions from all projects', () => {
+      const project2 = projectRepo.create('Project 2', '/tmp/project2');
+
+      const session1 = repo.create(projectId, 'Session 1', 'Prompt 1');
+      const session2 = repo.create(project2.id, 'Session 2', 'Prompt 2');
+
+      repo.update(session1.id, { prUrl: 'https://github.com/org/repo1/pull/1' });
+      repo.update(session2.id, { prUrl: 'https://github.com/org/repo2/pull/2' });
+
+      const result = repo.getSessionsWithPrUrls();
+      expect(result).toHaveLength(2);
+      expect(result.map(s => s.projectId)).toContain(projectId);
+      expect(result.map(s => s.projectId)).toContain(project2.id);
+    });
+
+    it('returns correct session properties', () => {
+      const session = repo.create(projectId, 'Test Session', 'Prompt');
+      repo.update(session.id, {
+        prUrl: 'https://github.com/org/repo/pull/123',
+        status: 'completed',
+        gitBranch: 'feature/test',
+      });
+
+      const result = repo.getSessionsWithPrUrls();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: session.id,
+        projectId: projectId,
+        name: 'Test Session',
+        prUrl: 'https://github.com/org/repo/pull/123',
+        status: 'completed',
+        gitBranch: 'feature/test',
+      });
+    });
+  });
 });

--- a/packages/server/src/services/prStatusService.js
+++ b/packages/server/src/services/prStatusService.js
@@ -10,8 +10,15 @@ const DEFAULT_POLL_INTERVAL_MS = 60000;
 const FINAL_PR_STATES = ['merged', 'closed'];
 
 // Session states that should have their PRs polled (allowlist for future-proofing)
+// Includes completed/stopped because CI may still be running after session ends
 // When 'archived' is added, it won't be in this list
-const ACTIVE_SESSION_STATES = ['running', 'waiting'];
+const POLLABLE_SESSION_STATES = ['running', 'waiting', 'completed', 'stopped'];
+
+// Time-based filtering constants
+// Sessions updated within this time are polled regardless of subscribers
+const RECENT_ACTIVITY_MS = 2 * 60 * 60 * 1000; // 2 hours
+// Maximum age for polling sessions (even with pending CI)
+const MAX_POLL_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // Polling interval handle
 let pollIntervalId = null;
@@ -45,36 +52,62 @@ export function stop() {
 
 /**
  * Get all sessions with PRs that should be checked
+ * Uses time-based filtering to poll recently active sessions without requiring subscribers
  * @returns {Array<{sessionId: string, prUrl: string}>}
  */
 export function getSessionsToCheck() {
+  // Get all sessions that have PR URLs
+  const sessionsWithPrs = sessions.getSessionsWithPrUrls();
   const subscriptions = webSocketManager.getSessionSubscriptions();
+  const now = Date.now();
   const result = [];
 
-  for (const sessionId of subscriptions.keys()) {
-    // Check if there are active subscribers
-    const subscribers = subscriptions.get(sessionId);
-    if (!subscribers || subscribers.size === 0) continue;
-
-    const session = sessions.getById(sessionId);
-
-    // Skip if session not found
-    if (!session) continue;
-
-    // Skip if no PR URL
-    if (!session.prUrl) continue;
-
-    // Skip if session is not in an active state (future-proofs for 'archived')
-    if (!ACTIVE_SESSION_STATES.includes(session.status)) continue;
+  for (const session of sessionsWithPrs) {
+    // Skip if session is not in a pollable state (future-proofs for 'archived')
+    if (!POLLABLE_SESSION_STATES.includes(session.status)) continue;
 
     // Skip if PR is in a final state (merged/closed)
-    const summary = sessionSummaries.getBySessionId(sessionId);
+    const summary = sessionSummaries.getBySessionId(session.id);
     if (summary?.prState && FINAL_PR_STATES.includes(summary.prState)) continue;
 
-    result.push({ sessionId, prUrl: session.prUrl });
+    // Calculate session age based on updatedAt
+    const sessionAge = now - new Date(session.updatedAt).getTime();
+    const hasSubscribers = subscriptions.get(session.id)?.size > 0;
+
+    // Always poll sessions with active subscribers
+    if (hasSubscribers) {
+      result.push({ sessionId: session.id, prUrl: session.prUrl });
+      continue;
+    }
+
+    // Skip sessions older than max poll age
+    if (sessionAge > MAX_POLL_AGE_MS) continue;
+
+    // For sessions within recent activity window, poll without subscribers
+    if (sessionAge <= RECENT_ACTIVITY_MS) {
+      result.push({ sessionId: session.id, prUrl: session.prUrl });
+      continue;
+    }
+
+    // For older sessions without subscribers, only poll if CI is pending
+    if (summary?.ciStatus === 'pending') {
+      result.push({ sessionId: session.id, prUrl: session.prUrl });
+    }
   }
 
   return result;
+}
+
+/**
+ * Immediately check CI status for a specific session
+ * Used for on-demand checks when a session completes or PR URL is set
+ * @param {string} sessionId
+ * @returns {Promise<boolean>} Whether status was updated
+ */
+export async function checkSessionCiStatusNow(sessionId) {
+  const session = sessions.getById(sessionId);
+  if (!session?.prUrl) return false;
+  return await checkPrStatus(sessionId, session.prUrl);
 }
 
 /**
@@ -165,6 +198,8 @@ async function pollLoop() {
 export {
   DEFAULT_POLL_INTERVAL_MS,
   FINAL_PR_STATES,
-  ACTIVE_SESSION_STATES,
+  POLLABLE_SESSION_STATES,
+  RECENT_ACTIVITY_MS,
+  MAX_POLL_AGE_MS,
   pollLoop,
 };

--- a/packages/server/src/services/prStatusService.test.js
+++ b/packages/server/src/services/prStatusService.test.js
@@ -21,9 +21,12 @@ import * as ghService from './ghService.js';
 import {
   DEFAULT_POLL_INTERVAL_MS,
   FINAL_PR_STATES,
-  ACTIVE_SESSION_STATES,
+  POLLABLE_SESSION_STATES,
+  RECENT_ACTIVITY_MS,
+  MAX_POLL_AGE_MS,
   getSessionsToCheck,
   checkPrStatus,
+  checkSessionCiStatusNow,
 } from './prStatusService.js';
 
 describe('prStatusService', () => {
@@ -54,21 +57,42 @@ describe('prStatusService', () => {
       expect(FINAL_PR_STATES).toEqual(['merged', 'closed']);
     });
 
-    it('has running and waiting as active session states', () => {
-      expect(ACTIVE_SESSION_STATES).toEqual(['running', 'waiting']);
+    it('has running, waiting, completed, and stopped as pollable session states', () => {
+      expect(POLLABLE_SESSION_STATES).toEqual(['running', 'waiting', 'completed', 'stopped']);
+    });
+
+    it('has 2 hour recent activity window', () => {
+      expect(RECENT_ACTIVITY_MS).toBe(2 * 60 * 60 * 1000);
+    });
+
+    it('has 24 hour max poll age', () => {
+      expect(MAX_POLL_AGE_MS).toBe(24 * 60 * 60 * 1000);
     });
   });
 
   describe('getSessionsToCheck', () => {
-    it('returns empty array when no subscriptions', () => {
+    it('returns empty array when no sessions have PR URLs', () => {
+      // Session has no PR URL
+      sessions.update(sessionId, { status: 'waiting' });
       webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
       expect(result).toEqual([]);
     });
 
-    it('returns sessions with PRs that have subscribers', () => {
+    it('returns recently active sessions with PRs (no subscribers needed)', () => {
       // Update session to have PR URL and be in waiting state
+      // Session is recently updated so should be polled without subscribers
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // No subscribers
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([{ sessionId, prUrl: 'https://github.com/org/repo/pull/123' }]);
+    });
+
+    it('returns sessions with PRs that have subscribers', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
 
       // Mock subscription with active subscriber
@@ -92,29 +116,27 @@ describe('prStatusService', () => {
       expect(result).toEqual([]);
     });
 
-    it('excludes sessions not in active states (completed)', () => {
+    it('includes sessions in completed state (recently updated)', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'completed' });
 
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
     });
 
-    it('excludes sessions not in active states (stopped)', () => {
+    it('includes sessions in stopped state (recently updated)', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'stopped' });
 
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
     });
 
-    it('excludes sessions not in active states (error)', () => {
+    it('excludes sessions in error state', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'error' });
 
       const mockSubscriptions = new Map();
@@ -128,9 +150,7 @@ describe('prStatusService', () => {
     it('includes sessions in running state', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'running' });
 
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
       expect(result).toHaveLength(1);
@@ -140,9 +160,7 @@ describe('prStatusService', () => {
     it('includes sessions in waiting state', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
 
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
       expect(result).toHaveLength(1);
@@ -159,9 +177,7 @@ describe('prStatusService', () => {
         prState: 'merged',
       });
 
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
       expect(result).toEqual([]);
@@ -177,9 +193,7 @@ describe('prStatusService', () => {
         prState: 'closed',
       });
 
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
 
       const result = getSessionsToCheck();
       expect(result).toEqual([]);
@@ -195,24 +209,58 @@ describe('prStatusService', () => {
         prState: 'open',
       });
 
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+    });
+
+    it('always includes subscribed sessions regardless of age', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'completed' });
+
+      // Mock subscription with active subscriber
       const mockSubscriptions = new Map();
       mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
       webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
 
       const result = getSessionsToCheck();
       expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
+    });
+  });
+
+  describe('checkSessionCiStatusNow', () => {
+    const prUrl = 'https://github.com/org/repo/pull/123';
+
+    it('returns false when session has no PR URL', async () => {
+      // Session has no PR URL
+      sessions.update(sessionId, { status: 'waiting' });
+
+      const result = await checkSessionCiStatusNow(sessionId);
+      expect(result).toBe(false);
     });
 
-    it('excludes subscriptions with no active subscribers', () => {
-      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+    it('checks and updates CI status for session with PR URL', async () => {
+      sessions.update(sessionId, { prUrl, status: 'completed' });
 
-      // Mock subscription with empty set
-      const mockSubscriptions = new Map();
-      mockSubscriptions.set(sessionId, new Set());
-      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'success',
+        ciFailures: [],
+      });
 
-      const result = getSessionsToCheck();
-      expect(result).toEqual([]);
+      const result = await checkSessionCiStatusNow(sessionId);
+      expect(result).toBe(true);
+
+      const summary = sessionSummaries.getBySessionId(sessionId);
+      expect(summary.ciStatus).toBe('success');
+    });
+
+    it('returns false when session does not exist', async () => {
+      const result = await checkSessionCiStatusNow('non-existent-id');
+      expect(result).toBe(false);
     });
   });
 
@@ -427,12 +475,12 @@ describe('prStatusService', () => {
     it('would exclude archived sessions (if state existed)', () => {
       // This test documents the intended behavior when 'archived' is added
       // Currently we can't actually set status to 'archived' due to CHECK constraint
-      // But the logic should work because 'archived' is not in ACTIVE_SESSION_STATES
+      // But the logic should work because 'archived' is not in POLLABLE_SESSION_STATES
 
-      expect(ACTIVE_SESSION_STATES).not.toContain('archived');
+      expect(POLLABLE_SESSION_STATES).not.toContain('archived');
 
       // If a session somehow had status 'archived', it would be excluded
-      // because !ACTIVE_SESSION_STATES.includes('archived') === true
+      // because !POLLABLE_SESSION_STATES.includes('archived') === true
     });
   });
 });

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -3,6 +3,7 @@ import { sessions, messages, sessionSummaries } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 import * as ghService from './ghService.js';
+// Note: prStatusService is imported dynamically in onSessionComplete to avoid circular dependency
 
 // Debounce timers per session
 const debounceTimers = new Map();
@@ -415,6 +416,7 @@ export function onSessionActivity(sessionId) {
 
 /**
  * Called when session completes - generate immediately
+ * Also schedules follow-up CI checks for sessions with PRs
  * @param {string} sessionId
  */
 export function onSessionComplete(sessionId) {
@@ -426,6 +428,23 @@ export function onSessionComplete(sessionId) {
 
   // Generate summary immediately
   generateSummary(sessionId);
+
+  // Schedule follow-up CI checks for sessions with PRs
+  // CI might still be running after the session completes
+  const session = sessions.getById(sessionId);
+  if (session?.prUrl) {
+    // Use dynamic import to avoid circular dependency with prStatusService
+    const scheduleCiCheck = async () => {
+      const prStatusService = await import('./prStatusService.js');
+      prStatusService.checkSessionCiStatusNow(sessionId);
+    };
+
+    // Check after 2 minutes (CI often takes a few minutes)
+    setTimeout(scheduleCiCheck, 2 * 60 * 1000);
+
+    // Check again after 5 minutes
+    setTimeout(scheduleCiCheck, 5 * 60 * 1000);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixed PR CI status indicators not displaying because the polling service was too restrictive
- Sessions in 'completed' and 'stopped' states now have their CI status polled (previously only 'running' and 'waiting')
- Recently active sessions (< 2 hours) are now polled regardless of WebSocket subscribers
- Sessions with PRs now get follow-up CI checks at 2 and 5 minutes after completion

## Changes

1. **prStatusService.js**
   - Expanded `POLLABLE_SESSION_STATES` to include 'completed' and 'stopped'
   - Added time-based filtering constants (2hr recent activity, 24hr max poll age)
   - Rewrote `getSessionsToCheck()` to use time-based logic instead of requiring subscribers
   - Added `checkSessionCiStatusNow()` for on-demand CI status checks

2. **SessionRepository.js**
   - Added `getSessionsWithPrUrls()` method to efficiently fetch all sessions with PR URLs

3. **summaryService.js**
   - Modified `onSessionComplete()` to schedule follow-up CI checks at 2 and 5 minutes
   - Uses dynamic import to avoid circular dependency issues

4. **Tests**
   - Updated prStatusService tests for new constants and logic
   - Added tests for `checkSessionCiStatusNow()`
   - Added tests for `getSessionsWithPrUrls()`

## Test plan

- [ ] Create a session that creates a PR
- [ ] Complete the session and verify CI status appears within a few minutes
- [ ] Verify CI status updates when checks complete
- [ ] Verify both passing and failing CI statuses are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)