### PR TITLE
Add token usage statistics tracking and display

### DIFF
--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -141,6 +141,29 @@ export class DatabaseManager {
     if (!conversationsColumns.includes('claude_session_id')) {
       this.#db.exec('ALTER TABLE conversations ADD COLUMN claude_session_id TEXT');
     }
+
+    // Token usage columns for sessions table (re-fetch column info)
+    const sessionsUsageTableInfo = this.#db.prepare('PRAGMA table_info(sessions)').all();
+    const sessionsUsageColumns = sessionsUsageTableInfo.map((col) => col.name);
+
+    if (!sessionsUsageColumns.includes('input_tokens')) {
+      this.#db.exec('ALTER TABLE sessions ADD COLUMN input_tokens INTEGER DEFAULT 0');
+    }
+    if (!sessionsUsageColumns.includes('output_tokens')) {
+      this.#db.exec('ALTER TABLE sessions ADD COLUMN output_tokens INTEGER DEFAULT 0');
+    }
+    if (!sessionsUsageColumns.includes('cache_read_input_tokens')) {
+      this.#db.exec('ALTER TABLE sessions ADD COLUMN cache_read_input_tokens INTEGER DEFAULT 0');
+    }
+    if (!sessionsUsageColumns.includes('cache_creation_input_tokens')) {
+      this.#db.exec('ALTER TABLE sessions ADD COLUMN cache_creation_input_tokens INTEGER DEFAULT 0');
+    }
+    if (!sessionsUsageColumns.includes('web_search_requests')) {
+      this.#db.exec('ALTER TABLE sessions ADD COLUMN web_search_requests INTEGER DEFAULT 0');
+    }
+    if (!sessionsUsageColumns.includes('context_window')) {
+      this.#db.exec('ALTER TABLE sessions ADD COLUMN context_window INTEGER DEFAULT 200000');
+    }
   }
 
   /**

--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -27,6 +27,13 @@ export class SessionRepository extends BaseRepository {
       model: row.model,
       nextTemplateId: row.next_template_id,
       parentSessionId: row.parent_session_id,
+      // Token usage fields
+      inputTokens: row.input_tokens || 0,
+      outputTokens: row.output_tokens || 0,
+      cacheReadInputTokens: row.cache_read_input_tokens || 0,
+      cacheCreationInputTokens: row.cache_creation_input_tokens || 0,
+      webSearchRequests: row.web_search_requests || 0,
+      contextWindow: row.context_window || 200000,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -159,5 +166,44 @@ export class SessionRepository extends BaseRepository {
       .prepare('SELECT * FROM sessions WHERE pr_url IS NOT NULL ORDER BY updated_at DESC, created_at DESC, rowid DESC')
       .all();
     return this.mapAll(rows);
+  }
+
+  /**
+   * Update token usage statistics for a session
+   * @param {string} id - Session ID
+   * @param {Object} usage - Usage data
+   * @param {number} usage.inputTokens
+   * @param {number} usage.outputTokens
+   * @param {number} usage.cacheReadInputTokens
+   * @param {number} usage.cacheCreationInputTokens
+   * @param {number} usage.webSearchRequests
+   * @param {number} usage.contextWindow
+   * @returns {Object} Updated session
+   */
+  updateUsage(id, usage) {
+    const now = Date.now();
+    this.db
+      .prepare(
+        `UPDATE sessions SET
+          input_tokens = ?,
+          output_tokens = ?,
+          cache_read_input_tokens = ?,
+          cache_creation_input_tokens = ?,
+          web_search_requests = ?,
+          context_window = ?,
+          updated_at = ?
+        WHERE id = ?`
+      )
+      .run(
+        usage.inputTokens,
+        usage.outputTokens,
+        usage.cacheReadInputTokens,
+        usage.cacheCreationInputTokens,
+        usage.webSearchRequests,
+        usage.contextWindow,
+        now,
+        id
+      );
+    return this.getById(id);
   }
 }

--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -535,4 +535,185 @@ describe('SessionRepository', () => {
       });
     });
   });
