### PR TITLE
Fix work logs not displaying after Claude's turn ends

### DIFF
--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -545,4 +545,57 @@ describe.skip('ConversationTab', () => {
       expect(mockSessionsStore.fetchWorkLogs).toHaveBeenCalledWith('sess-123');
     });
   });
+
+  describe('Work logs re-fetch on status change', () => {
+    it('re-fetches work logs when status changes from running to waiting', async () => {
+      // Start with running status
+      mockSessionsStore.currentSession = { id: 'sess-123', status: 'running', mode: 'standard' };
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Clear mock to track new calls
+      mockSessionsStore.fetchWorkLogs.mockClear();
+
+      // Simulate status change to waiting
+      mockSessionsStore.currentSession = { id: 'sess-123', status: 'waiting', mode: 'standard' };
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.fetchWorkLogs).toHaveBeenCalledWith('sess-123');
+    });
+
+    it('re-fetches work logs when status changes from running to completed', async () => {
+      // Start with running status
+      mockSessionsStore.currentSession = { id: 'sess-123', status: 'running', mode: 'standard' };
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Clear mock to track new calls
+      mockSessionsStore.fetchWorkLogs.mockClear();
+
+      // Simulate status change to completed
+      mockSessionsStore.currentSession = { id: 'sess-123', status: 'completed', mode: 'standard' };
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.fetchWorkLogs).toHaveBeenCalledWith('sess-123');
+    });
+
+    it('does not re-fetch work logs for other status transitions', async () => {
+      // Start with waiting status
+      mockSessionsStore.currentSession = { id: 'sess-123', status: 'waiting', mode: 'standard' };
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Clear mock to track new calls
+      mockSessionsStore.fetchWorkLogs.mockClear();
+
+      // Change to running (not from running, so should not trigger)
+      mockSessionsStore.currentSession = { id: 'sess-123', status: 'running', mode: 'standard' };
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.fetchWorkLogs).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -335,6 +335,17 @@ watch(
   }
 );
 
