### PR TITLE
feat: Display Claude model information in session list and detail views

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -296,6 +296,60 @@ describe('SessionCard', () => {
     });
   });
 
+  describe('model display', () => {
+    it('displays Opus 4.5 for claude-opus-4-5-20251101 model', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, model: 'claude-opus-4-5-20251101' },
+      });
+      expect(wrapper.find('.session-model').text()).toBe('Opus 4.5');
+    });
+
+    it('displays Sonnet 4.5 for claude-sonnet-4-5-20250929 model', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, model: 'claude-sonnet-4-5-20250929' },
+      });
+      expect(wrapper.find('.session-model').text()).toBe('Sonnet 4.5');
+    });
+
+    it('displays Haiku 4.5 for claude-haiku-4-5-20251001 model', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, model: 'claude-haiku-4-5-20251001' },
+      });
+      expect(wrapper.find('.session-model').text()).toBe('Haiku 4.5');
+    });
+
+    it('displays Default when model is null', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, model: null },
+      });
+      expect(wrapper.find('.session-model').text()).toBe('Default');
+    });
+
+    it('displays Default when model is undefined', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession },
+      });
+      expect(wrapper.find('.session-model').text()).toBe('Default');
+    });
+
+    it('displays Unknown for unrecognized model ID', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, model: 'unknown-model-id' },
+      });
+      expect(wrapper.find('.session-model').text()).toBe('Unknown');
+    });
+
+    it('renders model in session-meta alongside status and mode', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, model: 'claude-opus-4-5-20251101' },
+      });
+      const sessionMeta = wrapper.find('.session-meta');
+      expect(sessionMeta.find('.status-badge').exists()).toBe(true);
+      expect(sessionMeta.find('.session-mode').exists()).toBe(true);
+      expect(sessionMeta.find('.session-model').exists()).toBe(true);
+    });
+  });
+
   describe('PR status indicators', () => {
     describe('PR state badge', () => {
       it('shows merged badge when prState is merged', () => {

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -6,6 +6,7 @@
         <p class="session-meta">
           <span :class="['status-badge', `status-${session.status}`]">{{ session.status }}</span>
           <span class="session-mode">{{ formattedMode }}</span>
+          <span class="session-model">{{ formattedModel }}</span>
         </p>
         <div v-if="session.gitBranch || session.prUrl" class="branch-row">
           <span v-if="session.gitBranch" class="session-branch">{{ session.gitBranch }}</span>
@@ -77,6 +78,7 @@
 <script setup>
 import { computed } from 'vue';
 import { formatDate } from '../utils/formatters.js';
+import { useModelInfo } from '../composables/useModelInfo.js';
 import PrIndicators from './PrIndicators.vue';
 
 const props = defineProps({
@@ -116,6 +118,8 @@ const props = defineProps({
 
 defineEmits(['retrySummary', 'archive', 'unarchive']);
 
+const { getModelDisplayName } = useModelInfo();
+
 // Show archive for any status except running
 const canArchive = computed(() => {
   return props.session.status !== 'running';
@@ -131,6 +135,10 @@ const formattedMode = computed(() => {
   if (mode === 'yolo') return 'YOLO';
   // Capitalize first letter for other modes
   return mode ? mode.charAt(0).toUpperCase() + mode.slice(1) : '';
+});
+
+const formattedModel = computed(() => {
+  return getModelDisplayName(props.session.model);
 });
 </script>
 
@@ -168,6 +176,11 @@ const formattedMode = computed(() => {
 }
 
 .session-mode {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.session-model {
   font-size: 0.75rem;
   color: var(--color-text-soft);
 }

--- a/packages/web/src/composables/useModelInfo.js
+++ b/packages/web/src/composables/useModelInfo.js
@@ -1,0 +1,54 @@
+import { CLAUDE_MODELS, DEFAULT_MODEL } from '@claudetools/shared';
+
+/**
+ * Composable for handling Claude model information
+ * Provides utilities to get display names and descriptions for models
+ */
+export function useModelInfo() {
+  /**
+   * Get human-readable display name for a model ID
+   * @param {string|null} modelId - The model ID (e.g., 'claude-opus-4-5-20251101')
+   * @returns {string} - The display name (e.g., 'Opus 4.5') or 'Default' if null
+   */
+  function getModelDisplayName(modelId) {
+    if (!modelId) {
+      return 'Default';
+    }
+
+    const model = CLAUDE_MODELS.find((m) => m.id === modelId);
+    return model ? model.name : 'Unknown';
+  }
+
+  /**
+   * Get description for a model ID
+   * @param {string|null} modelId - The model ID
+   * @returns {string} - The description or empty string if not found
+   */
+  function getModelDescription(modelId) {
+    if (!modelId) {
+      const defaultModel = CLAUDE_MODELS.find((m) => m.id === DEFAULT_MODEL);
+      return defaultModel ? defaultModel.description : '';
+    }
+
+    const model = CLAUDE_MODELS.find((m) => m.id === modelId);
+    return model ? model.description : '';
+  }
+
+  /**
+   * Get both display name and description
+   * @param {string|null} modelId - The model ID
+   * @returns {Object} - Object with name and description
+   */
+  function getModelInfo(modelId) {
+    return {
+      name: getModelDisplayName(modelId),
+      description: getModelDescription(modelId),
+    };
+  }
+
+  return {
+    getModelDisplayName,
+    getModelDescription,
+    getModelInfo,
+  };
+}

--- a/packages/web/src/composables/useModelInfo.test.js
+++ b/packages/web/src/composables/useModelInfo.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { useModelInfo } from './useModelInfo.js';
+
+describe('useModelInfo', () => {
+  describe('getModelDisplayName', () => {
+    it('returns "Opus 4.5" for claude-opus-4-5-20251101', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName('claude-opus-4-5-20251101')).toBe('Opus 4.5');
+    });
+
+    it('returns "Sonnet 4.5" for claude-sonnet-4-5-20250929', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName('claude-sonnet-4-5-20250929')).toBe('Sonnet 4.5');
+    });
+
+    it('returns "Haiku 4.5" for claude-haiku-4-5-20251001', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
+    });
+
+    it('returns "Default" when modelId is null', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName(null)).toBe('Default');
+    });
+
+    it('returns "Default" when modelId is undefined', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName(undefined)).toBe('Default');
+    });
+
+    it('returns "Default" when modelId is empty string', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName('')).toBe('Default');
+    });
+
+    it('returns "Unknown" for unrecognized model ID', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName('some-unknown-model')).toBe('Unknown');
+    });
+  });
+
+  describe('getModelDescription', () => {
+    it('returns "Most capable (default)" for Opus model', () => {
+      const { getModelDescription } = useModelInfo();
+      expect(getModelDescription('claude-opus-4-5-20251101')).toBe('Most capable (default)');
+    });
+
+    it('returns "Balanced" for Sonnet model', () => {
+      const { getModelDescription } = useModelInfo();
+      expect(getModelDescription('claude-sonnet-4-5-20250929')).toBe('Balanced');
+    });
+
+    it('returns "Fast & lightweight" for Haiku model', () => {
+      const { getModelDescription } = useModelInfo();
+      expect(getModelDescription('claude-haiku-4-5-20251001')).toBe('Fast & lightweight');
+    });
+
+    it('returns default model description when modelId is null', () => {
+      const { getModelDescription } = useModelInfo();
+      // Default model is Opus, so it should return Opus description
+      expect(getModelDescription(null)).toBe('Most capable (default)');
+    });
+
+    it('returns empty string for unrecognized model ID', () => {
+      const { getModelDescription } = useModelInfo();
+      expect(getModelDescription('unknown-model')).toBe('');
+    });
+  });
+
+  describe('getModelInfo', () => {
+    it('returns object with name and description for valid model', () => {
+      const { getModelInfo } = useModelInfo();
+      const info = getModelInfo('claude-opus-4-5-20251101');
+
+      expect(info).toEqual({
+        name: 'Opus 4.5',
+        description: 'Most capable (default)',
+      });
+    });
+
+    it('returns object with name and description for Sonnet', () => {
+      const { getModelInfo } = useModelInfo();
+      const info = getModelInfo('claude-sonnet-4-5-20250929');
+
+      expect(info).toEqual({
+        name: 'Sonnet 4.5',
+        description: 'Balanced',
+      });
+    });
+
+    it('returns object with name and description for Haiku', () => {
+      const { getModelInfo } = useModelInfo();
+      const info = getModelInfo('claude-haiku-4-5-20251001');
+
+      expect(info).toEqual({
+        name: 'Haiku 4.5',
+        description: 'Fast & lightweight',
+      });
+    });
+
+    it('returns Default name with default description for null model', () => {
+      const { getModelInfo } = useModelInfo();
+      const info = getModelInfo(null);
+
+      expect(info).toEqual({
+        name: 'Default',
+        description: 'Most capable (default)',
+      });
+    });
+
+    it('returns Unknown name with empty description for unrecognized model', () => {
+      const { getModelInfo } = useModelInfo();
+      const info = getModelInfo('unknown-model-id');
+
+      expect(info).toEqual({
+        name: 'Unknown',
+        description: '',
+      });
+    });
+  });
+
+  describe('composable reusability', () => {
+    it('returns new function instances on each call', () => {
+      const result1 = useModelInfo();
+      const result2 = useModelInfo();
+
+      // Functions should be different instances
+      expect(result1.getModelDisplayName).not.toBe(result2.getModelDisplayName);
+    });
+
+    it('all functions behave consistently across instances', () => {
+      const { getModelDisplayName: fn1 } = useModelInfo();
+      const { getModelDisplayName: fn2 } = useModelInfo();
+
+      expect(fn1('claude-opus-4-5-20251101')).toBe(fn2('claude-opus-4-5-20251101'));
+      expect(fn1(null)).toBe(fn2(null));
+    });
+  });
+});

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -33,6 +33,12 @@ vi.mock('../composables/useWebSocket.js', () => ({
   })),
 }));
 