+
+  describe('updateUsage', () => {
+    it('updates all token usage fields', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+
+      const usage = {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        webSearchRequests: 2,
+        contextWindow: 200000,
+      };
+
+      const updated = repo.updateUsage(session.id, usage);
+
+      expect(updated.inputTokens).toBe(1000);
+      expect(updated.outputTokens).toBe(500);
+      expect(updated.cacheReadInputTokens).toBe(200);
+      expect(updated.cacheCreationInputTokens).toBe(100);
+      expect(updated.webSearchRequests).toBe(2);
+      expect(updated.contextWindow).toBe(200000);
+    });
+
+    it('updates usage with zero values', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+
+      const usage = {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        webSearchRequests: 0,
+        contextWindow: 200000,
+      };
+
+      const updated = repo.updateUsage(session.id, usage);
+
+      expect(updated.inputTokens).toBe(0);
+      expect(updated.outputTokens).toBe(0);
+      expect(updated.cacheReadInputTokens).toBe(0);
+      expect(updated.cacheCreationInputTokens).toBe(0);
+    });
+
+    it('updates usage with large token counts', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+
+      const usage = {
+        inputTokens: 1500000,
+        outputTokens: 500000,
+        cacheReadInputTokens: 1000000,
+        cacheCreationInputTokens: 50000,
+        webSearchRequests: 10,
+        contextWindow: 200000,
+      };
+
+      const updated = repo.updateUsage(session.id, usage);
+
+      expect(updated.inputTokens).toBe(1500000);
+      expect(updated.outputTokens).toBe(500000);
+      expect(updated.cacheReadInputTokens).toBe(1000000);
+    });
+
+    it('updates updatedAt timestamp', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      const originalUpdatedAt = session.updatedAt;
+
+      // Small delay to ensure different timestamp
+      const usage = {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        webSearchRequests: 0,
+        contextWindow: 200000,
+      };
+
+      const updated = repo.updateUsage(session.id, usage);
+
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(originalUpdatedAt);
+    });
+
+    it('returns updated session with all fields', () => {
+      const session = repo.create(projectId, 'Test Session', 'Prompt');
+
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 250,
+        cacheReadInputTokens: 100,
+        cacheCreationInputTokens: 50,
+        webSearchRequests: 1,
+        contextWindow: 200000,
+      };
+
+      const updated = repo.updateUsage(session.id, usage);
+
+      // Verify other fields are preserved
+      expect(updated.id).toBe(session.id);
+      expect(updated.name).toBe('Test Session');
+      expect(updated.projectId).toBe(projectId);
+      expect(updated.status).toBe('starting');
+    });
+
+    it('can be retrieved after update', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+
+      const usage = {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        webSearchRequests: 3,
+        contextWindow: 200000,
+      };
+
+      repo.updateUsage(session.id, usage);
+
+      // Retrieve and verify
+      const retrieved = repo.getById(session.id);
+      expect(retrieved.inputTokens).toBe(1000);
+      expect(retrieved.outputTokens).toBe(500);
+      expect(retrieved.cacheReadInputTokens).toBe(200);
+      expect(retrieved.cacheCreationInputTokens).toBe(100);
+      expect(retrieved.webSearchRequests).toBe(3);
+    });
+  });
+
+  describe('token usage in getById', () => {
+    it('returns default token usage values for new session', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      const retrieved = repo.getById(session.id);
+
+      expect(retrieved.inputTokens).toBe(0);
+      expect(retrieved.outputTokens).toBe(0);
+      expect(retrieved.cacheReadInputTokens).toBe(0);
+      expect(retrieved.cacheCreationInputTokens).toBe(0);
+      expect(retrieved.webSearchRequests).toBe(0);
+      expect(retrieved.contextWindow).toBe(200000);
+    });
+  });
+
+  describe('token usage in getByProjectId', () => {
+    it('includes token usage in session list', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      repo.updateUsage(session.id, {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        webSearchRequests: 2,
+        contextWindow: 200000,
+      });
+
+      const sessions = repo.getByProjectId(projectId);
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].inputTokens).toBe(1000);
+      expect(sessions[0].outputTokens).toBe(500);
+    });
+  });
+
+  describe('token usage in getActiveAndWaiting', () => {
+    it('includes token usage in active sessions', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      repo.update(session.id, { status: 'running' });
+      repo.updateUsage(session.id, {
+        inputTokens: 750,
+        outputTokens: 350,
+        cacheReadInputTokens: 150,
+        cacheCreationInputTokens: 75,
+        webSearchRequests: 1,
+        contextWindow: 200000,
+      });
+
+      const sessions = repo.getActiveAndWaiting();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].inputTokens).toBe(750);
+      expect(sessions[0].outputTokens).toBe(350);
+    });
+  });
 });

--- a/packages/server/src/services/sessionManager.broadcasts.test.js
+++ b/packages/server/src/services/sessionManager.broadcasts.test.js
@@ -219,4 +219,219 @@ describe('sessionManager broadcasts', () => {
       expect(waitingStatusCall[0]).toBe(projectId);
     });
   });
