### PR TITLE
feat: Add status filter buttons to session list views

### DIFF
--- a/packages/web/src/views/ActiveSessionsView.test.js
+++ b/packages/web/src/views/ActiveSessionsView.test.js
@@ -278,6 +278,140 @@ describe('ActiveSessionsView', () => {
   });
 });
 
+describe('Status filtering', () => {
+  let mockSessionsStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    setActivePinia(createPinia());
+
+    onSessionCreatedCallback = null;
+    onSessionUpdatedCallback = null;
+    onSessionDeletedCallback = null;
+    onSessionSummaryUpdatedCallback = null;
+
+    mockGetSessionSummary.mockReset();
+    mockGetSessionSummary.mockResolvedValue(null);
+
+    mockSessionsStore = {
+      loading: false,
+      error: null,
+      activeSessions: [
+        { id: 'session-1', name: 'Running Session', status: 'running', projectId: 'project-1' },
+        { id: 'session-2', name: 'Waiting Session', status: 'waiting', projectId: 'project-2' },
+        { id: 'session-3', name: 'Starting Session', status: 'starting', projectId: 'project-1' },
+      ],
+      fetchActiveSessions: vi.fn().mockResolvedValue(),
+    };
+    useSessionsStore.mockReturnValue(mockSessionsStore);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('renders filter buttons for running and waiting statuses', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const filterButtons = wrapper.findAll('.filter-btn');
+    expect(filterButtons).toHaveLength(2);
+    expect(filterButtons[0].text()).toBe('running');
+    expect(filterButtons[1].text()).toBe('waiting');
+  });
+
+  it('shows all sessions when no filters are active', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(3);
+  });
+
+  it('filters to show only running sessions when running filter is clicked', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    await runningButton.trigger('click');
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(1);
+    expect(sessionCards[0].attributes('data-session-id')).toBe('session-1');
+  });
+
+  it('filters to show only waiting sessions when waiting filter is clicked', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const waitingButton = wrapper.findAll('.filter-btn')[1];
+    await waitingButton.trigger('click');
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(1);
+    expect(sessionCards[0].attributes('data-session-id')).toBe('session-2');
+  });
+
+  it('shows both running and waiting sessions when both filters are active', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const filterButtons = wrapper.findAll('.filter-btn');
+    await filterButtons[0].trigger('click'); // running
+    await filterButtons[1].trigger('click'); // waiting
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(2);
+  });
+
+  it('toggles filter off when clicked again', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+
+    // Click to enable filter
+    await runningButton.trigger('click');
+    expect(wrapper.findAll('.session-card')).toHaveLength(1);
+
+    // Click again to disable filter
+    await runningButton.trigger('click');
+    expect(wrapper.findAll('.session-card')).toHaveLength(3);
+  });
+
+  it('adds active class to selected filter button', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    expect(runningButton.classes()).not.toContain('active');
+
+    await runningButton.trigger('click');
+    expect(runningButton.classes()).toContain('active');
+  });
+
+  it('shows empty state message when filters return no results', async () => {
+    // Set up store with only starting sessions (no running or waiting)
+    mockSessionsStore.activeSessions = [
+      { id: 'session-1', name: 'Starting Session', status: 'starting', projectId: 'project-1' },
+    ];
+    useSessionsStore.mockReturnValue(mockSessionsStore);
+
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    // Click running filter - no running sessions exist
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    await runningButton.trigger('click');
+
+    const emptyState = wrapper.find('.empty-state');
+    expect(emptyState.exists()).toBe(true);
+    expect(emptyState.text()).toContain('No sessions match the current filter');
+  });
+});
+
 describe('ActiveSessionsView polling fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -6,6 +6,18 @@
       </div>
     </div>
 
+    <div class="status-filters">
+      <span class="filter-label">Filter:</span>
+      <button
+        v-for="status in ['running', 'waiting']"
+        :key="status"
+        :class="['filter-btn', { active: statusFilters.includes(status) }]"
+        @click="toggleFilter(status)"
+      >
+        {{ status }}
+      </button>
+    </div>
+
     <div v-if="sessionsStore.loading" class="skeleton-list">
       <div v-for="i in 3" :key="i" class="skeleton card" style="height: 120px"></div>
     </div>
@@ -19,9 +31,13 @@
       <router-link to="/" class="btn btn-primary">View Projects</router-link>
     </div>
 
+    <div v-else-if="filteredSessions.length === 0" class="empty-state">
+      <p>No sessions match the current filter.</p>
+    </div>
+
     <div v-else class="session-list">
       <SessionCard
-        v-for="session in sessionsStore.activeSessions"
+        v-for="session in filteredSessions"
         :key="session.id"
         :session="session"
         :show-project="true"
@@ -36,13 +52,31 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, reactive, watch } from 'vue';
+import { onMounted, onUnmounted, reactive, watch, ref, computed } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useGlobalSessionSubscription } from '../composables/useWebSocket.js';
 import { api } from '../composables/useApi.js';
 import SessionCard from '../components/SessionCard.vue';
 
 const sessionsStore = useSessionsStore();