+// Re-fetch work logs when session status changes from running to waiting/completed
+// This ensures work logs are properly associated after Claude's turn ends
+watch(
+  () => sessionsStore.currentSession?.status,
+  async (newStatus, oldStatus) => {
+    if (oldStatus === 'running' && (newStatus === 'waiting' || newStatus === 'completed')) {
+      await sessionsStore.fetchWorkLogs(props.sessionId);
+    }
+  }
+);
+
 function formatTime(timestamp) {
   return new Date(timestamp).toLocaleTimeString();
 }

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -455,9 +455,10 @@ export const useSessionsStore = defineStore('sessions', {
         const messages = await api.getConversationMessages(sessionId, conversationId);
         this.messages = messages;
 
-        // Clear work logs and thinking for new conversation context
+        // Clear work logs and thinking, then re-fetch for new conversation context
         this.workLogs = {};
         this.partialThinking = null;
+        await this.fetchWorkLogs(sessionId);
       } catch (err) {
         this.error = err.message;
         throw err;

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -445,6 +445,7 @@ describe('Sessions Store', () => {
 
         api.updateConversation.mockResolvedValue({ id: 'conv-2', isActive: true });
         api.getConversationMessages.mockResolvedValue([{ id: 'msg-1', content: 'Hello' }]);
+        api.getSessionWorkLogs.mockResolvedValue({ 'msg-1': [] });
 
         await store.switchConversation('session-1', 'conv-2');
 
@@ -452,6 +453,34 @@ describe('Sessions Store', () => {
         expect(store.conversations.find((c) => c.id === 'conv-2').isActive).toBe(true);
         expect(store.conversations.find((c) => c.id === 'conv-1').isActive).toBe(false);
         expect(store.messages).toEqual([{ id: 'msg-1', content: 'Hello' }]);
+      });
+
+      it('clears work logs and re-fetches them when switching conversations', async () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', isActive: true },
+          { id: 'conv-2', isActive: false },
+        ];
+        store.activeConversationId = 'conv-1';
+        store.workLogs = { 'msg-old': [{ id: 'old-log' }] };
+        store.partialThinking = 'some thinking';
+
+        api.updateConversation.mockResolvedValue({ id: 'conv-2', isActive: true });
+        api.getConversationMessages.mockResolvedValue([{ id: 'msg-1', content: 'Hello' }]);
+        api.getSessionWorkLogs.mockResolvedValue({
+          'msg-1': [{ id: 'new-log', content: 'New work log' }],
+        });
+
+        await store.switchConversation('session-1', 'conv-2');
+
+        // Work logs should have been re-fetched
+        expect(api.getSessionWorkLogs).toHaveBeenCalledWith('session-1');
+        // New work logs should be present
+        expect(store.workLogs['msg-1']).toEqual([{ id: 'new-log', content: 'New work log' }]);
+        // Old work logs should be gone
+        expect(store.workLogs['msg-old']).toBeUndefined();
+        // Partial thinking should be cleared
+        expect(store.partialThinking).toBeNull();
       });
 
       it('does nothing if switching to same conversation', async () => {

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -279,6 +279,40 @@ describe('SessionDetailView', () => {
     });
   });
 
+  describe('data fetching on mount', () => {
+    it('fetches session, messages, and work logs on mount', async () => {
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(mockSessionsStore.fetchSession).toHaveBeenCalledWith('test-session-id');
+      expect(mockSessionsStore.fetchMessages).toHaveBeenCalledWith('test-session-id');
+      expect(mockSessionsStore.fetchWorkLogs).toHaveBeenCalledWith('test-session-id');
+    });
+
+    it('fetches work logs after messages to ensure proper ordering', async () => {
+      const callOrder = [];
+      mockSessionsStore.fetchSession.mockImplementation(() => {
+        callOrder.push('fetchSession');
+        return Promise.resolve();
+      });
+      mockSessionsStore.fetchMessages.mockImplementation(() => {
+        callOrder.push('fetchMessages');
+        return Promise.resolve();
+      });
+      mockSessionsStore.fetchWorkLogs.mockImplementation(() => {
+        callOrder.push('fetchWorkLogs');
+        return Promise.resolve();
+      });
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(callOrder).toEqual(['fetchSession', 'fetchMessages', 'fetchWorkLogs']);
+    });
+  });
+
   describe('session ID capturing (race condition prevention)', () => {
     it('captures session ID at component creation time', async () => {
       // Mount component with initial session ID

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -199,6 +199,7 @@ onMounted(async () => {
   // Then fetch data - this ensures we don't miss updates
   await sessionsStore.fetchSession(sessionId);
   await sessionsStore.fetchMessages(sessionId);
+  await sessionsStore.fetchWorkLogs(sessionId);
   canvasStore.fetchItems(sessionId);
   todosStore.fetchTodos(sessionId);
 


### PR DESCRIPTION
## Summary
- Fix work logs not appearing in the UI after Claude Code completes its turn
- Work logs were showing during active work (in LiveWorkLogPanel) but not persisting to WorkLogPanel for completed messages
- Root cause: missing fetchWorkLogs calls in multiple scenarios

## Changes
- **SessionDetailView.vue**: Add `fetchWorkLogs()` call on initial session load
- **sessions.js**: Re-fetch work logs after `switchConversation` clears them  
- **ConversationTab.vue**: Add watcher to re-fetch work logs when session status changes from 'running' to 'waiting/completed'

## Test plan
- [ ] Start a new session and watch work logs appear in LiveWorkLogPanel during Claude's work
- [ ] Wait for Claude's turn to complete and verify work logs appear in WorkLogPanel under the assistant message
- [ ] Refresh the page and verify work logs are still visible for historical messages
- [ ] Switch conversations and verify work logs load correctly for the new conversation
- [ ] Test multi-turn conversations to ensure work logs persist across turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)