### PR TITLE
Fix multi-conversation context isolation

### DIFF
--- a/packages/server/src/db/ConversationRepository.js
+++ b/packages/server/src/db/ConversationRepository.js
@@ -17,6 +17,7 @@ export class ConversationRepository extends BaseRepository {
       summary: row.summary,
       summaryGeneratedAt: row.summary_generated_at,
       isActive: row.is_active === 1,
+      claudeSessionId: row.claude_session_id,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -118,6 +119,10 @@ export class ConversationRepository extends BaseRepository {
     if (data.summaryGeneratedAt !== undefined) {
       updates.push('summary_generated_at = ?');
       values.push(data.summaryGeneratedAt);
+    }
+    if (data.claudeSessionId !== undefined) {
+      updates.push('claude_session_id = ?');
+      values.push(data.claudeSessionId);
     }
     if (data.isActive !== undefined) {
       // If setting this conversation as active, deactivate others first

--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -127,6 +127,14 @@ export class DatabaseManager {
 
     // Create default conversations for existing sessions that don't have one
     this.#migrateExistingSessionsToConversations();
+
+    // Add claude_session_id column to conversations table for per-conversation context isolation
+    const conversationsTableInfo = this.#db.prepare('PRAGMA table_info(conversations)').all();
+    const conversationsColumns = conversationsTableInfo.map((col) => col.name);
+
+    if (!conversationsColumns.includes('claude_session_id')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN claude_session_id TEXT');
+    }
   }
 
   /**

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS conversations (
   summary TEXT,                        -- Per-conversation summary
   summary_generated_at INTEGER,        -- When summary was last generated
   is_active INTEGER NOT NULL DEFAULT 0, -- Currently selected conversation (1 = active)
+  claude_session_id TEXT,              -- Claude SDK session ID for this conversation's context
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -529,16 +529,15 @@ export async function continueSession(sessionId, content, workingDirectory, syst
     throw new Error('Session not found');
   }
 
-  if (!session.claudeSessionId && !isMockMode()) {
-    throw new Error('Session has no Claude session ID - cannot resume');
-  }
-
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
   try {
     // Ensure there's an active conversation for this session
     const activeConversation = conversations.ensureActiveConversation(sessionId);
+
+    // Each conversation has its own Claude session context
+    // If null, Claude will start a fresh session (no resume)
 
     // Store the user message with conversation ID
     const message = messages.create(sessionId, 'user', content, null, activeConversation.id);
@@ -571,7 +570,9 @@ export async function continueSession(sessionId, content, workingDirectory, syst
             abortController: controller,
             includePartialMessages: true,
             permissionMode: getPermissionModeForSession(session.mode),
-            resume: session.claudeSessionId,
+            // Use conversation's claudeSessionId for context isolation
+            // Only pass resume if the conversation has an existing Claude session
+            ...(activeConversation.claudeSessionId && { resume: activeConversation.claudeSessionId }),
             ...(sessionEnv && { env: sessionEnv }),
             ...(session.model && { model: session.model }),
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
@@ -704,8 +705,15 @@ async function handleStreamEvent(sessionId, event) {
     case 'system': {
       // Store Claude's session info
       if (event.subtype === 'init') {
+        // Save Claude session ID to the active conversation for context isolation
+        const activeConversation = conversations.getActiveBySessionId(sessionId);
+        if (activeConversation) {
+          conversations.update(activeConversation.id, {
+            claudeSessionId: event.session_id,
+          });
+        }
+        // Still update session's model
         sessions.update(sessionId, {
-          claudeSessionId: event.session_id,
           model: event.model,
         });
         // Reset message tracking for new session


### PR DESCRIPTION
## Summary

- Move `claudeSessionId` from session to conversation level so each conversation maintains its own Claude context
- New conversations now start fresh (no previous context sent to Claude)
- Switching to existing conversations resumes their saved context
- True context isolation between conversation threads

## Problem

When a new conversation was started, the entire past conversation history was still being sent to Claude Code. This defeated the purpose of multi-conversation, which is to reset context.

## Solution

Store `claude_session_id` per conversation instead of per session:
- Add `claude_session_id` column to conversations table
- Update `ConversationRepository` to handle the new field
- Modify `sessionManager` to use `activeConversation.claudeSessionId`
- Only pass `resume` param to Claude SDK when conversation has existing context

## Behavior After Fix

| Action | claudeSessionId | Claude SDK Behavior |
|--------|-----------------|---------------------|
| Create new conversation | `null` | Fresh start, no `resume` param |
| Send message in new conv | Set from response | Stores new ID on conversation |
| Switch to existing conv | Has stored ID | Passes `resume` with that ID |

## Test plan

- [x] All 921 existing tests pass
- [ ] Create a session with initial conversation
- [ ] Send a few messages to build context
- [ ] Create a new conversation - verify Claude starts fresh (no memory of previous messages)
- [ ] Switch back to original conversation - verify Claude remembers the previous context

🤖 Generated with [Claude Code](https://claude.com/claude-code)