### PR TITLE
Display YOLO mode in uppercase on session list views

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -49,9 +49,16 @@ describe('SessionCard', () => {
       expect(badge.classes()).toContain('status-running');
     });
 
-    it('renders session mode', () => {
+    it('renders session mode capitalized', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('.session-mode').text()).toBe('code');
+      expect(wrapper.find('.session-mode').text()).toBe('Code');
+    });
+
+    it('renders YOLO mode in uppercase', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, mode: 'yolo' },
+      });
+      expect(wrapper.find('.session-mode').text()).toBe('YOLO');
     });
 
     it('links to session detail page', () => {

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -5,7 +5,7 @@
         <h3 class="session-name">{{ session.name }}</h3>
         <p class="session-meta">
           <span :class="['status-badge', `status-${session.status}`]">{{ session.status }}</span>
-          <span class="session-mode">{{ session.mode }}</span>
+          <span class="session-mode">{{ formattedMode }}</span>
         </p>
         <div v-if="session.gitBranch || session.prUrl" class="branch-row">
           <span v-if="session.gitBranch" class="session-branch">{{ session.gitBranch }}</span>
@@ -83,6 +83,13 @@ const dateToShow = computed(() => {
   // For active sessions view, prefer updatedAt; for project view, prefer createdAt
   return props.showProject ? props.session.updatedAt : props.session.createdAt;
 });
+
+const formattedMode = computed(() => {
+  const mode = props.session.mode;
+  if (mode === 'yolo') return 'YOLO';
+  // Capitalize first letter for other modes
+  return mode ? mode.charAt(0).toUpperCase() + mode.slice(1) : '';
+});
 </script>
 
 <style scoped>
@@ -121,7 +128,6 @@ const dateToShow = computed(() => {
 .session-mode {
   font-size: 0.75rem;
   color: var(--color-text-soft);
-  text-transform: capitalize;
 }
 
 .branch-row {


### PR DESCRIPTION
## Summary
- Changed mode display in SessionCard from CSS `text-transform: capitalize` to JavaScript formatting
- "yolo" mode now displays as "YOLO" instead of "Yolo" to match how it appears elsewhere in the app
- Other modes are still properly capitalized (e.g., "code" → "Code")

## Test plan
- [x] Verified SessionCard tests pass with updated expectations
- [ ] Check session list view displays "YOLO" in uppercase for yolo mode sessions
- [ ] Verify other modes still display correctly capitalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)