+
+  describe('usage tracking', () => {
+    it('broadcasts partial usage update during assistant message', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Test response' }],
+            usage: {
+              input_tokens: 100,
+              output_tokens: 50,
+              cache_read_input_tokens: 20,
+              cache_creation_input_tokens: 10,
+            },
+          },
+        };
+        yield { type: 'result', subtype: 'success' };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find SESSION_USAGE_UPDATE broadcasts
+      const usageUpdateCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE
+      );
+
+      expect(usageUpdateCalls.length).toBeGreaterThan(0);
+
+      // Find the partial update (isFinal = false)
+      const partialUpdate = usageUpdateCalls.find((call) => call[2]?.isFinal === false);
+      expect(partialUpdate).toBeDefined();
+      expect(partialUpdate[2].usage.inputTokens).toBe(100);
+      expect(partialUpdate[2].usage.outputTokens).toBe(50);
+    });
+
+    it('broadcasts final usage update on result', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: {
+            input_tokens: 200,
+            output_tokens: 100,
+            cache_read_input_tokens: 50,
+            cache_creation_input_tokens: 25,
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find SESSION_USAGE_UPDATE broadcasts
+      const usageUpdateCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE
+      );
+
+      // Find the final update (isFinal = true)
+      const finalUpdate = usageUpdateCalls.find((call) => call[2]?.isFinal === true);
+      expect(finalUpdate).toBeDefined();
+      expect(finalUpdate[2].usage.inputTokens).toBe(200);
+      expect(finalUpdate[2].usage.outputTokens).toBe(100);
+    });
+
+    it('stores cumulative usage in database on result', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: {
+            input_tokens: 300,
+            output_tokens: 150,
+            cache_read_input_tokens: 75,
+            cache_creation_input_tokens: 30,
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      const session = sessions.getById(sessionId);
+      expect(session.inputTokens).toBe(300);
+      expect(session.outputTokens).toBe(150);
+      expect(session.cacheReadInputTokens).toBe(75);
+      expect(session.cacheCreationInputTokens).toBe(30);
+    });
+
+    it('accumulates usage across multiple assistant messages', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'First response' }],
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        };
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Second response' }],
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        };
+        yield { type: 'result', subtype: 'success' };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find all partial usage updates
+      const usageUpdateCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE && call[2]?.isFinal === false
+      );
+
+      // Should have 2 partial updates
+      expect(usageUpdateCalls.length).toBe(2);
+
+      // First update should have first message's usage
+      expect(usageUpdateCalls[0][2].usage.inputTokens).toBe(100);
+
+      // Second update should have accumulated usage
+      expect(usageUpdateCalls[1][2].usage.inputTokens).toBe(200);
+      expect(usageUpdateCalls[1][2].usage.outputTokens).toBe(100);
+    });
+
+    it('uses modelUsage when available in result', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-sonnet-4-5-20250929' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          modelUsage: {
+            'claude-sonnet-4-5-20250929': {
+              inputTokens: 500,
+              outputTokens: 250,
+              cacheReadInputTokens: 100,
+              cacheCreationInputTokens: 50,
+              webSearchRequests: 2,
+              contextWindow: 200000,
+            },
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      const session = sessions.getById(sessionId);
+      expect(session.inputTokens).toBe(500);
+      expect(session.outputTokens).toBe(250);
+      expect(session.cacheReadInputTokens).toBe(100);
+      expect(session.cacheCreationInputTokens).toBe(50);
+      expect(session.webSearchRequests).toBe(2);
+      expect(session.contextWindow).toBe(200000);
+    });
+
+    it('broadcasts turnUsage in final update', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: {
+            input_tokens: 400,
+            output_tokens: 200,
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find the final update
+      const usageUpdateCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE
+      );
+
+      const finalUpdate = usageUpdateCalls.find((call) => call[2]?.isFinal === true);
+      expect(finalUpdate).toBeDefined();
+      expect(finalUpdate[2].turnUsage).toBeDefined();
+      expect(finalUpdate[2].turnUsage.inputTokens).toBe(400);
+      expect(finalUpdate[2].turnUsage.outputTokens).toBe(200);
+    });
+
+    it('broadcasts session update with usage to project', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: {
+            input_tokens: 600,
+            output_tokens: 300,
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find SESSION_UPDATED broadcasts to project
+      const projectUpdatedCalls = broadcastToProject.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_UPDATED
+      );
+
+      // Find the one with usage info
+      const usageUpdate = projectUpdatedCalls.find(
+        (call) => call[2]?.session?.inputTokens === 600
+      );
+
+      expect(usageUpdate).toBeDefined();
+      expect(usageUpdate[0]).toBe(projectId);
+      expect(usageUpdate[2].session.inputTokens).toBe(600);
+      expect(usageUpdate[2].session.outputTokens).toBe(300);
+    });
+  });
 });

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -14,6 +14,56 @@ const thinkingAccumulators = new Map();
 /** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
 
+/** @type {Map<string, {inputTokens: number, outputTokens: number, cacheReadInputTokens: number, cacheCreationInputTokens: number}>} */
+const usageAccumulators = new Map();
+
+/**
+ * Initialize or reset usage accumulator for a session turn
+ * @param {string} sessionId
+ */
+function resetUsageAccumulator(sessionId) {
+  usageAccumulators.set(sessionId, {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+  });
+}
+
+/**
+ * Accumulate usage from an assistant message
+ * @param {string} sessionId
+ * @param {Object} usage - Usage data from SDK (snake_case)
+ * @returns {Object} Accumulated usage
+ */
+function accumulateUsage(sessionId, usage) {
+  const current = usageAccumulators.get(sessionId) || {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+  };
+
+  const accumulated = {
+    inputTokens: current.inputTokens + (usage.input_tokens || 0),
+    outputTokens: current.outputTokens + (usage.output_tokens || 0),
+    cacheReadInputTokens: current.cacheReadInputTokens + (usage.cache_read_input_tokens || 0),
+    cacheCreationInputTokens: current.cacheCreationInputTokens + (usage.cache_creation_input_tokens || 0),
+  };
+
+  usageAccumulators.set(sessionId, accumulated);
+  return accumulated;
+}
+
+/**
+ * Get current accumulated usage for a session
+ * @param {string} sessionId
+ * @returns {Object|undefined}
+ */
+function _getAccumulatedUsage(sessionId) {
+  return usageAccumulators.get(sessionId);
+}
+
 /** Check if mock mode is enabled (for E2E testing) */
 const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
 
