### PR TITLE
feat: Add conversation-level token usage tracking (Issue #175)

### DIFF
--- a/packages/server/src/db/ConversationRepository.js
+++ b/packages/server/src/db/ConversationRepository.js
@@ -18,6 +18,14 @@ export class ConversationRepository extends BaseRepository {
       summaryGeneratedAt: row.summary_generated_at,
       isActive: row.is_active === 1,
       claudeSessionId: row.claude_session_id,
+      // Token usage fields
+      inputTokens: row.input_tokens || 0,
+      outputTokens: row.output_tokens || 0,
+      cacheReadInputTokens: row.cache_read_input_tokens || 0,
+      cacheCreationInputTokens: row.cache_creation_input_tokens || 0,
+      webSearchRequests: row.web_search_requests || 0,
+      contextWindow: row.context_window || 200000,
+      model: row.model,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -231,5 +239,52 @@ export class ConversationRepository extends BaseRepository {
     }
 
     return this.update(id, { name });
+  }
+
+  /**
+   * Update token usage statistics for a conversation
+   * @param {string} id - Conversation ID
+   * @param {Object} usage - Usage data
+   * @param {number} usage.inputTokens
+   * @param {number} usage.outputTokens
+   * @param {number} usage.cacheReadInputTokens
+   * @param {number} usage.cacheCreationInputTokens
+   * @param {number} usage.webSearchRequests
+   * @param {number} usage.contextWindow
+   * @param {string} [usage.model]
+   * @returns {Object|null} Updated conversation or null if not found
+   */
+  updateUsage(id, usage) {
+    const conversation = this.getById(id);
+    if (!conversation) {
+      return null;
+    }
+
+    const now = Date.now();
+    this.db
+      .prepare(
+        `UPDATE conversations SET
+          input_tokens = ?,
+          output_tokens = ?,
+          cache_read_input_tokens = ?,
+          cache_creation_input_tokens = ?,
+          web_search_requests = ?,
+          context_window = ?,
+          model = COALESCE(?, model),
+          updated_at = ?
+        WHERE id = ?`
+      )
+      .run(
+        usage.inputTokens,
+        usage.outputTokens,
+        usage.cacheReadInputTokens,
+        usage.cacheCreationInputTokens,
+        usage.webSearchRequests,
+        usage.contextWindow,
+        usage.model || null,
+        now,
+        id
+      );
+    return this.getById(id);
   }
 }

--- a/packages/server/src/db/ConversationRepository.test.js
+++ b/packages/server/src/db/ConversationRepository.test.js
@@ -316,4 +316,88 @@ describe('ConversationRepository', () => {
       expect(updated.name.length).toBeLessThanOrEqual(55);
     });
   });
+
+  describe('updateUsage', () => {
+    it('updates token usage fields on conversation', () => {
+      const conv = repo.create(sessionId, 'Test Conv');
+
+      const usage = {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 200,
+        cacheCreationInputTokens: 100,
+        webSearchRequests: 2,
+        contextWindow: 200000,
+        model: 'claude-sonnet-4-20250514',
+      };
+
+      const updated = repo.updateUsage(conv.id, usage);
+
+      expect(updated.inputTokens).toBe(1000);
+      expect(updated.outputTokens).toBe(500);
+      expect(updated.cacheReadInputTokens).toBe(200);
+      expect(updated.cacheCreationInputTokens).toBe(100);
+      expect(updated.webSearchRequests).toBe(2);
+      expect(updated.contextWindow).toBe(200000);
+      expect(updated.model).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('handles partial usage updates', () => {
+      const conv = repo.create(sessionId, 'Test Conv');
+
+      // Only update some fields
+      const usage = {
+        inputTokens: 500,
+        outputTokens: 250,
+      };
+
+      const updated = repo.updateUsage(conv.id, usage);
+
+      expect(updated.inputTokens).toBe(500);
+      expect(updated.outputTokens).toBe(250);
+      // Other fields should remain at defaults
+      expect(updated.cacheReadInputTokens).toBe(0);
+      expect(updated.cacheCreationInputTokens).toBe(0);
+      expect(updated.webSearchRequests).toBe(0);
+    });
+
+    it('returns null for non-existent conversation', () => {
+      const result = repo.updateUsage('non-existent-id', { inputTokens: 100 });
+      expect(result).toBeNull();
+    });
+
+    it('updates updatedAt timestamp', () => {
+      const conv = repo.create(sessionId, 'Test Conv');
+      const originalUpdatedAt = conv.updatedAt;
+
+      // Small delay to ensure different timestamp
+      const updated = repo.updateUsage(conv.id, { inputTokens: 100 });
+
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(originalUpdatedAt);
+    });
+
+    it('preserves other conversation fields', () => {
+      const conv = repo.create(sessionId, 'My Conversation');
+      repo.update(conv.id, { summary: 'Test summary' });
+
+      const updated = repo.updateUsage(conv.id, { inputTokens: 100 });
+
+      expect(updated.name).toBe('My Conversation');
+      expect(updated.summary).toBe('Test summary');
+      expect(updated.sessionId).toBe(sessionId);
+    });
+
+    it('can accumulate usage across multiple updates', () => {
+      const conv = repo.create(sessionId, 'Test Conv');
+
+      // First update
+      repo.updateUsage(conv.id, { inputTokens: 100, outputTokens: 50 });
+
+      // Second update (simulating accumulated totals)
+      const updated = repo.updateUsage(conv.id, { inputTokens: 300, outputTokens: 150 });
+
+      expect(updated.inputTokens).toBe(300);
+      expect(updated.outputTokens).toBe(150);
+    });
+  });
 });

--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -145,6 +145,33 @@ export class DatabaseManager {
       this.#db.exec('ALTER TABLE conversations ADD COLUMN claude_session_id TEXT');
     }
 
+    // Add token usage columns to conversations table (Issue #175)
+    // Re-fetch column info after potential claude_session_id migration
+    const conversationsUsageTableInfo = this.#db.prepare('PRAGMA table_info(conversations)').all();
+    const conversationsUsageColumns = conversationsUsageTableInfo.map((col) => col.name);
+
+    if (!conversationsUsageColumns.includes('input_tokens')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN input_tokens INTEGER DEFAULT 0');
+    }
+    if (!conversationsUsageColumns.includes('output_tokens')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN output_tokens INTEGER DEFAULT 0');
+    }
+    if (!conversationsUsageColumns.includes('cache_read_input_tokens')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN cache_read_input_tokens INTEGER DEFAULT 0');
+    }
+    if (!conversationsUsageColumns.includes('cache_creation_input_tokens')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN cache_creation_input_tokens INTEGER DEFAULT 0');
+    }
+    if (!conversationsUsageColumns.includes('web_search_requests')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN web_search_requests INTEGER DEFAULT 0');
+    }
+    if (!conversationsUsageColumns.includes('context_window')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN context_window INTEGER DEFAULT 200000');
+    }
+    if (!conversationsUsageColumns.includes('model')) {
+      this.#db.exec('ALTER TABLE conversations ADD COLUMN model TEXT');
+    }
+
     // Token usage columns for sessions table (re-fetch column info)
     const sessionsUsageTableInfo = this.#db.prepare('PRAGMA table_info(sessions)').all();
     const sessionsUsageColumns = sessionsUsageTableInfo.map((col) => col.name);

--- a/packages/server/src/db/DatabaseManager.test.js
+++ b/packages/server/src/db/DatabaseManager.test.js
@@ -299,4 +299,164 @@ describe('DatabaseManager', () => {
       }).toThrow();
     });
   });
+
+  // Issue #175 - Conversation-level token usage columns
+  describe('conversations token usage columns', () => {
+    it('has input_tokens column with default 0', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'input_tokens');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('INTEGER');
+      expect(column.dflt_value).toBe('0');
+    });
+
+    it('has output_tokens column with default 0', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'output_tokens');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('INTEGER');
+      expect(column.dflt_value).toBe('0');
+    });
+
+    it('has cache_read_input_tokens column with default 0', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'cache_read_input_tokens');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('INTEGER');
+      expect(column.dflt_value).toBe('0');
+    });
+
+    it('has cache_creation_input_tokens column with default 0', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'cache_creation_input_tokens');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('INTEGER');
+      expect(column.dflt_value).toBe('0');
+    });
+
+    it('has web_search_requests column with default 0', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'web_search_requests');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('INTEGER');
+      expect(column.dflt_value).toBe('0');
+    });
+
+    it('has context_window column with default 200000', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'context_window');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('INTEGER');
+      expect(column.dflt_value).toBe('200000');
+    });
+
+    it('has model column (TEXT, nullable)', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(conversations)').all();
+      const column = columns.find((col) => col.name === 'model');
+
+      expect(column).toBeDefined();
+      expect(column.type).toBe('TEXT');
+      expect(column.notnull).toBe(0); // nullable
+    });
+
+    it('creates conversation with default token values', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      // Create project and session first
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-conv-tokens', 'Test Project', '/tmp', now, now);
+      db.prepare('INSERT INTO sessions (id, project_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('sess-conv-tokens', 'proj-conv-tokens', 'Test Session', 'running', now, now);
+
+      // Create conversation without specifying token columns
+      db.prepare('INSERT INTO conversations (id, session_id, name, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('conv-tokens', 'sess-conv-tokens', 'Test Conversation', 1, now, now);
+
+      // Verify defaults
+      const conv = db.prepare('SELECT * FROM conversations WHERE id = ?').get('conv-tokens');
+      expect(conv.input_tokens).toBe(0);
+      expect(conv.output_tokens).toBe(0);
+      expect(conv.cache_read_input_tokens).toBe(0);
+      expect(conv.cache_creation_input_tokens).toBe(0);
+      expect(conv.web_search_requests).toBe(0);
+      expect(conv.context_window).toBe(200000);
+      expect(conv.model).toBeNull();
+    });
+
+    it('can update conversation with token usage values', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      // Create project, session, and conversation
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-conv-update', 'Test Project', '/tmp', now, now);
+      db.prepare('INSERT INTO sessions (id, project_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('sess-conv-update', 'proj-conv-update', 'Test Session', 'running', now, now);
+      db.prepare('INSERT INTO conversations (id, session_id, name, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('conv-update', 'sess-conv-update', 'Test Conversation', 1, now, now);
+
+      // Update with token usage
+      db.prepare(`
+        UPDATE conversations SET
+          input_tokens = ?,
+          output_tokens = ?,
+          cache_read_input_tokens = ?,
+          cache_creation_input_tokens = ?,
+          web_search_requests = ?,
+          context_window = ?,
+          model = ?
+        WHERE id = ?
+      `).run(1000, 500, 200, 100, 2, 200000, 'claude-sonnet-4-20250514', 'conv-update');
+
+      // Verify the update
+      const conv = db.prepare('SELECT * FROM conversations WHERE id = ?').get('conv-update');
+      expect(conv.input_tokens).toBe(1000);
+      expect(conv.output_tokens).toBe(500);
+      expect(conv.cache_read_input_tokens).toBe(200);
+      expect(conv.cache_creation_input_tokens).toBe(100);
+      expect(conv.web_search_requests).toBe(2);
+      expect(conv.context_window).toBe(200000);
+      expect(conv.model).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('accumulates token usage across multiple updates', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      // Create project, session, and conversation
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-conv-accum', 'Test Project', '/tmp', now, now);
+      db.prepare('INSERT INTO sessions (id, project_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('sess-conv-accum', 'proj-conv-accum', 'Test Session', 'running', now, now);
+      db.prepare('INSERT INTO conversations (id, session_id, name, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('conv-accum', 'sess-conv-accum', 'Test Conversation', 1, now, now);
+
+      // First update
+      db.prepare('UPDATE conversations SET input_tokens = input_tokens + ?, output_tokens = output_tokens + ? WHERE id = ?')
+        .run(100, 50, 'conv-accum');
+
+      // Second update (simulate second turn)
+      db.prepare('UPDATE conversations SET input_tokens = input_tokens + ?, output_tokens = output_tokens + ? WHERE id = ?')
+        .run(200, 100, 'conv-accum');
+
+      // Verify accumulated values
+      const conv = db.prepare('SELECT * FROM conversations WHERE id = ?').get('conv-accum');
+      expect(conv.input_tokens).toBe(300);
+      expect(conv.output_tokens).toBe(150);
+    });
+  });
 });

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -59,6 +59,14 @@ CREATE TABLE IF NOT EXISTS conversations (
   summary_generated_at INTEGER,        -- When summary was last generated
   is_active INTEGER NOT NULL DEFAULT 0, -- Currently selected conversation (1 = active)
   claude_session_id TEXT,              -- Claude SDK session ID for this conversation's context
+  -- Token usage fields (per-conversation tracking)
+  input_tokens INTEGER DEFAULT 0,
+  output_tokens INTEGER DEFAULT 0,
+  cache_read_input_tokens INTEGER DEFAULT 0,
+  cache_creation_input_tokens INTEGER DEFAULT 0,
+  web_search_requests INTEGER DEFAULT 0,
+  context_window INTEGER DEFAULT 200000,
+  model TEXT,
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/server/src/services/sessionManager.broadcasts.test.js
+++ b/packages/server/src/services/sessionManager.broadcasts.test.js
@@ -443,6 +443,170 @@ describe('sessionManager broadcasts', () => {
     });
   });
 
