### PR TITLE
Remove Projects back-link from Active Sessions view

### DIFF
--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -2,7 +2,6 @@
   <div class="container">
     <div class="page-header">
       <div>
-        <router-link to="/" class="back-link">&larr; Projects</router-link>
         <p class="page-description">Sessions that are running or waiting for input</p>
       </div>
     </div>
@@ -186,13 +185,6 @@ async function retryFetchSummary(sessionId) {
   justify-content: space-between;
   align-items: flex-start;
   margin-bottom: 2rem;
-}
-
-.back-link {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  display: inline-block;
-  margin-bottom: 0.5rem;
 }
 
 .page-header h1 {


### PR DESCRIPTION
## Summary
- Removes the "← Projects" back-link from the Active Sessions view
- Removes the associated `.back-link` CSS styles
- Cleans up unnecessary UI clutter

## Test plan
- [ ] Navigate to the Active Sessions view
- [ ] Verify the Projects back-link is no longer displayed
- [ ] Verify the layout still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)