### PR TITLE
Fix command button status indicators not showing on session list cards

### DIFF
--- a/packages/web/src/views/ActiveSessionsView.test.js
+++ b/packages/web/src/views/ActiveSessionsView.test.js
@@ -48,6 +48,11 @@ vi.mock('../stores/sessions.js', () => ({
   useSessionsStore: vi.fn(),
 }));
 
+// Mock command buttons store
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: vi.fn(),
+}));
+
 // Mock API
 const mockGetSessionSummary = vi.fn();
 vi.mock('../composables/useApi.js', () => ({
@@ -68,10 +73,12 @@ vi.mock('../components/SessionCard.vue', () => ({
 
 import ActiveSessionsView from './ActiveSessionsView.vue';
 import { useSessionsStore } from '../stores/sessions.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useGlobalSessionSubscription } from '../composables/useWebSocket.js';
 
 describe('ActiveSessionsView', () => {
   let mockSessionsStore;
+  let mockCommandButtonsStore;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -100,6 +107,18 @@ describe('ActiveSessionsView', () => {
       setStatusFilter: vi.fn(),
     };
     useSessionsStore.mockReturnValue(mockSessionsStore);
+
+    // Setup command buttons store mock
+    mockCommandButtonsStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn().mockResolvedValue(),
+      getButtonsByProjectId: vi.fn(() => []),
+      getLatestRunForButton: vi.fn(() => null),
+    };
+    useCommandButtonsStore.mockReturnValue(mockCommandButtonsStore);
   });
 
   afterEach(() => {
@@ -522,6 +541,8 @@ describe('Status filtering', () => {
 });
 
 describe('ActiveSessionsView polling fallback', () => {
+  let mockCommandButtonsStore;
+
   beforeEach(() => {
     vi.useFakeTimers();
 
@@ -531,11 +552,26 @@ describe('ActiveSessionsView polling fallback', () => {
       loading: false,
       error: null,
       statusFilter: null,
-      activeSessions: [{ id: 'session-1', status: 'running' }],
+      activeSessions: [
+        { id: 'session-1', status: 'running', projectId: 'project-1' },
+        { id: 'session-2', status: 'waiting', projectId: 'project-2' },
+      ],
       fetchActiveSessions: vi.fn().mockResolvedValue(),
       restoreStatusFilter: vi.fn(),
       setStatusFilter: vi.fn(),
     });
+
+    // Setup command buttons store mock
+    mockCommandButtonsStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn().mockResolvedValue(),
+      getButtonsByProjectId: vi.fn(() => []),
+      getLatestRunForButton: vi.fn(() => null),
+    };
+    useCommandButtonsStore.mockReturnValue(mockCommandButtonsStore);
 
     mockGetSessionSummary.mockResolvedValue(null);
   });
@@ -558,5 +594,29 @@ describe('ActiveSessionsView polling fallback', () => {
 
     // Should have called fetchActiveSessions again
     expect(sessionsStore.fetchActiveSessions).toHaveBeenCalledTimes(2);
+  });
+
+  describe('Command buttons loading for multiple projects', () => {
+    it('fetches command buttons for projects with active sessions on mount', async () => {
+      mockCommandButtonsStore.fetchButtons.mockClear();
+      mount(ActiveSessionsView);
+      await flushPromises();
+
+      // Should fetch buttons for both projects
+      expect(mockCommandButtonsStore.fetchButtons).toHaveBeenCalledWith('project-1');
+      expect(mockCommandButtonsStore.fetchButtons).toHaveBeenCalledWith('project-2');
+    });
+
+    it('handles errors when fetching buttons gracefully', async () => {
+      mockCommandButtonsStore.fetchButtons.mockRejectedValueOnce(new Error('API Error'));
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mount(ActiveSessionsView);
+      await flushPromises();
+
+      // Should not throw, just log the error
+      expect(mockCommandButtonsStore.fetchButtons).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/packages/web/src/views/ActiveSessionsView.vue
+++ b/packages/web/src/views/ActiveSessionsView.vue
@@ -54,16 +54,21 @@
 <script setup>
 import { onMounted, onUnmounted, reactive, watch, ref, computed } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useGlobalSessionSubscription } from '../composables/useWebSocket.js';
 import { api } from '../composables/useApi.js';
 import SessionCard from '../components/SessionCard.vue';
 
 const sessionsStore = useSessionsStore();
+const commandButtonsStore = useCommandButtonsStore();
 
 // Statuses that count as "idle" (not actively running)
 const IDLE_STATUSES = ['waiting', 'stopped', 'error'];
 // Statuses that count as "running" (actively processing or starting up)
 const RUNNING_STATUSES = ['running', 'starting'];
+
+// Track which projects we've already fetched buttons for
+const fetchedProjectIds = ref(new Set());
 
 const toggleFilter = (status) => {
   // If the clicked filter is already active, clear all filters (show all)
@@ -106,9 +111,33 @@ const cleanups = [];
 // Get global session subscription for real-time updates across all projects
 const { onSessionCreated, onSessionUpdated, onSessionDeleted, onSessionSummaryUpdated } = useGlobalSessionSubscription();
 
-onMounted(() => {
+/**
+ * Fetch buttons for projects that have active sessions
+ * Only fetches for projects we haven't already loaded
+ */
+async function ensureButtonsLoadedForSessions() {
+  const uniqueProjectIds = new Set(
+    sessionsStore.activeSessions
+      .map((s) => s.projectId)
+      .filter((id) => id && !fetchedProjectIds.value.has(id))
+  );
+
+  for (const projectId of uniqueProjectIds) {
+    try {
+      await commandButtonsStore.fetchButtons(projectId);
+      fetchedProjectIds.value.add(projectId);
+    } catch (error) {
+      console.error(`Failed to fetch buttons for project ${projectId}:`, error);
+    }
+  }
+}
+
+onMounted(async () => {
   sessionsStore.restoreStatusFilter();
-  sessionsStore.fetchActiveSessions();
+  await sessionsStore.fetchActiveSessions();
+
+  // Fetch buttons for projects with active sessions
+  await ensureButtonsLoadedForSessions();
 
   // Set up WebSocket listeners for real-time updates
   cleanups.push(
@@ -119,6 +148,11 @@ onMounted(() => {
         const exists = sessionsStore.activeSessions.some((s) => s.id === session.id);
         if (!exists) {
           sessionsStore.activeSessions.unshift(session);
+          // Fetch buttons for this project if we haven't already
+          if (session.projectId && !fetchedProjectIds.value.has(session.projectId)) {
+            commandButtonsStore.fetchButtons(session.projectId);
+            fetchedProjectIds.value.add(session.projectId);
+          }
         }
       }
     })
@@ -187,11 +221,13 @@ onUnmounted(() => {
   }
 });
 
-// Watch for sessions changes and fetch summaries
+// Watch for sessions changes and fetch summaries + command buttons
 watch(
   () => sessionsStore.activeSessions,
   () => {
     fetchSummaries();
+    // Also ensure buttons are loaded for any new projects
+    ensureButtonsLoadedForSessions();
   },
   { immediate: true }
 );

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -57,6 +57,10 @@ vi.mock('../stores/sessions.js', () => ({
   useSessionsStore: vi.fn(),
 }));
 
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: vi.fn(),
+}));
+
 // Mock API
 const mockGetSessionSummary = vi.fn();
 vi.mock('../composables/useApi.js', () => ({
@@ -94,6 +98,7 @@ vi.mock('../components/CommandButtonsPanel.vue', () => ({
 import SessionListView from './SessionListView.vue';
 import { useProjectsStore } from '../stores/projects.js';
 import { useSessionsStore } from '../stores/sessions.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useProjectSubscription } from '../composables/useWebSocket.js';
 
 // Helper to create a sessions store mock with proper groupedSessions getter
@@ -143,6 +148,7 @@ function createSessionsStoreMock(sessions = [], overrides = {}) {
 describe('SessionListView', () => {
   let mockProjectsStore;
   let mockSessionsStore;
+  let mockCommandButtonsStore;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -174,6 +180,18 @@ describe('SessionListView', () => {
       { id: 'session-2', name: 'Session 2', status: 'running' },
     ]);
     useSessionsStore.mockReturnValue(mockSessionsStore);
+
+    // Setup command buttons store mock - MUST be created fresh in each test
+    mockCommandButtonsStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn().mockResolvedValue(),
+      getButtonsByProjectId: vi.fn(() => []),
+      getLatestRunForButton: vi.fn(() => null),
+    };
+    useCommandButtonsStore.mockReturnValue(mockCommandButtonsStore);
   });
 
   afterEach(() => {
@@ -877,6 +895,7 @@ describe('SessionListView integration', () => {
 describe('SessionListView Archived Tab', () => {
   let mockSessionsStore;
   let mockProjectsStore;
+  let mockCommandButtonsStore;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -897,6 +916,18 @@ describe('SessionListView Archived Tab', () => {
       { id: 'session-2', name: 'Session 2', status: 'running' },
     ]);
     useSessionsStore.mockReturnValue(mockSessionsStore);
+
+    // Setup command buttons store mock
+    mockCommandButtonsStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn().mockResolvedValue(),
+      getButtonsByProjectId: vi.fn(() => []),
+      getLatestRunForButton: vi.fn(() => null),
+    };
+    useCommandButtonsStore.mockReturnValue(mockCommandButtonsStore);
 
     mockGetSessionSummary.mockResolvedValue(null);
   });
@@ -1038,5 +1069,25 @@ describe('SessionListView Archived Tab', () => {
 
     // Button should be hidden
     expect(wrapper.find('.btn-primary').exists()).toBe(false);
+  });
+
+  describe('Command buttons loading', () => {
+    it('fetches command buttons when component mounts', async () => {
+      mockCommandButtonsStore.fetchButtons.mockClear();
+      mount(SessionListView);
+      await flushPromises();
+
+      expect(mockCommandButtonsStore.fetchButtons).toHaveBeenCalledWith('test-project-id');
+    });
+
+    it('fetches buttons alongside session data on mount', async () => {
+      mockCommandButtonsStore.fetchButtons.mockClear();
+      mount(SessionListView);
+      await flushPromises();
+
+      // Verify both sessions and buttons are fetched
+      expect(mockSessionsStore.fetchSessions).toHaveBeenCalledWith('test-project-id');
+      expect(mockCommandButtonsStore.fetchButtons).toHaveBeenCalledWith('test-project-id');
+    });
   });
 });

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -153,6 +153,7 @@ import { ref, onMounted, onUnmounted, reactive, watch, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 import { useSessionsStore } from '../stores/sessions.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useProjectSubscription } from '../composables/useWebSocket.js';
 import { api } from '../composables/useApi.js';
 import SessionCard from '../components/SessionCard.vue';
@@ -163,6 +164,7 @@ const route = useRoute();
 const activeTab = ref('sessions');
 const projectsStore = useProjectsStore();
 const sessionsStore = useSessionsStore();
+const commandButtonsStore = useCommandButtonsStore();
 
 const toggleFilter = (status) => {
   // If the clicked filter is already active, clear all filters (show all)
@@ -234,6 +236,7 @@ watch(
     // Fetch new project data
     projectsStore.fetchProject(newProjectId);
     await sessionsStore.fetchSessions(newProjectId);
+    await commandButtonsStore.fetchButtons(newProjectId);
     fetchSummaries();
 
     // Create new subscription for new project


### PR DESCRIPTION
## Summary
Command button status indicators now display correctly on session list cards in both the project sessions view and active sessions view.

## Problem
The command button statuses were not showing up on session cards because the buttons were never being fetched when viewing the session lists. The buttons were only loaded when explicitly viewing the "Commands" tab, leaving the `commandButtonsStore` empty for session list views.

## Solution
- **SessionListView**: Fetch command buttons when the project changes
- **ActiveSessionsView**: Fetch command buttons for all projects with active sessions, with deduplication to avoid duplicate fetches
- **Real-time updates**: Handle new sessions arriving via WebSocket and fetch buttons for new projects

## Test Plan
- ✅ SessionListView tests: 46 tests PASSED
- ✅ ActiveSessionsView tests: 25 tests PASSED
- ✅ SessionCard component tests: 83 tests PASSED
- ✅ Full test suite: 1191 tests passed (68 skipped)

## Visual Changes
Session cards now display colored circular indicators showing command button statuses:
- 🟡 Running (yellow/amber, pulsing)
- 🟢 Success (green)
- 🔴 Error/Killed (red)

Clicking on indicators opens a modal with button details.

## Files Changed
- `packages/web/src/views/SessionListView.vue` - Added button fetching on project selection
- `packages/web/src/views/ActiveSessionsView.vue` - Added intelligent button loading for multi-project sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)