+
+// Filter state - empty means show all
+const statusFilters = ref([]);
+
+const toggleFilter = (status) => {
+  const index = statusFilters.value.indexOf(status);
+  if (index >= 0) {
+    statusFilters.value.splice(index, 1);
+  } else {
+    statusFilters.value.push(status);
+  }
+};
+
+const filteredSessions = computed(() => {
+  const sessions = sessionsStore.activeSessions;
+  if (statusFilters.value.length === 0) return sessions;
+  return sessions.filter(s => statusFilters.value.includes(s.status));
+});
 
 // Store summaries keyed by session ID
 const summaries = reactive({});
@@ -224,5 +258,40 @@ async function retryFetchSummary(sessionId) {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.status-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.filter-label {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+}
+
+.filter-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--color-text-soft);
+  cursor: pointer;
+  border-radius: var(--border-radius);
+  transition: all 0.15s;
+  text-transform: capitalize;
+}
+
+.filter-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.filter-btn.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
 }
 </style>

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -265,6 +265,166 @@ describe('SessionListView', () => {
   });
 });
 
+describe('Status filtering', () => {
+  let mockProjectsStore;
+  let mockSessionsStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+
+    mockRouteParams.id = 'test-project-id';
+
+    onSessionCreatedCallback = null;
+    onSessionUpdatedCallback = null;
+    onSessionDeletedCallback = null;
+    onSessionSummaryUpdatedCallback = null;
+
+    mockGetSessionSummary.mockReset();
+    mockGetSessionSummary.mockResolvedValue(null);
+
+    mockProjectsStore = {
+      currentProject: { id: 'test-project-id', name: 'Test Project', workingDirectory: '/test/path' },
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    mockSessionsStore = {
+      loading: false,
+      error: null,
+      sessions: [
+        { id: 'session-1', name: 'Running Session', status: 'running' },
+        { id: 'session-2', name: 'Waiting Session', status: 'waiting' },
+        { id: 'session-3', name: 'Completed Session', status: 'completed' },
+        { id: 'session-4', name: 'Error Session', status: 'error' },
+      ],
+      fetchSessions: vi.fn().mockResolvedValue(),
+      addSessionToList: vi.fn(),
+      updateSession: vi.fn(),
+      removeSessionFromList: vi.fn(),
+    };
+    useSessionsStore.mockReturnValue(mockSessionsStore);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders filter buttons for running and waiting statuses', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const filterButtons = wrapper.findAll('.filter-btn');
+    expect(filterButtons).toHaveLength(2);
+    expect(filterButtons[0].text()).toBe('running');
+    expect(filterButtons[1].text()).toBe('waiting');
+  });
+
+  it('shows all sessions when no filters are active', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(4);
+  });
+
+  it('filters to show only running sessions when running filter is clicked', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    await runningButton.trigger('click');
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(1);
+    expect(sessionCards[0].attributes('data-session-id')).toBe('session-1');
+  });
+
+  it('filters to show only waiting sessions when waiting filter is clicked', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const waitingButton = wrapper.findAll('.filter-btn')[1];
+    await waitingButton.trigger('click');
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(1);
+    expect(sessionCards[0].attributes('data-session-id')).toBe('session-2');
+  });
+
+  it('shows both running and waiting sessions when both filters are active', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const filterButtons = wrapper.findAll('.filter-btn');
+    await filterButtons[0].trigger('click'); // running
+    await filterButtons[1].trigger('click'); // waiting
+
+    const sessionCards = wrapper.findAll('.session-card');
+    expect(sessionCards).toHaveLength(2);
+  });
+
+  it('toggles filter off when clicked again', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+
+    // Click to enable filter
+    await runningButton.trigger('click');
+    expect(wrapper.findAll('.session-card')).toHaveLength(1);
+
+    // Click again to disable filter
+    await runningButton.trigger('click');
+    expect(wrapper.findAll('.session-card')).toHaveLength(4);
+  });
+
+  it('adds active class to selected filter button', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    expect(runningButton.classes()).not.toContain('active');
+
+    await runningButton.trigger('click');
+    expect(runningButton.classes()).toContain('active');
+  });
+
+  it('shows empty state message when filters return no results', async () => {
+    // Set up store with only completed sessions
+    mockSessionsStore.sessions = [
+      { id: 'session-1', name: 'Completed Session', status: 'completed' },
+    ];
+    useSessionsStore.mockReturnValue(mockSessionsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    // Click running filter - no running sessions exist
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    await runningButton.trigger('click');
+
+    const emptyState = wrapper.find('.empty-state');
+    expect(emptyState.exists()).toBe(true);
+    expect(emptyState.text()).toContain('No sessions match the current filter');
+  });
+
+  it('only shows filter buttons on sessions tab', async () => {
+    const wrapper = mount(SessionListView);
+    await flushPromises();
+
+    // Filters should be visible on sessions tab
+    expect(wrapper.find('.status-filters').exists()).toBe(true);
+
+    // Click on templates tab
+    const templatesTab = wrapper.findAll('.tab')[1];
+    await templatesTab.trigger('click');
+
+    // Filters should not be visible on templates tab
+    expect(wrapper.find('.status-filters').exists()).toBe(false);
+  });
+});
+
 describe('SessionListView integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -30,6 +30,19 @@
       </button>
     </div>
 
+    <!-- Status Filters -->
+    <div v-if="activeTab === 'sessions'" class="status-filters">
+      <span class="filter-label">Filter:</span>
+      <button
+        v-for="status in ['running', 'waiting']"
+        :key="status"
+        :class="['filter-btn', { active: statusFilters.includes(status) }]"
+        @click="toggleFilter(status)"
+      >
+        {{ status }}
+      </button>
+    </div>
+
     <!-- Sessions Tab -->
     <div v-if="activeTab === 'sessions'">
       <div v-if="sessionsStore.loading" class="skeleton-list">
@@ -47,9 +60,13 @@
         </router-link>
       </div>
 
+      <div v-else-if="filteredSessions.length === 0" class="empty-state">
+        <p>No sessions match the current filter.</p>
+      </div>
+
       <div v-else class="session-list">
         <SessionCard
-          v-for="session in sessionsStore.sessions"
+          v-for="session in filteredSessions"
           :key="session.id"
           :session="session"
           :show-summary="true"
@@ -82,6 +99,24 @@ const route = useRoute();
 const activeTab = ref('sessions');
 const projectsStore = useProjectsStore();
 const sessionsStore = useSessionsStore();
+
+// Filter state - empty means show all
+const statusFilters = ref([]);
+
+const toggleFilter = (status) => {
+  const index = statusFilters.value.indexOf(status);
+  if (index >= 0) {
+    statusFilters.value.splice(index, 1);
+  } else {
+    statusFilters.value.push(status);
+  }
+};
+
+const filteredSessions = computed(() => {
+  const sessions = sessionsStore.sessions;
+  if (statusFilters.value.length === 0) return sessions;
+  return sessions.filter(s => statusFilters.value.includes(s.status));
+});
 
 // Get projectId as computed to handle route changes
 const projectId = computed(() => route.params.id);
@@ -289,6 +324,41 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.status-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.filter-label {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+}
+
+.filter-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--color-text-soft);
+  cursor: pointer;
+  border-radius: var(--border-radius);
+  transition: all 0.15s;
+  text-transform: capitalize;
+}
+
+.filter-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.filter-btn.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Add running/waiting filter toggle buttons to ActiveSessionsView and SessionListView
- Users can click filter buttons to show only sessions with specific statuses
- When no filters are active, all sessions are shown
- Empty state message displayed when filters return no results

## Test plan
- [ ] Navigate to Active Sessions view and verify filter buttons appear
- [ ] Click "running" filter - only running sessions should show
- [ ] Click "waiting" filter - only waiting sessions should show
- [ ] Click both filters - sessions with either status should show
- [ ] Click a filter again to deselect it
- [ ] With no filters active, all sessions should show
- [ ] Repeat tests on project SessionListView

🤖 Generated with [Claude Code](https://claude.com/claude-code)