@@ -430,6 +480,9 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
+  // Reset usage accumulator for this turn
+  resetUsageAccumulator(sessionId);
+
   try {
     // Get session for settings
     const session = sessions.getById(sessionId);
@@ -531,6 +584,9 @@ export async function continueSession(sessionId, content, workingDirectory, syst
 
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
+
+  // Reset usage accumulator for this turn
+  resetUsageAccumulator(sessionId);
 
   try {
     // Ensure there's an active conversation for this session
@@ -732,6 +788,19 @@ async function handleStreamEvent(sessionId, event) {
       // Extract tool use for logging
       const toolUseBlocks = event.message?.content?.filter((c) => c.type === 'tool_use') || [];
 
+      // Extract and broadcast usage from assistant message
+      const messageUsage = event.message?.usage;
+      if (messageUsage) {
+        const accumulated = accumulateUsage(sessionId, messageUsage);
+
+        // Broadcast partial usage update
+        broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, {
+          sessionId,
+          usage: accumulated,
+          isFinal: false,
+        });
+      }
+
       if (textContent) {
         const toolUse = toolUseBlocks.length > 0 ? toolUseBlocks : null;
         const activeConversation = conversations.getActiveBySessionId(sessionId);
@@ -849,15 +918,55 @@ async function handleStreamEvent(sessionId, event) {
       } else {
         // Store cost info and broadcast to project subscribers
         if (event.total_cost_usd !== undefined) {
-          const updatedSession = sessions.update(sessionId, { costUsd: event.total_cost_usd });
-          // Broadcast cost update to project subscribers for session list updates
-          if (updatedSession) {
-            broadcastToProject(updatedSession.projectId, WS_MESSAGE_TYPES.SESSION_UPDATED, {
-              projectId: updatedSession.projectId,
-              sessionId,
-              session: updatedSession,
-            });
-          }
+          sessions.update(sessionId, { costUsd: event.total_cost_usd });
+        }
+
+        // Store final usage stats
+        if (event.usage || event.modelUsage) {
+          // Extract from modelUsage if available (has more detail)
+          const modelUsageEntry = event.modelUsage
+            ? Object.values(event.modelUsage)[0]
+            : null;
+
+          const finalUsage = {
+            inputTokens: modelUsageEntry?.inputTokens || event.usage?.input_tokens || 0,
+            outputTokens: modelUsageEntry?.outputTokens || event.usage?.output_tokens || 0,
+            cacheReadInputTokens: modelUsageEntry?.cacheReadInputTokens || event.usage?.cache_read_input_tokens || 0,
+            cacheCreationInputTokens: modelUsageEntry?.cacheCreationInputTokens || event.usage?.cache_creation_input_tokens || 0,
+            webSearchRequests: modelUsageEntry?.webSearchRequests || 0,
+            contextWindow: modelUsageEntry?.contextWindow || 200000,
+          };
+
+          // Get existing session usage and add to it (cumulative across turns)
+          const currentSession = sessions.getById(sessionId);
+          const cumulativeUsage = {
+            inputTokens: (currentSession.inputTokens || 0) + finalUsage.inputTokens,
+            outputTokens: (currentSession.outputTokens || 0) + finalUsage.outputTokens,
+            cacheReadInputTokens: (currentSession.cacheReadInputTokens || 0) + finalUsage.cacheReadInputTokens,
+            cacheCreationInputTokens: (currentSession.cacheCreationInputTokens || 0) + finalUsage.cacheCreationInputTokens,
+            webSearchRequests: (currentSession.webSearchRequests || 0) + finalUsage.webSearchRequests,
+            contextWindow: finalUsage.contextWindow,
+          };
+
+          const updatedSession = sessions.updateUsage(sessionId, cumulativeUsage);
+
+          // Broadcast final usage update
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, {
+            sessionId,
+            usage: cumulativeUsage,
+            turnUsage: finalUsage,
+            isFinal: true,
+          });
+
+          // Also broadcast session update for session list
+          broadcastToProject(updatedSession.projectId, WS_MESSAGE_TYPES.SESSION_UPDATED, {
+            projectId: updatedSession.projectId,
+            sessionId,
+            session: updatedSession,
+          });
+
+          // Clean up accumulator
+          usageAccumulators.delete(sessionId);
         }
       }
       // Note: Don't clear lastMessageIds here - let the post-loop association code handle it.

--- a/packages/shared/src/protocol.js
+++ b/packages/shared/src/protocol.js
@@ -31,6 +31,9 @@ export const WS_MESSAGE_TYPES = {
   CONVERSATION_UPDATED: 'conversation:updated',
   CONVERSATION_DELETED: 'conversation:deleted',
   CONVERSATION_SUMMARY_UPDATED: 'conversation:summary_updated',
+
+  // Usage events
+  SESSION_USAGE_UPDATE: 'session:usage_update',
 };
 
 /**

--- a/packages/web/src/components/TokenUsagePanel.test.js
+++ b/packages/web/src/components/TokenUsagePanel.test.js
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// Mock the sessions store
+vi.mock('../stores/sessions.js', () => ({
+  useSessionsStore: vi.fn(),
+}));
+
+import TokenUsagePanel from './TokenUsagePanel.vue';
+import { useSessionsStore } from '../stores/sessions.js';
+
+describe('TokenUsagePanel', () => {
+  let mockSessionsStore;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+
+    mockSessionsStore = {
+      currentSession: null,
+      formattedTokens: { input: '0', output: '0', total: '0', cacheRead: '0', cacheCreation: '0' },
+      isUsageUpdating: false,
+    };
+
+    vi.mocked(useSessionsStore).mockReturnValue(mockSessionsStore);
+  });
+
+  function mountComponent() {
+    return mount(TokenUsagePanel, {
+      global: {
+        stubs: {},
+      },
+    });
+  }
+
+  describe('basic rendering', () => {
+    it('renders the panel', () => {
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.token-usage-panel').exists()).toBe(true);
+    });
+
+    it('displays token usage title', () => {
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.usage-title').text()).toBe('Token Usage');
+    });
+
+    it('displays input, output, and total stats', () => {
+      mockSessionsStore.formattedTokens = {
+        input: '1.5K',
+        output: '500',
+        total: '2K',
+        cacheRead: '0',
+        cacheCreation: '0',
+      };
+
+      const wrapper = mountComponent();
+
+      const stats = wrapper.findAll('.stat');
+      expect(stats).toHaveLength(3);
+
+      expect(wrapper.text()).toContain('Input');
+      expect(wrapper.text()).toContain('Output');
+      expect(wrapper.text()).toContain('Total');
+      expect(wrapper.text()).toContain('1.5K');
+      expect(wrapper.text()).toContain('500');
+      expect(wrapper.text()).toContain('2K');
+    });
+  });
+
+  describe('updating indicator', () => {
+    it('does not show updating indicator when not updating', () => {
+      mockSessionsStore.isUsageUpdating = false;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.updating-indicator').exists()).toBe(false);
+    });
+
+    it('shows updating indicator when usage is updating', () => {
+      mockSessionsStore.isUsageUpdating = true;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.updating-indicator').exists()).toBe(true);
+      expect(wrapper.findAll('.updating-indicator .dot')).toHaveLength(3);
+    });
+  });
+
+  describe('show details button', () => {
+    it('does not show toggle button when no details to show', () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+      };
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.toggle-details').exists()).toBe(false);
+    });
+
+    it('shows toggle button when cache tokens exist', () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 100,
+        cacheCreationInputTokens: 0,
+      };
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.toggle-details').exists()).toBe(true);
+      expect(wrapper.find('.toggle-details').text()).toBe('Show details');
+    });
+
+    it('toggles details on button click', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 100,
+        cacheCreationInputTokens: 50,
+        contextWindow: 200000,
+      };
+      mockSessionsStore.formattedTokens = {
+        input: '1K',
+        output: '500',
+        total: '1.5K',
+        cacheRead: '100',
+        cacheCreation: '50',
+      };
+
+      const wrapper = mountComponent();
+
+      // Initially details should be hidden
+      expect(wrapper.find('.usage-details').exists()).toBe(false);
+
+      // Click to show details
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.find('.usage-details').exists()).toBe(true);
+      expect(wrapper.find('.toggle-details').text()).toBe('Hide details');
+
+      // Click to hide details
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.find('.usage-details').exists()).toBe(false);
+    });
+  });
+
+  describe('details section', () => {
+    it('shows cache read and creation values', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        contextWindow: 200000,
+      };
+      mockSessionsStore.formattedTokens = {
+        input: '1K',
+        output: '500',
+        total: '1.5K',
+        cacheRead: '200',
+        cacheCreation: '100',
+      };
+
+      const wrapper = mountComponent();
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.text()).toContain('Cache Read');
+      expect(wrapper.text()).toContain('200');
+      expect(wrapper.text()).toContain('Cache Creation');
+      expect(wrapper.text()).toContain('100');
+    });
+
+    it('shows context bar when tokens exist', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 10000,
+        outputTokens: 5000,
+        cacheReadInputTokens: 100,
+        cacheCreationInputTokens: 0,
+        contextWindow: 200000,
+      };
+
+      const wrapper = mountComponent();
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.find('.context-bar').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Context Usage');
+    });
+  });
+
+  describe('context bar styling', () => {
+    it('shows normal style for low usage', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 50000,
+        outputTokens: 10000,
+        cacheReadInputTokens: 100,
+        contextWindow: 200000,
+      };
+
+      const wrapper = mountComponent();
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.find('.context-bar-fill.normal').exists()).toBe(true);
+    });
+
+    it('shows warning style for 70-89% usage', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 140000,
+        outputTokens: 10000,
+        cacheReadInputTokens: 100,
+        contextWindow: 200000,
+      };
+
+      const wrapper = mountComponent();
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.find('.context-bar-fill.warning').exists()).toBe(true);
+    });
+
+    it('shows critical style for 90%+ usage', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'session-1',
+        inputTokens: 180000,
+        outputTokens: 10000,
+        cacheReadInputTokens: 100,
+        contextWindow: 200000,
+      };
+
+      const wrapper = mountComponent();
+      await wrapper.find('.toggle-details').trigger('click');
+
+      expect(wrapper.find('.context-bar-fill.critical').exists()).toBe(true);
+    });
+  });
+
+  describe('formatted values', () => {
+    it('displays formatted token values from store', () => {
+      mockSessionsStore.formattedTokens = {
+        input: '5.5K',
+        output: '2.5K',
+        total: '8K',
+        cacheRead: '1K',
+        cacheCreation: '500',
+      };
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.text()).toContain('5.5K');
+      expect(wrapper.text()).toContain('2.5K');
+      expect(wrapper.text()).toContain('8K');
+    });
+  });
+});

--- a/packages/web/src/components/TokenUsagePanel.vue
+++ b/packages/web/src/components/TokenUsagePanel.vue
@@ -1,0 +1,247 @@
+<template>
+  <div class="token-usage-panel">
+    <div class="usage-header">
+      <span class="usage-title">Token Usage</span>
+      <span v-if="isUpdating" class="updating-indicator">
+        <span class="dot"></span>
+        <span class="dot"></span>
+        <span class="dot"></span>
+      </span>
+    </div>
+    <div class="usage-stats">
+      <div class="stat">
+        <span class="stat-label">Input</span>
+        <span class="stat-value">{{ formattedTokens.input }}</span>
+      </div>
+      <div class="stat">
+        <span class="stat-label">Output</span>
+        <span class="stat-value">{{ formattedTokens.output }}</span>
+      </div>
+      <div class="stat stat-total">
+        <span class="stat-label">Total</span>
+        <span class="stat-value">{{ formattedTokens.total }}</span>
+      </div>
+    </div>
+    <div v-if="showDetails" class="usage-details">
+      <div class="detail-row">
+        <span class="detail-label">Cache Read</span>
+        <span class="detail-value">{{ formattedTokens.cacheRead }}</span>
+      </div>
+      <div class="detail-row">
+        <span class="detail-label">Cache Creation</span>
+        <span class="detail-value">{{ formattedTokens.cacheCreation }}</span>
+      </div>
+      <div v-if="contextPercentage > 0" class="context-bar">
+        <div class="context-bar-label">
+          <span>Context Usage</span>
+          <span>{{ contextPercentage }}%</span>
+        </div>
+        <div class="context-bar-track">
+          <div
+            class="context-bar-fill"
+            :style="{ width: `${contextPercentage}%` }"
+            :class="contextBarClass"
+          ></div>
+        </div>
+      </div>
+    </div>
+    <button
+      v-if="hasDetailsToShow"
+      class="toggle-details"
+      @click="showDetails = !showDetails"
+    >
+      {{ showDetails ? 'Hide details' : 'Show details' }}
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { useSessionsStore } from '../stores/sessions.js';
+
+const sessionsStore = useSessionsStore();
+const showDetails = ref(false);
+
+const formattedTokens = computed(() => sessionsStore.formattedTokens);
+const isUpdating = computed(() => sessionsStore.isUsageUpdating);
+
+const contextPercentage = computed(() => {
+  const session = sessionsStore.currentSession;
+  if (!session) return 0;
+  const total = (session.inputTokens || 0) + (session.outputTokens || 0);
+  const window = session.contextWindow || 200000;
+  return Math.round((total / window) * 100);
+});
+
+const contextBarClass = computed(() => {
+  const pct = contextPercentage.value;
+  if (pct >= 90) return 'critical';
+  if (pct >= 70) return 'warning';
+  return 'normal';
+});
+
+const hasDetailsToShow = computed(() => {
+  const session = sessionsStore.currentSession;
+  return session && ((session.cacheReadInputTokens || 0) > 0 ||
+                     (session.cacheCreationInputTokens || 0) > 0 ||
+                     contextPercentage.value > 0);
+});
+</script>
+
+<style scoped>
+.token-usage-panel {
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.usage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.usage-title {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.updating-indicator {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
+.updating-indicator .dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+.updating-indicator .dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.updating-indicator .dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.usage-stats {
+  display: flex;
+  gap: 1rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 60px;
+}
+
+.stat-label {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+  margin-bottom: 0.125rem;
+}
+
+.stat-value {
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+}
+
+.stat-total .stat-value {
+  color: var(--color-primary);
+}
+
+.usage-details {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.detail-value {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+}
+
+.context-bar {
+  margin-top: 0.5rem;
+}
+
+.context-bar-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.625rem;
+  color: var(--color-text-soft);
+  margin-bottom: 0.25rem;
+}
+
+.context-bar-track {
+  height: 4px;
+  background: var(--color-background-mute);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.context-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.context-bar-fill.normal {
+  background: var(--color-success, #10b981);
+}
+
+.context-bar-fill.warning {
+  background: var(--color-warning, #f59e0b);
+}
+
+.context-bar-fill.critical {
+  background: var(--color-danger, #ef4444);
+}
+
+.toggle-details {
+  background: none;
+  border: none;
+  color: var(--color-text-soft);
+  font-size: 0.625rem;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 0.5rem;
+  text-decoration: underline;
+}
+
+.toggle-details:hover {
+  color: var(--color-text);
+}
+</style>

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -280,6 +280,16 @@ export function useSessionSubscription(sessionId) {
     return () => off(WS_MESSAGE_TYPES.CONVERSATION_DELETED, handler);
   };
 
+  const onUsageUpdate = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg);
+      }
+    };
+    on(WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, handler);
+    return () => off(WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, handler);
+  };
+
   // Auto-cleanup on unmount
   onUnmounted(() => {
     unsubscribe();
@@ -304,6 +314,7 @@ export function useSessionSubscription(sessionId) {
     onConversationCreated,
     onConversationUpdated,
     onConversationDeleted,
+    onUsageUpdate,
   };
 }
 

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -11,6 +11,7 @@ export const useSessionsStore = defineStore('sessions', {
     activeConversationId: null, // Currently selected conversation ID
     workLogs: {}, // Keyed by messageId: { [messageId]: WorkLog[] }
     partialThinking: null, // Current streaming thinking content
+    runningUsage: null, // Partial usage during a turn
     loading: false,
     error: null,
   }),
@@ -30,6 +31,33 @@ export const useSessionsStore = defineStore('sessions', {
     },
     getConversationById: (state) => (id) => {
       return state.conversations.find((c) => c.id === id);
+    },
+    // Token usage getters
+    totalTokens: (state) => {
+      const session = state.currentSession;
+      if (!session) return 0;
+      return (session.inputTokens || 0) + (session.outputTokens || 0);
+    },
+    formattedTokens: (state) => {
+      const session = state.currentSession;
+      if (!session) return { input: '0', output: '0', total: '0' };
+
+      const format = (n) => {
+        if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+        if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+        return String(n);
+      };
+
+      return {
+        input: format(session.inputTokens || 0),
+        output: format(session.outputTokens || 0),
+        total: format((session.inputTokens || 0) + (session.outputTokens || 0)),
+        cacheRead: format(session.cacheReadInputTokens || 0),
+        cacheCreation: format(session.cacheCreationInputTokens || 0),
+      };
+    },
+    isUsageUpdating: (state) => {
+      return state.runningUsage !== null;
     },
   },
 
@@ -248,6 +276,42 @@ export const useSessionsStore = defineStore('sessions', {
     // Clear partial thinking when complete
     clearPartialThinking() {
       this.partialThinking = null;
+    },
+
+    // ==================== USAGE ACTIONS ====================
+
+    /**
+     * Update running usage during a turn (partial update)
+     * @param {Object} usage - Usage data
+     */
+    updateRunningUsage(usage) {
+      this.runningUsage = usage;
+    },
+
+    /**
+     * Finalize usage at end of turn (update session with final values)
+     * @param {Object} usage - Final cumulative usage
+     */
+    finalizeUsage(usage) {
+      if (this.currentSession) {
+        this.currentSession = {
+          ...this.currentSession,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          cacheReadInputTokens: usage.cacheReadInputTokens,
+          cacheCreationInputTokens: usage.cacheCreationInputTokens,
+          webSearchRequests: usage.webSearchRequests,
+          contextWindow: usage.contextWindow,
+        };
+      }
+      this.runningUsage = null;
+    },
+
+    /**
+     * Clear running usage (on session unmount)
+     */
+    clearRunningUsage() {
+      this.runningUsage = null;
     },
 
     updateSessionStatus(sessionId, status) {

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -725,4 +725,238 @@ describe('Sessions Store', () => {
       });
     });
   });