+  // Issue #175 - Conversation-level token tracking
+  describe('conversation-level usage tracking', () => {
+    it('includes conversationId in usage updates', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Test response' }],
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        };
+        yield { type: 'result', subtype: 'success' };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find SESSION_USAGE_UPDATE broadcasts
+      const usageUpdateCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE
+      );
+
+      expect(usageUpdateCalls.length).toBeGreaterThan(0);
+
+      // All usage updates should include conversationId
+      usageUpdateCalls.forEach((call) => {
+        expect(call[2]).toHaveProperty('conversationId');
+      });
+    });
+
+    it('stores usage in conversation on final result', async () => {
+      // Import conversations repo to verify
+      const { conversations } = await import('../database.js');
+
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: {
+            input_tokens: 500,
+            output_tokens: 250,
+            cache_read_input_tokens: 100,
+            cache_creation_input_tokens: 50,
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Get the active conversation for this session
+      const activeConversation = conversations.getActiveBySessionId(sessionId);
+      expect(activeConversation).not.toBeNull();
+      expect(activeConversation.inputTokens).toBe(500);
+      expect(activeConversation.outputTokens).toBe(250);
+      expect(activeConversation.cacheReadInputTokens).toBe(100);
+      expect(activeConversation.cacheCreationInputTokens).toBe(50);
+    });
+
+    it('stores model in conversation when modelUsage is available', async () => {
+      const { conversations } = await import('../database.js');
+
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-sonnet-4-20250514' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          modelUsage: {
+            'claude-sonnet-4-20250514': {
+              inputTokens: 600,
+              outputTokens: 300,
+              cacheReadInputTokens: 120,
+              cacheCreationInputTokens: 60,
+              webSearchRequests: 1,
+              contextWindow: 200000,
+            },
+          },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      const activeConversation = conversations.getActiveBySessionId(sessionId);
+      expect(activeConversation).not.toBeNull();
+      expect(activeConversation.model).toBe('claude-sonnet-4-20250514');
+      expect(activeConversation.contextWindow).toBe(200000);
+      expect(activeConversation.webSearchRequests).toBe(1);
+    });
+
+    it('broadcasts CONVERSATION_UPDATED with usage after final result', async () => {
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 400, output_tokens: 200 },
+        };
+      });
+
+      await runSession(sessionId, 'Test prompt', tempDir);
+
+      // Find CONVERSATION_UPDATED broadcasts
+      const convUpdateCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === WS_MESSAGE_TYPES.CONVERSATION_UPDATED
+      );
+
+      expect(convUpdateCalls.length).toBeGreaterThan(0);
+
+      // Should include conversation with usage data
+      const lastUpdate = convUpdateCalls[convUpdateCalls.length - 1];
+      expect(lastUpdate[2].conversation).toBeDefined();
+      expect(lastUpdate[2].conversation.inputTokens).toBe(400);
+      expect(lastUpdate[2].conversation.outputTokens).toBe(200);
+    });
+
+    it('usage is tracked per-conversation, not per-session', async () => {
+      const { conversations, messages } = await import('../database.js');
+
+      // Create first conversation and run session
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-123', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 100, output_tokens: 50 },
+        };
+      });
+
+      await runSession(sessionId, 'First prompt', tempDir);
+
+      const firstConv = conversations.getActiveBySessionId(sessionId);
+      expect(firstConv.inputTokens).toBe(100);
+      expect(firstConv.outputTokens).toBe(50);
+
+      // Create a new conversation
+      const newConv = conversations.create(sessionId, 'Second Conversation');
+
+      // Update session with new claude session ID for continueSession
+      sessions.update(sessionId, { claudeSessionId: 'claude-session-456' });
+
+      // Run second turn in new conversation
+      query.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'init', session_id: 'claude-session-456', model: 'claude-3' };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 200, output_tokens: 100 },
+        };
+      });
+
+      const { continueSession } = await import('./sessionManager.js');
+      await continueSession(sessionId, 'Second prompt', tempDir);
+
+      // Verify each conversation has its own usage
+      const conv1 = conversations.getById(firstConv.id);
+      const conv2 = conversations.getById(newConv.id);
+
+      expect(conv1.inputTokens).toBe(100);
+      expect(conv1.outputTokens).toBe(50);
+      expect(conv2.inputTokens).toBe(200);
+      expect(conv2.outputTokens).toBe(100);
+    });
+  });
+
   describe('template triggering (handleTemplateTriggerIfNeeded)', () => {
     let templateId;
 

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -15,15 +15,20 @@ const thinkingAccumulators = new Map();
 /** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
 
-/** @type {Map<string, {inputTokens: number, outputTokens: number, cacheReadInputTokens: number, cacheCreationInputTokens: number}>} */
+/** @type {Map<string, {inputTokens: number, outputTokens: number, cacheReadInputTokens: number, cacheCreationInputTokens: number}>}
+ * Usage accumulators keyed by conversationId (Issue #175)
+ */
 const usageAccumulators = new Map();
 
+/** @type {Map<string, string>} Map sessionId -> conversationId for current turn */
+const activeConversationIds = new Map();
+
 /**
- * Initialize or reset usage accumulator for a session turn
- * @param {string} sessionId
+ * Initialize or reset usage accumulator for a conversation turn
+ * @param {string} conversationId
  */
-function resetUsageAccumulator(sessionId) {
-  usageAccumulators.set(sessionId, {
+function resetUsageAccumulator(conversationId) {
+  usageAccumulators.set(conversationId, {
     inputTokens: 0,
     outputTokens: 0,
     cacheReadInputTokens: 0,
@@ -33,12 +38,12 @@ function resetUsageAccumulator(sessionId) {
 
 /**
  * Accumulate usage from an assistant message
- * @param {string} sessionId
+ * @param {string} conversationId
  * @param {Object} usage - Usage data from SDK (snake_case)
  * @returns {Object} Accumulated usage
  */
-function accumulateUsage(sessionId, usage) {
-  const current = usageAccumulators.get(sessionId) || {
+function accumulateUsage(conversationId, usage) {
+  const current = usageAccumulators.get(conversationId) || {
     inputTokens: 0,
     outputTokens: 0,
     cacheReadInputTokens: 0,
@@ -52,17 +57,17 @@ function accumulateUsage(sessionId, usage) {
     cacheCreationInputTokens: current.cacheCreationInputTokens + (usage.cache_creation_input_tokens || 0),
   };
 
-  usageAccumulators.set(sessionId, accumulated);
+  usageAccumulators.set(conversationId, accumulated);
   return accumulated;
 }
 
 /**
- * Get current accumulated usage for a session
- * @param {string} sessionId
+ * Get current accumulated usage for a conversation
+ * @param {string} conversationId
  * @returns {Object|undefined}
  */
-function _getAccumulatedUsage(sessionId) {
-  return usageAccumulators.get(sessionId);
+function _getAccumulatedUsage(conversationId) {
+  return usageAccumulators.get(conversationId);
 }
 
 /** Check if mock mode is enabled (for E2E testing) */
@@ -509,12 +514,16 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
-  // Reset usage accumulator for this turn
-  resetUsageAccumulator(sessionId);
-
   try {
     // Get session for settings
     const session = sessions.getById(sessionId);
+
+    // Get the active conversation for this session (created in SessionRepository.create)
+    const activeConversation = conversations.ensureActiveConversation(sessionId);
+    activeConversationIds.set(sessionId, activeConversation.id);
+
+    // Reset usage accumulator for this conversation turn
+    resetUsageAccumulator(activeConversation.id);
 
     // Update status to running
     sessions.update(sessionId, { status: 'running' });
@@ -618,12 +627,13 @@ export async function continueSession(sessionId, content, workingDirectory, syst
   const controller = new AbortController();
   activeSessions.set(sessionId, { controller });
 
-  // Reset usage accumulator for this turn
-  resetUsageAccumulator(sessionId);
-
   try {
     // Ensure there's an active conversation for this session
     const activeConversation = conversations.ensureActiveConversation(sessionId);
+    activeConversationIds.set(sessionId, activeConversation.id);
+
+    // Reset usage accumulator for this conversation turn
+    resetUsageAccumulator(activeConversation.id);
 
     // Each conversation has its own Claude session context
     // If null, Claude will start a fresh session (no resume)
@@ -828,11 +838,13 @@ async function handleStreamEvent(sessionId, event) {
       // Extract and broadcast usage from assistant message
       const messageUsage = event.message?.usage;
       if (messageUsage) {
-        const accumulated = accumulateUsage(sessionId, messageUsage);
+        const conversationId = activeConversationIds.get(sessionId);
+        const accumulated = accumulateUsage(conversationId, messageUsage);
 
-        // Broadcast partial usage update
+        // Broadcast partial usage update with conversationId
         broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, {
           sessionId,
+          conversationId,
           usage: accumulated,
           isFinal: false,
         });
@@ -958,40 +970,69 @@ async function handleStreamEvent(sessionId, event) {
           sessions.update(sessionId, { costUsd: event.total_cost_usd });
         }
 
-        // Store final usage stats
+        // Store final usage stats to conversation (Issue #175)
         if (event.usage || event.modelUsage) {
           // Extract from modelUsage if available (has more detail)
           const modelUsageEntry = event.modelUsage
             ? Object.values(event.modelUsage)[0]
             : null;
 
-          const finalUsage = {
+          const turnUsage = {
             inputTokens: modelUsageEntry?.inputTokens || event.usage?.input_tokens || 0,
             outputTokens: modelUsageEntry?.outputTokens || event.usage?.output_tokens || 0,
             cacheReadInputTokens: modelUsageEntry?.cacheReadInputTokens || event.usage?.cache_read_input_tokens || 0,
             cacheCreationInputTokens: modelUsageEntry?.cacheCreationInputTokens || event.usage?.cache_creation_input_tokens || 0,
             webSearchRequests: modelUsageEntry?.webSearchRequests || 0,
             contextWindow: modelUsageEntry?.contextWindow || 200000,
+            model: Object.keys(event.modelUsage || {})[0] || null,
           };
 
-          // Get existing session usage and add to it (cumulative across turns)
+          // Get the conversation ID for this session's current turn
+          const conversationId = activeConversationIds.get(sessionId);
+          const currentConversation = conversationId ? conversations.getById(conversationId) : null;
+
+          // Update conversation with cumulative usage (add to existing)
+          let updatedConversation = null;
+          if (currentConversation) {
+            const cumulativeConversationUsage = {
+              inputTokens: (currentConversation.inputTokens || 0) + turnUsage.inputTokens,
+              outputTokens: (currentConversation.outputTokens || 0) + turnUsage.outputTokens,
+              cacheReadInputTokens: (currentConversation.cacheReadInputTokens || 0) + turnUsage.cacheReadInputTokens,
+              cacheCreationInputTokens: (currentConversation.cacheCreationInputTokens || 0) + turnUsage.cacheCreationInputTokens,
+              webSearchRequests: (currentConversation.webSearchRequests || 0) + turnUsage.webSearchRequests,
+              contextWindow: turnUsage.contextWindow,
+              model: turnUsage.model,
+            };
+
+            updatedConversation = conversations.updateUsage(conversationId, cumulativeConversationUsage);
+          }
+
+          // Also update session-level usage (aggregate of all conversations) for backward compatibility
           const currentSession = sessions.getById(sessionId);
-          const cumulativeUsage = {
-            inputTokens: (currentSession.inputTokens || 0) + finalUsage.inputTokens,
-            outputTokens: (currentSession.outputTokens || 0) + finalUsage.outputTokens,
-            cacheReadInputTokens: (currentSession.cacheReadInputTokens || 0) + finalUsage.cacheReadInputTokens,
-            cacheCreationInputTokens: (currentSession.cacheCreationInputTokens || 0) + finalUsage.cacheCreationInputTokens,
-            webSearchRequests: (currentSession.webSearchRequests || 0) + finalUsage.webSearchRequests,
-            contextWindow: finalUsage.contextWindow,
+          const cumulativeSessionUsage = {
+            inputTokens: (currentSession.inputTokens || 0) + turnUsage.inputTokens,
+            outputTokens: (currentSession.outputTokens || 0) + turnUsage.outputTokens,
+            cacheReadInputTokens: (currentSession.cacheReadInputTokens || 0) + turnUsage.cacheReadInputTokens,
+            cacheCreationInputTokens: (currentSession.cacheCreationInputTokens || 0) + turnUsage.cacheCreationInputTokens,
+            webSearchRequests: (currentSession.webSearchRequests || 0) + turnUsage.webSearchRequests,
+            contextWindow: turnUsage.contextWindow,
           };
 
-          const updatedSession = sessions.updateUsage(sessionId, cumulativeUsage);
+          const updatedSession = sessions.updateUsage(sessionId, cumulativeSessionUsage);
 
-          // Broadcast final usage update
+          // Broadcast final usage update with conversationId
           broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE, {
             sessionId,
-            usage: cumulativeUsage,
-            turnUsage: finalUsage,
+            conversationId,
+            usage: updatedConversation ? {
+              inputTokens: updatedConversation.inputTokens,
+              outputTokens: updatedConversation.outputTokens,
+              cacheReadInputTokens: updatedConversation.cacheReadInputTokens,
+              cacheCreationInputTokens: updatedConversation.cacheCreationInputTokens,
+              webSearchRequests: updatedConversation.webSearchRequests,
+              contextWindow: updatedConversation.contextWindow,
+            } : cumulativeSessionUsage,
+            turnUsage,
             isFinal: true,
           });
 
@@ -1002,8 +1043,17 @@ async function handleStreamEvent(sessionId, event) {
             session: updatedSession,
           });
 
-          // Clean up accumulator
-          usageAccumulators.delete(sessionId);
+          // Broadcast conversation update for real-time UI updates
+          if (updatedConversation) {
+            broadcastToSession(sessionId, WS_MESSAGE_TYPES.CONVERSATION_UPDATED, {
+              sessionId,
+              conversation: updatedConversation,
+            });
+          }
+
+          // Clean up accumulators
+          usageAccumulators.delete(conversationId);
+          activeConversationIds.delete(sessionId);
         }
       }
       // Note: Don't clear lastMessageIds here - let the post-loop association code handle it.

--- a/packages/shared/src/routeParams.test.js
+++ b/packages/shared/src/routeParams.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { ROUTE_PARAMS, validateRouteParams } from './routeParams.js';
+
+describe('ROUTE_PARAMS', () => {
+  it('exports PROJECT_ID constant', () => {
+    expect(ROUTE_PARAMS.PROJECT_ID).toBe('projectId');
+  });
+
+  it('exports PROJECT_ID_ALT constant', () => {
+    expect(ROUTE_PARAMS.PROJECT_ID_ALT).toBe('id');
+  });
+
+  it('exports BUTTON_ID constant', () => {
+    expect(ROUTE_PARAMS.BUTTON_ID).toBe('buttonId');
+  });
+
+  it('exports SESSION_ID constant', () => {
+    expect(ROUTE_PARAMS.SESSION_ID).toBe('id');
+  });
+
+  it('exports SESSION_TAB constant', () => {
+    expect(ROUTE_PARAMS.SESSION_TAB).toBe('tab');
+  });
+
+  it('has all expected keys', () => {
+    const expectedKeys = ['PROJECT_ID', 'PROJECT_ID_ALT', 'BUTTON_ID', 'SESSION_ID', 'SESSION_TAB'];
+    expect(Object.keys(ROUTE_PARAMS).sort()).toEqual(expectedKeys.sort());
+  });
+});
+
+describe('validateRouteParams', () => {
+  it('returns true when all expected params are present', () => {
+    const route = {
+      path: '/projects/:projectId/buttons/:buttonId',
+      params: { projectId: 'proj-1', buttonId: 'btn-1' },
+    };
+
+    expect(validateRouteParams(route, ['projectId', 'buttonId'])).toBe(true);
+  });
+
+  it('returns true when route has extra params beyond expected', () => {
+    const route = {
+      path: '/sessions/:id/:tab',
+      params: { id: 'sess-1', tab: 'conversation', extra: 'value' },
+    };
+
+    expect(validateRouteParams(route, ['id', 'tab'])).toBe(true);
+  });
+
+  it('returns true for empty expected params array', () => {
+    const route = {
+      path: '/home',
+      params: {},
+    };
+
+    expect(validateRouteParams(route, [])).toBe(true);
+  });
+
+  it('throws error when expected params are missing', () => {
+    const route = {
+      path: '/projects/:projectId/buttons/:buttonId',
+      params: { projectId: 'proj-1' }, // missing buttonId
+    };
+
+    expect(() => validateRouteParams(route, ['projectId', 'buttonId'])).toThrow(
+      'Route /projects/:projectId/buttons/:buttonId is missing expected params: buttonId. Got: projectId'
+    );
+  });
+
+  it('throws error listing all missing params', () => {
+    const route = {
+      path: '/projects/:projectId/buttons/:buttonId',
+      params: {}, // missing both
+    };
+
+    expect(() => validateRouteParams(route, ['projectId', 'buttonId'])).toThrow(
+      'is missing expected params: projectId, buttonId'
+    );
+  });
+
+  it('handles route with no params property', () => {
+    const route = {
+      path: '/home',
+    };
+
+    // Should handle undefined params gracefully
+    expect(validateRouteParams(route, [])).toBe(true);
+  });
+
+  it('throws when params is undefined and expected params exist', () => {
+    const route = {
+      path: '/projects/:id',
+    };
+
+    expect(() => validateRouteParams(route, ['id'])).toThrow(
+      'is missing expected params: id'
+    );
+  });
+
+  it('handles null params property', () => {
+    const route = {
+      path: '/home',
+      params: null,
+    };
+
+    expect(validateRouteParams(route, [])).toBe(true);
+  });
+
+  it('includes route path in error message', () => {
+    const route = {
+      path: '/custom/route/path',
+      params: {},
+    };
+
+    expect(() => validateRouteParams(route, ['required'])).toThrow(
+      'Route /custom/route/path is missing expected params'
+    );
+  });
+
+  it('includes actual params in error message', () => {
+    const route = {
+      path: '/test',
+      params: { actual1: 'a', actual2: 'b' },
+    };
+
+    expect(() => validateRouteParams(route, ['expected'])).toThrow(
+      'Got: actual1, actual2'
+    );
+  });
+});

--- a/packages/web/src/components/ConversationSelector.test.js
+++ b/packages/web/src/components/ConversationSelector.test.js
@@ -302,4 +302,84 @@ describe('ConversationSelector', () => {
       expect(wrapper.find('.delete-btn').exists()).toBe(false);
     });
   });
+
+  // Issue #175 - Conversation-level token tracking
+  describe('token count display', () => {
+    it('shows token count for each conversation in dropdown', async () => {
+      mockSessionsStore.conversations = [
+        { id: 'conv-1', name: 'First', isActive: false, messageCount: 5, inputTokens: 1000, outputTokens: 500 },
+        { id: 'conv-2', name: 'Second', isActive: true, messageCount: 10, inputTokens: 5000, outputTokens: 2500 },
+      ];
+
+      const wrapper = mountComponent();
+      await wrapper.find('.dropdown-trigger').trigger('click');
+
+      const items = wrapper.findAll('.dropdown-item');
+      // Check that token counts are displayed
+      expect(items[0].text()).toContain('1.5K');
+      expect(items[1].text()).toContain('7.5K');
+    });
+
+    it('shows 0 tokens for conversations with no usage', async () => {
+      mockSessionsStore.conversations = [
+        { id: 'conv-1', name: 'Empty', isActive: true, messageCount: 0 },
+      ];
+
+      const wrapper = mountComponent();
+      await wrapper.find('.dropdown-trigger').trigger('click');
+
+      const item = wrapper.find('.dropdown-item');
+      expect(item.text()).toContain('0');
+    });
+
+    it('formats large token counts with K suffix', async () => {
+      mockSessionsStore.conversations = [
+        { id: 'conv-1', name: 'Large', isActive: true, messageCount: 20, inputTokens: 50000, outputTokens: 25000 },
+      ];
+
+      const wrapper = mountComponent();
+      await wrapper.find('.dropdown-trigger').trigger('click');
+
+      const item = wrapper.find('.dropdown-item');
+      expect(item.text()).toContain('75.0K');
+    });
+
+    it('formats very large token counts with M suffix', async () => {
+      mockSessionsStore.conversations = [
+        { id: 'conv-1', name: 'Huge', isActive: true, messageCount: 100, inputTokens: 1500000, outputTokens: 500000 },
+      ];
+
+      const wrapper = mountComponent();
+      await wrapper.find('.dropdown-trigger').trigger('click');
+
+      const item = wrapper.find('.dropdown-item');
+      expect(item.text()).toContain('2.0M');
+    });
+
+    it('handles missing token fields gracefully', async () => {
+      mockSessionsStore.conversations = [
+        { id: 'conv-1', name: 'Missing', isActive: true, messageCount: 5 },
+      ];
+
+      const wrapper = mountComponent();
+      await wrapper.find('.dropdown-trigger').trigger('click');
+
+      // Should not throw and should show some value
+      const item = wrapper.find('.dropdown-item');
+      expect(item.exists()).toBe(true);
+    });
+
+    it('shows token count in meta section', async () => {
+      mockSessionsStore.conversations = [
+        { id: 'conv-1', name: 'Test', isActive: true, messageCount: 5, inputTokens: 2000, outputTokens: 1000 },
+      ];
+
+      const wrapper = mountComponent();
+      await wrapper.find('.dropdown-trigger').trigger('click');
+
+      const meta = wrapper.find('.conv-meta');
+      expect(meta.exists()).toBe(true);
+      expect(meta.text()).toContain('3.0K'); // 2000 + 1000 = 3000 = 3.0K
+    });
+  });
 });

--- a/packages/web/src/components/ConversationSelector.vue
+++ b/packages/web/src/components/ConversationSelector.vue
@@ -25,7 +25,12 @@
             @click="selectConversation(conv.id)"
           >
             <span class="conv-name">{{ getConversationDisplayName(conv, index) }}</span>
-            <span class="conv-meta">{{ conv.messageCount || 0 }} msgs</span>
+            <span class="conv-meta">
+              {{ conv.messageCount || 0 }} msgs
+              <span v-if="getConversationTokens(conv)" class="conv-tokens">
+                · {{ getConversationTokens(conv) }}
+              </span>
+            </span>
             <button
               v-if="conversations.length > 1 && conv.id !== activeConversationId"
               type="button"
@@ -83,6 +88,19 @@ const activeConversation = computed(() => sessionsStore.activeConversation);
 // Generate display names for conversations (fallback to "Conversation N" if no name)
 function getConversationDisplayName(conv, index) {
   return conv.name || `Conversation ${index + 1}`;
+}
+
+// Format token count for display (Issue #175)
+function formatTokens(n) {
+  if (!n || n === 0) return null;
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return String(n);
+}
+
+function getConversationTokens(conv) {
+  const total = (conv.inputTokens || 0) + (conv.outputTokens || 0);
+  return formatTokens(total);
 }
 
 // Get display name for the active conversation
@@ -270,6 +288,10 @@ onUnmounted(() => {
   font-size: 0.75rem;
   color: var(--color-text-soft);
   white-space: nowrap;
+}
+
+.conv-tokens {
+  font-family: var(--font-mono);
 }
 
 .delete-btn {

--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -59,6 +59,14 @@ vi.mock('./ModelSelector.vue', () => ({
   },
 }));
 
+// Issue #175 - TokenUsagePanel is now rendered in ConversationTab
+vi.mock('./TokenUsagePanel.vue', () => ({
+  default: {
+    name: 'TokenUsagePanel',
+    template: '<div class="token-usage-panel-stub"></div>',
+  },
+}));
+
 vi.mock('@claudetools/shared', async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -138,6 +146,8 @@ describe.skip('ConversationTab', () => {
           LiveWorkLogPanel: { template: '<div class="live-work-log-panel-stub"></div>' },
           MarkdownViewer: { template: '<div class="markdown-stub"><slot /></div>' },
           FileAttachment: { template: '<div class="file-attachment-stub"></div>' },
+          // Issue #175 - TokenUsagePanel is now rendered in ConversationTab
+          TokenUsagePanel: { template: '<div class="token-usage-panel-stub"></div>' },
         },
       },
     });

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -3,6 +3,9 @@
     <!-- Conversation Selector -->
     <ConversationSelector :session-id="sessionId" />
 
+    <!-- Token Usage Panel - shows conversation-level usage (Issue #175) -->
+    <TokenUsagePanel class="conversation-usage" />
+
     <div class="messages" ref="messagesContainer">
       <div
         v-for="message in sessionsStore.messages"
@@ -174,6 +177,7 @@ import WorkLogPanel from './WorkLogPanel.vue';
 import MarkdownViewer from './MarkdownViewer.vue';
 import LiveWorkLogPanel from './LiveWorkLogPanel.vue';
 import ConversationSelector from './ConversationSelector.vue';
+import TokenUsagePanel from './TokenUsagePanel.vue';
 import FileAttachment from './FileAttachment.vue';
 import ModelSelector from './ModelSelector.vue';
 import TemplateSelector from './TemplateSelector.vue';
@@ -503,6 +507,10 @@ async function handleTemplateChange(templateId) {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.conversation-usage {
+  margin-bottom: 1rem;
 }
 
 .messages {

--- a/packages/web/src/components/TokenUsagePanel.test.js
+++ b/packages/web/src/components/TokenUsagePanel.test.js
@@ -21,6 +21,9 @@ describe('TokenUsagePanel', () => {
       currentSession: null,
       formattedTokens: { input: '0', output: '0', total: '0', cacheRead: '0', cacheCreation: '0' },
       isUsageUpdating: false,
+      // Issue #175 - Conversation-level token tracking
+      contextPercentage: 0,
+      conversationTokens: null,
     };
 
     vi.mocked(useSessionsStore).mockReturnValue(mockSessionsStore);
@@ -41,13 +44,24 @@ describe('TokenUsagePanel', () => {
       expect(wrapper.find('.token-usage-panel').exists()).toBe(true);
     });
 
-    it('displays token usage title', () => {
+    it('renders compact view with token count and context bar', () => {
+      mockSessionsStore.formattedTokens = {
+        input: '1K',
+        output: '500',
+        total: '1.5K',
+        cacheRead: '0',
+        cacheCreation: '0',
+      };
+      mockSessionsStore.contextPercentage = 10;
+
       const wrapper = mountComponent();
 
-      expect(wrapper.find('.usage-title').text()).toBe('Token Usage');
+      expect(wrapper.find('.usage-compact').exists()).toBe(true);
+      expect(wrapper.find('.compact-tokens').exists()).toBe(true);
+      expect(wrapper.find('.context-bar-compact').exists()).toBe(true);
     });
 
-    it('displays input, output, and total stats', () => {
+    it('displays total token count', () => {
       mockSessionsStore.formattedTokens = {
         input: '1.5K',
         output: '500',
@@ -58,15 +72,61 @@ describe('TokenUsagePanel', () => {
 
       const wrapper = mountComponent();
 
-      const stats = wrapper.findAll('.stat');
-      expect(stats).toHaveLength(3);
+      expect(wrapper.find('.total-label').text()).toBe('2K');
+      expect(wrapper.find('.total-suffix').text()).toBe('tokens');
+    });
+  });
 
-      expect(wrapper.text()).toContain('Input');
-      expect(wrapper.text()).toContain('Output');
-      expect(wrapper.text()).toContain('Total');
-      expect(wrapper.text()).toContain('1.5K');
-      expect(wrapper.text()).toContain('500');
-      expect(wrapper.text()).toContain('2K');
+  describe('context bar', () => {
+    it('always shows context bar in compact view', () => {
+      mockSessionsStore.contextPercentage = 25;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.context-bar-compact').exists()).toBe(true);
+      expect(wrapper.find('.context-bar-track-compact').exists()).toBe(true);
+      expect(wrapper.find('.context-bar-fill').exists()).toBe(true);
+    });
+
+    it('shows context percentage', () => {
+      mockSessionsStore.contextPercentage = 25;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.context-pct').text()).toBe('25%');
+    });
+
+    it('sets context bar width from percentage', () => {
+      mockSessionsStore.contextPercentage = 50;
+
+      const wrapper = mountComponent();
+
+      const fill = wrapper.find('.context-bar-fill');
+      expect(fill.attributes('style')).toContain('width: 50%');
+    });
+
+    it('shows normal style for low usage (under 70%)', () => {
+      mockSessionsStore.contextPercentage = 30;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.context-bar-fill.normal').exists()).toBe(true);
+    });
+
+    it('shows warning style for 70-89% usage', () => {
+      mockSessionsStore.contextPercentage = 75;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.context-bar-fill.warning').exists()).toBe(true);
+    });
+
+    it('shows critical style for 90%+ usage', () => {
+      mockSessionsStore.contextPercentage = 95;
+
+      const wrapper = mountComponent();
+
+      expect(wrapper.find('.context-bar-fill.critical').exists()).toBe(true);
     });
   });
 
@@ -89,12 +149,12 @@ describe('TokenUsagePanel', () => {
     });
   });
 
-  describe('show details button', () => {
-    it('does not show toggle button when no details to show', () => {
+  describe('details toggle button', () => {
+    it('does not show toggle button when no cache tokens', () => {
       mockSessionsStore.currentSession = {
         id: 'session-1',
-        inputTokens: 0,
-        outputTokens: 0,
+        inputTokens: 1000,
+        outputTokens: 500,
         cacheReadInputTokens: 0,
         cacheCreationInputTokens: 0,
       };
@@ -116,7 +176,6 @@ describe('TokenUsagePanel', () => {
       const wrapper = mountComponent();
 
       expect(wrapper.find('.toggle-details').exists()).toBe(true);
-      expect(wrapper.find('.toggle-details').text()).toBe('Show details');
     });
 
     it('toggles details on button click', async () => {
@@ -126,7 +185,6 @@ describe('TokenUsagePanel', () => {
         outputTokens: 500,
         cacheReadInputTokens: 100,
         cacheCreationInputTokens: 50,
-        contextWindow: 200000,
       };
       mockSessionsStore.formattedTokens = {
         input: '1K',
@@ -145,7 +203,6 @@ describe('TokenUsagePanel', () => {
       await wrapper.find('.toggle-details').trigger('click');
 
       expect(wrapper.find('.usage-details').exists()).toBe(true);
-      expect(wrapper.find('.toggle-details').text()).toBe('Hide details');
 
       // Click to hide details
       await wrapper.find('.toggle-details').trigger('click');
@@ -155,14 +212,13 @@ describe('TokenUsagePanel', () => {
   });
 
   describe('details section', () => {
-    it('shows cache read and creation values', async () => {
+    it('shows input, output, cache read and cache creation values', async () => {
       mockSessionsStore.currentSession = {
         id: 'session-1',
         inputTokens: 1000,
         outputTokens: 500,
         cacheReadInputTokens: 200,
         cacheCreationInputTokens: 100,
-        contextWindow: 200000,
       };
       mockSessionsStore.formattedTokens = {
         input: '1K',
@@ -175,92 +231,53 @@ describe('TokenUsagePanel', () => {
       const wrapper = mountComponent();
       await wrapper.find('.toggle-details').trigger('click');
 
+      expect(wrapper.text()).toContain('Input');
+      expect(wrapper.text()).toContain('Output');
       expect(wrapper.text()).toContain('Cache Read');
-      expect(wrapper.text()).toContain('200');
       expect(wrapper.text()).toContain('Cache Creation');
+      expect(wrapper.text()).toContain('1K');
+      expect(wrapper.text()).toContain('500');
+      expect(wrapper.text()).toContain('200');
       expect(wrapper.text()).toContain('100');
     });
-
-    it('shows context bar when tokens exist', async () => {
-      mockSessionsStore.currentSession = {
-        id: 'session-1',
-        inputTokens: 10000,
-        outputTokens: 5000,
-        cacheReadInputTokens: 100,
-        cacheCreationInputTokens: 0,
-        contextWindow: 200000,
-      };
-
-      const wrapper = mountComponent();
-      await wrapper.find('.toggle-details').trigger('click');
-
-      expect(wrapper.find('.context-bar').exists()).toBe(true);
-      expect(wrapper.text()).toContain('Context Usage');
-    });
   });
 
-  describe('context bar styling', () => {
-    it('shows normal style for low usage', async () => {
-      mockSessionsStore.currentSession = {
-        id: 'session-1',
-        inputTokens: 50000,
-        outputTokens: 10000,
-        cacheReadInputTokens: 100,
-        contextWindow: 200000,
+  // Issue #175 - Conversation-level token tracking
+  describe('conversation-level data', () => {
+    it('uses conversation tokens when available for hasDetailsToShow', () => {
+      mockSessionsStore.conversationTokens = {
+        inputTokens: 500,
+        outputTokens: 250,
+        cacheReadInputTokens: 50,
+        cacheCreationInputTokens: 25,
       };
 
       const wrapper = mountComponent();
-      await wrapper.find('.toggle-details').trigger('click');
 
-      expect(wrapper.find('.context-bar-fill.normal').exists()).toBe(true);
+      // Should show toggle button because conversationTokens has cache data
+      expect(wrapper.find('.toggle-details').exists()).toBe(true);
     });
 
-    it('shows warning style for 70-89% usage', async () => {
-      mockSessionsStore.currentSession = {
-        id: 'session-1',
-        inputTokens: 140000,
-        outputTokens: 10000,
-        cacheReadInputTokens: 100,
-        contextWindow: 200000,
-      };
+    it('uses store contextPercentage getter', () => {
+      mockSessionsStore.contextPercentage = 42;
 
       const wrapper = mountComponent();
-      await wrapper.find('.toggle-details').trigger('click');
 
-      expect(wrapper.find('.context-bar-fill.warning').exists()).toBe(true);
+      expect(wrapper.find('.context-pct').text()).toBe('42%');
     });
 
-    it('shows critical style for 90%+ usage', async () => {
-      mockSessionsStore.currentSession = {
-        id: 'session-1',
-        inputTokens: 180000,
-        outputTokens: 10000,
-        cacheReadInputTokens: 100,
-        contextWindow: 200000,
-      };
-
-      const wrapper = mountComponent();
-      await wrapper.find('.toggle-details').trigger('click');
-
-      expect(wrapper.find('.context-bar-fill.critical').exists()).toBe(true);
-    });
-  });
-
-  describe('formatted values', () => {
-    it('displays formatted token values from store', () => {
+    it('displays formatted total from store', () => {
       mockSessionsStore.formattedTokens = {
-        input: '5.5K',
-        output: '2.5K',
-        total: '8K',
-        cacheRead: '1K',
-        cacheCreation: '500',
+        input: '2K',
+        output: '1K',
+        total: '3K',
+        cacheRead: '0',
+        cacheCreation: '0',
       };
 
       const wrapper = mountComponent();
 
-      expect(wrapper.text()).toContain('5.5K');
-      expect(wrapper.text()).toContain('2.5K');
-      expect(wrapper.text()).toContain('8K');
+      expect(wrapper.find('.total-label').text()).toBe('3K');
     });
   });
 });

--- a/packages/web/src/components/TokenUsagePanel.vue
+++ b/packages/web/src/components/TokenUsagePanel.vue
@@ -1,57 +1,56 @@
 <template>
   <div class="token-usage-panel">
-    <div class="usage-header">
-      <span class="usage-title">Token Usage</span>
-      <span v-if="isUpdating" class="updating-indicator">
-        <span class="dot"></span>
-        <span class="dot"></span>
-        <span class="dot"></span>
-      </span>
-    </div>
-    <div class="usage-stats">
-      <div class="stat">
-        <span class="stat-label">Input</span>
-        <span class="stat-value">{{ formattedTokens.input }}</span>
+    <!-- Compact view: Total tokens + context bar (always visible) -->
+    <div class="usage-compact">
+      <div class="compact-tokens">
+        <span class="total-label">{{ formattedTokens.total }}</span>
+        <span class="total-suffix">tokens</span>
+        <span v-if="isUpdating" class="updating-indicator">
+          <span class="dot"></span>
+          <span class="dot"></span>
+          <span class="dot"></span>
+        </span>
       </div>
-      <div class="stat">
-        <span class="stat-label">Output</span>
-        <span class="stat-value">{{ formattedTokens.output }}</span>
-      </div>
-      <div class="stat stat-total">
-        <span class="stat-label">Total</span>
-        <span class="stat-value">{{ formattedTokens.total }}</span>
-      </div>
-    </div>
-    <div v-if="showDetails" class="usage-details">
-      <div class="detail-row">
-        <span class="detail-label">Cache Read</span>
-        <span class="detail-value">{{ formattedTokens.cacheRead }}</span>
-      </div>
-      <div class="detail-row">
-        <span class="detail-label">Cache Creation</span>
-        <span class="detail-value">{{ formattedTokens.cacheCreation }}</span>
-      </div>
-      <div v-if="contextPercentage > 0" class="context-bar">
-        <div class="context-bar-label">
-          <span>Context Usage</span>
-          <span>{{ contextPercentage }}%</span>
-        </div>
-        <div class="context-bar-track">
+      <div class="context-bar-compact">
+        <div class="context-bar-track-compact">
           <div
             class="context-bar-fill"
             :style="{ width: `${contextPercentage}%` }"
             :class="contextBarClass"
           ></div>
         </div>
+        <span class="context-pct">{{ contextPercentage }}%</span>
+      </div>
+      <button
+        v-if="hasDetailsToShow"
+        class="toggle-details"
+        @click="showDetails = !showDetails"
+      >
+        {{ showDetails ? '▲' : '▼' }}
+      </button>
+    </div>
+
+    <!-- Expanded details -->
+    <div v-if="showDetails" class="usage-details">
+      <div class="usage-stats">
+        <div class="stat">
+          <span class="stat-label">Input</span>
+          <span class="stat-value">{{ formattedTokens.input }}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Output</span>
+          <span class="stat-value">{{ formattedTokens.output }}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Cache Read</span>
+          <span class="stat-value">{{ formattedTokens.cacheRead }}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Cache Creation</span>
+          <span class="stat-value">{{ formattedTokens.cacheCreation }}</span>
+        </div>
       </div>
     </div>
-    <button
-      v-if="hasDetailsToShow"
-      class="toggle-details"
-      @click="showDetails = !showDetails"
-    >
-      {{ showDetails ? 'Hide details' : 'Show details' }}
-    </button>
   </div>
 </template>
 
@@ -65,13 +64,8 @@ const showDetails = ref(false);
 const formattedTokens = computed(() => sessionsStore.formattedTokens);
 const isUpdating = computed(() => sessionsStore.isUsageUpdating);
 
-const contextPercentage = computed(() => {
-  const session = sessionsStore.currentSession;
-  if (!session) return 0;
-  const total = (session.inputTokens || 0) + (session.outputTokens || 0);
-  const window = session.contextWindow || 200000;
-  return Math.round((total / window) * 100);
-});
+// Use the store's contextPercentage getter (Issue #175 - conversation-level)
+const contextPercentage = computed(() => sessionsStore.contextPercentage);
 
 const contextBarClass = computed(() => {
   const pct = contextPercentage.value;
@@ -81,10 +75,9 @@ const contextBarClass = computed(() => {
 });
 
 const hasDetailsToShow = computed(() => {
-  const session = sessionsStore.currentSession;
-  return session && ((session.cacheReadInputTokens || 0) > 0 ||
-                     (session.cacheCreationInputTokens || 0) > 0 ||
-                     contextPercentage.value > 0);
+  const tokens = sessionsStore.conversationTokens || sessionsStore.currentSession;
+  return tokens && ((tokens.cacheReadInputTokens || 0) > 0 ||
+                     (tokens.cacheCreationInputTokens || 0) > 0);
 });
 </script>
 
@@ -93,26 +86,64 @@ const hasDetailsToShow = computed(() => {
   background: var(--color-background-soft);
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
-  padding: 0.75rem;
+  padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
 }
 
-.usage-header {
+/* Compact view - always visible */
+.usage-compact {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.5rem;
+  gap: 1rem;
 }
 
-.usage-title {
+.compact-tokens {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.total-label {
   font-weight: 600;
+  font-family: var(--font-mono);
   color: var(--color-text);
+}
+
+.total-suffix {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.context-bar-compact {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 80px;
+  max-width: 150px;
+}
+
+.context-bar-track-compact {
+  flex: 1;
+  height: 6px;
+  background: var(--color-background-mute);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.context-pct {
+  font-size: 0.625rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-soft);
+  min-width: 28px;
+  text-align: right;
 }
 
 .updating-indicator {
   display: flex;
   gap: 2px;
   align-items: center;
+  margin-left: 0.25rem;
 }
 
 .updating-indicator .dot {
@@ -142,79 +173,9 @@ const hasDetailsToShow = computed(() => {
   }
 }
 
-.usage-stats {
-  display: flex;
-  gap: 1rem;
-}
-
-.stat {
-  display: flex;
-  flex-direction: column;
-  min-width: 60px;
-}
-
-.stat-label {
-  font-size: 0.625rem;
-  text-transform: uppercase;
-  color: var(--color-text-soft);
-  margin-bottom: 0.125rem;
-}
-
-.stat-value {
-  font-weight: 600;
-  font-family: var(--font-mono);
-  color: var(--color-text);
-}
-
-.stat-total .stat-value {
-  color: var(--color-primary);
-}
-
-.usage-details {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--color-border);
-}
-
-.detail-row {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 0.25rem;
-}
-
-.detail-label {
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
-}
-
-.detail-value {
-  font-size: 0.75rem;
-  font-family: var(--font-mono);
-  color: var(--color-text);
-}
-
-.context-bar {
-  margin-top: 0.5rem;
-}
-
-.context-bar-label {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.625rem;
-  color: var(--color-text-soft);
-  margin-bottom: 0.25rem;
-}
-
-.context-bar-track {
-  height: 4px;
-  background: var(--color-background-mute);
-  border-radius: 2px;
-  overflow: hidden;
-}
-
 .context-bar-fill {
   height: 100%;
-  border-radius: 2px;
+  border-radius: 3px;
   transition: width 0.3s ease;
 }
 
@@ -236,12 +197,44 @@ const hasDetailsToShow = computed(() => {
   color: var(--color-text-soft);
   font-size: 0.625rem;
   cursor: pointer;
-  padding: 0;
-  margin-top: 0.5rem;
-  text-decoration: underline;
+  padding: 0.25rem;
+  margin-left: auto;
 }
 
 .toggle-details:hover {
   color: var(--color-text);
+}
+
+/* Expanded details */
+.usage-details {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.usage-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 60px;
+}
+
+.stat-label {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+  margin-bottom: 0.125rem;
+}
+
+.stat-value {
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  font-size: 0.75rem;
 }
 </style>

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -33,29 +33,61 @@ export const useSessionsStore = defineStore('sessions', {
     getConversationById: (state) => (id) => {
       return state.conversations.find((c) => c.id === id);
     },
-    // Token usage getters
+    // Token usage getters - now conversation-level (Issue #175)
+    conversationTokens: (state) => {
+      const conv = state.conversations.find((c) => c.id === state.activeConversationId);
+      return conv
+        ? {
+            inputTokens: conv.inputTokens || 0,
+            outputTokens: conv.outputTokens || 0,
+            cacheReadInputTokens: conv.cacheReadInputTokens || 0,
+            cacheCreationInputTokens: conv.cacheCreationInputTokens || 0,
+            webSearchRequests: conv.webSearchRequests || 0,
+            contextWindow: conv.contextWindow || 200000,
+            model: conv.model,
+          }
+        : null;
+    },
     totalTokens: (state) => {
+      // Use active conversation tokens if available, fallback to session
+      const conv = state.conversations.find((c) => c.id === state.activeConversationId);
+      if (conv) {
+        return (conv.inputTokens || 0) + (conv.outputTokens || 0);
+      }
       const session = state.currentSession;
       if (!session) return 0;
       return (session.inputTokens || 0) + (session.outputTokens || 0);
     },
     formattedTokens: (state) => {
-      const session = state.currentSession;
-      if (!session) return { input: '0', output: '0', total: '0' };
-
       const format = (n) => {
         if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
         if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
         return String(n);
       };
 
+      // Use active conversation tokens if available, fallback to session
+      const conv = state.conversations.find((c) => c.id === state.activeConversationId);
+      const source = conv || state.currentSession;
+
+      if (!source) return { input: '0', output: '0', total: '0', cacheRead: '0', cacheCreation: '0' };
+
       return {
-        input: format(session.inputTokens || 0),
-        output: format(session.outputTokens || 0),
-        total: format((session.inputTokens || 0) + (session.outputTokens || 0)),
-        cacheRead: format(session.cacheReadInputTokens || 0),
-        cacheCreation: format(session.cacheCreationInputTokens || 0),
+        input: format(source.inputTokens || 0),
+        output: format(source.outputTokens || 0),
+        total: format((source.inputTokens || 0) + (source.outputTokens || 0)),
+        cacheRead: format(source.cacheReadInputTokens || 0),
+        cacheCreation: format(source.cacheCreationInputTokens || 0),
       };
+    },
+    contextPercentage: (state) => {
+      // Calculate context usage percentage for the active conversation
+      const conv = state.conversations.find((c) => c.id === state.activeConversationId);
+      const source = conv || state.currentSession;
+      if (!source) return 0;
+
+      const totalTokens = (source.inputTokens || 0) + (source.outputTokens || 0);
+      const contextWindow = source.contextWindow || 200000;
+      return Math.min(100, Math.round((totalTokens / contextWindow) * 100));
     },
     isUsageUpdating: (state) => {
       return state.runningUsage !== null;
@@ -335,16 +367,36 @@ export const useSessionsStore = defineStore('sessions', {
     /**
      * Update running usage during a turn (partial update)
      * @param {Object} usage - Usage data
+     * @param {string} [conversationId] - Conversation ID (Issue #175)
      */
-    updateRunningUsage(usage) {
-      this.runningUsage = usage;
+    updateRunningUsage(usage, conversationId = null) {
+      this.runningUsage = { ...usage, conversationId };
     },
 
     /**
-     * Finalize usage at end of turn (update session with final values)
+     * Finalize usage at end of turn (update conversation and session with final values)
      * @param {Object} usage - Final cumulative usage
+     * @param {string} [conversationId] - Conversation ID (Issue #175)
      */
-    finalizeUsage(usage) {
+    finalizeUsage(usage, conversationId = null) {
+      // Update conversation usage if conversationId provided (Issue #175)
+      if (conversationId) {
+        const index = this.conversations.findIndex((c) => c.id === conversationId);
+        if (index !== -1) {
+          this.conversations[index] = {
+            ...this.conversations[index],
+            inputTokens: usage.inputTokens,
+            outputTokens: usage.outputTokens,
+            cacheReadInputTokens: usage.cacheReadInputTokens,
+            cacheCreationInputTokens: usage.cacheCreationInputTokens,
+            webSearchRequests: usage.webSearchRequests,
+            contextWindow: usage.contextWindow,
+            model: usage.model,
+          };
+        }
+      }
+
+      // Also update session for backward compatibility
       if (this.currentSession) {
         this.currentSession = {
           ...this.currentSession,
@@ -357,6 +409,27 @@ export const useSessionsStore = defineStore('sessions', {
         };
       }
       this.runningUsage = null;
+    },
+
+    /**
+     * Update conversation usage from WebSocket event (Issue #175)
+     * @param {string} conversationId - Conversation ID
+     * @param {Object} usage - Usage data
+     */
+    updateConversationUsage(conversationId, usage) {
+      const index = this.conversations.findIndex((c) => c.id === conversationId);
+      if (index !== -1) {
+        this.conversations[index] = {
+          ...this.conversations[index],
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          cacheReadInputTokens: usage.cacheReadInputTokens,
+          cacheCreationInputTokens: usage.cacheCreationInputTokens,
+          webSearchRequests: usage.webSearchRequests,
+          contextWindow: usage.contextWindow,
+          model: usage.model,
+        };
+      }
     },
 
     /**

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -864,7 +864,8 @@ describe('Sessions Store', () => {
 
         store.updateRunningUsage(usage);
 
-        expect(store.runningUsage).toEqual(usage);
+        // runningUsage includes conversationId tracking (Issue #175)
+        expect(store.runningUsage).toEqual({ ...usage, conversationId: null });
       });
 
       it('can update runningUsage multiple times', () => {
@@ -958,6 +959,281 @@ describe('Sessions Store', () => {
         store.clearRunningUsage();
 
         expect(store.runningUsage).toBeNull();
+      });
+    });
+
+    // Issue #175 - Conversation-level token tracking tests
+    describe('conversationTokens getter', () => {
+      it('returns null when no active conversation', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = null;
+        store.conversations = [];
+
+        expect(store.conversationTokens).toBeNull();
+      });
+
+      it('returns null when active conversation not found', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'non-existent';
+        store.conversations = [{ id: 'other-conv', inputTokens: 100 }];
+
+        expect(store.conversationTokens).toBeNull();
+      });
+
+      it('returns token data for active conversation', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 1000,
+            outputTokens: 500,
+            cacheReadInputTokens: 200,
+            cacheCreationInputTokens: 100,
+            webSearchRequests: 2,
+          },
+        ];
+
+        const tokens = store.conversationTokens;
+
+        expect(tokens.inputTokens).toBe(1000);
+        expect(tokens.outputTokens).toBe(500);
+        expect(tokens.cacheReadInputTokens).toBe(200);
+        expect(tokens.cacheCreationInputTokens).toBe(100);
+        expect(tokens.webSearchRequests).toBe(2);
+      });
+
+      it('returns 0 for missing token fields', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'conv-1';
+        store.conversations = [{ id: 'conv-1' }]; // no token fields
+
+        const tokens = store.conversationTokens;
+
+        expect(tokens.inputTokens).toBe(0);
+        expect(tokens.outputTokens).toBe(0);
+        expect(tokens.cacheReadInputTokens).toBe(0);
+        expect(tokens.cacheCreationInputTokens).toBe(0);
+        expect(tokens.webSearchRequests).toBe(0);
+      });
+    });
+
+    describe('contextPercentage getter', () => {
+      it('returns 0 when no session or conversation', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+        store.activeConversationId = null;
+        store.conversations = [];
+
+        expect(store.contextPercentage).toBe(0);
+      });
+
+      it('calculates percentage from active conversation', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 40000,
+            outputTokens: 10000,
+            contextWindow: 200000,
+          },
+        ];
+
+        // (40000 + 10000) / 200000 = 25%
+        expect(store.contextPercentage).toBe(25);
+      });
+
+      it('falls back to session data when no conversation', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = null;
+        store.conversations = [];
+        store.currentSession = {
+          id: 'session-1',
+          inputTokens: 20000,
+          outputTokens: 10000,
+          contextWindow: 200000,
+        };
+
+        // (20000 + 10000) / 200000 = 15%
+        expect(store.contextPercentage).toBe(15);
+      });
+
+      it('uses default context window when not specified', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 20000,
+            outputTokens: 0,
+            // no contextWindow specified
+          },
+        ];
+
+        // (20000 + 0) / 200000 (default) = 10%
+        expect(store.contextPercentage).toBe(10);
+      });
+
+      it('caps at 100%', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 250000,
+            outputTokens: 50000,
+            contextWindow: 200000,
+          },
+        ];
+
+        expect(store.contextPercentage).toBe(100);
+      });
+
+      it('rounds to nearest integer', () => {
+        const store = useSessionsStore();
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 33333,
+            outputTokens: 0,
+            contextWindow: 200000,
+          },
+        ];
+
+        // 33333 / 200000 = 16.67%
+        expect(store.contextPercentage).toBe(17);
+      });
+    });
+
+    describe('updateRunningUsage with conversationId', () => {
+      it('tracks conversationId with usage', () => {
+        const store = useSessionsStore();
+        const usage = { inputTokens: 100, outputTokens: 50 };
+
+        store.updateRunningUsage(usage, 'conv-123');
+
+        expect(store.runningUsage.conversationId).toBe('conv-123');
+        expect(store.runningUsage.inputTokens).toBe(100);
+        expect(store.runningUsage.outputTokens).toBe(50);
+      });
+
+      it('defaults conversationId to null when not provided', () => {
+        const store = useSessionsStore();
+        store.updateRunningUsage({ inputTokens: 100, outputTokens: 50 });
+
+        expect(store.runningUsage.conversationId).toBeNull();
+      });
+
+      it('updates conversationId on subsequent calls', () => {
+        const store = useSessionsStore();
+
+        store.updateRunningUsage({ inputTokens: 50, outputTokens: 25 }, 'conv-1');
+        expect(store.runningUsage.conversationId).toBe('conv-1');
+
+        store.updateRunningUsage({ inputTokens: 100, outputTokens: 50 }, 'conv-2');
+        expect(store.runningUsage.conversationId).toBe('conv-2');
+      });
+    });
+
+    describe('finalizeUsage with conversationId', () => {
+      it('updates conversation with usage when conversationId provided', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 0, outputTokens: 0 },
+          { id: 'conv-2', inputTokens: 0, outputTokens: 0 },
+        ];
+
+        const usage = {
+          inputTokens: 1000,
+          outputTokens: 500,
+          cacheReadInputTokens: 200,
+          cacheCreationInputTokens: 100,
+          contextWindow: 200000,
+          model: 'claude-sonnet-4-20250514',
+        };
+
+        store.finalizeUsage(usage, 'conv-1');
+
+        const updatedConv = store.conversations.find((c) => c.id === 'conv-1');
+        expect(updatedConv.inputTokens).toBe(1000);
+        expect(updatedConv.outputTokens).toBe(500);
+        expect(updatedConv.cacheReadInputTokens).toBe(200);
+        expect(updatedConv.cacheCreationInputTokens).toBe(100);
+        expect(updatedConv.contextWindow).toBe(200000);
+        expect(updatedConv.model).toBe('claude-sonnet-4-20250514');
+
+        // Other conversation should be unchanged
+        const otherConv = store.conversations.find((c) => c.id === 'conv-2');
+        expect(otherConv.inputTokens).toBe(0);
+      });
+
+      it('still updates session when conversationId provided', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1', inputTokens: 0, outputTokens: 0 };
+        store.conversations = [{ id: 'conv-1', inputTokens: 0, outputTokens: 0 }];
+
+        store.finalizeUsage({ inputTokens: 1000, outputTokens: 500 }, 'conv-1');
+
+        // Session should still be updated for backward compatibility
+        expect(store.currentSession.inputTokens).toBe(1000);
+        expect(store.currentSession.outputTokens).toBe(500);
+      });
+
+      it('handles missing conversation gracefully', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1', inputTokens: 0 };
+        store.conversations = [];
+
+        // Should not throw
+        store.finalizeUsage({ inputTokens: 1000, outputTokens: 500 }, 'non-existent');
+
+        // Session should still be updated
+        expect(store.currentSession.inputTokens).toBe(1000);
+      });
+    });
+
+    describe('updateConversationUsage action', () => {
+      it('updates conversation in list', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', name: 'First', inputTokens: 0, outputTokens: 0 },
+          { id: 'conv-2', name: 'Second', inputTokens: 0, outputTokens: 0 },
+        ];
+
+        store.updateConversationUsage('conv-1', { inputTokens: 1000, outputTokens: 500 });
+
+        const conv = store.conversations.find((c) => c.id === 'conv-1');
+        expect(conv.inputTokens).toBe(1000);
+        expect(conv.outputTokens).toBe(500);
+      });
+
+      it('does nothing if conversation not found', () => {
+        const store = useSessionsStore();
+        store.conversations = [{ id: 'conv-1', inputTokens: 0 }];
+
+        // Should not throw
+        store.updateConversationUsage('non-existent', { inputTokens: 1000 });
+
+        expect(store.conversations).toHaveLength(1);
+        expect(store.conversations[0].inputTokens).toBe(0);
+      });
+
+      it('preserves other conversation properties', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', name: 'Test Conv', summary: 'A summary', isActive: true, inputTokens: 0 },
+        ];
+
+        store.updateConversationUsage('conv-1', { inputTokens: 500, outputTokens: 250 });
+
+        const conv = store.conversations[0];
+        expect(conv.name).toBe('Test Conv');
+        expect(conv.summary).toBe('A summary');
+        expect(conv.isActive).toBe(true);
+        expect(conv.inputTokens).toBe(500);
       });
     });
   });

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -30,6 +30,7 @@ vi.mock('../composables/useWebSocket.js', () => ({
     onSessionUpdate: vi.fn(() => vi.fn()),
     onSummaryUpdate: vi.fn(() => vi.fn()),
     onUsageUpdate: vi.fn(() => vi.fn()),
+    onConversationUpdated: vi.fn(() => vi.fn()),
   })),
 }));
 
@@ -116,6 +117,7 @@ describe('SessionDetailView', () => {
       onSessionUpdate: vi.fn(() => vi.fn()),
       onSummaryUpdate: vi.fn(() => vi.fn()),
       onUsageUpdate: vi.fn(() => vi.fn()),
+      onConversationUpdated: vi.fn(() => vi.fn()),
     }));
 
     mockSessionsStore = {
@@ -137,6 +139,10 @@ describe('SessionDetailView', () => {
       updateSessionStatus: vi.fn(),
       addMessage: vi.fn(),
       updateSession: vi.fn(),
+      // Issue #175 - Conversation-level token tracking methods
+      finalizeUsage: vi.fn(),
+      updateRunningUsage: vi.fn(),
+      updateConversation: vi.fn(),
     };
 
     useSessionsStore.mockReturnValue(mockSessionsStore);
@@ -831,6 +837,209 @@ describe('SessionDetailView', () => {
         expect(container.find('.btn-archive-session').exists()).toBe(true);
         expect(container.find('.btn-delete-session').exists()).toBe(true);
       });
+    });
+  });
+
+  // Issue #175 - Conversation-level token usage tracking
+  describe('WebSocket usage update handlers', () => {
+    it('registers onUsageUpdate callback on mount', async () => {
+      let mockOnUsageUpdate = vi.fn(() => vi.fn());
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn(() => vi.fn()),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+        onUsageUpdate: mockOnUsageUpdate,
+        onConversationUpdated: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(mockOnUsageUpdate).toHaveBeenCalled();
+    });
+
+    it('calls finalizeUsage with conversationId when isFinal is true', async () => {
+      let capturedUsageCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn(() => vi.fn()),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+        onUsageUpdate: vi.fn((callback) => {
+          capturedUsageCallback = callback;
+          return vi.fn();
+        }),
+        onConversationUpdated: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Simulate final usage update with conversationId
+      const usageData = {
+        isFinal: true,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+        conversationId: 'conv-123',
+      };
+      capturedUsageCallback(usageData);
+
+      expect(mockSessionsStore.finalizeUsage).toHaveBeenCalledWith(
+        usageData.usage,
+        'conv-123'
+      );
+    });
+
+    it('calls updateRunningUsage with conversationId when isFinal is false', async () => {
+      let capturedUsageCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn(() => vi.fn()),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+        onUsageUpdate: vi.fn((callback) => {
+          capturedUsageCallback = callback;
+          return vi.fn();
+        }),
+        onConversationUpdated: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Simulate partial usage update with conversationId
+      const usageData = {
+        isFinal: false,
+        usage: { inputTokens: 500, outputTokens: 250 },
+        conversationId: 'conv-456',
+      };
+      capturedUsageCallback(usageData);
+
+      expect(mockSessionsStore.updateRunningUsage).toHaveBeenCalledWith(
+        usageData.usage,
+        'conv-456'
+      );
+    });
+
+    it('handles usage update without conversationId for backward compatibility', async () => {
+      let capturedUsageCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn(() => vi.fn()),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+        onUsageUpdate: vi.fn((callback) => {
+          capturedUsageCallback = callback;
+          return vi.fn();
+        }),
+        onConversationUpdated: vi.fn(() => vi.fn()),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Simulate usage update without conversationId
+      const usageData = {
+        isFinal: true,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+        // no conversationId
+      };
+      capturedUsageCallback(usageData);
+
+      expect(mockSessionsStore.finalizeUsage).toHaveBeenCalledWith(
+        usageData.usage,
+        undefined
+      );
+    });
+  });
+
+  describe('WebSocket conversation update handlers', () => {
+    it('registers onConversationUpdated callback on mount', async () => {
+      let mockOnConversationUpdated = vi.fn(() => vi.fn());
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn(() => vi.fn()),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+        onUsageUpdate: vi.fn(() => vi.fn()),
+        onConversationUpdated: mockOnConversationUpdated,
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(mockOnConversationUpdated).toHaveBeenCalled();
+    });
+
+    it('calls updateConversation when conversation update is received', async () => {
+      let capturedConversationCallback;
+      useSessionSubscription.mockImplementation(() => ({
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: vi.fn(() => vi.fn()),
+        onMessage: vi.fn(() => vi.fn()),
+        onError: vi.fn(() => vi.fn()),
+        onCanvasAdd: vi.fn(() => vi.fn()),
+        onCanvasRemove: vi.fn(() => vi.fn()),
+        onTodosUpdate: vi.fn(() => vi.fn()),
+        onSessionUpdate: vi.fn(() => vi.fn()),
+        onSummaryUpdate: vi.fn(() => vi.fn()),
+        onUsageUpdate: vi.fn(() => vi.fn()),
+        onConversationUpdated: vi.fn((callback) => {
+          capturedConversationCallback = callback;
+          return vi.fn();
+        }),
+      }));
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      // Simulate conversation update
+      const conversationData = {
+        id: 'conv-789',
+        name: 'Test Conversation',
+        inputTokens: 1500,
+        outputTokens: 750,
+      };
+      capturedConversationCallback(conversationData);
+
+      expect(mockSessionsStore.updateConversation).toHaveBeenCalledWith(conversationData);
     });
   });
 });

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -18,7 +18,6 @@
               🔗 Next: {{ getTemplateName(sessionsStore.currentSession.nextTemplateId) }}
             </span>
           </div>
-          <TokenUsagePanel class="session-usage" />
           <div class="branch-line">
             <div class="branch-pr-indicators">
               <span
@@ -123,7 +122,6 @@ import CanvasTab from '../components/CanvasTab.vue';
 import NotesTab from '../components/NotesTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
 import PrIndicators from '../components/PrIndicators.vue';
-import TokenUsagePanel from '../components/TokenUsagePanel.vue';
 import { useTemplatesStore } from '../stores/templates.js';
 
 const route = useRoute();
@@ -160,7 +158,7 @@ function navigateToTab(tabId) {
   router.push(`/sessions/${route.params.id}/${tabId}`);
 }
 
-const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onUsageUpdate } =
+const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onUsageUpdate, onConversationUpdated } =
   useSessionSubscription(sessionId);
 
 let cleanups = [];
@@ -313,10 +311,18 @@ onMounted(async () => {
   cleanups.push(
     onUsageUpdate((msg) => {
       if (msg.isFinal) {
-        sessionsStore.finalizeUsage(msg.usage);
+        // Pass conversationId for conversation-level usage tracking (Issue #175)
+        sessionsStore.finalizeUsage(msg.usage, msg.conversationId);
       } else {
-        sessionsStore.updateRunningUsage(msg.usage);
+        sessionsStore.updateRunningUsage(msg.usage, msg.conversationId);
       }
+    })
+  );
+
+  // Handle conversation updates for usage tracking (Issue #175)
+  cleanups.push(
+    onConversationUpdated((conversation) => {
+      sessionsStore.updateConversation(conversation);
     })
   );
 });

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -3,4 +3,16 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
   plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5001',
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: 'ws://localhost:5001',
+        ws: true,
+      },
+    },
+  },
 });

--- a/tests/e2e/screenshots-175.spec.ts
+++ b/tests/e2e/screenshots-175.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Screenshot capture for Issue #175: Token Usage Per Conversation
+ *
+ * This test file captures screenshots demonstrating the new conversation-level
+ * token usage feature and posts them to the session canvas.
+ *
+ * Run with: ./scripts/pw.sh test tests/e2e/screenshots-175.spec.ts
+ */
+import { test, expect } from '@playwright/test';
+import { join } from 'path';
+
+// Session in the worktree's database with token usage data
+const EXISTING_SESSION_ID = '1bfc83eb-4ca2-4322-b0f8-a8656eec9bda';
+const CANVAS_SESSION_ID = 'b8ed79d9-5f87-4b6b-9920-fb419ad1cf07';
+// Our worktree frontend runs on port 5173, backend on 5001
+// Screenshots are posted to the MAIN server's canvas (port 5000)
+const WORKTREE_FRONTEND_URL = 'http://localhost:5173';
+const MAIN_API_URL = 'http://localhost:5000';
+
+async function postScreenshotToCanvas(filePath: string, label: string, filename: string) {
+  console.log(`Posting screenshot to canvas: ${filename}`);
+  const response = await fetch(`${MAIN_API_URL}/api/sessions/${CANVAS_SESSION_ID}/canvas`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      type: 'image',
+      filePath,
+      filename,
+      label,
+    }),
+  });
+  if (!response.ok) {
+    console.error('Failed to post screenshot to canvas:', await response.text());
+  } else {
+    console.log(`Successfully posted ${filename} to canvas`);
+  }
+  return response.ok;
+}
+
+test.describe('Issue #175 Screenshots', () => {
+  // Use longer timeout since we're taking multiple screenshots
+  test.setTimeout(60000);
+
+  test('1. Compact Token Usage Panel', async ({ page }) => {
+    await page.goto(`${WORKTREE_FRONTEND_URL}/sessions/${EXISTING_SESSION_ID}/conversation`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Take screenshot of the conversation tab header area (includes ConversationSelector + TokenUsagePanel)
+    const conversationTab = page.locator('.conversation-tab');
+    await expect(conversationTab).toBeVisible();
+
+    // Screenshot the top portion showing ConversationSelector and TokenUsagePanel
+    const screenshotPath = 'screenshots/175-01-compact-token-panel.png';
+    await page.screenshot({
+      path: screenshotPath,
+      clip: await (async () => {
+        const box = await conversationTab.boundingBox();
+        if (!box) throw new Error('Could not get bounding box');
+        return { x: box.x, y: box.y, width: box.width, height: Math.min(250, box.height) };
+      })(),
+    });
+
+    await postScreenshotToCanvas(
+      join(process.cwd(), screenshotPath),
+      '175: Compact Token Usage Panel - Shows total tokens + context bar always visible',
+      '175-01-compact-token-panel.png'
+    );
+  });
+
+  test('2. Expanded Token Usage Details', async ({ page }) => {
+    await page.goto(`${WORKTREE_FRONTEND_URL}/sessions/${EXISTING_SESSION_ID}/conversation`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Click expand button if present
+    const expandButton = page.locator('.toggle-details');
+    const hasExpandButton = await expandButton.count() > 0;
+
+    if (hasExpandButton) {
+      await expandButton.click();
+      await page.waitForTimeout(500);
+    }
+
+    // Screenshot the token usage panel with details expanded
+    const tokenPanel = page.locator('.token-usage-panel');
+    await expect(tokenPanel).toBeVisible();
+
+    const screenshotPath = 'screenshots/175-02-expanded-details.png';
+    await tokenPanel.screenshot({ path: screenshotPath });
+
+    await postScreenshotToCanvas(
+      join(process.cwd(), screenshotPath),
+      '175: Expanded Token Details - Input/Output/Cache breakdown',
+      '175-02-expanded-details.png'
+    );
+  });
+
+  test('3. Conversation Selector Dropdown with Tokens', async ({ page }) => {
+    await page.goto(`${WORKTREE_FRONTEND_URL}/sessions/${EXISTING_SESSION_ID}/conversation`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Click the conversation dropdown to open it
+    const dropdownTrigger = page.locator('.dropdown-trigger');
+    await expect(dropdownTrigger).toBeVisible();
+    await dropdownTrigger.click();
+    await page.waitForTimeout(500);
+
+    // Screenshot the dropdown showing token counts - capture a larger area
+    const conversationSelector = page.locator('.conversation-selector');
+    const screenshotPath = 'screenshots/175-03-conversation-dropdown.png';
+    await conversationSelector.screenshot({ path: screenshotPath });
+
+    await postScreenshotToCanvas(
+      join(process.cwd(), screenshotPath),
+      '175: Conversation Dropdown - Shows token count per conversation',
+      '175-03-conversation-dropdown.png'
+    );
+  });
+
+  test('4. Full Conversation Tab Layout', async ({ page }) => {
+    await page.goto(`${WORKTREE_FRONTEND_URL}/sessions/${EXISTING_SESSION_ID}/conversation`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Take a full screenshot of the conversation tab
+    const screenshotPath = 'screenshots/175-04-full-conversation-tab.png';
+    await page.screenshot({
+      path: screenshotPath,
+      fullPage: false,
+    });
+
+    await postScreenshotToCanvas(
+      join(process.cwd(), screenshotPath),
+      '175: Full Conversation Tab - ConversationSelector + TokenUsagePanel + Messages',
+      '175-04-full-conversation-tab.png'
+    );
+  });
+
+  test('5. Session Header (Token Panel Removed)', async ({ page }) => {
+    await page.goto(`${WORKTREE_FRONTEND_URL}/sessions/${EXISTING_SESSION_ID}`);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // Screenshot the session header to show TokenUsagePanel is NOT there
+    const sessionHeader = page.locator('.session-header');
+    await expect(sessionHeader).toBeVisible();
+
+    const screenshotPath = 'screenshots/175-05-session-header.png';
+    await sessionHeader.screenshot({ path: screenshotPath });
+
+    await postScreenshotToCanvas(
+      join(process.cwd(), screenshotPath),
+      '175: Session Header - Token panel moved to conversation level',
+      '175-05-session-header.png'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Track token usage per conversation instead of only at the session level
- Display conversation-specific token counts in the ConversationSelector dropdown and TokenUsagePanel
- Store usage data in conversations table with proper database migrations

## Changes
- **Database**: Added token usage columns to `conversations` table (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `web_search_requests`, `context_window`, `model`)
- **Server**: Updated `ConversationRepository` with `updateUsage()` method, modified `sessionManager` to track usage per conversation and broadcast `CONVERSATION_UPDATED` events
- **Frontend**: Updated `TokenUsagePanel` to prioritize conversation usage with session fallback, added token counts to `ConversationSelector` dropdown items
- **Tests**: Added comprehensive unit tests for new repository methods, WebSocket broadcasts, and Vue component behavior

## Test plan
- [x] Verify token usage columns are added via database migration
- [x] Verify `updateUsage()` correctly stores and retrieves usage data
- [x] Verify WebSocket broadcasts include `conversationId` in usage updates
- [x] Verify `TokenUsagePanel` displays conversation usage when available
- [x] Verify `ConversationSelector` shows token counts per conversation
- [x] Run unit tests: `yarn test`
- [ ] Manual testing of token tracking across multiple conversations

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)