### PR TITLE
feat: Add command buttons feature for managing Claude Code sessions

### DIFF
--- a/packages/server/src/api/commandButtons.js
+++ b/packages/server/src/api/commandButtons.js
@@ -1,0 +1,166 @@
+import { Router } from 'express';
+import { commandButtons, sessions } from '../database.js';
+import { CreateCommandButtonRequest, UpdateCommandButtonRequest } from '@claudetools/shared/contracts/commandButtons';
+import { commandRunner } from '../services/commandRunner.js';
+import { broadcastToSession } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import { databaseManager } from '../db/DatabaseManager.js';
+
+const router = Router();
+
+// GET /api/projects/:projectId/command-buttons - List all command buttons for project
+router.get('/', (req, res) => {
+  const { projectId } = req.params;
+  const buttons = commandButtons.getByProjectId(projectId);
+  res.json(buttons);
+});
+
+// POST /api/projects/:projectId/command-buttons - Create new command button
+router.post('/', (req, res) => {
+  const result = CreateCommandButtonRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.errors[0].message });
+  }
+
+  const button = commandButtons.create({
+    projectId: req.params.projectId,
+    label: result.data.label,
+    command: result.data.command,
+    sortOrder: result.data.sortOrder,
+  });
+
+  res.status(201).json(button);
+});
+
+// GET /api/projects/:projectId/command-buttons/:id - Get single button
+router.get('/:id', (req, res) => {
+  const button = commandButtons.getById(req.params.id);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+  res.json(button);
+});
+
+// PATCH /api/projects/:projectId/command-buttons/:id - Update button
+router.patch('/:id', (req, res) => {
+  const button = commandButtons.getById(req.params.id);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  const result = UpdateCommandButtonRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.errors[0].message });
+  }
+
+  const updated = commandButtons.update(req.params.id, result.data);
+  res.json(updated);
+});
+
+// DELETE /api/projects/:projectId/command-buttons/:id - Delete button
+router.delete('/:id', (req, res) => {
+  const button = commandButtons.getById(req.params.id);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  commandButtons.delete(req.params.id);
+  res.status(204).send();
+});
+
+// POST /api/sessions/:sessionId/command-buttons/:buttonId/run - Execute button command
+router.post('/run/:buttonId', (req, res) => {
+  const { sessionId } = req.params;
+  const { buttonId } = req.params;
+
+  // Get session and button
+  const session = sessions.getById(sessionId);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const button = commandButtons.getById(buttonId);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  // Determine working directory
+  const workingDirectory = session.gitWorktree || session.project?.workingDirectory || process.cwd();
+
+  // Generate run ID
+  const runId = databaseManager.generateId();
+
+  // Return immediately with runId
+  res.json({ runId, buttonId, status: 'running', output: '' });
+
+  // Execute command asynchronously
+  (async () => {
+    try {
+      let output = '';
+
+      await commandRunner.run(
+        runId,
+        button.command,
+        workingDirectory,
+        (text) => {
+          output += text;
+          // Broadcast output via WebSocket
+          broadcastToSession(sessionId, {
+            type: WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT,
+            runId,
+            buttonId,
+            output: text,
+          });
+        },
+        (exitCode) => {
+          // Broadcast completion via WebSocket
+          const status = exitCode === 0 ? 'success' : 'error';
+          broadcastToSession(sessionId, {
+            type: WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE,
+            runId,
+            buttonId,
+            status,
+            exitCode,
+            output,
+          });
+        },
+        (message) => {
+          // Broadcast error via WebSocket
+          broadcastToSession(sessionId, {
+            type: WS_MESSAGE_TYPES.COMMAND_RUN_ERROR,
+            runId,
+            buttonId,
+            message,
+          });
+        }
+      );
+    } catch (error) {
+      console.error(`Error running command button ${buttonId}:`, error);
+      broadcastToSession(sessionId, {
+        type: WS_MESSAGE_TYPES.COMMAND_RUN_ERROR,
+        runId,
+        buttonId,
+        message: error.message,
+      });
+    }
+  })();
+});
+
+// POST /api/sessions/:sessionId/command-buttons/runs/:runId/kill - Kill running command
+router.post('/runs/:runId/kill', (req, res) => {
+  const { sessionId, runId } = req.params;
+
+  const session = sessions.getById(sessionId);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const killed = commandRunner.kill(runId);
+  if (!killed) {
+    return res.status(404).json({ error: 'Run not found or already completed' });
+  }
+
+  res.json({ success: true, runId });
+});
+
+export default router;

--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -1,12 +1,15 @@
 import { Router } from 'express';
-import { projects, sessions, sessionTemplates, attachments } from '../database.js';
+import { projects, sessions, sessionTemplates, attachments, commandButtons } from '../database.js';
 import { CreateProjectRequest, UpdateProjectRequest } from '@claudetools/shared/contracts/projects';
 import { CreateSessionTemplateRequest } from '@claudetools/shared/contracts/templates';
+import { CreateCommandButtonRequest, UpdateCommandButtonRequest } from '@claudetools/shared/contracts/commandButtons';
 import { setupGitForSession } from '../services/gitSessionSetup.js';
 import { executeHookAsync } from '../services/hookService.js';
-import { broadcastToProject } from '../websocket.js';
+import { broadcastToProject, broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 import { upload, handleUploadError } from '../middleware/upload.js';
+import { commandRunner } from '../services/commandRunner.js';
+import { databaseManager } from '../db/DatabaseManager.js';
 
 const router = Router();
 
@@ -236,6 +239,90 @@ router.post('/:id/templates', (req, res) => {
     ...result.data,
   });
   res.status(201).json(template);
+});
+
+// GET /api/projects/:id/command-buttons - List all command buttons for project
+router.get('/:id/command-buttons', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  const buttons = commandButtons.getByProjectId(req.params.id);
+  res.json(buttons);
+});
+
+// POST /api/projects/:id/command-buttons - Create new command button
+router.post('/:id/command-buttons', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  const result = CreateCommandButtonRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.errors[0].message });
+  }
+
+  const button = commandButtons.create({
+    projectId: req.params.id,
+    label: result.data.label,
+    command: result.data.command,
+    sortOrder: result.data.sortOrder,
+  });
+
+  res.status(201).json(button);
+});
+
+// GET /api/projects/:id/command-buttons/:buttonId - Get single button
+router.get('/:id/command-buttons/:buttonId', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  const button = commandButtons.getById(req.params.buttonId);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+  res.json(button);
+});
+
+// PATCH /api/projects/:id/command-buttons/:buttonId - Update button
+router.patch('/:id/command-buttons/:buttonId', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  const button = commandButtons.getById(req.params.buttonId);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  const result = UpdateCommandButtonRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.errors[0].message });
+  }
+
+  const updated = commandButtons.update(req.params.buttonId, result.data);
+  res.json(updated);
+});
+
+// DELETE /api/projects/:id/command-buttons/:buttonId - Delete button
+router.delete('/:id/command-buttons/:buttonId', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  const button = commandButtons.getById(req.params.buttonId);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  commandButtons.delete(req.params.buttonId);
+  res.status(204).send();
 });
 
 export default router;

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { sessions, messages, sessionNotes, projects, todos, workLogs, sessionTemplates, conversations, attachments } from '../database.js';
+import { sessions, messages, sessionNotes, projects, todos, workLogs, sessionTemplates, conversations, attachments, commandButtons } from '../database.js';
 import { continueSession, stopSession, restartSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges } from '../services/diffService.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
@@ -8,6 +8,8 @@ import * as gitService from '../services/gitService.js';
 import * as summaryService from '../services/summaryService.js';
 import { executeHookAsync } from '../services/hookService.js';
 import { upload, handleUploadError } from '../middleware/upload.js';
+import { commandRunner } from '../services/commandRunner.js';
+import { databaseManager } from '../db/DatabaseManager.js';
 
 const router = Router();
 
@@ -634,6 +636,103 @@ router.delete('/:id', async (req, res) => {
   }
 
   res.status(204).send();
+});
+
+// POST /api/sessions/:id/command-buttons/:buttonId/run - Execute button command
+router.post('/:id/command-buttons/:buttonId/run', (req, res) => {
+  const sessionId = req.params.id;
+  const buttonId = req.params.buttonId;
+
+  // Get session and button
+  const session = sessions.getById(sessionId);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const button = commandButtons.getById(buttonId);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  const project = projects.getById(session.projectId);
+  // Determine working directory: use session's git_worktree if set, otherwise project's working_directory
+  const workingDirectory = session.gitWorktree || (project?.workingDirectory) || process.cwd();
+
+  // Generate run ID
+  const runId = databaseManager.generateId();
+
+  // Return immediately with runId
+  res.json({ runId, buttonId, status: 'running', output: '' });
+
+  // Execute command asynchronously
+  (async () => {
+    try {
+      let output = '';
+
+      await commandRunner.run(
+        runId,
+        button.command,
+        workingDirectory,
+        (text) => {
+          output += text;
+          // Broadcast output via WebSocket
+          broadcastToSession(sessionId, {
+            type: WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT,
+            runId,
+            buttonId,
+            output: text,
+          });
+        },
+        (exitCode) => {
+          // Broadcast completion via WebSocket
+          const status = exitCode === 0 ? 'success' : 'error';
+          broadcastToSession(sessionId, {
+            type: WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE,
+            runId,
+            buttonId,
+            status,
+            exitCode,
+            output,
+          });
+        },
+        (message) => {
+          // Broadcast error via WebSocket
+          broadcastToSession(sessionId, {
+            type: WS_MESSAGE_TYPES.COMMAND_RUN_ERROR,
+            runId,
+            buttonId,
+            message,
+          });
+        }
+      );
+    } catch (error) {
+      console.error(`Error running command button ${buttonId}:`, error);
+      broadcastToSession(sessionId, {
+        type: WS_MESSAGE_TYPES.COMMAND_RUN_ERROR,
+        runId,
+        buttonId,
+        message: error.message,
+      });
+    }
+  })();
+});
+
+// POST /api/sessions/:id/command-buttons/runs/:runId/kill - Kill running command
+router.post('/:id/command-buttons/runs/:runId/kill', (req, res) => {
+  const sessionId = req.params.id;
+  const runId = req.params.runId;
+
+  const session = sessions.getById(sessionId);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const killed = commandRunner.kill(runId);
+  if (!killed) {
+    return res.status(404).json({ error: 'Run not found or already completed' });
+  }
+
+  res.json({ success: true, runId });
 });
 
 export default router;

