### PR TITLE
Fix model selector blue highlight delay on selection

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -120,11 +120,7 @@
         </div>
       </div>
       <div class="model-row">
-        <ModelSelector
-          :modelValue="sessionsStore.currentSession?.model || DEFAULT_MODEL"
-          @update:modelValue="handleModelChange"
-          :disabled="togglingModel"
-        />
+        <ModelSelector :sessionId="sessionId" />
       </div>
     </form>
 
@@ -156,7 +152,6 @@ import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
-import { DEFAULT_MODEL } from '@claudetools/shared';
 import TodoDrawer from './TodoDrawer.vue';
 import WorkLogPanel from './WorkLogPanel.vue';
 import MarkdownViewer from './MarkdownViewer.vue';
@@ -178,7 +173,6 @@ const stopping = ref(false);
 const restarting = ref(false);
 const togglingThinking = ref(false);
 const togglingMode = ref(false);
-const togglingModel = ref(false);
 const messagesContainer = ref(null);
 const attachedFiles = ref([]);
 const fileAttachment = ref(null);
@@ -477,19 +471,6 @@ async function handleModeChange(newMode) {
   }
 }
 
-async function handleModelChange(newModel) {
-  if (togglingModel.value) return;
-  if (sessionsStore.currentSession?.model === newModel) return;
-
-  togglingModel.value = true;
-  try {
-    await sessionsStore.updateSessionModel(props.sessionId, newModel);
-  } catch (err) {
-    uiStore.error(err.message);
-  } finally {
-    togglingModel.value = false;
-  }
-}
 </script>
 
 <style scoped>
