### PR TITLE
Fix scroll jump issue on archived sessions tab

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -50,6 +50,9 @@
       </button>
     </div>
 
+    <!-- Spacer for archived tab to match sessions tab structure -->
+    <div v-else-if="activeTab === 'archived'" class="tab-spacer"></div>
+
     <!-- Sessions Tab -->
     <div v-if="activeTab === 'sessions'">
       <div v-if="sessionsStore.loading" class="skeleton-list">
@@ -425,6 +428,10 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.tab-spacer {
+  height: 1rem;
 }
 
 .filter-label {


### PR DESCRIPTION
## Summary
- Add spacer div to archived tab to match the sessions tab structure
- The missing buffer between sticky tabs and session list was causing scroll position calculation issues
- Sessions tab has `.status-filters` between tabs and list; archived tab now has equivalent spacing

## Test plan
- [ ] Navigate to a project with archived sessions
- [ ] Click on the Archived tab
- [ ] Scroll to the bottom of the list
- [ ] Verify the viewport no longer jumps back up unexpectedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)