### PR TITLE
fix: Fix draft detection for sessions with multiple conversations

### DIFF
--- a/packages/server/src/api/sessions.hasResponses.test.js
+++ b/packages/server/src/api/sessions.hasResponses.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, messages, conversations } from '../database.js';
+
+// Mock websocket before importing the router
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock sessionManager
+vi.mock('../services/sessionManager.js', () => ({
+  runSession: vi.fn().mockResolvedValue(undefined),
+  continueSession: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn(),
+  restartSession: vi.fn(),
+}));
+
+// Mock summaryService
+vi.mock('../services/summaryService.js', () => ({
+  getSummary: vi.fn().mockResolvedValue(null),
+  generateSummary: vi.fn().mockResolvedValue('mock summary'),
+  generateConversationSummary: vi.fn().mockResolvedValue('mock conversation summary'),
+}));
+
+// Mock diffService
+vi.mock('../services/diffService.js', () => ({
+  getDiff: vi.fn().mockResolvedValue({ staged: [], unstaged: [] }),
+}));
+
+// Import after mocks are set up
+import sessionsRouter from './sessions.js';
+
+describe('Sessions API - hasResponses', () => {
+  let app;
+  let project;
+  let session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    // Create test project and session
+    project = projects.create('Test Project', '/tmp/test');
+    session = sessions.create(project.id, 'Test Session', 'Initial prompt', 'standard');
+    // Set session to waiting for most tests
+    sessions.update(session.id, { status: 'waiting' });
+  });
+
+  describe('GET /api/sessions/:id', () => {
+    it('returns hasResponses=false for session with no assistant messages', async () => {
+      // Session is created with only a user message (the initial prompt)
+      const res = await request(app).get(`/api/sessions/${session.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(session.id);
+      expect(res.body.hasResponses).toBe(false);
+    });
+
+    it('returns hasResponses=true for session with assistant messages', async () => {
+      // Get the initial conversation
+      const conv = conversations.getActiveBySessionId(session.id);
+
+      // Add an assistant message
+      messages.create(session.id, 'assistant', 'Hello! How can I help?', null, conv.id);
+
+      const res = await request(app).get(`/api/sessions/${session.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(session.id);
+      expect(res.body.hasResponses).toBe(true);
+    });
+
+    it('returns hasResponses=true when assistant message is in a different conversation', async () => {
+      // Get the initial conversation and add assistant response
+      const conv1 = conversations.getActiveBySessionId(session.id);
+      messages.create(session.id, 'assistant', 'Response to first conv', null, conv1.id);
+
+      // Create a new conversation (empty)
+      const conv2 = conversations.create(session.id, 'New Conversation', true);
+
+      // Even though the new conversation is now active and has no messages,
+      // hasResponses should still be true because the session has assistant messages
+      const res = await request(app).get(`/api/sessions/${session.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.hasResponses).toBe(true);
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app).get('/api/sessions/non-existent-id');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Session not found');
+    });
+  });
+
+  describe('Draft session detection with hasResponses', () => {
+    it('draft session has waiting status and hasResponses=false', async () => {
+      // Create a draft session (waiting status, no responses)
+      const draftSession = sessions.create(project.id, 'Draft Session', 'Draft prompt', 'standard', false, null, null, 'waiting');
+
+      const res = await request(app).get(`/api/sessions/${draftSession.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('waiting');
+      expect(res.body.hasResponses).toBe(false);
+    });
+
+    it('non-draft session in waiting status has hasResponses=true', async () => {
+      // Add an assistant response to make it a non-draft
+      const conv = conversations.getActiveBySessionId(session.id);
+      messages.create(session.id, 'assistant', 'I responded', null, conv.id);
+
+      // Session is in waiting status but has responses
+      const res = await request(app).get(`/api/sessions/${session.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('waiting');
+      expect(res.body.hasResponses).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -25,7 +25,11 @@ router.get('/:id', (req, res) => {
   if (!session) {
     return res.status(404).json({ error: 'Session not found' });
   }
-  res.json(session);
+  // Add hasResponses flag to indicate if session has ever received assistant responses
+  // This is used by the frontend to determine if a session is a draft
+  const allMessages = messages.getBySessionId(req.params.id);
+  const hasResponses = allMessages.some(msg => msg.role === 'assistant');
+  res.json({ ...session, hasResponses });
 });
 
 // GET /api/sessions/:id/changes - Get git changes for session

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -34,8 +34,14 @@ export const useSessionsStore = defineStore('sessions', {
       return state.conversations.find((c) => c.id === id);
     },
     isDraftSession: (state) => (session) => {
-      // A session is a draft if it's in waiting status and has no assistant messages
+      // A session is a draft if it's in waiting status and has never received any assistant responses
+      // We use session.hasResponses (from server) as the authoritative source since it checks
+      // all messages across all conversations, not just the currently loaded conversation
       if (!session || session.status !== 'waiting') return false;
+      // If hasResponses is available (from server), use it; otherwise fall back to checking loaded messages
+      if (session.hasResponses !== undefined) {
+        return !session.hasResponses;
+      }
       return !state.messages.some((msg) => msg.role === 'assistant');
     },
     // Token usage getters - now conversation-level (Issue #175)

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -1425,4 +1425,58 @@ describe('Sessions Store', () => {
       });
     });
   });
+
+  describe('isDraftSession getter', () => {
+    it('returns false for null session', () => {
+      const store = useSessionsStore();
+      expect(store.isDraftSession(null)).toBe(false);
+    });
+
+    it('returns false for session not in waiting status', () => {
+      const store = useSessionsStore();
+      expect(store.isDraftSession({ id: 'session-1', status: 'running' })).toBe(false);
+      expect(store.isDraftSession({ id: 'session-1', status: 'completed' })).toBe(false);
+      expect(store.isDraftSession({ id: 'session-1', status: 'error' })).toBe(false);
+    });
+
+    it('returns true for waiting session with hasResponses=false from server', () => {
+      const store = useSessionsStore();
+      const session = { id: 'session-1', status: 'waiting', hasResponses: false };
+      expect(store.isDraftSession(session)).toBe(true);
+    });
+
+    it('returns false for waiting session with hasResponses=true from server', () => {
+      const store = useSessionsStore();
+      const session = { id: 'session-1', status: 'waiting', hasResponses: true };
+      expect(store.isDraftSession(session)).toBe(false);
+    });
+
+    it('falls back to checking messages if hasResponses is undefined', () => {
+      const store = useSessionsStore();
+      const session = { id: 'session-1', status: 'waiting' }; // no hasResponses
+
+      // No messages loaded - should be a draft
+      store.messages = [];
+      expect(store.isDraftSession(session)).toBe(true);
+
+      // Has assistant message - not a draft
+      store.messages = [{ role: 'assistant', content: 'Hello' }];
+      expect(store.isDraftSession(session)).toBe(false);
+    });
+
+    it('prioritizes hasResponses over local messages state', () => {
+      const store = useSessionsStore();
+
+      // Even with empty messages array, if server says hasResponses=true, it's not a draft
+      store.messages = [];
+      const sessionWithResponses = { id: 'session-1', status: 'waiting', hasResponses: true };
+      expect(store.isDraftSession(sessionWithResponses)).toBe(false);
+
+      // Even with assistant messages in store, if server says hasResponses=false, it's a draft
+      // (this case shouldn't happen in practice, but tests the priority)
+      store.messages = [{ role: 'assistant', content: 'Hello' }];
+      const sessionNoDraft = { id: 'session-1', status: 'waiting', hasResponses: false };
+      expect(store.isDraftSession(sessionNoDraft)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `hasResponses` flag to session API response that checks all messages across all conversations
- Updates frontend `isDraftSession` getter to use server-provided `hasResponses` for accurate draft detection
- Fixes issue where creating a new conversation in an existing session incorrectly showed "Start Session" button

## Problem
When creating a new conversation within an existing session that already had responses, the frontend incorrectly identified the session as a "draft" because:
1. The `isDraftSession` getter only checked `state.messages` (current conversation's messages)
2. A new conversation has no messages, so it appeared as a draft
3. Clicking "Start Session" failed with "Session is not a draft - it already has responses"

## Solution
- Server now returns `hasResponses: true/false` on `GET /api/sessions/:id` 
- This flag checks ALL messages across ALL conversations for the session
- Frontend prioritizes this server-provided flag over local message state

## Test plan
- [x] Added 6 server-side tests for `hasResponses` property
- [x] Added 6 frontend tests for `isDraftSession` getter
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)