+
+  describe('token usage', () => {
+    describe('totalTokens getter', () => {
+      it('returns 0 when no current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+
+        expect(store.totalTokens).toBe(0);
+      });
+
+      it('returns sum of input and output tokens', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 1000,
+          outputTokens: 500,
+        };
+
+        expect(store.totalTokens).toBe(1500);
+      });
+
+      it('handles missing token values', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          // no token values set
+        };
+
+        expect(store.totalTokens).toBe(0);
+      });
+    });
+
+    describe('formattedTokens getter', () => {
+      it('returns zeros when no current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+
+        const formatted = store.formattedTokens;
+        expect(formatted.input).toBe('0');
+        expect(formatted.output).toBe('0');
+        expect(formatted.total).toBe('0');
+      });
+
+      it('formats small numbers as-is', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 500,
+          outputTokens: 250,
+          cacheReadInputTokens: 100,
+          cacheCreationInputTokens: 50,
+        };
+
+        const formatted = store.formattedTokens;
+        expect(formatted.input).toBe('500');
+        expect(formatted.output).toBe('250');
+        expect(formatted.total).toBe('750');
+        expect(formatted.cacheRead).toBe('100');
+        expect(formatted.cacheCreation).toBe('50');
+      });
+
+      it('formats thousands with K suffix', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 5500,
+          outputTokens: 2500,
+        };
+
+        const formatted = store.formattedTokens;
+        expect(formatted.input).toBe('5.5K');
+        expect(formatted.output).toBe('2.5K');
+        expect(formatted.total).toBe('8.0K');
+      });
+
+      it('formats millions with M suffix', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 1500000,
+          outputTokens: 500000,
+        };
+
+        const formatted = store.formattedTokens;
+        expect(formatted.input).toBe('1.5M');
+        expect(formatted.output).toBe('500.0K'); // 500K is below 1M threshold
+        expect(formatted.total).toBe('2.0M');
+      });
+
+      it('handles exactly 1000 tokens', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 1000,
+          outputTokens: 0,
+        };
+
+        const formatted = store.formattedTokens;
+        expect(formatted.input).toBe('1.0K');
+      });
+
+      it('handles exactly 1000000 tokens', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 1000000,
+          outputTokens: 0,
+        };
+
+        const formatted = store.formattedTokens;
+        expect(formatted.input).toBe('1.0M');
+      });
+    });
+
+    describe('isUsageUpdating getter', () => {
+      it('returns false when runningUsage is null', () => {
+        const store = useSessionsStore();
+        store.runningUsage = null;
+
+        expect(store.isUsageUpdating).toBe(false);
+      });
+
+      it('returns true when runningUsage has value', () => {
+        const store = useSessionsStore();
+        store.runningUsage = { inputTokens: 100, outputTokens: 50 };
+
+        expect(store.isUsageUpdating).toBe(true);
+      });
+    });
+
+    describe('updateRunningUsage action', () => {
+      it('sets runningUsage value', () => {
+        const store = useSessionsStore();
+        const usage = { inputTokens: 100, outputTokens: 50 };
+
+        store.updateRunningUsage(usage);
+
+        expect(store.runningUsage).toEqual(usage);
+      });
+
+      it('can update runningUsage multiple times', () => {
+        const store = useSessionsStore();
+
+        store.updateRunningUsage({ inputTokens: 100, outputTokens: 50 });
+        expect(store.runningUsage.inputTokens).toBe(100);
+
+        store.updateRunningUsage({ inputTokens: 200, outputTokens: 100 });
+        expect(store.runningUsage.inputTokens).toBe(200);
+      });
+    });
+
+    describe('finalizeUsage action', () => {
+      it('updates currentSession with usage values', () => {
+        const store = useSessionsStore();
+        store.currentSession = {
+          id: 'session-1',
+          name: 'Test',
+          inputTokens: 0,
+          outputTokens: 0,
+        };
+
+        const usage = {
+          inputTokens: 1000,
+          outputTokens: 500,
+          cacheReadInputTokens: 200,
+          cacheCreationInputTokens: 100,
+          webSearchRequests: 2,
+          contextWindow: 200000,
+        };
+
+        store.finalizeUsage(usage);
+
+        expect(store.currentSession.inputTokens).toBe(1000);
+        expect(store.currentSession.outputTokens).toBe(500);
+        expect(store.currentSession.cacheReadInputTokens).toBe(200);
+        expect(store.currentSession.cacheCreationInputTokens).toBe(100);
+        expect(store.currentSession.webSearchRequests).toBe(2);
+        expect(store.currentSession.contextWindow).toBe(200000);
+      });
+
+      it('clears runningUsage', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.runningUsage = { inputTokens: 100 };
+
+        store.finalizeUsage({ inputTokens: 1000, outputTokens: 500 });
+
+        expect(store.runningUsage).toBeNull();
+      });
+
+      it('creates new object reference for reactivity', () => {
+        const store = useSessionsStore();
+        const originalSession = { id: 'session-1', name: 'Test' };
+        store.currentSession = originalSession;
+
+        store.finalizeUsage({ inputTokens: 1000, outputTokens: 500 });
+
+        expect(store.currentSession).not.toBe(originalSession);
+        expect(store.currentSession.id).toBe('session-1');
+        expect(store.currentSession.name).toBe('Test');
+      });
+
+      it('does nothing when currentSession is null', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+        store.runningUsage = { inputTokens: 100 };
+
+        store.finalizeUsage({ inputTokens: 1000, outputTokens: 500 });
+
+        expect(store.currentSession).toBeNull();
+        expect(store.runningUsage).toBeNull();
+      });
+    });
+
+    describe('clearRunningUsage action', () => {
+      it('clears runningUsage to null', () => {
+        const store = useSessionsStore();
+        store.runningUsage = { inputTokens: 100, outputTokens: 50 };
+
+        store.clearRunningUsage();
+
+        expect(store.runningUsage).toBeNull();
+      });
+
+      it('is idempotent', () => {
+        const store = useSessionsStore();
+        store.runningUsage = null;
+
+        store.clearRunningUsage();
+
+        expect(store.runningUsage).toBeNull();
+      });
+    });
+  });
 });

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -18,6 +18,7 @@
               🔗 Next: {{ getTemplateName(sessionsStore.currentSession.nextTemplateId) }}
             </span>
           </div>
