### PR TITLE
Fix textarea input lag on iPad by debouncing Vue reactivity

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -84,10 +84,11 @@
 
     <form v-if="canSendMessage" @submit.prevent="isDraft ? handleStart() : handleSend()" class="input-form">
       <textarea
-        v-model="input"
+        ref="textareaRef"
         class="form-input form-textarea"
         :placeholder="isDraft ? 'Edit your prompt...' : (isStopped ? 'Send a message to resume session...' : 'Send a follow-up message...')"
         rows="3"
+        @input="handleInput"
         @keydown="handleKeydown"
       ></textarea>
       <div class="input-controls">
@@ -138,7 +139,7 @@
               </span>
             </div>
           </div>
-          <button v-else type="submit" class="btn btn-primary btn-send" :disabled="!input.trim() || sending">
+          <button v-else type="submit" class="btn btn-primary btn-send" :disabled="isSendDisabled">
             <span v-if="sending" class="loading-spinner"></span>
             {{ sending ? 'Sending...' : 'Send' }}
           </button>
@@ -214,8 +215,11 @@ const sessionsStore = useSessionsStore();
 const uiStore = useUiStore();
 
 const input = ref('');
+const inputHasContent = ref(false); // Tracks if textarea has content (for button disabled state)
 const saveStatus = ref('saved'); // 'saved', 'saving', 'error', 'unsaved'
 const saveError = ref('');