--- a/packages/server/src/db/CommandButtonRepository.js
+++ b/packages/server/src/db/CommandButtonRepository.js
@@ -1,0 +1,70 @@
+import { BaseRepository } from './BaseRepository.js';
+import { databaseManager } from './DatabaseManager.js';
+
+/**
+ * Command button repository class
+ */
+export class CommandButtonRepository extends BaseRepository {
+  constructor() {
+    super('command_buttons', CommandButtonRepository.#mapButton);
+  }
+
+  static #mapButton(row) {
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      label: row.label,
+      command: row.command,
+      sortOrder: row.sort_order,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  create({ projectId, label, command, sortOrder = 0 }) {
+    const id = databaseManager.generateId();
+    const now = Date.now();
+    this.db
+      .prepare(
+        `INSERT INTO command_buttons (id, project_id, label, command, sort_order, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(id, projectId, label, command, sortOrder, now, now);
+    return this.getById(id);
+  }
+
+  getByProjectId(projectId) {
+    const rows = this.db
+      .prepare('SELECT * FROM command_buttons WHERE project_id = ? ORDER BY sort_order ASC, created_at ASC')
+      .all(projectId);
+    return this.mapAll(rows);
+  }
+
+  update(id, data) {
+    const updates = [];
+    const values = [];
+
+    if (data.label !== undefined) {
+      updates.push('label = ?');
+      values.push(data.label);
+    }
+    if (data.command !== undefined) {
+      updates.push('command = ?');
+      values.push(data.command);
+    }
+    if (data.sortOrder !== undefined) {
+      updates.push('sort_order = ?');
+      values.push(data.sortOrder);
+    }
+
+    if (updates.length === 0) return this.getById(id);
+
+    updates.push('updated_at = ?');
+    values.push(Date.now());
+    values.push(id);
+
+    this.db.prepare(`UPDATE command_buttons SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+
+    return this.getById(id);
+  }
+}

--- a/packages/server/src/db/CommandButtonRepository.test.js
+++ b/packages/server/src/db/CommandButtonRepository.test.js
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CommandButtonRepository } from './CommandButtonRepository.js';
+import { ProjectRepository } from './ProjectRepository.js';
+import { databaseManager } from './DatabaseManager.js';
+
+describe('CommandButtonRepository', () => {
+  let repo;
+  let projectRepo;
+  let projectId;
+
+  beforeEach(() => {
+    repo = new CommandButtonRepository();
+    projectRepo = new ProjectRepository();
+
+    const project = projectRepo.create('Test Project', '/tmp/test');
+    projectId = project.id;
+  });
+
+  describe('constructor', () => {
+    it('creates repository instance', () => {
+      expect(repo).toBeInstanceOf(CommandButtonRepository);
+      expect(repo.tableName).toBe('command_buttons');
+    });
+  });
+
+  describe('create', () => {
+    it('creates a button with all fields', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Build',
+        command: 'npm run build',
+        sortOrder: 1,
+      });
+
+      expect(button.id).toBeDefined();
+      expect(button.projectId).toBe(projectId);
+      expect(button.label).toBe('Build');
+      expect(button.command).toBe('npm run build');
+      expect(button.sortOrder).toBe(1);
+      expect(button.createdAt).toBeTypeOf('number');
+      expect(button.updatedAt).toBeTypeOf('number');
+    });
+
+    it('creates a button with default sortOrder', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'npm test',
+      });
+
+      expect(button.sortOrder).toBe(0);
+    });
+
+    it('sets createdAt and updatedAt to same value on creation', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Deploy',
+        command: 'npm run deploy',
+      });
+
+      expect(button.createdAt).toBe(button.updatedAt);
+    });
+
+    it('generates unique IDs', () => {
+      const button1 = repo.create({
+        projectId,
+        label: 'Button 1',
+        command: 'cmd1',
+      });
+      const button2 = repo.create({
+        projectId,
+        label: 'Button 2',
+        command: 'cmd2',
+      });
+
+      expect(button1.id).not.toBe(button2.id);
+    });
+  });
+
+  describe('getById', () => {
+    it('retrieves button by ID', () => {
+      const created = repo.create({
+        projectId,
+        label: 'Test Button',
+        command: 'echo test',
+      });
+      const retrieved = repo.getById(created.id);
+
+      expect(retrieved).toEqual(created);
+    });
+
+    it('returns null for non-existent ID', () => {
+      expect(repo.getById('non-existent')).toBeNull();
+    });
+  });
+
+  describe('getByProjectId', () => {
+    it('returns empty array when no buttons exist', () => {
+      const buttons = repo.getByProjectId(projectId);
+      expect(buttons).toEqual([]);
+    });
+
+    it('returns all buttons for a project', () => {
+      repo.create({ projectId, label: 'Button 1', command: 'cmd1' });
+      repo.create({ projectId, label: 'Button 2', command: 'cmd2' });
+      repo.create({ projectId, label: 'Button 3', command: 'cmd3' });
+
+      const buttons = repo.getByProjectId(projectId);
+
+      expect(buttons).toHaveLength(3);
+    });
+
+    it('returns buttons ordered by sort_order ascending', () => {
+      const b3 = repo.create({ projectId, label: 'Last', command: 'cmd', sortOrder: 2 });
+      const b1 = repo.create({ projectId, label: 'First', command: 'cmd', sortOrder: 0 });
+      const b2 = repo.create({ projectId, label: 'Second', command: 'cmd', sortOrder: 1 });
+
+      const buttons = repo.getByProjectId(projectId);
+
+      expect(buttons).toHaveLength(3);
+      expect(buttons[0].sortOrder).toBe(0);
+      expect(buttons[1].sortOrder).toBe(1);
+      expect(buttons[2].sortOrder).toBe(2);
+    });
+
+    it('returns buttons with same sort_order ordered by created_at', () => {
+      const b1 = repo.create({ projectId, label: 'First', command: 'cmd1', sortOrder: 0 });
+      const b2 = repo.create({ projectId, label: 'Second', command: 'cmd2', sortOrder: 0 });
+
+      const buttons = repo.getByProjectId(projectId);
+
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0].id).toBe(b1.id);
+      expect(buttons[1].id).toBe(b2.id);
+    });
+
+    it('does not return buttons from other projects', () => {
+      const project2 = projectRepo.create('Other Project', '/tmp/other');
+
+      repo.create({ projectId, label: 'Project 1 button', command: 'cmd1' });
+      repo.create({ projectId: project2.id, label: 'Project 2 button', command: 'cmd2' });
+
+      const buttons = repo.getByProjectId(projectId);
+
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0].label).toBe('Project 1 button');
+    });
+  });
+
+  describe('update', () => {
+    it('updates button label', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Original',
+        command: 'cmd',
+      });
+      const updated = repo.update(button.id, { label: 'Updated' });
+
+      expect(updated.label).toBe('Updated');
+    });
+
+    it('updates button command', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'original cmd',
+      });
+      const updated = repo.update(button.id, { command: 'new cmd' });
+
+      expect(updated.command).toBe('new cmd');
+    });
+
+    it('updates button sortOrder', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'cmd',
+        sortOrder: 0,
+      });
+      const updated = repo.update(button.id, { sortOrder: 5 });
+
+      expect(updated.sortOrder).toBe(5);
+    });
+
+    it('updates multiple fields at once', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Original',
+        command: 'original',
+        sortOrder: 0,
+      });
+      const updated = repo.update(button.id, {
+        label: 'New Label',
+        command: 'new cmd',
+        sortOrder: 10,
+      });
+
+      expect(updated.label).toBe('New Label');
+      expect(updated.command).toBe('new cmd');
+      expect(updated.sortOrder).toBe(10);
+    });
+
+    it('updates updatedAt timestamp', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'cmd',
+      });
+      const originalUpdatedAt = button.updatedAt;
+
+      const updated = repo.update(button.id, { label: 'Changed' });
+
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(originalUpdatedAt);
+    });
+
+    it('preserves createdAt timestamp', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'cmd',
+      });
+      const createdAt = button.createdAt;
+
+      const updated = repo.update(button.id, { label: 'Changed' });
+
+      expect(updated.createdAt).toBe(createdAt);
+    });
+
+    it('preserves projectId', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'cmd',
+      });
+
+      const updated = repo.update(button.id, { label: 'Changed' });
+
+      expect(updated.projectId).toBe(projectId);
+    });
+
+    it('returns unchanged button when no updates provided', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test',
+        command: 'cmd',
+      });
+
+      const unchanged = repo.update(button.id, {});
+
+      expect(unchanged.id).toBe(button.id);
+      expect(unchanged.label).toBe(button.label);
+      expect(unchanged.updatedAt).toBe(button.updatedAt);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes a button', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Delete me',
+        command: 'cmd',
+      });
+
+      repo.delete(button.id);
+
+      expect(repo.getById(button.id)).toBeNull();
+    });
+
+    it('does not throw when deleting non-existent button', () => {
+      expect(() => repo.delete('non-existent')).not.toThrow();
+    });
+
+    it('does not affect other buttons', () => {
+      const button1 = repo.create({
+        projectId,
+        label: 'Button 1',
+        command: 'cmd1',
+      });
+      const button2 = repo.create({
+        projectId,
+        label: 'Button 2',
+        command: 'cmd2',
+      });
+
+      repo.delete(button1.id);
+
+      expect(repo.getById(button1.id)).toBeNull();
+      expect(repo.getById(button2.id)).not.toBeNull();
+    });
+  });
+
+  describe('cascade delete', () => {
+    it('deletes buttons when project is deleted', () => {
+      const button = repo.create({
+        projectId,
+        label: 'Test Button',
+        command: 'cmd',
+      });
+
+      projectRepo.delete(projectId);
+
+      expect(repo.getById(button.id)).toBeNull();
+    });
+  });
+});

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -16,6 +16,7 @@ export { TodoRepository } from './TodoRepository.js';
 export { WorkLogRepository } from './WorkLogRepository.js';
 export { SessionSummaryRepository } from './SessionSummaryRepository.js';
 export { AttachmentRepository } from './AttachmentRepository.js';
+export { CommandButtonRepository } from './CommandButtonRepository.js';
 
 // Singleton instances
 import { ProjectRepository } from './ProjectRepository.js';
@@ -28,6 +29,7 @@ import { WorkLogRepository } from './WorkLogRepository.js';
 import { SessionSummaryRepository } from './SessionSummaryRepository.js';
 import { SessionTemplateRepository } from './SessionTemplateRepository.js';
 import { AttachmentRepository } from './AttachmentRepository.js';
+import { CommandButtonRepository } from './CommandButtonRepository.js';
 
 export const projects = new ProjectRepository();
 export const messages = new MessageRepository();
@@ -39,6 +41,7 @@ export const workLogs = new WorkLogRepository();
 export const sessionSummaries = new SessionSummaryRepository();
 export const sessionTemplates = new SessionTemplateRepository();
 export const attachments = new AttachmentRepository();
+export const commandButtons = new CommandButtonRepository();
 
 // SessionRepository needs to be instantiated after messages is available
 import { SessionRepository } from './SessionRepository.js';

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -175,6 +175,17 @@ CREATE TABLE IF NOT EXISTS message_attachments (
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );
 
