### PR TITLE
Add configurable summary debounce delay per project

### DIFF
--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -69,6 +69,15 @@ router.put('/:id', (req, res) => {
     return res.status(400).json({ error: result.error.errors[0].message });
   }
 
+  // Validate summaryDebounceMs if provided
+  if (result.data.summaryDebounceMs !== undefined) {
+    if (!Number.isInteger(result.data.summaryDebounceMs) || result.data.summaryDebounceMs < 100) {
+      return res.status(400).json({
+        error: 'summaryDebounceMs must be an integer >= 100 (milliseconds)'
+      });
+    }
+  }
+
   const updated = projects.update(req.params.id, result.data);
   res.json(updated);
 });

--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -76,6 +76,9 @@ export class DatabaseManager {
     if (!projectsColumns.includes('repo_url')) {
       this.#db.exec('ALTER TABLE projects ADD COLUMN repo_url TEXT');
     }
+    if (!projectsColumns.includes('summary_debounce_ms')) {
+      this.#db.exec('ALTER TABLE projects ADD COLUMN summary_debounce_ms INTEGER NOT NULL DEFAULT 5000');
+    }
 
     // Migrate sessions table to add 'stopped' status to CHECK constraint
     // SQLite doesn't allow modifying CHECK constraints, so we need to recreate the table

--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -21,6 +21,7 @@ export class ProjectRepository extends BaseRepository {
       disableSessionSummaries: row.disable_session_summaries === 1,
       disableConversationSummaries: row.disable_conversation_summaries === 1,
       repoUrl: row.repo_url,
+      summaryDebounceMs: row.summary_debounce_ms || 5000,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -36,11 +37,12 @@ export class ProjectRepository extends BaseRepository {
       disableSessionSummaries = false,
       disableConversationSummaries = false,
       repoUrl = null,
+      summaryDebounceMs = 5000,
     } = options;
     this.db
       .prepare(
-        `INSERT INTO projects (id, name, working_directory, system_prompt, on_session_created, on_session_deleted, pr_poll_interval, disable_session_summaries, disable_conversation_summaries, repo_url, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO projects (id, name, working_directory, system_prompt, on_session_created, on_session_deleted, pr_poll_interval, disable_session_summaries, disable_conversation_summaries, repo_url, summary_debounce_ms, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -53,6 +55,7 @@ export class ProjectRepository extends BaseRepository {
         disableSessionSummaries ? 1 : 0,
         disableConversationSummaries ? 1 : 0,
         repoUrl,
+        summaryDebounceMs,
         now,
         now
       );
@@ -103,6 +106,10 @@ export class ProjectRepository extends BaseRepository {
     if (data.repoUrl !== undefined) {
       updates.push('repo_url = ?');
       values.push(data.repoUrl);
+    }
+    if (data.summaryDebounceMs !== undefined) {
+      updates.push('summary_debounce_ms = ?');
+      values.push(data.summaryDebounceMs);
     }
 
     if (updates.length === 0) return this.getById(id);

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -133,6 +133,20 @@ describe('ProjectRepository', () => {
       expect(project.prPollInterval).toBe(30000);
       expect(project.disableSessionSummaries).toBe(true);
     });
+
+    it('creates project with summaryDebounceMs default of 5000', () => {
+      const project = repo.create('Test Project', '/tmp/test');
+
+      expect(project.summaryDebounceMs).toBe(5000);
+    });
+
+    it('creates project with custom summaryDebounceMs', () => {
+      const project = repo.create('Test Project', '/tmp/test', null, {
+        summaryDebounceMs: 10000,
+      });
+
+      expect(project.summaryDebounceMs).toBe(10000);
+    });
   });
 
   describe('getById', () => {
@@ -355,6 +369,29 @@ describe('ProjectRepository', () => {
         repoUrl: null,
       });
       expect(cleared.repoUrl).toBeNull();
+    });
+
+    it('updates summaryDebounceMs', () => {
+      const project = repo.create('Test', '/tmp/test');
+      expect(project.summaryDebounceMs).toBe(5000);
+
+      const updated = repo.update(project.id, {
+        summaryDebounceMs: 3000,
+      });
+
+      expect(updated.summaryDebounceMs).toBe(3000);
+    });
+
+    it('updates summaryDebounceMs to a larger value', () => {
+      const project = repo.create('Test', '/tmp/test', null, {
+        summaryDebounceMs: 5000,
+      });
+
+      const updated = repo.update(project.id, {
+        summaryDebounceMs: 15000,
+      });
+
+      expect(updated.summaryDebounceMs).toBe(15000);
     });
   });
 

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -279,9 +279,10 @@ function parseSummaryResponse(responseText) {
  * Generate summary for a session using Claude Code SDK
  * @param {string} sessionId
  * @param {number} retryCount - Internal retry counter (do not set manually)
+ * @param {boolean} force - Force generation even if summary is current (default: false)
  * @returns {Promise<Object|null>}
  */
-export async function generateSummary(sessionId, retryCount = 0) {
+export async function generateSummary(sessionId, retryCount = 0, force = false) {
   try {
     // Get session info
     const session = sessions.getById(sessionId);
@@ -300,8 +301,20 @@ export async function generateSummary(sessionId, retryCount = 0) {
     // Get existing summary for incremental generation
     const existingSummary = sessionSummaries.getBySessionId(sessionId);
 
+    // Skip regeneration for merged PRs (work is complete)
+    if (existingSummary?.prMerged) {
+      console.log(`[SummaryService] Session ${sessionId} has merged PR, skipping regeneration`);
+      return existingSummary;
+    }
+
     // Get recent messages
     const allMessages = messages.getBySessionId(sessionId);
+
+    // Skip if summary is current and not forced to regenerate
+    if (!force && !isSummaryStale(sessionId)) {
+      console.log(`[SummaryService] Summary for ${sessionId} is current, skipping regeneration`);
+      return existingSummary;
+    }
     const recentMessages = allMessages.slice(-MAX_MESSAGES);
 
     if (recentMessages.length === 0) {
@@ -331,7 +344,7 @@ export async function generateSummary(sessionId, retryCount = 0) {
       );
       const backoffMs = 1000 * (retryCount + 1); // 1s, 2s
       await new Promise((resolve) => setTimeout(resolve, backoffMs));
-      return generateSummary(sessionId, retryCount + 1);
+      return generateSummary(sessionId, retryCount + 1, force);
     }
 
     // Clean up internal flag before saving
@@ -454,11 +467,18 @@ export function onSessionActivity(sessionId) {
     clearTimeout(debounceTimers.get(sessionId));
   }
 
-  // Set new debounce timer
+  // Get project-specific debounce delay
+  const session = sessions.getById(sessionId);
+  if (!session) return;
+
+  const project = projects.getById(session.projectId);
+  const debounceDelay = project?.summaryDebounceMs || DEBOUNCE_DELAY;
+
+  // Set new debounce timer with project-specific delay
   const timer = setTimeout(() => {
     generateSummary(sessionId);
     debounceTimers.delete(sessionId);
-  }, DEBOUNCE_DELAY);
+  }, debounceDelay);
 
   debounceTimers.set(sessionId, timer);
 }
@@ -491,8 +511,8 @@ export function onSessionComplete(sessionId) {
     debounceTimers.delete(sessionId);
   }
 
-  // Generate summary immediately
-  generateSummary(sessionId);
+  // Generate summary immediately with force=true to update final state
+  generateSummary(sessionId, 0, true);
 
   // Schedule follow-up CI checks for sessions with PRs
   // CI might still be running after the session completes
@@ -534,7 +554,7 @@ export async function getSummary(sessionId, generateIfMissing = false) {
  * @returns {Promise<Object|null>}
  */
 export async function regenerateSummary(sessionId) {
-  return generateSummary(sessionId);
+  return generateSummary(sessionId, 0, true);
 }
 
 /**

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -781,6 +781,206 @@ describe('summaryService', () => {
       const projectAfter = projects.getById(projectId);
       expect(projectAfter.repoUrl).toBe(initialUrl);
     });
+
+    // Tests for prMerged check (Task 1)
+    it('skips regeneration when PR is already merged', async () => {
+      // Create initial messages
+      messages.create(sessionId, 'user', 'Task to do');
+      messages.create(sessionId, 'assistant', 'Task completed');
+
+      // Create summary with merged PR
+      const existingSummary = sessionSummaries.create(sessionId, {
+        shortSummary: 'Task done',
+        fullSummary: 'Task was completed successfully',
+        keyActions: ['Task completed'],
+        filesModified: ['file.js'],
+        outcome: 'completed',
+        prMerged: true,
+        messageCount: 2,
+      });
+
+      vi.clearAllMocks();
+
+      // Call generateSummary - should return existing without generating
+      const result = await summaryService.generateSummary(sessionId);
+
+      // Should return existing summary
+      expect(result.prMerged).toBe(true);
+      expect(result.shortSummary).toBe('Task done');
+
+      // Should NOT have called broadcastToSession for generation
+      const generatingCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === 'session:summary_generating'
+      );
+      expect(generatingCalls.length).toBe(0);
+    });
+
+    it('allows regeneration when PR is not merged', async () => {
+      // Create initial messages
+      messages.create(sessionId, 'user', 'Task');
+      messages.create(sessionId, 'assistant', 'Working...');
+
+      // Create summary with open PR
+      sessionSummaries.create(sessionId, {
+        shortSummary: 'Working',
+        fullSummary: 'Still in progress',
+        keyActions: [],
+        filesModified: [],
+        outcome: 'ongoing',
+        prMerged: false, // Not merged
+        messageCount: 2,
+      });
+
+      vi.clearAllMocks();
+
+      // Call generateSummary - should generate new summary
+      const result = await summaryService.generateSummary(sessionId);
+
+      // Should generate a new summary
+      expect(result).not.toBeNull();
+
+      // Should have broadcast generating status
+      const generatingCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === 'session:summary_generating'
+      );
+      expect(generatingCalls.length).toBeGreaterThan(0);
+    });
+
+    it('generates summary when none exists (null prMerged)', async () => {
+      messages.create(sessionId, 'user', 'New task');
+      messages.create(sessionId, 'assistant', 'Response');
+
+      // No existing summary
+      const result = await summaryService.generateSummary(sessionId);
+
+      expect(result).not.toBeNull();
+      expect(result.shortSummary).toBeDefined();
+      expect(result.outcome).toBe('ongoing');
+    });
+
+    // Tests for isSummaryStale check and force parameter (Task 2)
+    it('skips generation when summary is current and not forced', async () => {
+      // Create messages first
+      messages.create(sessionId, 'user', 'Message 0');
+      messages.create(sessionId, 'assistant', 'Message 1');
+      messages.create(sessionId, 'user', 'Message 2');
+
+      // Generate initial summary to get proper structure
+      const initialSummary = await summaryService.generateSummary(sessionId);
+
+      // Record the actual message count (may be 3 or 4 depending on session creation)
+      const messageCount = initialSummary.messageCount;
+
+      // Clear mocks to track new calls
+      vi.clearAllMocks();
+
+      // Call again without force (no new messages) - should skip
+      const result = await summaryService.generateSummary(sessionId);
+
+      // Should return the same summary (no new generation) with same message count
+      expect(result.messageCount).toBe(messageCount);
+
+      // Should NOT have broadcast generating status (indicating no generation happened)
+      const generatingCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === 'session:summary_generating'
+      );
+      expect(generatingCalls.length).toBe(0);
+    });
+
+    it('generates if message count changed (summary is stale)', async () => {
+      // Create initial summary
+      sessionSummaries.create(sessionId, {
+        shortSummary: 'Old',
+        fullSummary: 'Outdated',
+        keyActions: [],
+        filesModified: [],
+        outcome: 'ongoing',
+        messageCount: 2,
+      });
+
+      // Add more messages after summary
+      messages.create(sessionId, 'user', 'First msg');
+      messages.create(sessionId, 'assistant', 'First response');
+      messages.create(sessionId, 'user', 'Second msg');
+      messages.create(sessionId, 'assistant', 'Second response');
+      messages.create(sessionId, 'user', 'Third msg');
+
+      vi.clearAllMocks();
+
+      // Now messageCount = 5, summary.messageCount = 2 (stale)
+      const result = await summaryService.generateSummary(sessionId);
+
+      expect(result).not.toBeNull();
+
+      // Should have broadcast generating status (indicating generation happened)
+      const generatingCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === 'session:summary_generating'
+      );
+      expect(generatingCalls.length).toBeGreaterThan(0);
+    });
+
+    it('forces regeneration even if current when force=true', async () => {
+      const messageCount = 3;
+
+      // Create current summary
+      sessionSummaries.create(sessionId, {
+        shortSummary: 'Current',
+        fullSummary: 'Up to date',
+        keyActions: [],
+        filesModified: [],
+        outcome: 'ongoing',
+        messageCount: messageCount,
+      });
+
+      // Create matching messages
+      for (let i = 0; i < messageCount; i++) {
+        messages.create(sessionId, i % 2 === 0 ? 'user' : 'assistant', `Msg ${i}`);
+      }
+
+      vi.clearAllMocks();
+
+      // Call with force = true
+      const result = await summaryService.generateSummary(sessionId, 0, true);
+
+      // Should regenerate despite being current
+      expect(result).not.toBeNull();
+
+      // Should have broadcast generating status
+      const generatingCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === 'session:summary_generating'
+      );
+      expect(generatingCalls.length).toBeGreaterThan(0);
+    });
+
+    it('onSessionComplete forces regeneration regardless of staleness', async () => {
+      // Create current summary
+      sessionSummaries.create(sessionId, {
+        shortSummary: 'Current',
+        fullSummary: 'Status: ongoing',
+        keyActions: [],
+        filesModified: [],
+        outcome: 'ongoing',
+        messageCount: 2,
+      });
+
+      // Create matching messages
+      messages.create(sessionId, 'user', 'Msg');
+      messages.create(sessionId, 'assistant', 'Response');
+
+      vi.clearAllMocks();
+
+      // Call onSessionComplete
+      summaryService.onSessionComplete(sessionId);
+
+      // Wait for async generation
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Should have broadcast generating status (indicating force was used)
+      const generatingCalls = broadcastToSession.mock.calls.filter(
+        (call) => call[1] === 'session:summary_generating'
+      );
+      expect(generatingCalls.length).toBeGreaterThan(0);
+    });
   });
 
   describe('getSummary', () => {


### PR DESCRIPTION
## Summary

- **Feature**: Add per-project configuration for summary generation debounce timing
- **Default behavior**: 5000ms (5 seconds) debounce on session activity
- **Minimum allowed**: 100ms
- **Benefits**: Projects can control summary generation frequency based on their needs

## Implementation Details

### Database Changes
- Added `summary_debounce_ms` column to projects table with 5000ms default
- Database migration handles existing projects automatically

### API Changes
- Extended project update endpoint to accept `summaryDebounceMs` parameter
- Added validation for minimum value (100ms)

### Service Logic
- Implemented staleness checking to avoid unnecessary regeneration
- Added skip logic for sessions with merged PRs
- Project-specific debounce delays replace global constant

### Testing
- Added comprehensive test coverage for new functionality
- Tests cover create, update, and edge cases

## Test Plan

- [x] Project creation uses 5000ms default debounce
- [x] Projects can be updated with custom debounce delays
- [x] API validation rejects values < 100ms
- [x] Summary generation respects project-specific debounce settings
- [x] Existing projects automatically get 5000ms default

🤖 Generated with [Claude Code](https://claude.com/claude-code)