### PR TITLE
Fix conversation creation and navigation issues

### DIFF
--- a/packages/web/src/components/ConversationSelector.vue
+++ b/packages/web/src/components/ConversationSelector.vue
@@ -11,7 +11,7 @@
           :title="isDisabled ? 'Stop the session to switch conversations' : 'Switch conversation'"
         >
           <span class="dropdown-label">
-            {{ activeConversation?.name || 'Select conversation' }}
+            {{ activeConversationDisplayName }}
           </span>
           <span v-if="isDisabled" class="lock-icon">🔒</span>
           <span v-else class="dropdown-arrow">▼</span>
@@ -19,12 +19,12 @@
 
         <div v-if="isOpen && !isDisabled" class="dropdown-menu">
           <div
-            v-for="conv in conversations"
+            v-for="(conv, index) in conversations"
             :key="conv.id"
             :class="['dropdown-item', { active: conv.id === activeConversationId }]"
             @click="selectConversation(conv.id)"
           >
-            <span class="conv-name">{{ conv.name || 'Untitled' }}</span>
+            <span class="conv-name">{{ getConversationDisplayName(conv, index) }}</span>
             <span class="conv-meta">{{ conv.messageCount || 0 }} msgs</span>
             <button
               v-if="conversations.length > 1 && conv.id !== activeConversationId"
@@ -79,6 +79,18 @@ const showWarning = ref(false);
 const conversations = computed(() => sessionsStore.conversations);
 const activeConversationId = computed(() => sessionsStore.activeConversationId);
 const activeConversation = computed(() => sessionsStore.activeConversation);
