### PR TITLE
Make session status filters mutually exclusive

### DIFF
--- a/packages/web/src/views/ActiveSessionsView.test.js
+++ b/packages/web/src/views/ActiveSessionsView.test.js
@@ -301,6 +301,7 @@ describe('Status filtering', () => {
         { id: 'session-1', name: 'Running Session', status: 'running', projectId: 'project-1' },
         { id: 'session-2', name: 'Waiting Session', status: 'waiting', projectId: 'project-2' },
         { id: 'session-3', name: 'Starting Session', status: 'starting', projectId: 'project-1' },
+        { id: 'session-4', name: 'Error Session', status: 'error', projectId: 'project-1' },
       ],
       fetchActiveSessions: vi.fn().mockResolvedValue(),
     };
@@ -312,14 +313,14 @@ describe('Status filtering', () => {
     vi.clearAllMocks();
   });
 
-  it('renders filter buttons for running and waiting statuses', async () => {
+  it('renders filter buttons for running and idle statuses', async () => {
     const wrapper = mount(ActiveSessionsView);
     await flushPromises();
 
     const filterButtons = wrapper.findAll('.filter-btn');
     expect(filterButtons).toHaveLength(2);
     expect(filterButtons[0].text()).toBe('running');
-    expect(filterButtons[1].text()).toBe('waiting');
+    expect(filterButtons[1].text()).toBe('idle');
   });
 
   it('shows all sessions when no filters are active', async () => {
@@ -327,10 +328,10 @@ describe('Status filtering', () => {
     await flushPromises();
 
     const sessionCards = wrapper.findAll('.session-card');
-    expect(sessionCards).toHaveLength(3);
+    expect(sessionCards).toHaveLength(4);
   });
 
-  it('filters to show only running sessions when running filter is clicked', async () => {
+  it('filters to show only running sessions (running + starting) when running filter is clicked', async () => {
     const wrapper = mount(ActiveSessionsView);
     await flushPromises();
 
@@ -338,35 +339,65 @@ describe('Status filtering', () => {
     await runningButton.trigger('click');
 
     const sessionCards = wrapper.findAll('.session-card');
-    expect(sessionCards).toHaveLength(1);
-    expect(sessionCards[0].attributes('data-session-id')).toBe('session-1');
+    expect(sessionCards).toHaveLength(2);
+    const sessionIds = sessionCards.map(card => card.attributes('data-session-id'));
+    expect(sessionIds).toContain('session-1'); // running
+    expect(sessionIds).toContain('session-3'); // starting
   });
 
-  it('filters to show only waiting sessions when waiting filter is clicked', async () => {
+  it('filters to show only idle sessions (waiting + error) when idle filter is clicked', async () => {
     const wrapper = mount(ActiveSessionsView);
     await flushPromises();
 
-    const waitingButton = wrapper.findAll('.filter-btn')[1];
-    await waitingButton.trigger('click');
+    const idleButton = wrapper.findAll('.filter-btn')[1];
+    await idleButton.trigger('click');
 
     const sessionCards = wrapper.findAll('.session-card');
-    expect(sessionCards).toHaveLength(1);
-    expect(sessionCards[0].attributes('data-session-id')).toBe('session-2');
+    expect(sessionCards).toHaveLength(2);
+    const sessionIds = sessionCards.map(card => card.attributes('data-session-id'));
+    expect(sessionIds).toContain('session-2'); // waiting
+    expect(sessionIds).toContain('session-4'); // error
   });
 
-  it('shows both running and waiting sessions when both filters are active', async () => {
+  it('makes filters mutually exclusive - running filter disables idle filter', async () => {
     const wrapper = mount(ActiveSessionsView);
     await flushPromises();
 
     const filterButtons = wrapper.findAll('.filter-btn');
-    await filterButtons[0].trigger('click'); // running
-    await filterButtons[1].trigger('click'); // waiting
+    const runningButton = filterButtons[0];
+    const idleButton = filterButtons[1];
 
-    const sessionCards = wrapper.findAll('.session-card');
-    expect(sessionCards).toHaveLength(2);
+    // Click running filter
+    await runningButton.trigger('click');
+    expect(runningButton.classes()).toContain('active');
+    expect(idleButton.classes()).not.toContain('active');
+
+    // Click idle filter - should disable running and enable idle
+    await idleButton.trigger('click');
+    expect(runningButton.classes()).not.toContain('active');
+    expect(idleButton.classes()).toContain('active');
   });
 
-  it('toggles filter off when clicked again', async () => {
+  it('makes filters mutually exclusive - idle filter disables running filter', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const filterButtons = wrapper.findAll('.filter-btn');
+    const runningButton = filterButtons[0];
+    const idleButton = filterButtons[1];
+
+    // Click idle filter first
+    await idleButton.trigger('click');
+    expect(idleButton.classes()).toContain('active');
+    expect(runningButton.classes()).not.toContain('active');
+
+    // Click running filter - should disable idle and enable running
+    await runningButton.trigger('click');
+    expect(idleButton.classes()).not.toContain('active');
+    expect(runningButton.classes()).toContain('active');
+  });
+
+  it('toggles filter off when clicked again (shows all sessions)', async () => {
     const wrapper = mount(ActiveSessionsView);
     await flushPromises();
 
@@ -374,11 +405,13 @@ describe('Status filtering', () => {
 
     // Click to enable filter
     await runningButton.trigger('click');
-    expect(wrapper.findAll('.session-card')).toHaveLength(1);
+    expect(wrapper.findAll('.session-card')).toHaveLength(2);
+    expect(runningButton.classes()).toContain('active');
 
-    // Click again to disable filter
+    // Click again to disable filter (show all)
     await runningButton.trigger('click');
-    expect(wrapper.findAll('.session-card')).toHaveLength(3);
+    expect(wrapper.findAll('.session-card')).toHaveLength(4);
+    expect(runningButton.classes()).not.toContain('active');
   });
 
   it('adds active class to selected filter button', async () => {
@@ -392,19 +425,48 @@ describe('Status filtering', () => {
     expect(runningButton.classes()).toContain('active');
   });
 
+  it('includes starting status in running filter', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const runningButton = wrapper.findAll('.filter-btn')[0];
+    await runningButton.trigger('click');
+
+    const sessionCards = wrapper.findAll('.session-card');
+    const sessionIds = sessionCards.map(card => card.attributes('data-session-id'));
+
+    // Should include session-3 which has status 'starting'
+    expect(sessionIds).toContain('session-3');
+  });
+
+  it('includes waiting and error statuses in idle filter', async () => {
+    const wrapper = mount(ActiveSessionsView);
+    await flushPromises();
+
+    const idleButton = wrapper.findAll('.filter-btn')[1];
+    await idleButton.trigger('click');
+
+    const sessionCards = wrapper.findAll('.session-card');
+    const sessionIds = sessionCards.map(card => card.attributes('data-session-id'));
+
+    // Should include session-2 (waiting) and session-4 (error)
+    expect(sessionIds).toContain('session-2');
+    expect(sessionIds).toContain('session-4');
+  });
+
   it('shows empty state message when filters return no results', async () => {
-    // Set up store with only starting sessions (no running or waiting)
+    // Set up store with only running sessions
     mockSessionsStore.activeSessions = [
-      { id: 'session-1', name: 'Starting Session', status: 'starting', projectId: 'project-1' },
+      { id: 'session-1', name: 'Running Session', status: 'running', projectId: 'project-1' },
     ];
     useSessionsStore.mockReturnValue(mockSessionsStore);
 
     const wrapper = mount(ActiveSessionsView);
     await flushPromises();
 
-    // Click running filter - no running sessions exist
-    const runningButton = wrapper.findAll('.filter-btn')[0];
-    await runningButton.trigger('click');
+    // Click idle filter - no idle sessions exist
+    const idleButton = wrapper.findAll('.filter-btn')[1];
+    await idleButton.trigger('click');
 
     const emptyState = wrapper.find('.empty-state');
     expect(emptyState.exists()).toBe(true);

--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -2,14 +2,14 @@
   <div class="container">
     <div class="page-header">
       <div>
-        <p class="page-description">Sessions that are running or waiting for input</p>
+        <p class="page-description">All active sessions across your projects</p>
       </div>
     </div>
 
     <div class="status-filters">
       <span class="filter-label">Filter:</span>
       <button
-        v-for="status in ['running', 'waiting']"
+        v-for="status in ['running', 'idle']"
         :key="status"
         :class="['filter-btn', { active: statusFilters.includes(status) }]"
         @click="toggleFilter(status)"
@@ -63,19 +63,37 @@ const sessionsStore = useSessionsStore();
 // Filter state - empty means show all
 const statusFilters = ref([]);
 
+// Statuses that count as "idle" (not actively running)
+const IDLE_STATUSES = ['waiting', 'stopped', 'error'];
+// Statuses that count as "running" (actively processing or starting up)
+const RUNNING_STATUSES = ['running', 'starting'];
+
 const toggleFilter = (status) => {
-  const index = statusFilters.value.indexOf(status);
-  if (index >= 0) {
-    statusFilters.value.splice(index, 1);
+  // If the clicked filter is already active, clear all filters (show all)
+  if (statusFilters.value.includes(status)) {
+    statusFilters.value = [];
   } else {
-    statusFilters.value.push(status);
+    // Otherwise, set this filter as the only active one (exclusive)
+    statusFilters.value = [status];
   }
 };
 
 const filteredSessions = computed(() => {
   const sessions = sessionsStore.activeSessions;
   if (statusFilters.value.length === 0) return sessions;
-  return sessions.filter(s => statusFilters.value.includes(s.status));
+
+  return sessions.filter(session => {
+    const status = session.status;
+    // "idle" filter matches waiting, stopped, or error statuses
+    if (statusFilters.value.includes('idle') && IDLE_STATUSES.includes(status)) {
+      return true;
+    }
+    // "running" filter matches running and starting statuses
+    if (statusFilters.value.includes('running') && RUNNING_STATUSES.includes(status)) {
+      return true;
+    }
+    return false;
+  });
 });
 
 // Store summaries keyed by session ID

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -521,45 +521,24 @@ describe('Status filtering', () => {
     });
   });
 
-  describe('Combined filters', () => {
-    it('shows both running and idle sessions when both filters are active', async () => {
-      const wrapper = mount(SessionListView);
-      await flushPromises();
-
-      const filterButtons = wrapper.findAll('.filter-btn');
-      await filterButtons[0].trigger('click'); // running
-      await filterButtons[1].trigger('click'); // idle
-
-      const sessionCards = wrapper.findAll('.session-card');
-      // running (running + starting = 2) + idle (waiting, stopped, error = 3) = 5
-      expect(sessionCards).toHaveLength(5);
-
-      const sessionIds = sessionCards.map(c => c.attributes('data-session-id'));
-      expect(sessionIds).toContain('session-1'); // running
-      expect(sessionIds).toContain('session-2'); // waiting
-      expect(sessionIds).toContain('session-3'); // stopped
-      expect(sessionIds).toContain('session-4'); // error
-      expect(sessionIds).toContain('session-5'); // starting - included in running filter
-    });
-
-    it('can disable one filter while keeping the other active', async () => {
+  describe('Exclusive filter behavior', () => {
+    it('disables running filter when idle filter is clicked', async () => {
       const wrapper = mount(SessionListView);
       await flushPromises();
 
       const filterButtons = wrapper.findAll('.filter-btn');
 
-      // Enable both filters
-      await filterButtons[0].trigger('click'); // running
-      await filterButtons[1].trigger('click'); // idle
-
-      expect(wrapper.findAll('.session-card')).toHaveLength(5);
-
-      // Disable running filter
+      // Click running filter
       await filterButtons[0].trigger('click');
+      let sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(2); // running + starting
 
-      // Should only show idle sessions now (waiting, stopped, error)
-      const sessionCards = wrapper.findAll('.session-card');
-      expect(sessionCards).toHaveLength(3);
+      // Click idle filter (should disable running and enable idle)
+      await filterButtons[1].trigger('click');
+
+      // Should now show only idle sessions
+      sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(3); // waiting, stopped, error
 
       const sessionIds = sessionCards.map(c => c.attributes('data-session-id'));
       expect(sessionIds).not.toContain('session-1'); // running - now excluded
@@ -567,6 +546,169 @@ describe('Status filtering', () => {
       expect(sessionIds).toContain('session-2'); // waiting
       expect(sessionIds).toContain('session-3'); // stopped
       expect(sessionIds).toContain('session-4'); // error
+    });
+
+    it('disables idle filter when running filter is clicked', async () => {
+      const wrapper = mount(SessionListView);
+      await flushPromises();
+
+      const filterButtons = wrapper.findAll('.filter-btn');
+
+      // Click idle filter
+      await filterButtons[1].trigger('click');
+      let sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(3); // waiting, stopped, error
+
+      // Click running filter (should disable idle and enable running)
+      await filterButtons[0].trigger('click');
+
+      // Should now show only running sessions
+      sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(2); // running + starting
+
+      const sessionIds = sessionCards.map(c => c.attributes('data-session-id'));
+      expect(sessionIds).toContain('session-1'); // running
+      expect(sessionIds).toContain('session-5'); // starting
+      expect(sessionIds).not.toContain('session-2'); // waiting - now excluded
+      expect(sessionIds).not.toContain('session-3'); // stopped - now excluded
+      expect(sessionIds).not.toContain('session-4'); // error - now excluded
+    });
+
+    it('only allows one filter active at a time', async () => {
+      const wrapper = mount(SessionListView);
+      await flushPromises();
+
+      const filterButtons = wrapper.findAll('.filter-btn');
+
+      // Click running filter
+      await filterButtons[0].trigger('click');
+      expect(filterButtons[0].classes()).toContain('active');
+      expect(filterButtons[1].classes()).not.toContain('active');
+
+      // Click idle filter
+      await filterButtons[1].trigger('click');
+      expect(filterButtons[0].classes()).not.toContain('active');
+      expect(filterButtons[1].classes()).toContain('active');
+
+      // Click running again
+      await filterButtons[0].trigger('click');
+      expect(filterButtons[0].classes()).toContain('active');
+      expect(filterButtons[1].classes()).not.toContain('active');
+    });
+  });
+
+  describe('Grouped sessions filtering', () => {
+    it('filters grouped sessions by parent status (running filter)', async () => {
+      // Set up store with grouped sessions
+      mockSessionsStore = {
+        loading: false,
+        error: null,
+        sessions: [
+          { id: 'session-1', name: 'Running Session', status: 'running' },
+          { id: 'session-2', name: 'Waiting Session', status: 'waiting' },
+        ],
+        groupedSessions: [
+          {
+            parent: { id: 'session-1', name: 'Running Session', status: 'running' },
+            children: [{ id: 'child-1', name: 'Child', status: 'completed' }],
+          },
+          {
+            parent: { id: 'session-2', name: 'Waiting Session', status: 'waiting' },
+            children: [{ id: 'child-2', name: 'Child', status: 'completed' }],
+          },
+        ],
+        fetchSessions: vi.fn().mockResolvedValue(),
+        addSessionToList: vi.fn(),
+        updateSession: vi.fn(),
+        removeSessionFromList: vi.fn(),
+      };
+      useSessionsStore.mockReturnValue(mockSessionsStore);
+
+      const wrapper = mount(SessionListView);
+      await flushPromises();
+
+      const runningButton = wrapper.findAll('.filter-btn')[0];
+      await runningButton.trigger('click');
+
+      // Should show only the running parent group
+      const sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(1);
+      expect(sessionCards[0].attributes('data-session-id')).toBe('session-1');
+    });
+
+    it('filters grouped sessions by parent status (idle filter)', async () => {
+      // Set up store with grouped sessions
+      mockSessionsStore = {
+        loading: false,
+        error: null,
+        sessions: [
+          { id: 'session-1', name: 'Running Session', status: 'running' },
+          { id: 'session-2', name: 'Waiting Session', status: 'waiting' },
+        ],
+        groupedSessions: [
+          {
+            parent: { id: 'session-1', name: 'Running Session', status: 'running' },
+            children: [{ id: 'child-1', name: 'Child', status: 'completed' }],
+          },
+          {
+            parent: { id: 'session-2', name: 'Waiting Session', status: 'waiting' },
+            children: [{ id: 'child-2', name: 'Child', status: 'completed' }],
+          },
+        ],
+        fetchSessions: vi.fn().mockResolvedValue(),
+        addSessionToList: vi.fn(),
+        updateSession: vi.fn(),
+        removeSessionFromList: vi.fn(),
+      };
+      useSessionsStore.mockReturnValue(mockSessionsStore);
+
+      const wrapper = mount(SessionListView);
+      await flushPromises();
+
+      const idleButton = wrapper.findAll('.filter-btn')[1];
+      await idleButton.trigger('click');
+
+      // Should show only the waiting parent group
+      const sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(1);
+      expect(sessionCards[0].attributes('data-session-id')).toBe('session-2');
+    });
+
+    it('includes entire group (parent + children) when parent matches filter', async () => {
+      // Set up store with grouped sessions
+      mockSessionsStore = {
+        loading: false,
+        error: null,
+        sessions: [
+          { id: 'session-1', name: 'Running Session', status: 'running' },
+        ],
+        groupedSessions: [
+          {
+            parent: { id: 'session-1', name: 'Running Session', status: 'running' },
+            children: [
+              { id: 'child-1', name: 'Child 1', status: 'completed' },
+              { id: 'child-2', name: 'Child 2', status: 'completed' },
+            ],
+          },
+        ],
+        fetchSessions: vi.fn().mockResolvedValue(),
+        addSessionToList: vi.fn(),
+        updateSession: vi.fn(),
+        removeSessionFromList: vi.fn(),
+      };
+      useSessionsStore.mockReturnValue(mockSessionsStore);
+
+      const wrapper = mount(SessionListView);
+      await flushPromises();
+
+      // Click running filter
+      const runningButton = wrapper.findAll('.filter-btn')[0];
+      await runningButton.trigger('click');
+
+      // Should show the session card (which includes its children)
+      const sessionCards = wrapper.findAll('.session-card');
+      expect(sessionCards).toHaveLength(1);
+      expect(sessionCards[0].attributes('data-session-id')).toBe('session-1');
     });
   });
 

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -84,12 +84,12 @@
         </router-link>
       </div>
 
-      <div v-else-if="filteredSessions.length === 0" class="empty-state">
+      <div v-else-if="filteredGroupedSessions.length === 0" class="empty-state">
         <p>No sessions match the current filter.</p>
       </div>
 
       <div v-else class="session-list">
-        <template v-for="group in sessionsStore.groupedSessions" :key="group.parent.id">
+        <template v-for="group in filteredGroupedSessions" :key="group.parent.id">
           <SessionCard
             :session="group.parent"
             :show-summary="true"
@@ -168,11 +168,12 @@ const sessionsStore = useSessionsStore();
 const statusFilters = ref([]);
 
 const toggleFilter = (status) => {
-  const index = statusFilters.value.indexOf(status);
-  if (index >= 0) {
-    statusFilters.value.splice(index, 1);
+  // If the clicked filter is already active, clear all filters (show all)
+  if (statusFilters.value.includes(status)) {
+    statusFilters.value = [];
   } else {
-    statusFilters.value.push(status);
+    // Otherwise, set this filter as the only active one (exclusive)
+    statusFilters.value = [status];
   }
 };
 
@@ -181,17 +182,19 @@ const IDLE_STATUSES = ['waiting', 'stopped', 'error'];
 // Statuses that count as "running" (actively processing or starting up)
 const RUNNING_STATUSES = ['running', 'starting'];
 
-const filteredSessions = computed(() => {
-  const sessions = sessionsStore.sessions;
-  if (statusFilters.value.length === 0) return sessions;
+const filteredGroupedSessions = computed(() => {
+  const groups = sessionsStore.groupedSessions;
+  if (statusFilters.value.length === 0) return groups;
 
-  return sessions.filter(s => {
+  // Filter groups based on parent session status
+  return groups.filter(group => {
+    const parentStatus = group.parent.status;
     // "idle" filter matches waiting, stopped, or error statuses
-    if (statusFilters.value.includes('idle') && IDLE_STATUSES.includes(s.status)) {
+    if (statusFilters.value.includes('idle') && IDLE_STATUSES.includes(parentStatus)) {
       return true;
     }
     // "running" filter matches running and starting statuses
-    if (statusFilters.value.includes('running') && RUNNING_STATUSES.includes(s.status)) {
+    if (statusFilters.value.includes('running') && RUNNING_STATUSES.includes(parentStatus)) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- Changed ActiveSessionsView and SessionListView filters to be mutually exclusive (only one can be active at a time)
- Renamed 'waiting' filter to 'idle' for better clarity
- Updated filter logic so clicking a filter toggles it on/off, and switching to a different filter automatically disables the previous one

## Filter Behavior
- **'running' filter**: Shows sessions with status 'running' or 'starting'
- **'idle' filter**: Shows sessions with status 'waiting', 'stopped', or 'error'
- Filters are mutually exclusive - only one can be active
- Clicking an active filter disables it and shows all sessions

## Test Plan
- [x] All existing tests pass
- [x] Verified filter buttons toggle correctly
- [x] Verified switching filters disables the previous filter
- [x] Verified proper statuses are included in each filter group
- [x] Verified grouped sessions are filtered by parent status

🧠 Generated with [Claude Code](https://claude.com/claude-code)