### PR TITLE
Fix work logs associating only with final message of turn

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -725,7 +725,11 @@ async function handleStreamEvent(sessionId, event) {
         const toolUse = toolUseBlocks.length > 0 ? toolUseBlocks : null;
         const message = messages.create(sessionId, 'assistant', textContent, toolUse);
 
-        // Track the message ID for end-of-turn work log association
+        // Associate pending work logs with this message immediately
+        // This ensures work logs are attached to the correct message, not just the last one
+        associateAndBroadcastWorkLogs(sessionId, message.id);
+
+        // Track the message ID in case there are trailing work logs after the last message
         lastMessageIds.set(sessionId, message.id);
 
         // Broadcast message

--- a/packages/server/test/work-logs.test.js
+++ b/packages/server/test/work-logs.test.js
@@ -227,6 +227,165 @@ describe('Work Logs API', () => {
     });
   });
 
+  describe('Multi-message turn work log association', () => {
+    // These tests document the fix for the bug where all work logs were
+    // associated with the LAST message of a turn instead of being distributed
+    // across multiple messages. The fix associates logs immediately when
+    // each message is created.
+
+    it('associates work logs with each message as they are created', () => {
+      // Simulate: think -> message1 -> think -> tool -> message2
+
+      // First batch of work (before message 1)
+      workLogs.create(session.id, 'thinking', 'Analyzing the request');
+
+      // Message 1 is created - associate pending logs
+      const message1 = messages.create(session.id, 'assistant', 'Let me check that for you.');
+      const count1 = workLogs.associatePendingLogs(session.id, message1.id);
+      expect(count1).toBe(1);
+
+      // Second batch of work (before message 2)
+      workLogs.create(session.id, 'thinking', 'Now I need to run a command');
+      workLogs.create(session.id, 'tool_input', '{"command": "ls"}', null, 'Bash');
+      workLogs.create(session.id, 'tool_output', 'file1.txt', null, 'Bash');
+
+      // Message 2 is created - associate pending logs
+      const message2 = messages.create(session.id, 'assistant', 'Here are the files I found.');
+      const count2 = workLogs.associatePendingLogs(session.id, message2.id);
+      expect(count2).toBe(3);
+
+      // Verify logs are correctly distributed
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+
+      expect(grouped[message1.id]).toBeDefined();
+      expect(grouped[message1.id].length).toBe(1);
+      expect(grouped[message1.id][0].content).toBe('Analyzing the request');
+
+      expect(grouped[message2.id]).toBeDefined();
+      expect(grouped[message2.id].length).toBe(3);
+      expect(grouped[message2.id][0].content).toBe('Now I need to run a command');
+
+      // No unassociated logs remain
+      expect(grouped['_unassociated']).toBeUndefined();
+    });
+
+    it('handles three messages in a turn correctly', () => {
+      // Simulate a complex turn with 3 messages
+
+      // Work before message 1
+      workLogs.create(session.id, 'thinking', 'Step 1 thinking');
+      const msg1 = messages.create(session.id, 'assistant', 'First, let me...');
+      workLogs.associatePendingLogs(session.id, msg1.id);
+
+      // Work before message 2
+      workLogs.create(session.id, 'tool_input', 'tool1 input', null, 'Read');
+      workLogs.create(session.id, 'tool_output', 'tool1 output', null, 'Read');
+      const msg2 = messages.create(session.id, 'assistant', 'I found...');
+      workLogs.associatePendingLogs(session.id, msg2.id);
+
+      // Work before message 3
+      workLogs.create(session.id, 'thinking', 'Final analysis');
+      workLogs.create(session.id, 'tool_input', 'tool2 input', null, 'Write');
+      workLogs.create(session.id, 'tool_output', 'tool2 output', null, 'Write');
+      const msg3 = messages.create(session.id, 'assistant', 'Done! Here is the result.');
+      workLogs.associatePendingLogs(session.id, msg3.id);
+
+      // Verify distribution
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+
+      expect(grouped[msg1.id].length).toBe(1);
+      expect(grouped[msg2.id].length).toBe(2);
+      expect(grouped[msg3.id].length).toBe(3);
+      expect(grouped['_unassociated']).toBeUndefined();
+    });
+
+    it('handles message with no preceding work logs', () => {
+      // First message has work logs
+      workLogs.create(session.id, 'thinking', 'Initial thought');
+      const msg1 = messages.create(session.id, 'assistant', 'Let me help.');
+      workLogs.associatePendingLogs(session.id, msg1.id);
+
+      // Second message has NO work logs before it (quick follow-up)
+      const msg2 = messages.create(session.id, 'assistant', 'Actually, one more thing...');
+      const count = workLogs.associatePendingLogs(session.id, msg2.id);
+      expect(count).toBe(0);
+
+      // Verify
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+      expect(grouped[msg1.id].length).toBe(1);
+      expect(grouped[msg2.id]).toBeUndefined(); // No logs for this message
+    });
+
+    it('handles trailing work logs after the last message', () => {
+      // Message 1 with its logs
+      workLogs.create(session.id, 'thinking', 'Initial thought');
+      const msg1 = messages.create(session.id, 'assistant', 'First response.');
+      workLogs.associatePendingLogs(session.id, msg1.id);
+
+      // Trailing work logs (created after the last text message)
+      // This can happen when tool execution happens after the text
+      workLogs.create(session.id, 'tool_input', 'trailing tool', null, 'Bash');
+      workLogs.create(session.id, 'tool_output', 'trailing output', null, 'Bash');
+
+      // End of turn - associate trailing logs with last message
+      const trailingCount = workLogs.associatePendingLogs(session.id, msg1.id);
+      expect(trailingCount).toBe(2);
+
+      // Verify all logs are now with message 1
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+      expect(grouped[msg1.id].length).toBe(3); // 1 initial + 2 trailing
+      expect(grouped['_unassociated']).toBeUndefined();
+    });
+
+    it('preserves work log order within each message', () => {
+      // Create logs in specific order
+      workLogs.create(session.id, 'thinking', 'Think A');
+      workLogs.create(session.id, 'tool_input', 'Input B', null, 'Bash');
+      workLogs.create(session.id, 'tool_output', 'Output C', null, 'Bash');
+
+      const msg = messages.create(session.id, 'assistant', 'Response');
+      workLogs.associatePendingLogs(session.id, msg.id);
+
+      const grouped = workLogs.getBySessionIdGrouped(session.id);
+      const logs = grouped[msg.id];
+
+      // Logs should be in timestamp order (which is creation order)
+      expect(logs[0].content).toBe('Think A');
+      expect(logs[1].content).toBe('Input B');
+      expect(logs[2].content).toBe('Output C');
+    });
+
+    it('correctly separates logs between two sessions running simultaneously', () => {
+      // Create second session
+      const session2 = sessions.create(project.id, 'Session 2', 'Prompt 2', 'standard');
+
+      // Interleaved work logs from both sessions
+      workLogs.create(session.id, 'thinking', 'Session 1 thought');
+      workLogs.create(session2.id, 'thinking', 'Session 2 thought');
+      workLogs.create(session.id, 'tool_input', 'Session 1 tool', null, 'Bash');
+      workLogs.create(session2.id, 'tool_input', 'Session 2 tool', null, 'Bash');
+
+      // Each session creates a message and associates
+      const msg1 = messages.create(session.id, 'assistant', 'Session 1 response');
+      const msg2 = messages.create(session2.id, 'assistant', 'Session 2 response');
+
+      workLogs.associatePendingLogs(session.id, msg1.id);
+      workLogs.associatePendingLogs(session2.id, msg2.id);
+
+      // Verify each session has its own logs
+      const grouped1 = workLogs.getBySessionIdGrouped(session.id);
+      const grouped2 = workLogs.getBySessionIdGrouped(session2.id);
+
+      expect(grouped1[msg1.id].length).toBe(2);
+      expect(grouped1[msg1.id][0].content).toBe('Session 1 thought');
+      expect(grouped1[msg1.id][1].content).toBe('Session 1 tool');
+
+      expect(grouped2[msg2.id].length).toBe(2);
+      expect(grouped2[msg2.id][0].content).toBe('Session 2 thought');
+      expect(grouped2[msg2.id][1].content).toBe('Session 2 tool');
+    });
+  });
+
   describe('Session status update for polling', () => {
     it('can update session status', () => {
       // This tests that status can be updated, which is needed for the


### PR DESCRIPTION
## Summary
- Work logs were all being associated with the last assistant message of a turn instead of being distributed across the correct messages
- Fixed by associating work logs immediately when each assistant message is created, rather than waiting until end of turn
- The `lastMessageIds` tracking remains for any trailing work logs that occur after the last text message

## Root Cause
The issue was that:
1. Work logs were created as unassociated (`messageId = null`) during Claude's turn
2. `lastMessageIds` Map only stored ONE messageId per session, so each new message overwrote the previous
3. At end of turn, ALL pending logs were associated with whatever the last messageId was

## Test plan
- [x] All 880 existing tests pass
- [ ] Manual testing: Verify work logs appear under the correct assistant messages when Claude produces multiple messages in a turn
- [ ] Verify work logs still show correctly in LiveWorkLogPanel during streaming
- [ ] Verify work logs move to the correct WorkLogPanel after turn completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)