@@ -678,6 +659,8 @@ async function handleModelChange(newModel) {
   color: var(--color-text-soft);
   cursor: pointer;
   transition: background-color 0.15s, color 0.15s;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .mode-btn:last-child {
@@ -688,9 +671,11 @@ async function handleModelChange(newModel) {
   background: var(--color-bg-hover);
 }
 
-.mode-btn.active {
+.mode-btn.active,
+.mode-btn.active:focus {
   background: var(--color-primary);
   color: white;
+  outline: none;
 }
 
 .mode-btn:disabled {

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
 import ModelSelector from './ModelSelector.vue';
 import { CLAUDE_MODELS } from '@claudetools/shared';
 
@@ -7,6 +8,10 @@ import { CLAUDE_MODELS } from '@claudetools/shared';
 const [sonnet, opus, haiku] = CLAUDE_MODELS;
 
 describe('ModelSelector', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
   const mountComponent = (props = {}, attrs = {}) => {
     return mount(ModelSelector, {
       props: {
@@ -94,8 +99,9 @@ describe('ModelSelector', () => {
       );
       const buttons = wrapper.findAll('.model-btn');
 
+      // Clicking already selected model doesn't emit (early return optimization)
       await buttons[0].trigger('click');
-      expect(onUpdateModelValue).toHaveBeenCalledWith(sonnet.id);
+      expect(onUpdateModelValue).not.toHaveBeenCalled();
 
       await buttons[1].trigger('click');
       expect(onUpdateModelValue).toHaveBeenCalledWith(opus.id);
@@ -103,7 +109,7 @@ describe('ModelSelector', () => {
       await buttons[2].trigger('click');
       expect(onUpdateModelValue).toHaveBeenCalledWith(haiku.id);
 
-      expect(onUpdateModelValue).toHaveBeenCalledTimes(3);
+      expect(onUpdateModelValue).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -6,9 +6,9 @@
         v-for="m in models"
         :key="m.id"
         type="button"
-        :class="['model-btn', { active: modelValue === m.id }]"
-        @click="selectModel(m.id)"
-        :disabled="disabled"
+        :class="['model-btn', { active: currentModel === m.id }]"
+        @click="handleModelChange(m.id)"
+        :disabled="disabled || togglingModel"
         :title="m.description"
       >
         {{ m.name }}
@@ -18,12 +18,19 @@
 </template>
 
 <script setup>
+import { ref, computed } from 'vue';
 import { CLAUDE_MODELS } from '@claudetools/shared';
+import { useSessionsStore } from '../stores/sessions.js';
+import { useUiStore } from '../stores/ui.js';
 
-defineProps({
+const props = defineProps({
+  sessionId: {
+    type: String,
+    default: null,
+  },
   modelValue: {
     type: String,
-    required: true,
+    default: null,
   },
   disabled: {
     type: Boolean,
@@ -33,10 +40,37 @@ defineProps({
 
 const emit = defineEmits(['update:modelValue']);
 
+const sessionsStore = useSessionsStore();
+const uiStore = useUiStore();
 const models = CLAUDE_MODELS;
+const togglingModel = ref(false);
 
-function selectModel(id) {
-  emit('update:modelValue', id);
+// Use store state when sessionId provided, otherwise use modelValue prop
+const currentModel = computed(() => {
+  if (props.sessionId) {
+    return sessionsStore.currentSession?.model;
+  }
+  return props.modelValue;
+});
+
+async function handleModelChange(id) {
+  if (togglingModel.value) return;
+  if (currentModel.value === id) return;
+
+  if (props.sessionId) {
+    // Session context: update store directly for immediate visual feedback
+    togglingModel.value = true;
+    try {
+      await sessionsStore.updateSessionModel(props.sessionId, id);
+    } catch (err) {
+      uiStore.error(err.message);
+    } finally {
+      togglingModel.value = false;
+    }
+  } else {
+    // Form context: emit for v-model
+    emit('update:modelValue', id);
+  }
 }
 </script>
 
@@ -69,6 +103,8 @@ function selectModel(id) {
   color: var(--color-text-soft);
   cursor: pointer;
   transition: background-color 0.15s, color 0.15s;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .model-btn:last-child {
@@ -79,9 +115,11 @@ function selectModel(id) {
   background: var(--color-bg-hover);
 }
 
-.model-btn.active {
+.model-btn.active,
+.model-btn.active:focus {
   background: var(--color-primary);
   color: white;
+  outline: none;
 }
 
 .model-btn:disabled {

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -398,6 +398,8 @@ h1 {
   color: var(--color-text-soft);
   cursor: pointer;
   transition: background-color 0.15s, color 0.15s;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .mode-btn:last-child {
@@ -408,9 +410,11 @@ h1 {
   background: var(--color-bg-hover);
 }
 
-.mode-btn.active {
+.mode-btn.active,
+.mode-btn.active:focus {
   background: var(--color-primary);
   color: white;
+  outline: none;
 }
 
 .toggle-switch {


### PR DESCRIPTION
## Summary
- Fix cosmetic issue where clicking a model button wouldn't show the blue highlight until focus was lost
- Refactor ModelSelector to directly access the store (like the mode selector) for immediate visual feedback
- Add CSS improvements to prevent text selection and ensure focus states don't override active states

## Root Cause
The ModelSelector used a prop-based approach (`modelValue` prop + `update:modelValue` emit) which created an extra reactivity layer. When a model was clicked:
1. Event emitted → parent handles → async store update → prop flows back down → UI updates

The mode selector worked because it directly accessed `sessionsStore.currentSession?.mode`, updating immediately when the store changed.

## Changes
- `ModelSelector.vue`: Add `sessionId` prop for session context, directly access store state, handle model changes internally
- `ConversationTab.vue`: Use `sessionId` prop instead of `modelValue` + event handler, remove redundant code
- CSS: Add `user-select: none` and `.active:focus` rules to both selectors

## Test plan
- [ ] Click model buttons in New Session view - should highlight immediately
- [ ] Click model buttons in Session Detail conversation tab - should highlight immediately
- [ ] Verify mode selector still works correctly
- [ ] Verify v-model still works for New Session view form

🤖 Generated with [Claude Code](https://claude.com/claude-code)