### PR TITLE
Style delete session button to align left on small screens

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -357,6 +357,12 @@ async function handleDelete() {
   flex-shrink: 0;
 }
 
+@media (max-width: 768px) {
+  .btn-delete-session {
+    margin-left: 0;
+  }
+}
+
 .session-mode {
   font-size: 0.75rem;
   color: var(--color-text-soft);


### PR DESCRIPTION
## Summary
- Add responsive CSS media query for the delete session button
- On screens 768px and below, removes `margin-left: auto` so the button aligns left instead of being pushed to the right

## Test plan
- [ ] View session detail page on desktop (button should be on the right)
- [ ] Resize browser to < 768px or view on mobile (button should align left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)