### PR TITLE
Change default model from Sonnet to Opus

### DIFF
--- a/packages/shared/src/types.js
+++ b/packages/shared/src/types.js
@@ -109,8 +109,8 @@ export const CANVAS_ITEM_TYPES = ['image', 'markdown', 'text', 'json'];
 export const TOOL_TEMPLATE_PAYLOAD_TYPES = ['command', 'prompt'];
 
 export const CLAUDE_MODELS = [
-  { id: 'claude-sonnet-4-5-20250929', name: 'Sonnet 4.5', description: 'Balanced (default)' },
-  { id: 'claude-opus-4-5-20251101', name: 'Opus 4.5', description: 'Most capable' },
+  { id: 'claude-sonnet-4-5-20250929', name: 'Sonnet 4.5', description: 'Balanced' },
+  { id: 'claude-opus-4-5-20251101', name: 'Opus 4.5', description: 'Most capable (default)' },
   { id: 'claude-haiku-4-5-20251001', name: 'Haiku 4.5', description: 'Fast & lightweight' },
 ];
-export const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+export const DEFAULT_MODEL = 'claude-opus-4-5-20251101';


### PR DESCRIPTION
## Summary
- Updates `DEFAULT_MODEL` constant to use Opus 4.5 (`claude-opus-4-5-20251101`) instead of Sonnet 4.5
- Updates model descriptions to reflect the new default

## Test plan
- [ ] Verify new sessions default to Opus 4.5 in the model selector
- [ ] Verify ConversationTab fallback uses Opus when session model is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)