+
+// Generate display names for conversations (fallback to "Conversation N" if no name)
+function getConversationDisplayName(conv, index) {
+  return conv.name || `Conversation ${index + 1}`;
+}
+
+// Get display name for the active conversation
+const activeConversationDisplayName = computed(() => {
+  if (!activeConversation.value) return 'Select conversation';
+  const index = conversations.value.findIndex(c => c.id === activeConversationId.value);
+  return getConversationDisplayName(activeConversation.value, index >= 0 ? index : 0);
+});
 
 // Disable switching while session is running
 const isDisabled = computed(() => {

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -210,13 +210,25 @@ const unassociatedWorkLogs = computed(() => {
   return sessionsStore.getUnassociatedWorkLogs;
 });
 
-// Subscribe to partial messages for streaming and work logs
-const { onPartial, onMessage, onWorkLog, onWorkLogsAssociated, onThinkingPartial } = useSessionSubscription(props.sessionId);
+// Subscribe to partial messages for streaming, work logs, and conversation events
+const {
+  onPartial,
+  onMessage,
+  onWorkLog,
+  onWorkLogsAssociated,
+  onThinkingPartial,
+  onConversationCreated,
+  onConversationUpdated,
+  onConversationDeleted,
+} = useSessionSubscription(props.sessionId);
 let unsubPartial = null;
 let unsubMessage = null;
 let unsubWorkLog = null;
 let unsubWorkLogsAssociated = null;
 let unsubThinkingPartial = null;
+let unsubConvCreated = null;
+let unsubConvUpdated = null;
+let unsubConvDeleted = null;
 
 function handleScroll() {
   if (!messagesContainer.value) return;
@@ -276,6 +288,27 @@ onMounted(async () => {
     }
   });
 
+  // Subscribe to conversation events for real-time updates
+  unsubConvCreated = onConversationCreated((conversation) => {
+    sessionsStore.addConversation(conversation);
+    // If this is now the active conversation, fetch its messages
+    if (conversation.isActive) {
+      sessionsStore.fetchMessages(props.sessionId, false);
+    }
+  });
+
+  unsubConvUpdated = onConversationUpdated((conversation) => {
+    sessionsStore.updateConversation(conversation);
+  });
+
+  unsubConvDeleted = onConversationDeleted((conversationId, newActiveConv) => {
+    sessionsStore.removeConversation(conversationId, newActiveConv);
+    // If we have a new active conversation, fetch its messages
+    if (newActiveConv) {
+      sessionsStore.fetchMessages(props.sessionId, false);
+    }
+  });
+
   // Fetch initial work logs
   await sessionsStore.fetchWorkLogs(props.sessionId);
 
@@ -289,13 +322,17 @@ onUnmounted(() => {
   if (unsubWorkLog) unsubWorkLog();
   if (unsubWorkLogsAssociated) unsubWorkLogsAssociated();
   if (unsubThinkingPartial) unsubThinkingPartial();
+  if (unsubConvCreated) unsubConvCreated();
+  if (unsubConvUpdated) unsubConvUpdated();
+  if (unsubConvDeleted) unsubConvDeleted();
   if (debounceTimer) clearTimeout(debounceTimer);
   if (messagesContainer.value) {
     messagesContainer.value.removeEventListener('scroll', handleScroll);
   }
-  // Clear work logs and conversations when leaving the conversation tab
+  // Clear work logs when leaving the conversation tab
+  // Note: Don't clear conversations here - they should persist when switching tabs
+  // within the same session. They will be refreshed when switching sessions.
   sessionsStore.clearWorkLogs();
-  sessionsStore.clearConversations();
 });
 
 // Save draft to localStorage with debounce

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -250,6 +250,36 @@ export function useSessionSubscription(sessionId) {
     return () => off(WS_MESSAGE_TYPES.SESSION_UPDATED, handler);
   };
 
+  const onConversationCreated = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.conversation);
+      }
+    };
+    on(WS_MESSAGE_TYPES.CONVERSATION_CREATED, handler);
+    return () => off(WS_MESSAGE_TYPES.CONVERSATION_CREATED, handler);
+  };
+
+  const onConversationUpdated = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.conversation);
+      }
+    };
+    on(WS_MESSAGE_TYPES.CONVERSATION_UPDATED, handler);
+    return () => off(WS_MESSAGE_TYPES.CONVERSATION_UPDATED, handler);
+  };
+
+  const onConversationDeleted = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.conversationId, msg.newActiveConversation);
+      }
+    };
+    on(WS_MESSAGE_TYPES.CONVERSATION_DELETED, handler);
+    return () => off(WS_MESSAGE_TYPES.CONVERSATION_DELETED, handler);
+  };
+
   // Auto-cleanup on unmount
   onUnmounted(() => {
     unsubscribe();
@@ -271,6 +301,9 @@ export function useSessionSubscription(sessionId) {
     onSummaryUpdate,
     onSummaryGenerating,
     onSessionUpdate,
+    onConversationCreated,
+    onConversationUpdated,
+    onConversationDeleted,
   };
 }
 


### PR DESCRIPTION
## Summary

- Fixes issue where old conversation disappears when starting a new one
- Fixes dropdown only showing one "untitled conversation"
- Fixes response to new conversation being lost (work logs appear briefly then disappear)

**Root cause**: The server was broadcasting WebSocket events for conversation changes (`CONVERSATION_CREATED`, `CONVERSATION_UPDATED`, `CONVERSATION_DELETED`) but the frontend had **no handlers** for them, causing the UI to become stale immediately after mount.

## Changes

1. **Add WebSocket handlers** - Added `onConversationCreated`, `onConversationUpdated`, `onConversationDeleted` handlers in `useWebSocket.js`

2. **Subscribe to conversation events** - `ConversationTab.vue` now subscribes to conversation WebSocket events for real-time updates

3. **Stop clearing conversations on tab switch** - Removed `clearConversations()` from `onUnmounted` which was incorrectly wiping conversation data when switching tabs within the same session

4. **Better conversation names** - Added display names ("Conversation 1", "Conversation 2", etc.) instead of showing "Untitled" for nameless conversations

## Test plan

- [ ] Create a new session and verify conversation appears in dropdown
- [ ] Create a new conversation within session - verify old one stays in dropdown
- [ ] Switch between conversations - verify messages load correctly
- [ ] Send a message in new conversation - verify response appears (not lost)
- [ ] Switch to "Changes" tab and back - verify conversations still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)