### PR TITLE
Fix worktree directory isolation by adding working directory guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,36 @@ Dark mode only using Tailwind CSS. Key colors:
 | `PORT` | `5000` | Server port |
 | `DB_PATH` | `claudetools.db` | SQLite database path |
 | `VITE_API_URL` | `http://localhost:5000` | Backend API URL (frontend) |
+
+## Working Directory Guidelines
+
+**CRITICAL: Never use `cd` to change to a hardcoded project path before running commands.**
+
+When running in a claudetools.io session, your working directory is already set correctly. This may be:
+- The main project directory
+- A git worktree for branch isolation
+
+### Do NOT do this:
+```bash
+# BAD - bypasses worktree isolation
+cd /home/ubuntu/workspace/claudetools.io && git status
+cd /home/ubuntu/workspace/claudetools.io && yarn test
+```
+
+### Do this instead:
+```bash
+# GOOD - respects the session's working directory
+git status
+yarn test
+```
+
+### Why this matters:
+- Sessions may run in git worktrees for branch isolation
+- Using `cd` to hardcoded paths escapes the worktree context
+- This causes git operations to affect the wrong repository
+- Commands should use relative paths or run without `cd`
+
+### If you need to reference files:
+- Use relative paths: `packages/server/src/...`
+- Use `pwd` to check your current directory if unsure
+- Never assume the working directory is the main repo

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -476,6 +476,25 @@ function buildSessionEnv(session) {
 }
 
 /**
+ * Build worktree context for system prompt if session uses git worktree
+ * @param {Object} session - Session object
+ * @returns {string} Worktree context or empty string
+ */
+function buildWorktreeContext(session) {
+  if (!session || !session.gitWorktree) {
+    return '';
+  }
+
+  return `## Git Worktree Session
+
+This session is running in an isolated git worktree:
+- Worktree path: ${session.gitWorktree}
+- Branch: ${session.gitBranch || 'unknown'}
+
+CRITICAL: Do NOT use \`cd\` to navigate to the main repository. Your working directory is already set to the worktree. Running \`cd /home/ubuntu/workspace/claudetools.io && ...\` will escape the worktree isolation and affect the main repository instead.`;
+}
+
+/**
  * Build the full system prompt configuration
  * @param {string} sessionId
  * @param {string} projectId
@@ -484,17 +503,19 @@ function buildSessionEnv(session) {
  * @returns {string} System prompt string
  */
 export function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
+  const session = sessions.getById(sessionId);
   const canvasWriteInstructions = buildCanvasWriteSystemPrompt(sessionId);
   const canvasReadInstructions = buildCanvasReadSystemPrompt(sessionId);
   const sessionApiInstructions = buildSessionApiInstructions(sessionId, projectId);
   const attachmentsContext = getSessionAttachmentsContext(sessionId);
+  const worktreeContext = buildWorktreeContext(session);
   const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;
 
   // Prepend plan mode instructions if in plan mode
   const modePrompt = mode === 'plan' ? PLAN_MODE_PROMPT : '';
 
   // Build prompt parts, filtering out empty sections
-  const parts = [modePrompt, basePrompt, attachmentsContext, canvasWriteInstructions, canvasReadInstructions, sessionApiInstructions].filter(
+  const parts = [modePrompt, basePrompt, worktreeContext, attachmentsContext, canvasWriteInstructions, canvasReadInstructions, sessionApiInstructions].filter(
     Boolean
   );
 

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -10,4 +10,6 @@ export const WS_RECONNECT_MAX_DELAY = 30000;
 
 export const TOAST_DURATION = 5000;
 
-export const DEFAULT_SYSTEM_PROMPT = `You are Claude Code, an AI coding assistant. You help users with software engineering tasks including writing code, debugging, refactoring, and explaining code. You have full access to the shell and can execute any commands needed to assist the user. Be helpful, accurate, and thorough.`;
+export const DEFAULT_SYSTEM_PROMPT = `You are Claude Code, an AI coding assistant. You help users with software engineering tasks including writing code, debugging, refactoring, and explaining code. You have full access to the shell and can execute any commands needed to assist the user. Be helpful, accurate, and thorough.
+
+IMPORTANT: Your working directory is already set correctly for this session. NEVER use \`cd\` to change to a hardcoded project path before running commands (e.g., \`cd /path/to/project && git status\`). This bypasses git worktree isolation and causes commands to run in the wrong directory. Always run commands directly without changing directory.`;


### PR DESCRIPTION
## Summary

Implemented a three-phase plan to prevent Claude agents from bypassing git worktree isolation by using `cd` to hardcoded project paths.

**Problem:** Claude agents would sometimes see full file paths in context and decide to `cd` to a hardcoded path like `/home/ubuntu/workspace/claudetools.io && git status`, which escapes worktree isolation and causes git operations to affect the main repository instead of the isolated worktree.

**Solution:** Multi-layered approach combining documentation, system prompt guidance, and dynamic worktree context.

## Changes

### Phase 1: CLAUDE.md Documentation
- Added "Working Directory Guidelines" section with clear instructions
- Provided "Do NOT" vs "Do this instead" code examples
- Explained why `cd` to hardcoded paths breaks worktree isolation
- Detailed best practices for file referencing

### Phase 2: System Prompt Enhancement
- Updated `DEFAULT_SYSTEM_PROMPT` in `packages/shared/src/constants.js`
- Added explicit runtime enforcement instruction
- Included in every Claude session's system prompt

### Phase 3: Worktree Context Integration
- Implemented `buildWorktreeContext()` function in `sessionManager.js`
- Dynamically includes worktree path and branch information
- Integrated into `buildSystemPromptConfig()` for session-specific context

## Test Plan

- [x] Syntax checks passed for all modified files
- [x] All changes committed and pushed
- [ ] Test with new worktree session to verify Claude respects guidelines
- [ ] Monitor git branch creation to confirm commands run in correct location
- [ ] Verify uncommitted changes stay isolated per worktree

## Files Modified

| File | Changes |
|------|---------|
| `CLAUDE.md` | Added Working Directory Guidelines section |
| `packages/shared/src/constants.js` | Updated DEFAULT_SYSTEM_PROMPT |
| `packages/server/src/services/sessionManager.js` | Added buildWorktreeContext() function |

🤖 Generated with [Claude Code](https://claude.com/claude-code)