### PR TITLE
Simplify Playwright config to run tests on Chrome only

### DIFF
--- a/playwright.config.docker.ts
+++ b/playwright.config.docker.ts
@@ -74,43 +74,6 @@ export default defineConfig({
                 ...devices['Desktop Chrome'],
             },
         },
-
-        {
-            name: 'firefox',
-            use: {
-                ...devices['Desktop Firefox'],
-            },
-        },
-
-        {
-            name: 'webkit',
-            use: {
-                ...devices['Desktop Safari'],
-            },
-        },
-
-        // Mobile viewports
-        {
-            name: 'mobile-chrome',
-            use: {
-                ...devices['Pixel 5'],
-            },
-        },
-
-        {
-            name: 'mobile-safari',
-            use: {
-                ...devices['iPhone 14'],
-            },
-        },
-
-        // Tablet viewport
-        {
-            name: 'tablet',
-            use: {
-                ...devices['iPad Pro 11'],
-            },
-        },
     ],
 
     // Web server configuration (if running app from container)


### PR DESCRIPTION
## Summary

- Removed Firefox, WebKit, and mobile device browser configurations from `playwright.config.docker.ts`
- Tests now run only against Chromium (Chrome) to significantly speed up the test suite
- Individual browser testing can still be performed via the `BROWSER` environment variable if needed

## Rationale

This streamlines the default test execution while maintaining the flexibility to test against other browsers when explicitly requested. For faster feedback during development, running tests only on Chrome is typically sufficient.

## Test plan

- [x] Run tests locally with `./scripts/pw.sh test` to verify Chrome tests still pass
- [x] Verify configuration uses only Chromium project
- [x] Confirm BROWSER environment variable can still override to other browsers if needed

🤖 Generated with Claude Code