+// Mock useModelInfo composable - use real implementation to test model display
+vi.mock('../composables/useModelInfo.js', async () => {
+  const actual = await vi.importActual('../composables/useModelInfo.js');
+  return actual;
+});
+
 // Mock the stores
 vi.mock('../stores/sessions.js', () => ({
   useSessionsStore: vi.fn(),
@@ -83,6 +89,21 @@ vi.mock('../components/NotesTab.vue', () => ({
 }));
 vi.mock('../components/SummaryTab.vue', () => ({
   default: defineComponent({ name: 'SummaryTab', template: '<div />' }),
+}));
+vi.mock('../components/CommandsTab.vue', () => ({
+  default: defineComponent({ name: 'CommandsTab', template: '<div />' }),
+}));
+vi.mock('../components/PrIndicators.vue', () => ({
+  default: defineComponent({ name: 'PrIndicators', template: '<div />' }),
+}));
+vi.mock('../components/TokenUsagePanel.vue', () => ({
+  default: defineComponent({ name: 'TokenUsagePanel', template: '<div />' }),
+}));
+vi.mock('../stores/templates.js', () => ({
+  useTemplatesStore: vi.fn(() => ({
+    fetchProjectTemplates: vi.fn(),
+    getTemplateById: vi.fn(() => null),
+  })),
 }));
 
 import SessionDetailView from './SessionDetailView.vue';
@@ -265,6 +286,82 @@ describe('SessionDetailView', () => {
       await nextTick();
 
       expect(wrapper.find('.pr-link').exists()).toBe(false);
+    });
+  });
+
+  describe('model display', () => {
+    it('displays Opus 4.5 for claude-opus-4-5-20251101 model', async () => {
+      mockSessionsStore.currentSession.model = 'claude-opus-4-5-20251101';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-model').text()).toBe('Opus 4.5');
+    });
+
+    it('displays Sonnet 4.5 for claude-sonnet-4-5-20250929 model', async () => {
+      mockSessionsStore.currentSession.model = 'claude-sonnet-4-5-20250929';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-model').text()).toBe('Sonnet 4.5');
+    });
+
+    it('displays Haiku 4.5 for claude-haiku-4-5-20251001 model', async () => {
+      mockSessionsStore.currentSession.model = 'claude-haiku-4-5-20251001';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-model').text()).toBe('Haiku 4.5');
+    });
+
+    it('displays Default when model is null', async () => {
+      mockSessionsStore.currentSession.model = null;
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-model').text()).toBe('Default');
+    });
+
+    it('displays Default when model is undefined', async () => {
+      // model is not set (undefined)
+      delete mockSessionsStore.currentSession.model;
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-model').text()).toBe('Default');
+    });
+
+    it('displays Unknown for unrecognized model ID', async () => {
+      mockSessionsStore.currentSession.model = 'unknown-model-id';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.find('.session-model').text()).toBe('Unknown');
+    });
+
+    it('renders model in session-meta alongside status and mode', async () => {
+      mockSessionsStore.currentSession.model = 'claude-opus-4-5-20251101';
+
+      const wrapper = mountComponent();
+      await flushPromises();
+      await nextTick();
+
+      const sessionMeta = wrapper.find('.session-meta');
+      expect(sessionMeta.find('.status-badge').exists()).toBe(true);
+      expect(sessionMeta.find('.session-mode').exists()).toBe(true);
+      expect(sessionMeta.find('.session-model').exists()).toBe(true);
     });
   });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -14,6 +14,7 @@
               {{ sessionsStore.currentSession.status }}
             </span>
             <span class="session-mode">{{ formatMode(sessionsStore.currentSession.mode) }}</span>