+const textareaRef = ref(null);
+let inputSyncTimer = null;
 
 // Create keyboard shortcut handler
 const handleKeydown = useSubmitShortcut(() => {
@@ -267,6 +271,11 @@ const unassociatedWorkLogs = computed(() => {
   return sessionsStore.getUnassociatedWorkLogs;
 });
 
+// Computed for send button disabled state - avoids re-evaluating on every render
+const isSendDisabled = computed(() => {
+  return !inputHasContent.value || sending.value;
+});
+
 // Subscribe to partial messages for streaming, work logs, and conversation events
 const {
   onPartial,
@@ -305,6 +314,13 @@ onMounted(async () => {
     const userMessage = sessionsStore.messages.find(msg => msg.role === 'user');
     if (userMessage) {
       input.value = userMessage.content;
+      inputHasContent.value = userMessage.content.trim().length > 0;
+      // Set textarea value directly
+      nextTick(() => {
+        if (textareaRef.value) {
+          textareaRef.value.value = userMessage.content;
+        }
+      });
     }
   }
 
@@ -313,6 +329,13 @@ onMounted(async () => {
     const savedDraft = localStorage.getItem(STORAGE_KEY);
     if (savedDraft) {
       input.value = savedDraft;
+      inputHasContent.value = savedDraft.trim().length > 0;
+      // Set textarea value directly
+      nextTick(() => {
+        if (textareaRef.value) {
+          textareaRef.value.value = savedDraft;
+        }
+      });
     }
   }
 
@@ -394,6 +417,7 @@ onUnmounted(() => {
   if (unsubConvDeleted) unsubConvDeleted();
   if (debounceTimer) clearTimeout(debounceTimer);
   if (draftSaveTimer) clearTimeout(draftSaveTimer);
+  if (inputSyncTimer) clearTimeout(inputSyncTimer);
   if (messagesContainer.value) {
     messagesContainer.value.removeEventListener('scroll', handleScroll);
   }
@@ -403,28 +427,43 @@ onUnmounted(() => {
   sessionsStore.clearWorkLogs();
 });
 
-// Auto-save draft to database (for draft sessions) and localStorage with debounce
-watch(input, (newValue) => {
-  if (debounceTimer) clearTimeout(debounceTimer);
-  if (draftSaveTimer) clearTimeout(draftSaveTimer);
+// Handle textarea input with debounced sync to reactive state
+// This prevents Vue reactivity from firing on every keystroke
+function handleInput(event) {
+  const value = event.target.value;
+  const hasContent = value.trim().length > 0;
 
-  // Mark as unsaved immediately when user types
-  if (isDraft.value) {
+  // Only update the reactive flag if it changed (minimizes re-renders)
+  if (inputHasContent.value !== hasContent) {
+    inputHasContent.value = hasContent;
+  }
+
+  // Mark draft as unsaved immediately (but only if status changed)
+  if (isDraft.value && saveStatus.value !== 'unsaved' && saveStatus.value !== 'saving') {
     saveStatus.value = 'unsaved';
   }
 
-  debounceTimer = setTimeout(() => {
-    if (newValue.trim()) {
-      localStorage.setItem(STORAGE_KEY, newValue);
+  // Debounce the sync to reactive state and localStorage
+  if (inputSyncTimer) clearTimeout(inputSyncTimer);
+  if (debounceTimer) clearTimeout(debounceTimer);
+  if (draftSaveTimer) clearTimeout(draftSaveTimer);
+
+  inputSyncTimer = setTimeout(() => {
+    // Sync to reactive state (for handleSend/handleStart to access)
+    input.value = value;
+
+    // Save to localStorage
+    if (value.trim()) {
+      localStorage.setItem(STORAGE_KEY, value);
       // Auto-save draft to database
       if (isDraft.value) {
-        saveDraftPrompt(newValue);
+        saveDraftPrompt(value);
       }
     } else {
       localStorage.removeItem(STORAGE_KEY);
     }
-  }, 500);
-});
+  }, 150); // Short debounce for syncing, longer operations handled inside
+}
 
 function scrollToBottom(force = false) {
   nextTick(() => {
@@ -482,12 +521,16 @@ function getAttachmentIcon(mimeType) {
 }
 
 async function handleSend() {
-  if (!input.value.trim() || sending.value) return;
+  // Sync from textarea directly in case debounce timer hasn't fired
+  const currentValue = textareaRef.value?.value || input.value;
+  if (!currentValue.trim() || sending.value) return;
 
   sending.value = true;
   try {
-    await sessionsStore.sendMessage(props.sessionId, input.value, attachedFiles.value);
+    await sessionsStore.sendMessage(props.sessionId, currentValue, attachedFiles.value);
     input.value = '';
+    inputHasContent.value = false;
+    if (textareaRef.value) textareaRef.value.value = '';
     attachedFiles.value = [];
     fileAttachment.value?.clear();
     localStorage.removeItem(STORAGE_KEY);
@@ -547,12 +590,14 @@ async function saveDraftPrompt(prompt) {
 }
 
 async function handleStart() {
-  if (restarting.value || !input.value.trim()) return;
+  // Sync from textarea directly in case debounce timer hasn't fired
+  const currentValue = textareaRef.value?.value || input.value;
+  if (restarting.value || !currentValue.trim()) return;
 
   restarting.value = true;
   try {
     // Pass the current prompt to the start API
-    await api.startSession(props.sessionId, input.value);
+    await api.startSession(props.sessionId, currentValue);
     uiStore.success('Session started');
     // Clear localStorage draft on successful start
     localStorage.removeItem(STORAGE_KEY);

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -193,7 +193,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
@@ -264,24 +264,35 @@ const thinkingEnabled = ref(true);
 const quickGitMode = ref('worktree'); // '', 'branch', or 'worktree'
 const quickWorktreeBranch = ref('');
 const editingBranch = ref(false);
+let branchDebounceTimer = null;
 
-// Generate branch name from prompt
-const autoBranchName = computed(() => {
-  return generateWorktreeBranch('', prompt.value);
+// Store the branch name (debounced to avoid regenerating random ID on every keystroke)
+const autoBranchName = ref('');
+
+// Debounced function to update branch name from prompt
+function updateBranchNameFromPrompt(promptValue) {
+  if (branchDebounceTimer) clearTimeout(branchDebounceTimer);
+  branchDebounceTimer = setTimeout(() => {
+    autoBranchName.value = generateWorktreeBranch('', promptValue);
+    // Also update the input field if user hasn't manually edited it
+    if (!editingBranch.value) {
+      quickWorktreeBranch.value = autoBranchName.value;
+    }
+  }, 300);
+}
+
+// Watch prompt changes with debouncing for branch name generation
+watch(prompt, (newPrompt) => {
+  updateBranchNameFromPrompt(newPrompt);
 });
 
-// Update quick worktree branch when auto-generated name changes
-watch(autoBranchName, (newBranch) => {
-  if (!editingBranch.value) {
-    quickWorktreeBranch.value = newBranch;
-  }
-});
-
-// Initialize quick worktree branch
+// Initialize quick worktree branch when git status loads
 watch(
   () => gitStatus.value,
   (status) => {
-    if (status?.isGitRepo) {
+    if (status?.isGitRepo && !autoBranchName.value) {
+      // Generate initial branch name
+      autoBranchName.value = generateWorktreeBranch('', prompt.value);
       quickWorktreeBranch.value = autoBranchName.value;
     }
   },
@@ -311,6 +322,11 @@ watch(quickGitMode, () => {
 
 watch(quickWorktreeBranch, () => {
   usingDefaults.value.quickWorktreeBranch = false;
+});
+
+// Cleanup debounce timer on unmount
+onUnmounted(() => {
+  if (branchDebounceTimer) clearTimeout(branchDebounceTimer);
 });
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary

- **ConversationTab.vue**: Replace `v-model` with `@input` handler that debounces syncing to reactive state (150ms). Only update the send button's disabled state when content presence actually changes.
- **NewSessionView.vue**: Debounce branch name generation (300ms) to avoid regenerating random IDs on every keystroke.

## Problem

The textarea input was laggy on iPad because Vue's reactivity fired on every keystroke, causing expensive re-renders. This is especially noticeable on iPad which has less CPU power than desktop browsers.

Key issues fixed:
1. `v-model` triggers Vue reactivity on every keystroke
2. `saveStatus.value = 'unsaved'` fired immediately on every keystroke for draft sessions
3. `:disabled="!input.trim() || sending"` evaluated on every render
4. `generateWorktreeBranch()` generated new random IDs on every keystroke (in NewSessionView)

## Test plan

- [ ] Type in the ConversationTab textarea on iPad - should feel smooth
- [ ] Type in the NewSessionView prompt textarea on iPad - should feel smooth
- [ ] Verify sending messages still works correctly
- [ ] Verify draft auto-save still works
- [ ] Verify branch name still auto-generates from prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)