### PR TITLE
Move Session Template UI elements to bottom of form

### DIFF
--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -67,41 +67,6 @@
         </div>
       </div>
 
-      <!-- Session Template (optional) -->
-      <div v-if="allTemplates.length > 0" class="form-group">
-        <label class="form-label" for="template">Session Template (optional)</label>
-        <select id="template" v-model="selectedTemplateId" class="form-input">
-          <option :value="null">None - single session</option>
-          <optgroup v-if="projectTemplates.length" label="Project Templates">
-            <option v-for="template in projectTemplates" :key="template.id" :value="template.id">
-              {{ template.name }}
-            </option>
-          </optgroup>
-          <optgroup v-if="globalTemplates.length" label="Global Templates">
-            <option v-for="template in globalTemplates" :key="template.id" :value="template.id">
-              {{ template.name }}
-            </option>
-          </optgroup>
-        </select>
-        <p class="form-help">
-          When selected, the template's settings are applied and a new session will automatically start when Claude finishes.
-        </p>
-      </div>
-
-      <!-- Parent Session (optional) -->
-      <div v-if="availableSessions.length > 0" class="form-group">
-        <label class="form-label" for="parent-session">Parent Session (optional)</label>
-        <select id="parent-session" v-model="parentSessionId" class="form-input">
-          <option :value="null">None - create standalone session</option>
-          <option v-for="session in availableSessions" :key="session.id" :value="session.id">
-            {{ session.name }}
-          </option>
-        </select>
-        <p class="form-help">
-          Choose a parent session to link this as a child session. Child sessions help organize related work.
-        </p>
-      </div>
-
       <div v-if="error" class="error-message">{{ error }}</div>
 
       <div class="form-actions">
@@ -160,6 +125,41 @@
       <div v-if="loadingGit" class="git-loading">
         <span class="loading-spinner"></span>
         Loading git info...
+      </div>
+
+      <!-- Session Template (optional) -->
+      <div v-if="allTemplates.length > 0" class="form-group">
+        <label class="form-label" for="template">Session Template (optional)</label>
+        <select id="template" v-model="selectedTemplateId" class="form-input">
+          <option :value="null">None - single session</option>
+          <optgroup v-if="projectTemplates.length" label="Project Templates">
+            <option v-for="template in projectTemplates" :key="template.id" :value="template.id">
+              {{ template.name }}
+            </option>
+          </optgroup>
+          <optgroup v-if="globalTemplates.length" label="Global Templates">
+            <option v-for="template in globalTemplates" :key="template.id" :value="template.id">
+              {{ template.name }}
+            </option>
+          </optgroup>
+        </select>
+        <p class="form-help">
+          When selected, the template's settings are applied and a new session will automatically start when Claude finishes.
+        </p>
+      </div>
+
+      <!-- Parent Session (optional) -->
+      <div v-if="availableSessions.length > 0" class="form-group">
+        <label class="form-label" for="parent-session">Parent Session (optional)</label>
+        <select id="parent-session" v-model="parentSessionId" class="form-input">
+          <option :value="null">None - create standalone session</option>
+          <option v-for="session in availableSessions" :key="session.id" :value="session.id">
+            {{ session.name }}
+          </option>
+        </select>
+        <p class="form-help">
+          Choose a parent session to link this as a child session. Child sessions help organize related work.
+        </p>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Reorganized the new session form layout to improve UX by prioritizing core fields
- Moved Session Template and Parent Session sections to the bottom, after Git Options
- Form now flows logically: Prompt → Options → Submit button → Advanced settings (Git, Template, Parent)

## Changes
- Reordered form sections in `NewSessionView.vue`
- Session Template and Parent Session sections now appear at the bottom of the form
- All functionality preserved - sections still conditionally render based on data availability

## Test Plan
- [ ] Verify form displays all sections in the correct order
- [ ] Test that Session Template dropdown appears when templates are available
- [ ] Test that Parent Session dropdown appears when completed sessions are available
- [ ] Verify Git Options section displays for git repositories
- [ ] Ensure form submission still works correctly

🤖 Generated with Claude Code