### PR TITLE
fix: Resolve sticky sub nav positioning conflict with header

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -32,7 +32,9 @@ import ToastContainer from './components/ToastContainer.vue';
 .app-header {
   background-color: var(--color-background-soft);
   border-bottom: 1px solid var(--color-border);
-  padding: 0.75rem 0;
+  height: var(--header-height);
+  display: flex;
+  align-items: center;
   position: sticky;
   top: 0;
   z-index: 100;

--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -14,6 +14,7 @@
   --color-info: #58a6ff;
   --border-radius: 6px;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  --header-height: 3rem;
 }
 
 *,
@@ -242,11 +243,11 @@ input, textarea, select {
   display: flex;
   border-bottom: 1px solid var(--color-border);
   margin-bottom: 1rem;
-  /* Sticky positioning */
+  /* Sticky positioning - top value accounts for sticky header height */
   position: sticky;
-  top: 0;
+  top: var(--header-height, 3rem);
   background-color: var(--color-background);
-  z-index: 100;
+  z-index: 99;
   padding-top: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Fixes bug where session detail sub nav tabs were hidden behind the sticky header when scrolling
- Both elements had `position: sticky` with `top: 0` and `z-index: 100`, causing the conflict
- Adds `--header-height` CSS variable for consistent sizing across components

## Changes
- Added `--header-height: 3rem` CSS variable to `:root` in main.css
- Updated `.tabs` to use `top: var(--header-height)` so tabs stick below header
- Reduced tabs z-index to 99 (below header's 100) for proper stacking order
- Updated header to use the height variable for consistency

## Test plan
- [ ] Navigate to a session detail page
- [ ] Scroll down to verify the sub nav tabs stick just below the header
- [ ] Verify both header and tabs remain visible while scrolling
- [ ] Test on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)