### PR TITLE
Fix start-server.sh to pass port directly to node

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -119,4 +119,4 @@ echo "$SELECTED_PORT" > "$PORT_FILE"
 # Start the server
 # -----------------------------------------------------------------------------
 echo "Starting server on port ${SELECTED_PORT}..."
-PORT=$SELECTED_PORT yarn dev
+yarn build && NODE_ENV=production node packages/server/src/index.js -p ${SELECTED_PORT}


### PR DESCRIPTION
## Summary
- Fixed startup script to pass the selected port directly to the node server instead of relying on PORT environment variable
- The `yarn dev` script hardcoded `-p 5000`, causing worktree port detection to fail
- Now runs `yarn build && NODE_ENV=production node packages/server/src/index.js -p ${SELECTED_PORT}` directly

## Test plan
- [ ] Run `./scripts/start-server.sh` from main repo - should use port 5000
- [ ] Run `./scripts/start-server.sh` from a worktree - should auto-detect and use port 5001+
- [ ] Verify server starts successfully on the assigned port

🤖 Generated with [Claude Code](https://claude.com/claude-code)