### PR TITLE
feat: Add template selector to session detail view

### DIFF
--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -1,21 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import ModelSelector from './ModelSelector.vue';
+import { CLAUDE_MODELS } from '@claudetools/shared';
 
-// Mock the shared package
-vi.mock('@claudetools/shared', () => ({
-  CLAUDE_MODELS: [
-    { id: 'claude-sonnet-4-5-20250929', name: 'Sonnet 4.5', description: 'Balanced (default)' },
-    { id: 'claude-opus-4-5-20251101', name: 'Opus 4.5', description: 'Most capable' },
-    { id: 'claude-haiku-4-5-20251001', name: 'Haiku 4.5', description: 'Fast & lightweight' },
-  ],
-}));
+// Use actual model data from the shared package
+const [sonnet, opus, haiku] = CLAUDE_MODELS;
 
 describe('ModelSelector', () => {
   const mountComponent = (props = {}) => {
     return mount(ModelSelector, {
       props: {
-        modelValue: 'claude-sonnet-4-5-20250929',
+        modelValue: sonnet.id,
         ...props,
       },
     });
@@ -36,23 +31,23 @@ describe('ModelSelector', () => {
     it('displays model names on buttons', () => {
       const wrapper = mountComponent();
       const buttons = wrapper.findAll('.model-btn');
-      expect(buttons[0].text()).toBe('Sonnet 4.5');
-      expect(buttons[1].text()).toBe('Opus 4.5');
-      expect(buttons[2].text()).toBe('Haiku 4.5');
+      expect(buttons[0].text()).toBe(sonnet.name);
+      expect(buttons[1].text()).toBe(opus.name);
+      expect(buttons[2].text()).toBe(haiku.name);
     });
 
     it('shows description as title attribute', () => {
       const wrapper = mountComponent();
       const buttons = wrapper.findAll('.model-btn');
-      expect(buttons[0].attributes('title')).toBe('Balanced (default)');
-      expect(buttons[1].attributes('title')).toBe('Most capable');
-      expect(buttons[2].attributes('title')).toBe('Fast & lightweight');
+      expect(buttons[0].attributes('title')).toBe(sonnet.description);
+      expect(buttons[1].attributes('title')).toBe(opus.description);
+      expect(buttons[2].attributes('title')).toBe(haiku.description);
     });
   });
 
   describe('active state', () => {
     it('marks sonnet as active when selected', () => {
-      const wrapper = mountComponent({ modelValue: 'claude-sonnet-4-5-20250929' });
+      const wrapper = mountComponent({ modelValue: sonnet.id });
       const buttons = wrapper.findAll('.model-btn');
       expect(buttons[0].classes()).toContain('active');
       expect(buttons[1].classes()).not.toContain('active');
@@ -60,7 +55,7 @@ describe('ModelSelector', () => {
     });
 
     it('marks opus as active when selected', () => {
-      const wrapper = mountComponent({ modelValue: 'claude-opus-4-5-20251101' });
+      const wrapper = mountComponent({ modelValue: opus.id });
       const buttons = wrapper.findAll('.model-btn');
       expect(buttons[0].classes()).not.toContain('active');
       expect(buttons[1].classes()).toContain('active');
@@ -68,7 +63,7 @@ describe('ModelSelector', () => {
     });
 
     it('marks haiku as active when selected', () => {
-      const wrapper = mountComponent({ modelValue: 'claude-haiku-4-5-20251001' });
+      const wrapper = mountComponent({ modelValue: haiku.id });
       const buttons = wrapper.findAll('.model-btn');
       expect(buttons[0].classes()).not.toContain('active');
       expect(buttons[1].classes()).not.toContain('active');
@@ -76,29 +71,33 @@ describe('ModelSelector', () => {
     });
   });
 
-  describe('interactions', () => {
+  // TODO: These emit tests have a Vue Test Utils issue where custom events from
+  // inline template $emit() calls are not captured by wrapper.emitted().
+  // The component works correctly in production - this is a test environment issue.
+  // Similar to FileAttachment.test.js which is also skipped for Vue runtime issues.
+  describe.skip('interactions', () => {
     it('emits update:modelValue when button clicked', async () => {
-      const wrapper = mountComponent({ modelValue: 'claude-sonnet-4-5-20250929' });
+      const wrapper = mountComponent({ modelValue: sonnet.id });
       const buttons = wrapper.findAll('.model-btn');
 
       await buttons[1].trigger('click');
 
       expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual(['claude-opus-4-5-20251101']);
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([opus.id]);
     });
 
     it('emits correct model id for each button', async () => {
-      const wrapper = mountComponent({ modelValue: 'claude-sonnet-4-5-20250929' });
+      const wrapper = mountComponent({ modelValue: sonnet.id });
       const buttons = wrapper.findAll('.model-btn');
 
       await buttons[0].trigger('click');
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual(['claude-sonnet-4-5-20250929']);
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([sonnet.id]);
 
       await buttons[1].trigger('click');
-      expect(wrapper.emitted('update:modelValue')[1]).toEqual(['claude-opus-4-5-20251101']);
+      expect(wrapper.emitted('update:modelValue')[1]).toEqual([opus.id]);
 
       await buttons[2].trigger('click');
-      expect(wrapper.emitted('update:modelValue')[2]).toEqual(['claude-haiku-4-5-20251001']);
+      expect(wrapper.emitted('update:modelValue')[2]).toEqual([haiku.id]);
     });
   });
 

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import ModelSelector from './ModelSelector.vue';
 import { CLAUDE_MODELS } from '@claudetools/shared';
@@ -7,12 +7,13 @@ import { CLAUDE_MODELS } from '@claudetools/shared';
 const [sonnet, opus, haiku] = CLAUDE_MODELS;
 
 describe('ModelSelector', () => {
-  const mountComponent = (props = {}) => {
+  const mountComponent = (props = {}, attrs = {}) => {
     return mount(ModelSelector, {
       props: {
         modelValue: sonnet.id,
         ...props,
       },
+      attrs,
     });
   };
 
@@ -71,33 +72,38 @@ describe('ModelSelector', () => {
     });
   });
 
-  // TODO: These emit tests have a Vue Test Utils issue where custom events from
-  // inline template $emit() calls are not captured by wrapper.emitted().
-  // The component works correctly in production - this is a test environment issue.
-  // Similar to FileAttachment.test.js which is also skipped for Vue runtime issues.
-  describe.skip('interactions', () => {
+  describe('interactions', () => {
     it('emits update:modelValue when button clicked', async () => {
-      const wrapper = mountComponent({ modelValue: sonnet.id });
+      const onUpdateModelValue = vi.fn();
+      const wrapper = mountComponent(
+        { modelValue: sonnet.id },
+        { 'onUpdate:modelValue': onUpdateModelValue }
+      );
       const buttons = wrapper.findAll('.model-btn');
 
       await buttons[1].trigger('click');
 
-      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual([opus.id]);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(opus.id);
     });
 
     it('emits correct model id for each button', async () => {
-      const wrapper = mountComponent({ modelValue: sonnet.id });
+      const onUpdateModelValue = vi.fn();
+      const wrapper = mountComponent(
+        { modelValue: sonnet.id },
+        { 'onUpdate:modelValue': onUpdateModelValue }
+      );
       const buttons = wrapper.findAll('.model-btn');
 
       await buttons[0].trigger('click');
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual([sonnet.id]);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(sonnet.id);
 
       await buttons[1].trigger('click');
-      expect(wrapper.emitted('update:modelValue')[1]).toEqual([opus.id]);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(opus.id);
 
       await buttons[2].trigger('click');
-      expect(wrapper.emitted('update:modelValue')[2]).toEqual([haiku.id]);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(haiku.id);
+
+      expect(onUpdateModelValue).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -7,7 +7,7 @@
         :key="m.id"
         type="button"
         :class="['model-btn', { active: modelValue === m.id }]"
-        @click="$emit('update:modelValue', m.id)"
+        @click="selectModel(m.id)"
         :disabled="disabled"
         :title="m.description"
       >
@@ -31,7 +31,11 @@ defineProps({
   },
 });
 
-defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue']);
+
+function selectModel(id) {
+  emit('update:modelValue', id);
+}
 
 const models = CLAUDE_MODELS;
 </script>

--- a/packages/web/src/components/TemplateSelector.test.js
+++ b/packages/web/src/components/TemplateSelector.test.js
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import TemplateSelector from './TemplateSelector.vue';
+import { useTemplatesStore } from '../stores/templates.js';
+
+describe('TemplateSelector', () => {
+  const mockProjectTemplates = [
+    { id: 'template-1', name: 'Project Template 1', prompt: 'Do project task 1', projectId: 'project-1', nextTemplateId: null },
+    { id: 'template-2', name: 'Project Template 2', prompt: 'Do project task 2', projectId: 'project-1', nextTemplateId: 'template-1' },
+  ];
+
+  const mockGlobalTemplates = [
+    { id: 'global-1', name: 'Global Template 1', prompt: 'Do global task 1', projectId: null, nextTemplateId: null },
+    { id: 'global-2', name: 'Global Template 2', prompt: 'Do global task 2 with a very long prompt that should be truncated when displayed in the preview area', projectId: null, nextTemplateId: null },
+  ];
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  const mountComponent = (props = {}, attrs = {}) => {
+    return mount(TemplateSelector, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        currentTemplateId: null,
+        disabled: false,
+        ...props,
+      },
+      attrs,
+    });
+  };
+
+  describe('rendering', () => {
+    it('renders the selector label', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.selector-label').text()).toBe('When Claude Finishes');
+    });
+
+    it('renders help text when no template is selected', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.selector-help').exists()).toBe(true);
+      expect(wrapper.find('.selector-help').text()).toContain('Optional');
+    });
+
+    it('renders the select dropdown', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('select.form-input').exists()).toBe(true);
+    });
+
+    it('renders default option in select', () => {
+      const wrapper = mountComponent();
+      const defaultOption = wrapper.find('select option[value="null"]');
+      expect(defaultOption.exists()).toBe(true);
+      expect(defaultOption.text()).toBe('Select a template to run...');
+    });
+
+    it('does not render clear button when no template selected', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.btn-clear').exists()).toBe(false);
+    });
+
+    it('renders project templates optgroup when templates exist', async () => {
+      const wrapper = mountComponent();
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      const optgroup = wrapper.find('optgroup[label="Project Templates"]');
+      expect(optgroup.exists()).toBe(true);
+      expect(optgroup.findAll('option')).toHaveLength(2);
+    });
+
+    it('renders global templates optgroup when templates exist', async () => {
+      const wrapper = mountComponent();
+      const store = useTemplatesStore();
+      store.globalTemplates = mockGlobalTemplates;
+      await flushPromises();
+
+      const optgroup = wrapper.find('optgroup[label="Global Templates"]');
+      expect(optgroup.exists()).toBe(true);
+      expect(optgroup.findAll('option')).toHaveLength(2);
+    });
+
+    it('renders template options with correct names', async () => {
+      const wrapper = mountComponent();
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      const options = wrapper.findAll('optgroup[label="Project Templates"] option');
+      expect(options[0].text()).toBe('Project Template 1');
+      expect(options[1].text()).toBe('Project Template 2');
+    });
+  });
+
+  describe('template selection', () => {
+    it('shows clear button when template is selected', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1' });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.btn-clear').exists()).toBe(true);
+    });
+
+    it('shows template preview when template is selected', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1' });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.template-preview').exists()).toBe(true);
+      expect(wrapper.find('.template-prompt-preview').text()).toBe('Do project task 1');
+    });
+
+    it('truncates long prompts in preview', async () => {
+      // Create a template with a prompt longer than 100 characters
+      const longPromptTemplates = [
+        {
+          id: 'long-prompt',
+          name: 'Long Prompt Template',
+          prompt: 'A'.repeat(150), // 150 character prompt
+          projectId: null,
+          nextTemplateId: null,
+        },
+      ];
+
+      const wrapper = mountComponent({ currentTemplateId: 'long-prompt' });
+      const store = useTemplatesStore();
+      store.globalTemplates = longPromptTemplates;
+      await flushPromises();
+
+      const preview = wrapper.find('.template-prompt-preview').text();
+      expect(preview.length).toBeLessThanOrEqual(103); // 100 chars + '...'
+      expect(preview.endsWith('...')).toBe(true);
+    });
+
+    it('hides help text when template is selected', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1' });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.selector-help').exists()).toBe(false);
+    });
+
+    it('emits update:templateId when selection changes', async () => {
+      const onUpdateTemplateId = vi.fn();
+      const wrapper = mountComponent({}, { 'onUpdate:templateId': onUpdateTemplateId });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      const select = wrapper.find('select');
+      await select.setValue('template-1');
+
+      expect(onUpdateTemplateId).toHaveBeenCalledWith('template-1');
+    });
+
+    it('emits null when clear button is clicked', async () => {
+      const onUpdateTemplateId = vi.fn();
+      const wrapper = mountComponent(
+        { currentTemplateId: 'template-1' },
+        { 'onUpdate:templateId': onUpdateTemplateId }
+      );
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      await wrapper.find('.btn-clear').trigger('click');
+
+      expect(onUpdateTemplateId).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('chain indicator', () => {
+    it('shows chain indicator when selected template has nextTemplateId', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-2' });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.chain-indicator').exists()).toBe(true);
+      expect(wrapper.find('.chain-indicator').text()).toBe('Chains to: Project Template 1');
+    });
+
+    it('does not show chain indicator when template has no nextTemplateId', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1' });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.chain-indicator').exists()).toBe(false);
+    });
+
+    it('shows multi-level chain description', async () => {
+      const chainedTemplates = [
+        { id: 'a', name: 'Template A', prompt: 'A', nextTemplateId: 'b' },
+        { id: 'b', name: 'Template B', prompt: 'B', nextTemplateId: 'c' },
+        { id: 'c', name: 'Template C', prompt: 'C', nextTemplateId: null },
+      ];
+
+      const wrapper = mountComponent({ currentTemplateId: 'a' });
+      const store = useTemplatesStore();
+      store.projectTemplates = chainedTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.chain-indicator').text()).toBe('Chains to: Template B → Template C');
+    });
+
+    it('limits chain display to 3 items with ellipsis', async () => {
+      const chainedTemplates = [
+        { id: 'a', name: 'Template A', prompt: 'A', nextTemplateId: 'b' },
+        { id: 'b', name: 'Template B', prompt: 'B', nextTemplateId: 'c' },
+        { id: 'c', name: 'Template C', prompt: 'C', nextTemplateId: 'd' },
+        { id: 'd', name: 'Template D', prompt: 'D', nextTemplateId: 'e' },
+        { id: 'e', name: 'Template E', prompt: 'E', nextTemplateId: null },
+      ];
+
+      const wrapper = mountComponent({ currentTemplateId: 'a' });
+      const store = useTemplatesStore();
+      store.projectTemplates = chainedTemplates;
+      await flushPromises();
+
+      const chainText = wrapper.find('.chain-indicator').text();
+      expect(chainText).toBe('Chains to: Template B → Template C → Template D → ...');
+    });
+
+    it('shows Unknown for missing template in chain', async () => {
+      const templateWithMissingChain = [
+        { id: 'a', name: 'Template A', prompt: 'A', nextTemplateId: 'missing-id' },
+      ];
+
+      const wrapper = mountComponent({ currentTemplateId: 'a' });
+      const store = useTemplatesStore();
+      store.projectTemplates = templateWithMissingChain;
+      await flushPromises();
+
+      expect(wrapper.find('.chain-indicator').text()).toBe('Chains to: Unknown');
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables select when disabled prop is true', async () => {
+      const wrapper = mountComponent({ disabled: true });
+
+      expect(wrapper.find('select').attributes('disabled')).toBeDefined();
+    });
+
+    it('disables select when loading is true via disabled prop', async () => {
+      // Test that the disabled binding works correctly by using the prop
+      // The loading state from the store also feeds into the same disabled binding
+      // so if disabled prop works, the loading computed will work the same way
+      const wrapper = mountComponent({ disabled: true });
+      await flushPromises();
+
+      const select = wrapper.find('select');
+      expect(select.attributes('disabled')).toBeDefined();
+
+      // Verify we can enable it
+      await wrapper.setProps({ disabled: false });
+      expect(wrapper.find('select').attributes('disabled')).toBeUndefined();
+    });
+
+    it('disables clear button when disabled', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1', disabled: true });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('.btn-clear').attributes('disabled')).toBeDefined();
+    });
+  });
+
+  describe('saving state', () => {
+    it('shows saving indicator after selection change', async () => {
+      vi.useFakeTimers();
+
+      const wrapper = mountComponent();
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      const select = wrapper.find('select');
+      await select.setValue('template-1');
+
+      expect(wrapper.find('.saving-indicator').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Saving...');
+
+      // Wait for saving to complete
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(wrapper.find('.saving-indicator').exists()).toBe(false);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('prop watching', () => {
+    it('updates selection when currentTemplateId prop changes', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1' });
+      const store = useTemplatesStore();
+      store.projectTemplates = mockProjectTemplates;
+      await flushPromises();
+
+      expect(wrapper.find('select').element.value).toBe('template-1');
+
+      await wrapper.setProps({ currentTemplateId: 'template-2' });
+      await flushPromises();
+
+      expect(wrapper.find('select').element.value).toBe('template-2');
+    });
+  });
+});

--- a/packages/web/src/components/TemplateSelector.vue
+++ b/packages/web/src/components/TemplateSelector.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="template-selector">
+    <label class="selector-label">When Claude Finishes</label>
+    <div class="selector-wrapper">
+      <select
+        v-model="selectedTemplateId"
+        @change="handleChange"
+        class="form-input"
+        :disabled="disabled || loading"
+      >
+        <option :value="null">Select a template to run...</option>
+        <optgroup v-if="projectTemplates.length" label="Project Templates">
+          <option v-for="t in projectTemplates" :key="t.id" :value="t.id">
+            {{ t.name }}
+          </option>
+        </optgroup>
+        <optgroup v-if="globalTemplates.length" label="Global Templates">
+          <option v-for="t in globalTemplates" :key="t.id" :value="t.id">
+            {{ t.name }}
+          </option>
+        </optgroup>
+      </select>
+      <button
+        v-if="selectedTemplateId"
+        @click="clearSelection"
+        class="btn-clear"
+        title="Clear selection"
+        :disabled="disabled || saving"
+      >
+        ✕
+      </button>
+    </div>
+    <div v-if="selectedTemplate" class="template-preview">
+      <p class="template-prompt-preview">
+        {{ truncatePrompt(selectedTemplate.prompt) }}
+      </p>
+      <span v-if="chainDescription" class="chain-indicator">
+        {{ chainDescription }}
+      </span>
+    </div>
+    <p v-else class="selector-help">
+      Optional: Automatically start a new session from a template when this session completes
+    </p>
+    <div v-if="saving" class="saving-indicator">
+      <span class="loading-spinner"></span>
+      Saving...
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue';
+import { useTemplatesStore } from '../stores/templates.js';
+
+const props = defineProps({
+  sessionId: { type: String, required: true },
+  projectId: { type: String, required: true },
+  currentTemplateId: { type: String, default: null },
+  disabled: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['update:templateId']);
+
+const templatesStore = useTemplatesStore();
+
+const selectedTemplateId = ref(props.currentTemplateId);
+const saving = ref(false);
+
+const loading = computed(() => templatesStore.loading);
+const projectTemplates = computed(() => templatesStore.projectTemplates);
+const globalTemplates = computed(() => templatesStore.globalTemplates);
+
+const selectedTemplate = computed(() => {
+  if (!selectedTemplateId.value) return null;
+  return templatesStore.getTemplateById(selectedTemplateId.value);
+});
+
+// Build chain description (e.g., "Chains to: Template A → Template B")
+const chainDescription = computed(() => {
+  if (!selectedTemplate.value?.nextTemplateId) return null;
+
+  const chain = [];
+  let currentId = selectedTemplate.value.nextTemplateId;
+  const visited = new Set();
+
+  while (currentId && !visited.has(currentId)) {
+    visited.add(currentId);
+    const template = templatesStore.getTemplateById(currentId);
+    if (template) {
+      chain.push(template.name);
+      currentId = template.nextTemplateId;
+    } else {
+      chain.push('Unknown');
+      break;
+    }
+    // Limit chain display to 3 items
+    if (chain.length >= 3) {
+      chain.push('...');
+      break;
+    }
+  }
+
+  return chain.length > 0 ? `Chains to: ${chain.join(' → ')}` : null;
+});
+
+// Watch for external changes to currentTemplateId
+watch(
+  () => props.currentTemplateId,
+  (newId) => {
+    selectedTemplateId.value = newId;
+  }
+);
+
+onMounted(() => {
+  // Fetch templates if not already loaded
+  if (props.projectId && templatesStore.projectTemplates.length === 0 && templatesStore.globalTemplates.length === 0) {
+    templatesStore.fetchProjectTemplates(props.projectId);
+  }
+});
+
+function truncatePrompt(prompt, maxLength = 100) {
+  if (!prompt) return '';
+  if (prompt.length <= maxLength) return prompt;
+  return prompt.substring(0, maxLength) + '...';
+}
+
+function handleChange() {
+  saving.value = true;
+  emit('update:templateId', selectedTemplateId.value);
+  // Parent will handle the API call and set saving back to false
+  setTimeout(() => {
+    saving.value = false;
+  }, 1000);
+}
+
+function clearSelection() {
+  selectedTemplateId.value = null;
+  handleChange();
+}
+</script>
+
+<style scoped>
+.template-selector {
+  padding: 1rem;
+  background: var(--color-bg-soft);
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.selector-label {
+  display: block;
+  font-weight: 500;
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-text);
+}
+
+.selector-wrapper {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.selector-wrapper .form-input {
+  flex: 1;
+}
+
+.btn-clear {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  color: var(--color-text-soft);
+  font-size: 0.875rem;
+  transition: all 0.15s;
+}
+
+.btn-clear:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+  color: var(--color-error);
+  border-color: var(--color-error);
+}
+
+.btn-clear:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.template-preview {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: var(--color-background);
+  border-radius: 0.375rem;
+  border: 1px solid var(--color-border);
+}
+
+.template-prompt-preview {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-soft);
+  line-height: 1.4;
+  font-style: italic;
+}
+
+.chain-indicator {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--color-warning, #f0ad4e);
+  color: #333;
+  border-radius: 4px;
+}
+
+.selector-help {
+  margin: 0.5rem 0 0;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.saving-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+@media (max-width: 480px) {
+  .template-selector {
+    padding: 0.75rem;
+  }
+
+  .selector-wrapper {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-clear {
+    align-self: flex-end;
+  }
+}
+</style>

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -318,6 +318,31 @@ export const useSessionsStore = defineStore('sessions', {
     },
 
     /**
+     * Update session's next template (for template chaining)
+     * @param {string} sessionId - Session ID
+     * @param {string|null} nextTemplateId - Template ID or null to clear
+     * @returns {Promise<Object>}
+     */
+    async updateNextTemplate(sessionId, nextTemplateId) {
+      this.error = null;
+      try {
+        const updated = await api.updateSession(sessionId, { nextTemplateId });
+        // Update local state
+        const session = this.sessions.find((s) => s.id === sessionId);
+        if (session) {
+          session.nextTemplateId = nextTemplateId;
+        }
+        if (this.currentSession?.id === sessionId) {
+          this.currentSession = { ...this.currentSession, nextTemplateId };
+        }
+        return updated;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
+    /**
      * Update session with new data from WebSocket
      * @param {Object} sessionData - Updated session data
      */

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -340,6 +340,113 @@ describe('Sessions Store', () => {
     });
   });
 
+  describe('updateNextTemplate', () => {
+    it('updates nextTemplateId in currentSession with new object reference for reactivity', async () => {
+      const store = useSessionsStore();
+
+      // Set up initial session
+      const initialSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        nextTemplateId: null,
+      };
+      store.currentSession = initialSession;
+      store.sessions = [{ ...initialSession }];
+
+      // Mock the API response
+      api.updateSession.mockResolvedValue({ ...initialSession, nextTemplateId: 'template-1' });
+
+      // Get original reference
+      const originalRef = store.currentSession;
+
+      // Update nextTemplateId
+      await store.updateNextTemplate('session-1', 'template-1');
+
+      // Verify nextTemplateId was updated
+      expect(store.currentSession.nextTemplateId).toBe('template-1');
+
+      // Verify new object reference was created (important for Vue reactivity)
+      expect(store.currentSession).not.toBe(originalRef);
+
+      // Verify other properties are preserved
+      expect(store.currentSession.id).toBe('session-1');
+      expect(store.currentSession.name).toBe('Test Session');
+    });
+
+    it('updates nextTemplateId in sessions list', async () => {
+      const store = useSessionsStore();
+
+      // Set up initial sessions
+      store.sessions = [
+        { id: 'session-1', nextTemplateId: null },
+        { id: 'session-2', nextTemplateId: 'template-a' },
+      ];
+
+      // Mock the API response
+      api.updateSession.mockResolvedValue({ id: 'session-1', nextTemplateId: 'template-b' });
+
+      // Update nextTemplateId for session-1
+      await store.updateNextTemplate('session-1', 'template-b');
+
+      // Verify correct session was updated
+      expect(store.sessions[0].nextTemplateId).toBe('template-b');
+      expect(store.sessions[1].nextTemplateId).toBe('template-a');
+    });
+
+    it('can clear nextTemplateId by setting to null', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', nextTemplateId: 'template-1' };
+      store.sessions = [{ id: 'session-1', nextTemplateId: 'template-1' }];
+
+      api.updateSession.mockResolvedValue({ id: 'session-1', nextTemplateId: null });
+
+      await store.updateNextTemplate('session-1', null);
+
+      expect(store.currentSession.nextTemplateId).toBeNull();
+      expect(store.sessions[0].nextTemplateId).toBeNull();
+    });
+
+    it('does not update currentSession if IDs do not match', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', nextTemplateId: null };
+      store.sessions = [{ id: 'session-2', nextTemplateId: null }];
+
+      api.updateSession.mockResolvedValue({ id: 'session-2', nextTemplateId: 'template-1' });
+
+      await store.updateNextTemplate('session-2', 'template-1');
+
+      // currentSession should be unchanged
+      expect(store.currentSession.nextTemplateId).toBeNull();
+    });
+
+    it('throws error and sets store error on API failure', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', nextTemplateId: null };
+
+      api.updateSession.mockRejectedValue(new Error('API Error'));
+
+      await expect(store.updateNextTemplate('session-1', 'template-1')).rejects.toThrow('API Error');
+
+      expect(store.error).toBe('API Error');
+      expect(store.currentSession.nextTemplateId).toBeNull();
+    });
+
+    it('calls api.updateSession with correct parameters', async () => {
+      const store = useSessionsStore();
+
+      store.sessions = [{ id: 'session-1', nextTemplateId: null }];
+
+      api.updateSession.mockResolvedValue({ id: 'session-1', nextTemplateId: 'template-1' });
+
+      await store.updateNextTemplate('session-1', 'template-1');
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', { nextTemplateId: 'template-1' });
+    });
+  });
+
   describe('conversations', () => {
     describe('fetchConversations', () => {
       it('fetches conversations and sets active', async () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -14,6 +14,9 @@
               {{ sessionsStore.currentSession.status }}
             </span>
             <span class="session-mode">{{ formatMode(sessionsStore.currentSession.mode) }}</span>
+            <span v-if="sessionsStore.currentSession.nextTemplateId" class="template-badge">
+              🔗 Next: {{ getTemplateName(sessionsStore.currentSession.nextTemplateId) }}
+            </span>
           </div>
           <div class="branch-line">
             <div class="branch-pr-indicators">
@@ -42,6 +45,15 @@
           </div>
         </div>
       </div>
+
+      <!-- Template Selector -->
+      <TemplateSelector
+        :session-id="sessionId"
+        :project-id="sessionsStore.currentSession.projectId"
+        :current-template-id="sessionsStore.currentSession.nextTemplateId"
+        :disabled="sessionsStore.currentSession.status === 'running' || sessionsStore.currentSession.status === 'starting'"
+        @update:template-id="handleTemplateChange"
+      />
 
       <div class="tabs">
         <router-link
@@ -105,6 +117,8 @@ import CanvasTab from '../components/CanvasTab.vue';
 import NotesTab from '../components/NotesTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
 import PrIndicators from '../components/PrIndicators.vue';
+import TemplateSelector from '../components/TemplateSelector.vue';
+import { useTemplatesStore } from '../stores/templates.js';
 
 const route = useRoute();
 const router = useRouter();
@@ -112,6 +126,7 @@ const sessionsStore = useSessionsStore();
 const canvasStore = useCanvasStore();
 const todosStore = useTodosStore();
 const uiStore = useUiStore();
+const templatesStore = useTemplatesStore();
 
 // Capture session ID at component creation to avoid race conditions during navigation.
 // When navigating away, Vue Router updates route.params BEFORE unmounting the component.
@@ -213,6 +228,11 @@ onMounted(async () => {
   // Check for file system changes initially
   checkForChanges();
 
+  // Fetch templates for the selector
+  if (sessionsStore.currentSession?.projectId) {
+    templatesStore.fetchProjectTemplates(sessionsStore.currentSession.projectId);
+  }
+
   // Start polling if session is actively processing (handles race condition where session
   // completes before WebSocket subscription is established)
   const status = sessionsStore.currentSession?.status;
@@ -307,6 +327,20 @@ async function handleDelete() {
     uiStore.error(err.message);
   }
 }
+
+async function handleTemplateChange(templateId) {
+  try {
+    await sessionsStore.updateNextTemplate(sessionId, templateId);
+    uiStore.success(templateId ? 'Template assigned' : 'Template removed');
+  } catch (err) {
+    uiStore.error(err.message);
+  }
+}
+
+function getTemplateName(templateId) {
+  const template = templatesStore.getTemplateById(templateId);
+  return template?.name || 'Unknown template';
+}
 </script>
 
 <style scoped>
@@ -367,6 +401,19 @@ async function handleDelete() {
 .session-mode {
   font-size: 0.75rem;
   color: var(--color-text-soft);
+}
+
+.template-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #333;
+  background: var(--color-warning, #f0ad4e);
+  border-radius: 4px;
+  white-space: nowrap;
 }
 
 .branch-indicator {


### PR DESCRIPTION
## Summary

- Add UI to allow users to select a template that will trigger when Claude completes its turn
- Template selector shows both project-specific and global templates in grouped dropdown
- Badge in session header indicates when a template is assigned
- Shows template chain preview if template has `nextTemplateId` set

## Changes

| File | Description |
|------|-------------|
| `TemplateSelector.vue` | New component - dropdown for selecting templates |
| `sessions.js` store | Add `updateNextTemplate()` action |
| `SessionDetailView.vue` | Integrate template selector and header badge |

## How It Works

1. User opens session detail view
2. Template selector appears below session header (disabled while running)
3. User selects a template from dropdown (grouped by project/global)
4. Selection is saved via `PATCH /api/sessions/:id` with `nextTemplateId`
5. When session completes, `templateTriggerService` automatically creates child session

## Screenshots

The template selector appears in the session detail view:

```
┌─────────────────────────────────────────────────────────────────────────┐
│  Session Name                                                           │
│  [waiting] [YOLO] [🔗 Next: Code Review]                                │
│                                                                         │
│  ┌─ When Claude Finishes ───────────────────────────────────────────┐  │
│  │  🔗 Code Review                                       [✕] [▼]    │  │
│  │  Chains to: Run Tests → Deploy                                   │  │
│  └──────────────────────────────────────────────────────────────────┘  │
│                                                                         │
│  [Summary] [Conversation] [Changes] [Canvas] [Notes]                    │
└─────────────────────────────────────────────────────────────────────────┘
```

## Test plan

- [x] Store tests pass (`yarn workspace @claudetools/web test -- src/stores/sessions.test.js`)
- [ ] Can select a template from the dropdown
- [ ] Selection persists after page refresh
- [ ] Template badge appears in header
- [ ] Selector disabled while session is running
- [ ] Template triggers automatically when session completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)