+-- Command buttons (configurable buttons per project)
+CREATE TABLE IF NOT EXISTS command_buttons (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  command TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+);
+
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
@@ -194,3 +205,4 @@ CREATE INDEX IF NOT EXISTS idx_work_logs_message ON work_logs(message_id);
 CREATE INDEX IF NOT EXISTS idx_summaries_session ON session_summaries(session_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_message ON message_attachments(message_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_session ON message_attachments(session_id);
+CREATE INDEX IF NOT EXISTS idx_command_buttons_project ON command_buttons(project_id);

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -1,0 +1,111 @@
+import { spawn } from 'child_process';
+import { databaseManager } from '../database.js';
+
+/**
+ * Service for running commands and managing their execution
+ */
+export class CommandRunner {
+  constructor() {
+    this.processes = new Map(); // runId -> { process, timeout }
+  }
+
+  /**
+   * Run a command and stream output via callback
+   * @param {string} runId - Unique identifier for this run
+   * @param {string} command - The command to execute
+   * @param {string} workingDirectory - Directory to run command in
+   * @param {Function} onOutput - Callback for output: (text) => void
+   * @param {Function} onComplete - Callback for completion: (exitCode) => void
+   * @param {Function} onError - Callback for errors: (message) => void
+   * @returns {Promise<number>} Exit code
+   */
+  async run(runId, command, workingDirectory, onOutput, onComplete, onError) {
+    return new Promise((resolve) => {
+      try {
+        const child = spawn('sh', ['-c', command], {
+          cwd: workingDirectory,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          shell: true,
+        });
+
+        this.processes.set(runId, { process: child, startTime: Date.now() });
+
+        let output = '';
+
+        child.stdout.on('data', (data) => {
+          const text = data.toString();
+          output += text;
+          if (onOutput) onOutput(text);
+        });
+
+        child.stderr.on('data', (data) => {
+          const text = data.toString();
+          output += text;
+          if (onOutput) onOutput(text);
+        });
+
+        child.on('error', (err) => {
+          const msg = `Failed to execute command: ${err.message}`;
+          if (onError) onError(msg);
+          this.processes.delete(runId);
+          resolve(1);
+        });
+
+        child.on('close', (exitCode) => {
+          this.processes.delete(runId);
+          if (onComplete) onComplete(exitCode);
+          resolve(exitCode || 0);
+        });
+      } catch (err) {
+        const msg = `Error running command: ${err.message}`;
+        if (onError) onError(msg);
+        this.processes.delete(runId);
+        resolve(1);
+      }
+    });
+  }
+
+  /**
+   * Kill a running process
+   * @param {string} runId
+   * @returns {boolean} True if process was killed, false if not found
+   */
+  kill(runId) {
+    const entry = this.processes.get(runId);
+    if (!entry) return false;
+
+    try {
+      entry.process.kill('SIGTERM');
+      // Give it a moment to terminate gracefully, then force kill
+      setTimeout(() => {
+        if (!entry.process.killed) {
+          entry.process.kill('SIGKILL');
+        }
+      }, 1000);
+      return true;
+    } catch (err) {
+      console.error(`Error killing process ${runId}:`, err);
+      return false;
+    }
+  }
+
+  /**
+   * Get all active runs
+   * @returns {Map} Map of runId -> process info
+   */
+  getActiveRuns() {
+    return new Map(this.processes);
+  }
+
+  /**
+   * Check if a run is active
+   * @param {string} runId
+   * @returns {boolean}
+   */
+  isRunning(runId) {
+    return this.processes.has(runId);
+  }
+}
+
+// Singleton instance
+export const commandRunner = new CommandRunner();

--- a/packages/server/src/services/commandRunner.test.js
+++ b/packages/server/src/services/commandRunner.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CommandRunner } from './commandRunner.js';
+
+describe('CommandRunner', () => {
+  let runner;
+
+  beforeEach(() => {
+    runner = new CommandRunner();
+  });
+
+  describe('run', () => {
+    it('executes a simple command and captures output', async () => {
+      const outputs = [];
+      let completed = false;
+      let exitCode = null;
+
+      const result = await runner.run(
+        'test-run-1',
+        'echo "Hello, World!"',
+        process.cwd(),
+        (text) => outputs.push(text),
+        (code) => {
+          completed = true;
+          exitCode = code;
+        }
+      );
+
+      expect(result).toBe(0);
+      expect(completed).toBe(true);
+      expect(exitCode).toBe(0);
+      expect(outputs.join('').length).toBeGreaterThan(0);
+    });
+
+    it('returns exit code 0 for successful command', async () => {
+      const exitCode = await runner.run(
+        'test-run-2',
+        'true',
+        process.cwd(),
+        () => {},
+        () => {}
+      );
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('returns non-zero exit code for failed command', async () => {
+      const exitCode = await runner.run(
+        'test-run-3',
+        'false',
+        process.cwd(),
+        () => {},
+        () => {}
+      );
+
+      expect(exitCode).not.toBe(0);
+    });
+
+    it('uses specified working directory', async () => {
+      let output = '';
+      const tmpDir = process.cwd();
+
+      await runner.run(
+        'test-run-4',
+        'pwd',
+        tmpDir,
+        (text) => {
+          output += text;
+        },
+        () => {}
+      );
+
+      // pwd output should contain the working directory path
+      expect(output.trim().length).toBeGreaterThan(0);
+    });
+
+    it('captures both stdout and stderr', async () => {
+      let output = '';
+
+      await runner.run(
+        'test-run-5',
+        'echo "stdout"; >&2 echo "stderr"',
+        process.cwd(),
+        (text) => {
+          output += text;
+        },
+        () => {}
+      );
+
+      expect(output.length).toBeGreaterThan(0);
+    });
+
+    it('calls onComplete callback', async () => {
+      let callbackCalled = false;
+      let callbackExitCode = null;
+
+      await runner.run(
+        'test-run-6',
+        'echo test',
+        process.cwd(),
+        () => {},
+        (code) => {
+          callbackCalled = true;
+          callbackExitCode = code;
+        }
+      );
+
+      expect(callbackCalled).toBe(true);
+      expect(callbackExitCode).toBe(0);
+    });
+
+    it('handles command execution', async () => {
+      const exitCode = await runner.run(
+        'test-run-7',
+        'echo "test"',
+        process.cwd(),
+        () => {},
+        () => {}
+      );
+
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe('kill', () => {
+    it('returns false when killing non-existent process', () => {
+      const killed = runner.kill('nonexistent-run');
+      expect(killed).toBe(false);
+    });
+  });
+
+  describe('isRunning', () => {
+    it('returns false for non-existent run', () => {
+      expect(runner.isRunning('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('getActiveRuns', () => {
+    it('returns empty map when no runs active', () => {
+      const active = runner.getActiveRuns();
+      expect(active.size).toBe(0);
+    });
+  });
+});

--- a/packages/shared/src/contracts/commandButtons.js
+++ b/packages/shared/src/contracts/commandButtons.js
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const CreateCommandButtonRequest = z.object({
+  label: z.string().min(1, 'Label is required'),
+  command: z.string().min(1, 'Command is required'),
+  sortOrder: z.number().int().optional().default(0),
+});
+
+export const UpdateCommandButtonRequest = z.object({
+  label: z.string().min(1).optional(),
+  command: z.string().min(1).optional(),
+  sortOrder: z.number().int().optional(),
+}).refine(obj => Object.keys(obj).length > 0, 'At least one field must be provided for update');
+
+export const CommandButtonResponse = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  label: z.string(),
+  command: z.string(),
+  sortOrder: z.number().int(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const CommandButtonListResponse = z.array(CommandButtonResponse);
+
+export const CommandRunResponse = z.object({
+  runId: z.string(),
+  buttonId: z.string(),
+  status: z.enum(['running', 'success', 'error']),
+  exitCode: z.number().int().nullable(),
+  output: z.string().optional(),
+});

--- a/packages/shared/src/contracts/commandButtons.test.js
+++ b/packages/shared/src/contracts/commandButtons.test.js
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CreateCommandButtonRequest,
+  UpdateCommandButtonRequest,
+  CommandButtonResponse,
+  CommandRunResponse,
+} from './commandButtons.js';
+
+describe('Command Buttons Contracts', () => {
+  describe('CreateCommandButtonRequest', () => {
+    it('accepts valid create request with required fields', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: 'Build',
+        command: 'npm run build',
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.sortOrder).toBe(0);
+    });
+
+    it('accepts valid create request with all fields', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: 'Build',
+        command: 'npm run build',
+        sortOrder: 1,
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.sortOrder).toBe(1);
+    });
+
+    it('sets default sortOrder to 0', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: 'Test',
+        command: 'npm test',
+      });
+      expect(result.success).toBe(true);
+      expect(result.data.sortOrder).toBe(0);
+    });
+
+    it('rejects empty label', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: '',
+        command: 'npm run build',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing label', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        command: 'npm run build',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty command', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: 'Build',
+        command: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing command', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: 'Build',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-integer sortOrder', () => {
+      const result = CreateCommandButtonRequest.safeParse({
+        label: 'Build',
+        command: 'npm run build',
+        sortOrder: 1.5,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('UpdateCommandButtonRequest', () => {
+    it('accepts update with label only', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        label: 'Updated',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts update with command only', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        command: 'new command',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts update with sortOrder only', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        sortOrder: 5,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts update with multiple fields', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        label: 'Updated',
+        command: 'new command',
+        sortOrder: 5,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects empty object', () => {
+      const result = UpdateCommandButtonRequest.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty label', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        label: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty command', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        command: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-integer sortOrder', () => {
+      const result = UpdateCommandButtonRequest.safeParse({
+        sortOrder: 1.5,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('CommandButtonResponse', () => {
+    it('accepts valid button response', () => {
+      const result = CommandButtonResponse.safeParse({
+        id: 'btn-123',
+        projectId: 'proj-123',
+        label: 'Build',
+        command: 'npm run build',
+        sortOrder: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing fields', () => {
+      const result = CommandButtonResponse.safeParse({
+        id: 'btn-123',
+        label: 'Build',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('CommandRunResponse', () => {
+    it('accepts run response with running status', () => {
+      const result = CommandRunResponse.safeParse({
+        runId: 'run-123',
+        buttonId: 'btn-123',
+        status: 'running',
+        exitCode: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts run response with success status', () => {
+      const result = CommandRunResponse.safeParse({
+        runId: 'run-123',
+        buttonId: 'btn-123',
+        status: 'success',
+        exitCode: 0,
+        output: 'Build successful',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts run response with error status', () => {
+      const result = CommandRunResponse.safeParse({
+        runId: 'run-123',
+        buttonId: 'btn-123',
+        status: 'error',
+        exitCode: 1,
+        output: 'Build failed',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid status', () => {
+      const result = CommandRunResponse.safeParse({
+        runId: 'run-123',
+        buttonId: 'btn-123',
+        status: 'invalid',
+        exitCode: null,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/protocol.js
+++ b/packages/shared/src/protocol.js
@@ -34,6 +34,11 @@ export const WS_MESSAGE_TYPES = {
 
   // Usage events
   SESSION_USAGE_UPDATE: 'session:usage_update',
+
+  // Command button events
+  COMMAND_RUN_OUTPUT: 'command:run:output',
+  COMMAND_RUN_COMPLETE: 'command:run:complete',
+  COMMAND_RUN_ERROR: 'command:run:error',
 };
 
 /**

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -591,6 +591,78 @@ export class ApiClient {
   async getConversationMessages(sessionId, conversationId) {
     return this.#request('GET', `/sessions/${sessionId}/messages?conversation_id=${conversationId}`);
   }
+
+  // Command Buttons
+
+  /**
+   * Get all command buttons for a project
+   * @param {string} projectId - Project ID
+   * @returns {Promise<Array>}
+   */
+  async getCommandButtons(projectId) {
+    return this.#request('GET', `/projects/${projectId}/command-buttons`);
+  }
+
+  /**
+   * Create a new command button
+   * @param {string} projectId - Project ID
+   * @param {Object} data - Button data
+   * @returns {Promise<Object>}
+   */
+  async createCommandButton(projectId, data) {
+    return this.#request('POST', `/projects/${projectId}/command-buttons`, data);
+  }
+
+  /**
+   * Get a specific command button
+   * @param {string} projectId - Project ID
+   * @param {string} buttonId - Button ID
+   * @returns {Promise<Object>}
+   */
+  async getCommandButton(projectId, buttonId) {
+    return this.#request('GET', `/projects/${projectId}/command-buttons/${buttonId}`);
+  }
+
+  /**
+   * Update a command button
+   * @param {string} projectId - Project ID
+   * @param {string} buttonId - Button ID
+   * @param {Object} data - Update data
+   * @returns {Promise<Object>}
+   */
+  async updateCommandButton(projectId, buttonId, data) {
+    return this.#request('PATCH', `/projects/${projectId}/command-buttons/${buttonId}`, data);
+  }
+
+  /**
+   * Delete a command button
+   * @param {string} projectId - Project ID
+   * @param {string} buttonId - Button ID
+   * @returns {Promise<void>}
+   */
+  async deleteCommandButton(projectId, buttonId) {
+    return this.#request('DELETE', `/projects/${projectId}/command-buttons/${buttonId}`);
+  }
+
+  /**
+   * Run a command button
+   * @param {string} sessionId - Session ID
+   * @param {string} buttonId - Button ID
+   * @returns {Promise<Object>}
+   */
+  async runCommandButton(sessionId, buttonId) {
+    return this.#request('POST', `/sessions/${sessionId}/command-buttons/${buttonId}/run`);
+  }
+
+  /**
+   * Kill a running command
+   * @param {string} sessionId - Session ID
+   * @param {string} runId - Run ID
+   * @returns {Promise<Object>}
+   */
+  async killCommandRun(sessionId, runId) {
+    return this.#request('POST', `/sessions/${sessionId}/command-buttons/runs/${runId}/kill`);
+  }
 }
 
 // Singleton instance

--- a/packages/web/src/components/CommandButtonItem.test.js
+++ b/packages/web/src/components/CommandButtonItem.test.js
@@ -1,0 +1,495 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import CommandButtonItem from './CommandButtonItem.vue';
+
+describe('CommandButtonItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders button info in idle state', () => {
+    const button = {
+      id: '1',
+      label: 'Run Tests',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run: null,
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(wrapper.text()).toContain('Run Tests');
+    expect(wrapper.text()).toContain('npm test');
+    expect(wrapper.find('.btn-primary').exists()).toBe(true);
+  });
+
+  it('truncates long commands', () => {
+    const button = {
+      id: '1',
+      label: 'Long',
+      command: 'this is a very long command that should be truncated because it exceeds the maximum length allowed for display in the component',
+      sortOrder: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run: null,
+        sessionId: 'session-1',
+      },
+    });
+
+    const command = wrapper.find('.button-command').text();
+    expect(command).toContain('...');
+    expect(command.length).toBeLessThan(button.command.length);
+  });
+
+  it('emits run event when run button clicked', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run: null,
+        sessionId: 'session-1',
+      },
+    });
+
+    const runButton = wrapper.find('.btn-primary');
+    await runButton.trigger('click');
+
+    expect(wrapper.emitted('run')).toBeTruthy();
+    expect(wrapper.emitted('run')[0]).toEqual([]);
+  });
+
+  it('shows running state with spinner', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'running',
+      output: 'Starting tests...',
+      exitCode: null,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(wrapper.text()).toContain('Running');
+    expect(wrapper.find('.spinner').exists()).toBe(true);
+    expect(wrapper.find('.btn-outline-danger').exists()).toBe(true);
+  });
+
+  it('shows kill button when running', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'running',
+      output: '',
+      exitCode: null,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    const killButton = wrapper.find('.btn-outline-danger');
+    expect(killButton.exists()).toBe(true);
+    expect(killButton.text()).toContain('✕');
+  });
+
+  it('emits kill event when kill button clicked', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'running',
+      output: '',
+      exitCode: null,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    const killButton = wrapper.find('.btn-outline-danger');
+    await killButton.trigger('click');
+
+    expect(wrapper.emitted('kill')).toBeTruthy();
+  });
+
+  it('shows success state with checkmark', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'All tests passed',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(wrapper.text()).toContain('✓');
+    expect(wrapper.find('.status-success').exists()).toBe(true);
+    expect(wrapper.text()).toContain('exit code: 0');
+  });
+
+  it('shows error state with X indicator', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'error',
+      output: 'Test failed',
+      exitCode: 1,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(wrapper.text()).toContain('✕');
+    expect(wrapper.find('.status-error').exists()).toBe(true);
+    expect(wrapper.text()).toContain('exit code: 1');
+  });
+
+  it('shows output section when expanded', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    // Click to expand output
+    await wrapper.find('.output-header').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('.output-content').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Test output');
+  });
+
+  it('hides output section by default', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    // Output should not be visible initially
+    expect(wrapper.find('.output-content').exists()).toBe(false);
+  });
+
+  it('toggles output visibility', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    const header = wrapper.find('.output-header');
+
+    // Initially hidden
+    expect(wrapper.find('.output-content').exists()).toBe(false);
+
+    // Click to show
+    await header.trigger('click');
+    await nextTick();
+    expect(wrapper.find('.output-content').exists()).toBe(true);
+
+    // Click to hide
+    await header.trigger('click');
+    await nextTick();
+    expect(wrapper.find('.output-content').exists()).toBe(false);
+  });
+
+  it('shows copy button in output actions', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    // Expand output
+    await wrapper.find('.output-header').trigger('click');
+    await nextTick();
+
+    // Copy button exists
+    const copyBtn = wrapper.findAll('.btn').find((btn) => btn.text().includes('Copy'));
+    expect(copyBtn).toBeDefined();
+  });
+
+  it('emits copy-output event with output text', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output content',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    // Expand and find copy button
+    await wrapper.find('.output-header').trigger('click');
+    await nextTick();
+    const copyBtn = wrapper.findAll('.btn').find((btn) => btn.text().includes('Copy'));
+    await copyBtn.trigger('click');
+
+    expect(wrapper.emitted('copy-output')).toBeTruthy();
+    expect(wrapper.emitted('copy-output')[0]).toEqual(['Test output content']);
+  });
+
+  it('shows send to canvas button in output actions', async () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    // Expand output
+    await wrapper.find('.output-header').trigger('click');
+    await nextTick();
+
+    // Canvas button exists
+    const canvasBtn = wrapper.findAll('.btn').find((btn) => btn.text().includes('Canvas'));
+    expect(canvasBtn).toBeDefined();
+  });
+
+  it('emits send-to-canvas event', async () => {
+    const button = {
+      id: '1',
+      label: 'Run Tests',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Test output',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    // Expand and find canvas button
+    await wrapper.find('.output-header').trigger('click');
+    await nextTick();
+    const canvasBtn = wrapper.findAll('.btn').find((btn) => btn.text().includes('Canvas'));
+    await canvasBtn.trigger('click');
+
+    expect(wrapper.emitted('send-to-canvas')).toBeTruthy();
+    expect(wrapper.emitted('send-to-canvas')[0]).toEqual(['Run Tests', 'Test output']);
+  });
+
+  it('displays exit code in success state', () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'success',
+      output: 'Success',
+      exitCode: 0,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(wrapper.text()).toContain('exit code: 0');
+  });
+
+  it('displays exit code in error state', () => {
+    const button = {
+      id: '1',
+      label: 'Test',
+      command: 'npm test',
+      sortOrder: 0,
+    };
+    const run = {
+      runId: 'run-1',
+      buttonId: '1',
+      status: 'error',
+      output: 'Error',
+      exitCode: 127,
+    };
+
+    const wrapper = mount(CommandButtonItem, {
+      props: {
+        button,
+        run,
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(wrapper.text()).toContain('exit code: 127');
+  });
+});

--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -1,0 +1,322 @@
+<template>
+  <div class="command-button-item">
+    <!-- Header: Label and Run Button -->
+    <div class="button-header">
+      <div class="button-info">
+        <div class="button-label">{{ button.label }}</div>
+        <div class="button-command">{{ truncateCommand(button.command) }}</div>
+      </div>
+
+      <div class="button-actions">
+        <!-- Status Indicator -->
+        <div v-if="run" :class="['status-indicator', `status-${run.status}`]">
+          {{ statusIcon }}
+        </div>
+
+        <!-- Run Button (idle state) -->
+        <button
+          v-if="!run || run.status !== 'running'"
+          class="btn btn-primary btn-sm"
+          @click="$emit('run')"
+          :disabled="run?.status === 'running'"
+        >
+          ▶ Run
+        </button>
+
+        <!-- Kill Button (running state) -->
+        <button
+          v-if="run?.status === 'running'"
+          class="btn btn-outline-danger btn-sm"
+          @click="$emit('kill')"
+          title="Kill running command"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+
+    <!-- Output Section (collapsible) -->
+    <div v-if="run" class="output-section">
+      <div class="output-header" @click="showOutput = !showOutput">
+        <span class="expand-icon">{{ showOutput ? '▼' : '▶' }}</span>
+        <span class="output-label">
+          Output
+          <span v-if="run.exitCode !== null" class="exit-code">(exit code: {{ run.exitCode }})</span>
+        </span>
+      </div>
+
+      <!-- Output Content (when expanded) -->
+      <div v-if="showOutput" class="output-content">
+        <div class="output-text">{{ run.output || '(no output)' }}</div>
+
+        <!-- Output Actions (success/error states) -->
+        <div v-if="run.status !== 'running'" class="output-actions">
+          <button class="btn btn-sm btn-outline-secondary" @click="onCopyClick">
+            📋 Copy
+          </button>
+          <button class="btn btn-sm btn-outline-secondary" @click="onSendCanvasClick">
+            🎨 Send to Canvas
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading Spinner (running state) -->
+    <div v-if="run?.status === 'running'" class="running-indicator">
+      <span class="spinner"></span>
+      Running...
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits, ref, computed } from 'vue';
+
+const props = defineProps({
+  button: {
+    type: Object,
+    required: true,
+  },
+  run: {
+    type: Object,
+    default: null,
+  },
+  sessionId: {
+    type: String,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['run', 'kill', 'copy-output', 'send-to-canvas']);
+
+const showOutput = ref(false);
+
+const truncateCommand = (command) => {
+  const maxLength = 80;
+  if (command.length > maxLength) {
+    return command.substring(0, maxLength) + '...';
+  }
+  return command;
+};
+
+const statusIcon = computed(() => {
+  if (!props.run) return '';
+  switch (props.run.status) {
+    case 'running':
+      return '⊙';
+    case 'success':
+      return '✓';
+    case 'error':
+      return '✕';
+    default:
+      return '';
+  }
+});
+
+const onCopyClick = async () => {
+  emit('copy-output', props.run.output);
+};
+
+const onSendCanvasClick = () => {
+  emit('send-to-canvas', props.button.label, props.run.output);
+};
+</script>
+
+<style scoped>
+.command-button-item {
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Header Section */
+.button-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.button-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.button-label {
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+.button-command {
+  color: var(--color-text-soft);
+  font-size: 0.85rem;
+  font-family: var(--font-mono);
+}
+
+.button-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Status Indicator */
+.status-indicator {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: bold;
+}
+
+.status-success {
+  background-color: rgba(63, 185, 80, 0.2);
+  color: var(--color-success);
+}
+
+.status-error {
+  background-color: rgba(248, 81, 73, 0.2);
+  color: var(--color-error);
+}
+
+.status-running {
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+/* Output Section */
+.output-section {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.75rem;
+}
+
+.output-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  user-select: none;
+}
+
+.output-header:hover {
+  background-color: rgba(88, 166, 255, 0.1);
+}
+
+.expand-icon {
+  color: var(--color-text-soft);
+  font-size: 0.85rem;
+}
+
+.output-label {
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+
+.exit-code {
+  color: var(--color-text-soft);
+  font-size: 0.8rem;
+  margin-left: 0.5rem;
+}
+
+.output-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+
+.output-text {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--color-text-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 300px;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+
+.output-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.75rem;
+}
+
+/* Running Indicator */
+.running-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-text-soft);
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+/* Animations */
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .button-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .button-actions button {
+    flex: 1;
+  }
+
+  .output-actions {
+    flex-direction: column;
+  }
+
+  .output-actions button {
+    width: 100%;
+  }
+}
+</style>

--- a/packages/web/src/components/CommandButtonsPanel.test.js
+++ b/packages/web/src/components/CommandButtonsPanel.test.js
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
+import CommandButtonsPanel from './CommandButtonsPanel.vue';
+
+// Mock router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+// Mock store
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: vi.fn(),
+}));
+
+const { useCommandButtonsStore } = await import('../stores/commandButtons.js');
+
+describe('CommandButtonsPanel', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state', async () => {
+    const mockStore = {
+      buttons: [],
+      loading: true,
+      error: null,
+      fetchButtons: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Loading command buttons');
+    expect(wrapper.find('.loading-spinner').exists()).toBe(true);
+  });
+
+  it('renders error state', async () => {
+    const mockStore = {
+      buttons: [],
+      loading: false,
+      error: 'Failed to load buttons',
+      fetchButtons: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Failed to load buttons');
+  });
+
+  it('renders empty state when no buttons', async () => {
+    const mockStore = {
+      buttons: [],
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('No command buttons configured yet');
+  });
+
+  it('renders buttons table with data', async () => {
+    const mockStore = {
+      buttons: [
+        {
+          id: '1',
+          label: 'Run Tests',
+          command: 'npm test',
+          sortOrder: 0,
+        },
+        {
+          id: '2',
+          label: 'Build',
+          command: 'npm run build',
+          sortOrder: 1,
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Run Tests');
+    expect(wrapper.text()).toContain('Build');
+    expect(wrapper.text()).toContain('npm test');
+    expect(wrapper.text()).toContain('npm run build');
+  });
+
+  it('truncates long commands', async () => {
+    const mockStore = {
+      buttons: [
+        {
+          id: '1',
+          label: 'Long Command',
+          command: 'this is a very long command that should be truncated because it exceeds the maximum length allowed for display',
+          sortOrder: 0,
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    const commandCell = wrapper.find('.col-command');
+    expect(commandCell.text()).toContain('...');
+  });
+
+  it('shows delete confirmation dialog on delete click', async () => {
+    const mockStore = {
+      buttons: [
+        {
+          id: '1',
+          label: 'Run Tests',
+          command: 'npm test',
+          sortOrder: 0,
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // No dialog initially
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false);
+
+    // Click delete button
+    await wrapper.find('.btn-outline-danger').trigger('click');
+    await nextTick();
+
+    // Dialog appears
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Delete Command Button');
+  });
+
+  it('cancels delete when clicking cancel', async () => {
+    const mockStore = {
+      buttons: [
+        {
+          id: '1',
+          label: 'Run Tests',
+          command: 'npm test',
+          sortOrder: 0,
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Show dialog
+    await wrapper.find('.btn-outline-danger').trigger('click');
+    await nextTick();
+
+    // Click cancel
+    const cancelButton = wrapper.findAll('.btn').find((btn) => btn.text() === 'Cancel');
+    await cancelButton.trigger('click');
+    await nextTick();
+
+    // Dialog is gone
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false);
+  });
+
+  it('deletes button when confirmed', async () => {
+    const deleteButton = vi.fn().mockResolvedValue(undefined);
+    const mockStore = {
+      buttons: [
+        {
+          id: '1',
+          label: 'Run Tests',
+          command: 'npm test',
+          sortOrder: 0,
+        },
+      ],
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      deleteButton,
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    const wrapper = mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Show dialog and confirm
+    await wrapper.find('.btn-outline-danger').trigger('click');
+    await nextTick();
+    const confirmButton = wrapper.findAll('.btn').find((btn) => btn.text() === 'Delete');
+    await confirmButton.trigger('click');
+    await flushPromises();
+
+    // Verify delete was called
+    expect(deleteButton).toHaveBeenCalledWith('test-project', '1');
+  });
+
+  it('fetches buttons on mount', async () => {
+    const fetchButtons = vi.fn().mockResolvedValue(undefined);
+    const mockStore = {
+      buttons: [],
+      loading: false,
+      error: null,
+      fetchButtons,
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+
+    mount(CommandButtonsPanel, {
+      props: { projectId: 'test-project' },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    await flushPromises();
+    expect(fetchButtons).toHaveBeenCalledWith('test-project');
+  });
+});

--- a/packages/web/src/components/CommandButtonsPanel.vue
+++ b/packages/web/src/components/CommandButtonsPanel.vue
@@ -1,0 +1,314 @@
+<template>
+  <div class="command-buttons-panel">
+    <!-- Header with New Button -->
+    <div class="panel-header">
+      <h3>Command Buttons</h3>
+      <router-link :to="`/projects/${projectId}/command-buttons/new`" class="btn btn-primary btn-sm">
+        + New Command Button
+      </router-link>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="commandButtonsStore.loading" class="loading-state">
+      <span class="loading-spinner"></span>
+      Loading command buttons...
+    </div>
+
+    <!-- Error State -->
+    <div v-else-if="commandButtonsStore.error" class="error-message">
+      {{ commandButtonsStore.error }}
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="commandButtonsStore.buttons.length === 0" class="empty-state">
+      <p>No command buttons configured yet.</p>
+      <router-link :to="`/projects/${projectId}/command-buttons/new`" class="btn btn-primary">
+        Create First Button
+      </router-link>
+    </div>
+
+    <!-- Buttons Table -->
+    <div v-else class="buttons-table">
+      <div class="table-header">
+        <div class="col-label">Label</div>
+        <div class="col-command">Command</div>
+        <div class="col-order">Sort Order</div>
+        <div class="col-actions">Actions</div>
+      </div>
+
+      <div
+        v-for="button in commandButtonsStore.buttons"
+        :key="button.id"
+        class="table-row"
+        @click="onRowClick(button)"
+      >
+        <div class="col-label">{{ button.label }}</div>
+        <div class="col-command">
+          <code>{{ truncateCommand(button.command) }}</code>
+        </div>
+        <div class="col-order">{{ button.sortOrder }}</div>
+        <div class="col-actions" @click.stop>
+          <button class="btn btn-sm btn-outline-danger" @click="onDeleteClick(button)">
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete Confirmation Dialog -->
+    <div v-if="selectedButton" class="modal-overlay" @click="selectedButton = null">
+      <div class="modal-dialog" @click.stop>
+        <div class="modal-header">
+          <h4>Delete Command Button</h4>
+        </div>
+        <div class="modal-body">
+          <p>Are you sure you want to delete the command button "<strong>{{ selectedButton.label }}</strong>"?</p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline-secondary" @click="selectedButton = null">
+            Cancel
+          </button>
+          <button class="btn btn-danger" @click="confirmDelete">
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps, ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
+
+const props = defineProps({
+  projectId: {
+    type: String,
+    required: true,
+  },
+});
+
+const router = useRouter();
+const commandButtonsStore = useCommandButtonsStore();
+const selectedButton = ref(null);
+
+const truncateCommand = (command) => {
+  const maxLength = 50;
+  if (command.length > maxLength) {
+    return command.substring(0, maxLength) + '...';
+  }
+  return command;
+};
+
+const onRowClick = (button) => {
+  router.push(`/projects/${props.projectId}/command-buttons/${button.id}`);
+};
+
+const onDeleteClick = (button) => {
+  selectedButton.value = button;
+};
+
+const confirmDelete = async () => {
+  if (selectedButton.value) {
+    try {
+      await commandButtonsStore.deleteButton(props.projectId, selectedButton.value.id);
+      selectedButton.value = null;
+    } catch (err) {
+      console.error('Failed to delete button:', err);
+    }
+  }
+};
+
+onMounted(async () => {
+  await commandButtonsStore.fetchButtons(props.projectId);
+});
+</script>
+
+<style scoped>
+.command-buttons-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.panel-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--color-text);
+}
+
+.loading-state,
+.error-message,
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  color: var(--color-text-soft);
+}
+
+.error-message {
+  color: var(--color-error);
+  background-color: rgba(248, 81, 73, 0.1);
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.buttons-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
+
+.table-header {
+  display: grid;
+  grid-template-columns: 200px 1fr 100px 100px;
+  gap: 1rem;
+  padding: 1rem;
+  background-color: var(--color-background-mute);
+  border-bottom: 1px solid var(--color-border);
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 0.875rem;
+  text-transform: uppercase;
+}
+
+.table-row {
+  display: grid;
+  grid-template-columns: 200px 1fr 100px 100px;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-background);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.table-row:last-child {
+  border-bottom: none;
+}
+
+.table-row:hover {
+  background-color: var(--color-background-soft);
+}
+
+.col-label {
+  color: var(--color-text);
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.col-command {
+  color: var(--color-text-soft);
+  font-size: 0.875rem;
+  word-break: break-all;
+}
+
+.col-command code {
+  background-color: rgba(0, 0, 0, 0.2);
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.col-order {
+  color: var(--color-text-soft);
+  font-size: 0.875rem;
+}
+
+.col-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-dialog {
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  max-width: 400px;
+  width: 90%;
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.modal-header h4 {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.modal-body {
+  padding: 1.5rem 1rem;
+  color: var(--color-text-soft);
+}
+
+.modal-footer {
+  padding: 1rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .table-header,
+  .table-row {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .col-label::before { content: 'Label: '; font-weight: bold; color: var(--color-text-soft); }
+  .col-command::before { content: 'Command: '; font-weight: bold; color: var(--color-text-soft); }
+  .col-order::before { content: 'Order: '; font-weight: bold; color: var(--color-text-soft); }
+  .col-actions::before { content: 'Actions: '; font-weight: bold; color: var(--color-text-soft); }
+
+  .col-label,
+  .col-command,
+  .col-order,
+  .col-actions {
+    display: block;
+  }
+}
+</style>

--- a/packages/web/src/components/CommandsTab.test.js
+++ b/packages/web/src/components/CommandsTab.test.js
@@ -1,0 +1,407 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import CommandsTab from './CommandsTab.vue';
+
+// Mock router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+// Mock stores
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: vi.fn(),
+}));
+
+vi.mock('../stores/ui.js', () => ({
+  useUiStore: vi.fn(),
+}));
+
+// Mock WebSocket composable
+vi.mock('../composables/useWebSocket.js', () => ({
+  useSessionSubscription: vi.fn(),
+}));
+
+// Mock API
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    createCanvasItem: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+const { useCommandButtonsStore } = await import('../stores/commandButtons.js');
+const { useUiStore } = await import('../stores/ui.js');
+const { useSessionSubscription } = await import('../composables/useWebSocket.js');
+
+describe('CommandsTab', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+
+    // Default WebSocket subscription mock
+    vi.mocked(useSessionSubscription).mockReturnValue({
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      onCommandOutput: vi.fn((cb) => () => {}),
+      onCommandComplete: vi.fn((cb) => () => {}),
+      onCommandError: vi.fn((cb) => () => {}),
+    });
+  });
+
+  it('renders loading state', async () => {
+    const mockStore = {
+      buttons: [],
+      runs: {},
+      loading: true,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: true,
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Loading command buttons');
+  });
+
+  it('renders empty state when no buttons', async () => {
+    const mockStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: true,
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('No command buttons configured');
+  });
+
+  it('renders error state', async () => {
+    const mockStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: 'Failed to fetch buttons',
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: true,
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Failed to fetch buttons');
+  });
+
+  it('renders command button items', async () => {
+    const mockStore = {
+      buttons: [
+        { id: '1', label: 'Test', command: 'npm test', sortOrder: 0 },
+        { id: '2', label: 'Build', command: 'npm run build', sortOrder: 1 },
+      ],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: { template: '<div class="command-button-item">{{ button.label }}</div>' },
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Items should be rendered
+    const items = wrapper.findAll('.command-button-item');
+    expect(items).toHaveLength(2);
+  });
+
+  it('fetches buttons on mount', async () => {
+    const fetchButtons = vi.fn().mockResolvedValue(undefined);
+    const mockStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons,
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: true,
+          RouterLink: true,
+        },
+      },
+    });
+
+    await flushPromises();
+    expect(fetchButtons).toHaveBeenCalledWith('project-1');
+  });
+
+  it('handles button run event', async () => {
+    const runButton = vi.fn().mockResolvedValue('run-1');
+    const mockStore = {
+      buttons: [{ id: 'btn-1', label: 'Test', command: 'npm test', sortOrder: 0 }],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+      runButton,
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: {
+            template: '<button @click="$emit(\'run\')">Run</button>',
+            props: ['button'],
+          },
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Emit run event from child
+    const button = wrapper.find('button');
+    await button.trigger('click');
+    await flushPromises();
+
+    // Verify runButton was called
+    expect(runButton).toHaveBeenCalledWith('session-1', 'btn-1');
+  });
+
+  it('handles copy output event', async () => {
+    const mockStore = {
+      buttons: [{ id: 'btn-1', label: 'Test', command: 'npm test', sortOrder: 0 }],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    // Mock clipboard
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: {
+            template: '<button @click="$emit(\'copy-output\', \'test output\')">Copy</button>',
+            props: ['button'],
+          },
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Emit copy event
+    const button = wrapper.find('button');
+    await button.trigger('click');
+    await flushPromises();
+
+    // Verify success message
+    expect(mockUiStore.success).toHaveBeenCalledWith('Output copied to clipboard');
+  });
+
+  it('handles send to canvas event', async () => {
+    const { api } = await import('../composables/useApi.js');
+    const mockStore = {
+      buttons: [{ id: 'btn-1', label: 'Test Command', command: 'npm test', sortOrder: 0 }],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: {
+            template: '<button @click="$emit(\'send-to-canvas\', \'Test Button\', \'output\')">Send</button>',
+            props: ['button'],
+          },
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Emit send to canvas event
+    const button = wrapper.find('button');
+    await button.trigger('click');
+    await flushPromises();
+
+    // Verify success message and API call
+    expect(mockUiStore.success).toHaveBeenCalledWith('Output sent to canvas');
+    expect(vi.mocked(api.createCanvasItem)).toHaveBeenCalledWith('session-1', {
+      type: 'text',
+      filename: 'test-button-output.txt',
+      content: 'output',
+      label: 'Test Button output',
+    });
+  });
+
+  it('subscribes to WebSocket events on mount', async () => {
+    const onCommandOutput = vi.fn(() => () => {});
+    const onCommandComplete = vi.fn(() => () => {});
+    const onCommandError = vi.fn(() => () => {});
+    const subscribe = vi.fn();
+
+    vi.mocked(useSessionSubscription).mockReturnValue({
+      subscribe,
+      unsubscribe: vi.fn(),
+      onCommandOutput,
+      onCommandComplete,
+      onCommandError,
+    });
+
+    const mockStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn(),
+      getRun: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    mount(CommandsTab, {
+      props: {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+      },
+      global: {
+        stubs: {
+          CommandButtonItem: true,
+          RouterLink: true,
+        },
+      },
+    });
+
+    await flushPromises();
+    expect(subscribe).toHaveBeenCalled();
+    expect(onCommandOutput).toHaveBeenCalled();
+    expect(onCommandComplete).toHaveBeenCalled();
+    expect(onCommandError).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/CommandsTab.vue
+++ b/packages/web/src/components/CommandsTab.vue
@@ -1,0 +1,263 @@
+<template>
+  <div class="commands-tab">
+    <!-- Header with Configure Link -->
+    <div class="tab-header">
+      <h3>Command Buttons</h3>
+      <router-link
+        :to="`/projects/${projectId}/sessions`"
+        class="btn btn-sm btn-outline-secondary"
+      >
+        ⚙️ Configure
+      </router-link>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="commandButtonsStore.loading" class="loading-state">
+      <span class="loading-spinner"></span>
+      Loading command buttons...
+    </div>
+
+    <!-- Error State -->
+    <div v-else-if="commandButtonsStore.error" class="error-message">
+      {{ commandButtonsStore.error }}
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="commandButtonsStore.buttons.length === 0" class="empty-state">
+      <p>No command buttons configured for this project.</p>
+      <router-link
+        :to="`/projects/${projectId}/sessions`"
+        class="btn btn-primary"
+      >
+        Configure Command Buttons
+      </router-link>
+    </div>
+
+    <!-- Commands List -->
+    <div v-else class="commands-list">
+      <CommandButtonItem
+        v-for="button in commandButtonsStore.buttons"
+        :key="button.id"
+        :button="button"
+        :run="commandButtonsStore.getRun(currentRunIds[button.id])"
+        :session-id="sessionId"
+        @run="onButtonRun(button.id)"
+        @kill="onButtonKill(button.id)"
+        @copy-output="onCopyOutput"
+        @send-to-canvas="onSendToCanvas"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps, ref, onMounted, onUnmounted, reactive } from 'vue';
+import { useRouter } from 'vue-router';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
+import { useSessionSubscription } from '../composables/useWebSocket.js';
+import { useUiStore } from '../stores/ui.js';
+import { api } from '../composables/useApi.js';
+import CommandButtonItem from './CommandButtonItem.vue';
+
+const props = defineProps({
+  sessionId: {
+    type: String,
+    required: true,
+  },
+  projectId: {
+    type: String,
+    required: true,
+  },
+});
+
+const router = useRouter();
+const commandButtonsStore = useCommandButtonsStore();
+const uiStore = useUiStore();
+
+// Map button ID to current run ID
+const currentRunIds = reactive({});
+
+// Store cleanup functions for WebSocket handlers
+const cleanups = [];
+
+/**
+ * Handle button run event
+ */
+const onButtonRun = async (buttonId) => {
+  try {
+    const runId = await commandButtonsStore.runButton(props.sessionId, buttonId);
+    currentRunIds[buttonId] = runId;
+  } catch (err) {
+    uiStore.error(`Failed to run command: ${err.message}`);
+  }
+};
+
+/**
+ * Handle button kill event
+ */
+const onButtonKill = async (buttonId) => {
+  const runId = currentRunIds[buttonId];
+  if (!runId) return;
+
+  try {
+    await commandButtonsStore.killRun(props.sessionId, runId);
+  } catch (err) {
+    uiStore.error(`Failed to kill command: ${err.message}`);
+  }
+};
+
+/**
+ * Handle copy output event
+ */
+const onCopyOutput = async (output) => {
+  try {
+    await navigator.clipboard.writeText(output);
+    uiStore.success('Output copied to clipboard');
+  } catch (err) {
+    uiStore.error('Failed to copy output');
+  }
+};
+
+/**
+ * Handle send to canvas event
+ */
+const onSendToCanvas = async (buttonLabel, output) => {
+  try {
+    // Sanitize filename from button label
+    const sanitizedLabel = buttonLabel
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    await api.createCanvasItem(props.sessionId, {
+      type: 'text',
+      filename: `${sanitizedLabel}-output.txt`,
+      content: output,
+      label: `${buttonLabel} output`,
+    });
+
+    uiStore.success('Output sent to canvas');
+  } catch (err) {
+    uiStore.error(`Failed to send to canvas: ${err.message}`);
+  }
+};
+
+/**
+ * Setup WebSocket handlers for command events
+ */
+const setupWebSocketHandlers = () => {
+  const { subscribe, unsubscribe, onCommandOutput, onCommandComplete, onCommandError } =
+    useSessionSubscription(props.sessionId);
+
+  // Subscribe to session updates
+  subscribe();
+
+  // Handle command output updates
+  cleanups.push(
+    onCommandOutput((runId, text) => {
+      commandButtonsStore.appendOutput(runId, text);
+    })
+  );
+
+  // Handle command completion
+  cleanups.push(
+    onCommandComplete((runId, exitCode, output) => {
+      commandButtonsStore.completeRun(runId, exitCode, output);
+    })
+  );
+
+  // Handle command errors
+  cleanups.push(
+    onCommandError((runId, error) => {
+      commandButtonsStore.errorRun(runId, error);
+    })
+  );
+
+  // Add unsubscribe to cleanups
+  cleanups.push(unsubscribe);
+};
+
+onMounted(async () => {
+  // Fetch buttons for this project
+  await commandButtonsStore.fetchButtons(props.projectId);
+
+  // Setup WebSocket handlers
+  setupWebSocketHandlers();
+});
+
+onUnmounted(() => {
+  // Cleanup all WebSocket handlers
+  cleanups.forEach((cleanup) => cleanup());
+  cleanups.length = 0;
+});
+</script>
+
+<style scoped>
+.commands-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tab-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tab-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.loading-state,
+.error-message,
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  color: var(--color-text-soft);
+}
+
+.error-message {
+  color: var(--color-error);
+  background-color: rgba(248, 81, 73, 0.1);
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.commands-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .tab-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .commands-list {
+    gap: 1rem;
+  }
+}
+</style>

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -290,6 +290,36 @@ export function useSessionSubscription(sessionId) {
     return () => off(WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, handler);
   };
 
+  const onCommandOutput = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.runId, msg.text);
+      }
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, handler);
+  };
+
+  const onCommandComplete = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.runId, msg.exitCode, msg.output);
+      }
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, handler);
+  };
+
+  const onCommandError = (callback) => {
+    const handler = (msg) => {
+      if (msg.sessionId === sessionId) {
+        callback(msg.runId, msg.error);
+      }
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, handler);
+  };
+
   // Auto-cleanup on unmount
   onUnmounted(() => {
     unsubscribe();
@@ -315,6 +345,9 @@ export function useSessionSubscription(sessionId) {
     onConversationUpdated,
     onConversationDeleted,
     onUsageUpdate,
+    onCommandOutput,
+    onCommandComplete,
+    onCommandError,
   };
 }
 

--- a/packages/web/src/router.js
+++ b/packages/web/src/router.js
@@ -17,6 +17,16 @@ const routes = [
     component: () => import('./views/ProjectEditView.vue'),
   },
   {
+    path: '/projects/:projectId/command-buttons/new',
+    name: 'CommandButtonNew',
+    component: () => import('./views/CommandButtonDetailView.vue'),
+  },
+  {
+    path: '/projects/:projectId/command-buttons/:buttonId',
+    name: 'CommandButtonEdit',
+    component: () => import('./views/CommandButtonDetailView.vue'),
+  },
+  {
     path: '/projects/:id/sessions',
     name: 'SessionList',
     component: () => import('./views/SessionListView.vue'),

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -1,0 +1,128 @@
+import { defineStore } from 'pinia';
+import { api } from '../composables/useApi.js';
+
+export const useCommandButtonsStore = defineStore('commandButtons', {
+  state: () => ({
+    buttons: [],
+    runs: {}, // runId -> { runId, buttonId, status, output, exitCode }
+    loading: false,
+    error: null,
+  }),
+
+  getters: {
+    getButtonById: (state) => (buttonId) => state.buttons.find((b) => b.id === buttonId),
+    getRun: (state) => (runId) => state.runs[runId],
+    activeRuns: (state) => Object.values(state.runs).filter((r) => r.status === 'running'),
+  },
+
+  actions: {
+    async fetchButtons(projectId) {
+      this.loading = true;
+      this.error = null;
+      try {
+        this.buttons = await api.getCommandButtons(projectId);
+      } catch (err) {
+        this.error = err.message;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async createButton(projectId, data) {
+      this.error = null;
+      try {
+        const button = await api.createCommandButton(projectId, data);
+        this.buttons.push(button);
+        return button;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
+    async updateButton(projectId, buttonId, data) {
+      this.error = null;
+      try {
+        const updated = await api.updateCommandButton(projectId, buttonId, data);
+        const index = this.buttons.findIndex((b) => b.id === buttonId);
+        if (index >= 0) {
+          this.buttons[index] = updated;
+        }
+        return updated;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
+    async deleteButton(projectId, buttonId) {
+      this.error = null;
+      try {
+        await api.deleteCommandButton(projectId, buttonId);
+        this.buttons = this.buttons.filter((b) => b.id !== buttonId);
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
+    async runButton(sessionId, buttonId) {
+      this.error = null;
+      try {
+        const response = await api.runCommandButton(sessionId, buttonId);
+        const runId = response.runId;
+        this.runs[runId] = {
+          runId,
+          buttonId,
+          status: 'running',
+          output: '',
+          exitCode: null,
+        };
+        return runId;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
+    async killRun(sessionId, runId) {
+      this.error = null;
+      try {
+        await api.killCommandRun(sessionId, runId);
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      }
+    },
+
+    // Handle WebSocket messages
+    appendOutput(runId, text) {
+      if (this.runs[runId]) {
+        this.runs[runId].output += text;
+      }
+    },
+
+    completeRun(runId, exitCode, output) {
+      if (this.runs[runId]) {
+        this.runs[runId].exitCode = exitCode;
+        this.runs[runId].output = output;
+        this.runs[runId].status = exitCode === 0 ? 'success' : 'error';
+      }
+    },
+
+    errorRun(runId, message) {
+      if (this.runs[runId]) {
+        this.runs[runId].status = 'error';
+        this.runs[runId].output += `\n[Error] ${message}`;
+      }
+    },
+
+    clearRun(runId) {
+      delete this.runs[runId];
+    },
+
+    clearAllRuns() {
+      this.runs = {};
+    },
+  },
+});

--- a/packages/web/src/views/CommandButtonDetailView.test.js
+++ b/packages/web/src/views/CommandButtonDetailView.test.js
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
+import CommandButtonDetailView from './CommandButtonDetailView.vue';
+
+// Mock router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+  }),
+  useRoute: () => ({
+    params: {
+      id: 'test-project',
+      buttonId: null,
+    },
+  }),
+}));
+
+// Mock stores
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: vi.fn(),
+}));
+
+vi.mock('../stores/ui.js', () => ({
+  useUiStore: vi.fn(),
+}));
+
+const { useCommandButtonsStore } = await import('../stores/commandButtons.js');
+const { useUiStore } = await import('../stores/ui.js');
+
+describe('CommandButtonDetailView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('renders create form in create mode', async () => {
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue(null),
+      createButton: vi.fn().mockResolvedValue({ id: 'new' }),
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('New Command Button');
+    expect(wrapper.find('form').exists()).toBe(true);
+  });
+
+  it('renders form fields', async () => {
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue(null),
+      createButton: vi.fn(),
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    expect(wrapper.find('#label').exists()).toBe(true);
+    expect(wrapper.find('#command').exists()).toBe(true);
+    expect(wrapper.find('#sortOrder').exists()).toBe(true);
+  });
+
+  it('validates required fields on submit', async () => {
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue(null),
+      createButton: vi.fn(),
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Try to submit empty form
+    await wrapper.find('form').trigger('submit');
+    await nextTick();
+
+    // Should show validation errors
+    expect(wrapper.text()).toContain('Label is required');
+    expect(wrapper.text()).toContain('Command is required');
+  });
+
+  it('creates button with valid data', async () => {
+    const createButton = vi.fn().mockResolvedValue({ id: 'new' });
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue(null),
+      createButton,
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Fill in form
+    await wrapper.find('#label').setValue('Test Button');
+    await wrapper.find('#command').setValue('npm test');
+    await wrapper.find('#sortOrder').setValue(1);
+
+    // Submit form
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    // Verify create was called
+    expect(createButton).toHaveBeenCalledWith('test-project', {
+      label: 'Test Button',
+      command: 'npm test',
+      sortOrder: 1,
+    });
+
+    // Verify success message
+    expect(mockUiStore.success).toHaveBeenCalled();
+  });
+
+  it('shows delete button in edit mode', async () => {
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue({
+        id: 'btn-1',
+        label: 'Existing Button',
+        command: 'npm run',
+        sortOrder: 0,
+      }),
+      createButton: vi.fn(),
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    // Mock route with buttonId
+    vi.resetModules();
+    vi.doMock('vue-router', () => ({
+      useRouter: () => ({
+        push: vi.fn(),
+        back: vi.fn(),
+      }),
+      useRoute: () => ({
+        params: {
+          id: 'test-project',
+          buttonId: 'btn-1',
+        },
+      }),
+    }));
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Find delete button
+    const deleteBtn = wrapper.findAll('.btn').find((btn) => btn.text().includes('Delete'));
+    expect(deleteBtn).toBeDefined();
+  });
+
+  it('shows delete confirmation dialog', async () => {
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue(null),
+      createButton: vi.fn(),
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // No dialog initially
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false);
+
+    // Set form data to enable delete button in edit mode (simulate edit mode)
+    await wrapper.vm.formData.label = 'Test Button';
+    await wrapper.vm.formData.command = 'npm test';
+  });
+
+  it('handles API errors', async () => {
+    const createButton = vi.fn().mockRejectedValue(new Error('Network error'));
+    const mockCommandStore = {
+      loading: false,
+      error: null,
+      getButtonById: vi.fn().mockReturnValue(null),
+      createButton,
+      updateButton: vi.fn(),
+      deleteButton: vi.fn(),
+    };
+    const mockUiStore = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.mocked(useCommandButtonsStore).mockReturnValue(mockCommandStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    const wrapper = mount(CommandButtonDetailView, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    });
+
+    // Fill and submit
+    await wrapper.find('#label').setValue('Test');
+    await wrapper.find('#command').setValue('test');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    // Error handling
+    expect(mockUiStore.error).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/views/CommandButtonDetailView.vue
+++ b/packages/web/src/views/CommandButtonDetailView.vue
@@ -1,0 +1,422 @@
+<template>
+  <div class="container command-button-detail">
+    <div v-if="isLoading" class="loading-state">
+      <span class="loading-spinner"></span>
+      Loading...
+    </div>
+
+    <div v-else class="form-container">
+      <!-- Header -->
+      <div class="form-header">
+        <router-link :to="`/projects/${route.params.id}/sessions`" class="btn btn-outline-secondary">
+          ← Back
+        </router-link>
+        <h2>{{ isEditMode ? 'Edit Command Button' : 'New Command Button' }}</h2>
+      </div>
+
+      <!-- Form -->
+      <form @submit.prevent="onSubmit" class="command-button-form">
+        <!-- Label Field -->
+        <div class="form-group">
+          <label for="label">Label</label>
+          <input
+            id="label"
+            v-model="formData.label"
+            type="text"
+            class="form-input"
+            placeholder="e.g., Run Tests"
+            required
+          />
+          <span v-if="validationErrors.label" class="form-error">{{ validationErrors.label }}</span>
+        </div>
+
+        <!-- Command Field -->
+        <div class="form-group">
+          <label for="command">Command</label>
+          <textarea
+            id="command"
+            v-model="formData.command"
+            class="form-input"
+            placeholder="e.g., npm test"
+            rows="4"
+            required
+          ></textarea>
+          <span v-if="validationErrors.command" class="form-error">{{ validationErrors.command }}</span>
+        </div>
+
+        <!-- Sort Order Field -->
+        <div class="form-group">
+          <label for="sortOrder">Sort Order (optional)</label>
+          <input
+            id="sortOrder"
+            v-model.number="formData.sortOrder"
+            type="number"
+            class="form-input"
+            placeholder="0"
+            min="0"
+          />
+          <span v-if="validationErrors.sortOrder" class="form-error">{{ validationErrors.sortOrder }}</span>
+          <span class="form-help">Buttons are displayed in ascending order. Leave as 0 for default.</span>
+        </div>
+
+        <!-- Form Actions -->
+        <div class="form-actions">
+          <button type="button" class="btn btn-outline-secondary" @click="onCancel">
+            Cancel
+          </button>
+          <button v-if="isEditMode" type="button" class="btn btn-outline-danger" @click="onDelete">
+            Delete
+          </button>
+          <button type="submit" class="btn btn-primary" :disabled="isSaving">
+            {{ isSaving ? 'Saving...' : isEditMode ? 'Update' : 'Create' }}
+          </button>
+        </div>
+
+        <!-- Error Message -->
+        <div v-if="error" class="form-error-message">
+          {{ error }}
+        </div>
+      </form>
+    </div>
+
+    <!-- Delete Confirmation Dialog -->
+    <div v-if="showDeleteConfirm" class="modal-overlay" @click="showDeleteConfirm = false">
+      <div class="modal-dialog" @click.stop>
+        <div class="modal-header">
+          <h4>Delete Command Button</h4>
+        </div>
+        <div class="modal-body">
+          <p>Are you sure you want to delete "<strong>{{ formData.label }}</strong>"?</p>
+          <p>This action cannot be undone.</p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline-secondary" @click="showDeleteConfirm = false">
+            Cancel
+          </button>
+          <button class="btn btn-danger" @click="confirmDelete" :disabled="isDeleting">
+            {{ isDeleting ? 'Deleting...' : 'Delete' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps, ref, computed, onMounted } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
+import { useUiStore } from '../stores/ui.js';
+
+const route = useRoute();
+const router = useRouter();
+const commandButtonsStore = useCommandButtonsStore();
+const uiStore = useUiStore();
+
+const isLoading = ref(false);
+const isSaving = ref(false);
+const isDeleting = ref(false);
+const showDeleteConfirm = ref(false);
+const error = ref(null);
+const validationErrors = ref({});
+
+const formData = ref({
+  label: '',
+  command: '',
+  sortOrder: 0,
+});
+
+const isEditMode = computed(() => !!route.params.buttonId);
+
+const loadButton = async (buttonId) => {
+  isLoading.value = true;
+  try {
+    const button = commandButtonsStore.getButtonById(buttonId);
+    if (button) {
+      formData.value = {
+        label: button.label,
+        command: button.command,
+        sortOrder: button.sortOrder || 0,
+      };
+    }
+  } catch (err) {
+    error.value = `Failed to load button: ${err.message}`;
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const validateForm = () => {
+  validationErrors.value = {};
+
+  if (!formData.value.label.trim()) {
+    validationErrors.value.label = 'Label is required';
+  }
+
+  if (!formData.value.command.trim()) {
+    validationErrors.value.command = 'Command is required';
+  }
+
+  if (formData.value.sortOrder < 0) {
+    validationErrors.value.sortOrder = 'Sort order must be 0 or greater';
+  }
+
+  return Object.keys(validationErrors.value).length === 0;
+};
+
+const onSubmit = async () => {
+  error.value = null;
+
+  if (!validateForm()) {
+    return;
+  }
+
+  isSaving.value = true;
+  try {
+    const projectId = route.params.id;
+    const buttonData = {
+      label: formData.value.label,
+      command: formData.value.command,
+      sortOrder: formData.value.sortOrder,
+    };
+
+    if (isEditMode.value) {
+      await commandButtonsStore.updateButton(projectId, route.params.buttonId, buttonData);
+      uiStore.success('Command button updated');
+    } else {
+      await commandButtonsStore.createButton(projectId, buttonData);
+      uiStore.success('Command button created');
+    }
+
+    router.push(`/projects/${projectId}/sessions`);
+  } catch (err) {
+    error.value = err.message;
+    uiStore.error(err.message);
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const onCancel = () => {
+  router.back();
+};
+
+const onDelete = () => {
+  showDeleteConfirm.value = true;
+};
+
+const confirmDelete = async () => {
+  isDeleting.value = true;
+  try {
+    const projectId = route.params.id;
+    const buttonId = route.params.buttonId;
+
+    await commandButtonsStore.deleteButton(projectId, buttonId);
+    uiStore.success('Command button deleted');
+    showDeleteConfirm.value = false;
+
+    router.push(`/projects/${projectId}/sessions`);
+  } catch (err) {
+    error.value = err.message;
+    uiStore.error(err.message);
+  } finally {
+    isDeleting.value = false;
+  }
+};
+
+onMounted(async () => {
+  if (isEditMode.value) {
+    await loadButton(route.params.buttonId);
+  }
+});
+</script>
+
+<style scoped>
+.command-button-detail {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: var(--color-text-soft);
+}
+
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.form-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.form-header h2 {
+  margin: 0;
+  color: var(--color-text);
+  flex: 1;
+}
+
+.command-button-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 2rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-group label {
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.form-input {
+  padding: 0.75rem;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: border-color 0.2s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+}
+
+.form-input::placeholder {
+  color: var(--color-text-soft);
+}
+
+textarea.form-input {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  resize: vertical;
+  min-height: 100px;
+}
+
+.form-help {
+  font-size: 0.85rem;
+  color: var(--color-text-soft);
+}
+
+.form-error {
+  font-size: 0.85rem;
+  color: var(--color-error);
+}
+
+.form-error-message {
+  padding: 0.75rem;
+  background-color: rgba(248, 81, 73, 0.1);
+  border: 1px solid var(--color-error);
+  border-radius: var(--border-radius);
+  color: var(--color-error);
+  font-size: 0.9rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.form-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-dialog {
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  max-width: 400px;
+  width: 90%;
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.modal-header h4 {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.modal-body {
+  padding: 1.5rem 1rem;
+  color: var(--color-text-soft);
+}
+
+.modal-body p {
+  margin: 0.5rem 0;
+}
+
+.modal-footer {
+  padding: 1rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .command-button-detail {
+    padding: 1rem;
+  }
+
+  .form-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .command-button-form {
+    padding: 1.5rem 1rem;
+  }
+
+  .form-actions {
+    flex-direction: column-reverse;
+  }
+
+  .form-actions button {
+    width: 100%;
+  }
+}
+</style>

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -103,6 +103,7 @@
         <ChangesTab v-else-if="activeTab === 'changes'" :session-id="route.params.id" @update:file-count="changesFileCount = $event" />
         <CanvasTab v-else-if="activeTab === 'canvas'" :session-id="route.params.id" />
         <NotesTab v-else-if="activeTab === 'notes'" :session-id="route.params.id" />
+        <CommandsTab v-else-if="activeTab === 'commands'" :session-id="route.params.id" :project-id="sessionsStore.currentSession?.projectId" />
       </div>
     </template>
   </div>
@@ -122,6 +123,7 @@ import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
 import NotesTab from '../components/NotesTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
+import CommandsTab from '../components/CommandsTab.vue';
 import PrIndicators from '../components/PrIndicators.vue';
 import TokenUsagePanel from '../components/TokenUsagePanel.vue';
 import { useTemplatesStore } from '../stores/templates.js';
@@ -153,7 +155,8 @@ const tabs = computed(() => [
   { id: 'conversation', label: 'Conversation' },
   { id: 'changes', label: changesFileCount.value > 0 ? `Changes (${changesFileCount.value})` : 'Changes' },
   { id: 'canvas', label: 'Canvas' },
-  { id: 'notes', label: 'Notes' }
+  { id: 'notes', label: 'Notes' },
+  { id: 'commands', label: 'Commands' }
 ]);
 
 function navigateToTab(tabId) {

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -35,6 +35,13 @@
       >
         Templates
       </button>
+      <button
+        class="tab"
+        :class="{ active: activeTab === 'commands' }"
+        @click="activeTab = 'commands'"
+      >
+        Commands
+      </button>
     </div>
 
     <!-- Status Filters -->
@@ -121,6 +128,11 @@
     <div v-if="activeTab === 'templates'">
       <TemplatesPanel :project-id="route.params.id" />
     </div>
+
+    <!-- Commands Tab -->
+    <div v-if="activeTab === 'commands'">
+      <CommandButtonsPanel :project-id="route.params.id" />
+    </div>
   </div>
 </template>
 
@@ -133,6 +145,7 @@ import { useProjectSubscription } from '../composables/useWebSocket.js';
 import { api } from '../composables/useApi.js';
 import SessionCard from '../components/SessionCard.vue';
 import TemplatesPanel from '../components/TemplatesPanel.vue';
+import CommandButtonsPanel from '../components/CommandButtonsPanel.vue';
 
 const route = useRoute();
 const activeTab = ref('sessions');

--- a/tests/e2e/commandButtons.spec.ts
+++ b/tests/e2e/commandButtons.spec.ts
@@ -1,0 +1,374 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  cleanupAll,
+  getProject,
+  getProjectSessions,
+} from './helpers';
+
+test.describe('Command Buttons', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+  let session: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('[TEST] Command Buttons', '/tmp/test');
+    session = await seedSession(project.id, 'Test Session');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('create a new command button', async ({ page }) => {
+    // Navigate to project sessions page
+    await page.goto(`/projects/${project.id}/sessions`);
+
+    // Click Commands tab
+    await page.click('text=Commands');
+
+    // Click "Configure Command Buttons" or "Create First Button"
+    await page.click('button:has-text("Configure")');
+
+    // Should navigate to commands page (click tab again if not there)
+    await page.goto(`/projects/${project.id}/sessions`);
+    await page.click('text=Commands');
+    await page.click('button:has-text("New Command Button")');
+
+    // Should be on create form
+    expect(page.url()).toContain('/command-buttons/new');
+    await expect(page).toHaveURL(/\/projects\/[\w-]+\/command-buttons\/new/);
+
+    // Fill form
+    await page.fill('#label', 'Run Tests');
+    await page.fill('#command', 'npm test');
+    await page.fill('#sortOrder', '1');
+
+    // Submit
+    await page.click('button:has-text("Create")');
+
+    // Should be back on sessions page
+    await page.waitForURL(`/projects/${project.id}/sessions`);
+
+    // Verify success toast
+    await expect(page.getByText('Command button created')).toBeVisible();
+  });
+
+  test('edit an existing command button', async ({ page }) => {
+    // First create a button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Original Label');
+    await page.fill('#command', 'original command');
+    await page.click('button:has-text("Create")');
+
+    // Get the button ID from the database or by navigating
+    const project_data = await getProject(project.id);
+
+    // Navigate back to commands page
+    await page.goto(`/projects/${project.id}/sessions`);
+    await page.click('text=Commands');
+
+    // Click on the button row to edit
+    await page.click('text=Original Label');
+
+    // Should be on edit form
+    expect(page.url()).toContain('/command-buttons/');
+    expect(page.url()).not.toContain('/new');
+
+    // Update form
+    await page.fill('#label', 'Updated Label');
+    await page.fill('#command', 'updated command');
+
+    // Submit
+    await page.click('button:has-text("Update")');
+
+    // Should be back on sessions page
+    await page.waitForURL(`/projects/${project.id}/sessions`);
+
+    // Verify success
+    await expect(page.getByText('Command button updated')).toBeVisible();
+  });
+
+  test('delete a command button', async ({ page }) => {
+    // Create a button first
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Button to Delete');
+    await page.fill('#command', 'delete me');
+    await page.click('button:has-text("Create")');
+
+    // Navigate to commands tab
+    await page.goto(`/projects/${project.id}/sessions`);
+    await page.click('text=Commands');
+
+    // Click delete button
+    await page.click('.btn-outline-danger');
+
+    // Confirm deletion in modal
+    await page.click('button:has-text("Delete")');
+
+    // Verify success
+    await expect(page.getByText('Command button deleted')).toBeVisible();
+
+    // Verify button is gone
+    await expect(page.getByText('Button to Delete')).not.toBeVisible();
+  });
+
+  test('run command button from session detail view', async ({ page }) => {
+    // Create a command button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Echo Test');
+    await page.fill('#command', 'echo "Hello World"');
+    await page.click('button:has-text("Create")');
+
+    // Navigate to session detail
+    await page.goto(`/sessions/${session.id}/commands`);
+
+    // Should see the button
+    await expect(page.getByText('Echo Test')).toBeVisible();
+
+    // Click run button
+    await page.click('button:has-text("▶ Run")');
+
+    // Should show running state with spinner
+    await expect(page.getByText('Running...')).toBeVisible();
+
+    // Wait for completion (with timeout)
+    const maxWait = 5000;
+    const startTime = Date.now();
+    while (Date.now() - startTime < maxWait) {
+      const isRunning = await page.isVisible('text=Running...');
+      if (!isRunning) break;
+      await page.waitForTimeout(100);
+    }
+
+    // Should show success indicator
+    await expect(page.getByText('✓')).toBeVisible();
+  });
+
+  test('see real-time command output', async ({ page }) => {
+    // Create a button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Multi-line Output');
+    await page.fill('#command', 'echo "Line 1" && echo "Line 2" && echo "Line 3"');
+    await page.click('button:has-text("Create")');
+
+    // Navigate to session and run
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Wait for output to appear in running state
+    // The output section should expand automatically during running
+    await page.waitForTimeout(1000);
+
+    // Look for output text
+    const outputVisible = await page.isVisible('.output-text');
+    if (outputVisible) {
+      // Verify output is being displayed
+      const outputText = await page.textContent('.output-text');
+      expect(outputText).toBeTruthy();
+    }
+  });
+
+  test('kill running command', async ({ page }) => {
+    // Create a long-running command button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Sleep Command');
+    await page.fill('#command', 'sleep 10');
+    await page.click('button:has-text("Create")');
+
+    // Navigate to session and run
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Should show running state
+    await expect(page.getByText('Running...')).toBeVisible();
+
+    // Kill the command
+    const killButton = page.locator('.btn-outline-danger');
+    await killButton.click();
+
+    // Running state should eventually stop (command killed)
+    await page.waitForTimeout(1000);
+
+    // Should be in an ended state (not running anymore)
+    const isStillRunning = await page.isVisible('text=Running...');
+    expect(isStillRunning).toBe(false);
+  });
+
+  test('copy command output to clipboard', async ({ page }) => {
+    // Create a button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Copy Output');
+    await page.fill('#command', 'echo "Test output to copy"');
+    await page.click('button:has-text("Create")');
+
+    // Run the command
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Wait for completion
+    await page.waitForTimeout(2000);
+
+    // Expand output section
+    await page.click('.output-header');
+
+    // Click copy button
+    await page.click('button:has-text("Copy")');
+
+    // Verify toast message
+    await expect(page.getByText('Output copied to clipboard')).toBeVisible();
+  });
+
+  test('send command output to canvas', async ({ page }) => {
+    // Create a button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Canvas Output');
+    await page.fill('#command', 'echo "Send to canvas"');
+    await page.click('button:has-text("Create")');
+
+    // Run the command
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Wait for completion
+    await page.waitForTimeout(2000);
+
+    // Expand output section
+    await page.click('.output-header');
+
+    // Click send to canvas button
+    await page.click('button:has-text("Canvas")');
+
+    // Verify success toast
+    await expect(page.getByText('Output sent to canvas')).toBeVisible();
+
+    // Navigate to canvas tab to verify item was created
+    await page.click('text=Canvas');
+
+    // Should see the canvas item
+    await expect(page.getByText('canvas-output-output')).toBeVisible();
+  });
+
+  test('navigate between tabs with output persisting', async ({ page }) => {
+    // Create a button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Tab Test');
+    await page.fill('#command', 'echo "Persist output"');
+    await page.click('button:has-text("Create")');
+
+    // Run command
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Wait for output
+    await page.waitForTimeout(2000);
+
+    // Expand output
+    await page.click('.output-header');
+    const initialOutput = await page.textContent('.output-text');
+    expect(initialOutput).toBeTruthy();
+
+    // Switch to conversation tab
+    await page.click('text=Conversation');
+    await page.waitForTimeout(500);
+
+    // Switch back to commands tab
+    await page.click('text=Commands');
+    await page.waitForTimeout(500);
+
+    // Output should still be there
+    const persistedOutput = await page.textContent('.output-text');
+    expect(persistedOutput).toBe(initialOutput);
+  });
+
+  test('show empty state when no buttons configured', async ({ page }) => {
+    // Navigate to commands tab in session
+    await page.goto(`/sessions/${session.id}/commands`);
+
+    // Should show empty state
+    await expect(page.getByText('No command buttons configured')).toBeVisible();
+  });
+
+  test('show error state when command fails', async ({ page }) => {
+    // Create a command button with a failing command
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Failing Command');
+    await page.fill('#command', 'exit 1');
+    await page.click('button:has-text("Create")');
+
+    // Run the command
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Wait for completion
+    await page.waitForTimeout(2000);
+
+    // Should show error indicator
+    await expect(page.locator('.status-error')).toBeVisible();
+
+    // Should show exit code
+    await expect(page.getByText('exit code: 1')).toBeVisible();
+  });
+
+  test('show success state when command succeeds', async ({ page }) => {
+    // Create a command button that succeeds
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Successful Command');
+    await page.fill('#command', 'echo "Success"');
+    await page.click('button:has-text("Create")');
+
+    // Run the command
+    await page.goto(`/sessions/${session.id}/commands`);
+    await page.click('button:has-text("▶ Run")');
+
+    // Wait for completion
+    await page.waitForTimeout(2000);
+
+    // Should show success indicator
+    await expect(page.locator('.status-success')).toBeVisible();
+
+    // Should show exit code 0
+    await expect(page.getByText('exit code: 0')).toBeVisible();
+  });
+
+  test('validate required form fields', async ({ page }) => {
+    // Navigate to create form
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+
+    // Try to submit empty form
+    await page.click('button:has-text("Create")');
+
+    // Should show validation errors
+    await expect(page.getByText('Label is required')).toBeVisible();
+    await expect(page.getByText('Command is required')).toBeVisible();
+  });
+
+  test('display command buttons in table on management page', async ({ page }) => {
+    // Create multiple buttons
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Button 1');
+    await page.fill('#command', 'command 1');
+    await page.click('button:has-text("Create")');
+
+    // Create second button
+    await page.goto(`/projects/${project.id}/command-buttons/new`);
+    await page.fill('#label', 'Button 2');
+    await page.fill('#command', 'command 2');
+    await page.click('button:has-text("Create")');
+
+    // Navigate to commands panel
+    await page.goto(`/projects/${project.id}/sessions`);
+    await page.click('text=Commands');
+
+    // Should see both buttons in table
+    await expect(page.getByText('Button 1')).toBeVisible();
+    await expect(page.getByText('Button 2')).toBeVisible();
+
+    // Should show commands
+    await expect(page.getByText('command 1')).toBeVisible();
+    await expect(page.getByText('command 2')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a comprehensive command buttons feature that allows users to manage custom commands for Claude Code sessions. The feature enables users to create, configure, and execute custom commands directly from the UI.

## Changes Made

### Backend (`@claudetools/server`)
- **CommandButtonRepository**: New database repository for CRUD operations on command buttons with full lifecycle management
- **commandRunner service**: Service that executes commands with proper environment setup, working directory context, and output handling
- **API endpoints**: RESTful endpoints for managing command buttons across projects and sessions
- **WebSocket integration**: Real-time updates for command button changes

### Frontend (`@claudetools/web`)
- **CommandButtonsPanel**: Reusable component for displaying and managing command buttons
- **CommandButtonItem**: Individual command button component with delete and execute functionality
- **CommandsTab**: Tab view integrating command buttons into session detail view
- **CommandButtonDetailView**: Detailed view for viewing/editing individual command buttons
- **commandButtons store**: Pinia store for state management

### Shared (`@claudetools/shared`)
- **commandButtons contracts**: Zod validation schemas for command button data

### Database
- Schema updates to support command button storage and configuration

## Test Coverage
- Unit tests for CommandButtonRepository with database operations
- Unit tests for commandRunner service with various execution scenarios
- Contract tests for command button validation
- Component tests for all Vue components
- E2E tests with Playwright for full user workflows

## Test Plan
- [ ] Verify command buttons display in the UI
- [ ] Test creating a new command button
- [ ] Test executing a command button
- [ ] Test editing an existing command button
- [ ] Test deleting a command button
- [ ] Verify real-time updates via WebSocket
- [ ] Run unit tests: `yarn test`
- [ ] Run E2E tests: `./scripts/pw.sh test commandButtons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)