+          <TokenUsagePanel class="session-usage" />
           <div class="branch-line">
             <div class="branch-pr-indicators">
               <span
@@ -118,6 +119,7 @@ import NotesTab from '../components/NotesTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
 import PrIndicators from '../components/PrIndicators.vue';
 import TemplateSelector from '../components/TemplateSelector.vue';
+import TokenUsagePanel from '../components/TokenUsagePanel.vue';
 import { useTemplatesStore } from '../stores/templates.js';
 
 const route = useRoute();
@@ -148,7 +150,7 @@ function navigateToTab(tabId) {
   router.push(`/sessions/${route.params.id}/${tabId}`);
 }
 
-const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate } =
+const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onUsageUpdate } =
   useSessionSubscription(sessionId);
 
 let cleanups = [];
@@ -297,12 +299,23 @@ onMounted(async () => {
       summary.value = newSummary;
     })
   );
+
+  cleanups.push(
+    onUsageUpdate((msg) => {
+      if (msg.isFinal) {
+        sessionsStore.finalizeUsage(msg.usage);
+      } else {
+        sessionsStore.updateRunningUsage(msg.usage);
+      }
+    })
+  );
 });
 
 onUnmounted(() => {
   stopPolling();
   unsubscribe();
   cleanups.forEach((cleanup) => cleanup());
+  sessionsStore.clearRunningUsage();
 });
 
 function formatMode(mode) {
@@ -401,6 +414,10 @@ function getTemplateName(templateId) {
 .session-mode {
   font-size: 0.75rem;
   color: var(--color-text-soft);
+}
+
+.session-usage {
+  margin-top: 0.75rem;
 }
 
 .template-badge {


### PR DESCRIPTION
## Summary
- Adds real-time token usage tracking across Claude sessions with database persistence
- Creates TokenUsagePanel component showing input/output tokens with expandable details
- Broadcasts partial usage updates via WebSocket during processing for live updates
- Includes comprehensive tests for all new functionality

## Test plan
- [ ] Start a new session and verify token usage panel appears in session detail view
- [ ] Observe real-time updates as Claude processes requests
- [ ] Expand details to see cache read/creation tokens and context window usage bar
- [ ] Verify usage persists across page refreshes
- [ ] Check warning/critical states for high context window usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)