+            <span class="session-model">{{ formatModel(sessionsStore.currentSession.model) }}</span>
             <span v-if="sessionsStore.currentSession.nextTemplateId" class="template-badge">
               🔗 Next: {{ getTemplateName(sessionsStore.currentSession.nextTemplateId) }}
             </span>
@@ -117,6 +118,7 @@ import { useCanvasStore } from '../stores/canvas.js';
 import { useTodosStore } from '../stores/todos.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
+import { useModelInfo } from '../composables/useModelInfo.js';
 import { api } from '../composables/useApi.js';
 import ConversationTab from '../components/ConversationTab.vue';
 import ChangesTab from '../components/ChangesTab.vue';
@@ -135,6 +137,7 @@ const canvasStore = useCanvasStore();
 const todosStore = useTodosStore();
 const uiStore = useUiStore();
 const templatesStore = useTemplatesStore();
+const { getModelDisplayName } = useModelInfo();
 
 // Capture session ID at component creation to avoid race conditions during navigation.
 // When navigating away, Vue Router updates route.params BEFORE unmounting the component.
@@ -336,6 +339,10 @@ function formatMode(mode) {
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }
 
+function formatModel(modelId) {
+  return getModelDisplayName(modelId);
+}
+
 async function handleDelete() {
   if (!confirm('Are you sure you want to delete this session?')) return;
 
@@ -450,6 +457,11 @@ function getTemplateName(templateId) {
 }
 
 .session-mode {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.session-model {
   font-size: 0.75rem;
   color: var(--color-text-soft);
 }


### PR DESCRIPTION
## Summary
Display Claude model information (Opus 4.5, Sonnet 4.5, Haiku 4.5) in both the session list cards and the session detail view header. This helps users quickly identify which model is configured for each session.

## Changes
- **Created `useModelInfo.js` composable** - Reusable utilities for model display
  - `getModelDisplayName()` - Convert model IDs to human-readable names
  - `getModelDescription()` - Get model descriptions
  - `getModelInfo()` - Get combined name and description

- **Updated `SessionCard.vue`** - Display model in session cards
  - Model shown next to status and mode
  - Handles null/undefined models by displaying "Default"
  - Consistent styling with existing metadata

- **Updated `SessionDetailView.vue`** - Display model in detail view header
  - Model shown in session metadata section
  - Consistent placement alongside status and mode
  - Clear visibility of selected model

- **Comprehensive test coverage** - 33 new tests, all passing
  - 19 tests for `useModelInfo` composable
  - 7 model display tests for SessionCard
  - 7 model display tests for SessionDetailView

## Test Plan
- [x] `useModelInfo` composable tests all pass
  - Model display name conversion works for all models
  - Default handling for null/undefined models
  - Unknown model handling
  
- [x] SessionCard model display tests all pass
  - Model displays correctly in session cards
  - All three models (Opus, Sonnet, Haiku) render properly
  - Default and unknown models handled correctly
  
- [x] SessionDetailView model display tests all pass
  - Model displays in detail view header
  - All model variations work correctly
  - Model renders alongside status and mode

## Design Notes
- Model display uses human-readable names from CLAUDE_MODELS constant
- Null/undefined models display as "Default" for clarity
- Styling matches existing metadata fields (status, mode, branch)
- No backend or database changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)