### PR TITLE
Fix command button output not displaying in real-time

### DIFF
--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -40,7 +40,16 @@ export class CommandRunner {
           }
         }
 
-        const child = spawn('sh', ['-c', command], {
+        // Wrap command with 'script' to allocate a pseudo-TTY
+        // This ensures line-buffered output like a normal terminal, so output
+        // streams in real-time instead of being block-buffered
+        // -q = quiet mode (no header/footer messages)
+        // -e = return exit code of the child process (Linux)
+        // -c = run command
+        // /dev/null = don't save to file
+        const wrappedCommand = `script -q -e -c ${JSON.stringify(command)} /dev/null`;
+
+        const child = spawn('sh', ['-c', wrappedCommand], {
           cwd: workingDirectory,
           stdio: ['pipe', 'pipe', 'pipe'],
           detached: true, // Create a new process group for proper signal handling


### PR DESCRIPTION
## Summary
- Fixes command button output not appearing when running commands from the UI
- Output now streams in real-time like a normal shell instead of being buffered
- Commands run through command buttons behave identically to shell execution

## Problem
When running `scripts/pw.sh test` (or any script) from a command button, no output was displayed. This happened because:
- The command runner uses `spawn()` with `stdio: 'pipe'` (no TTY)
- Without a TTY, Docker and other programs use **block buffering** instead of line buffering
- Output is held until the buffer fills (typically 4KB) or the process exits

## Solution
Wrapped all commands with `script -q -e -c <command> /dev/null` which:
- Allocates a pseudo-TTY to force line-buffered output
- Streams output in real-time just like in a normal terminal
- Preserves exit codes with the `-e` flag for proper error detection
- Works universally with any script or command (no user changes needed)

## Testing
- All 1411 existing server tests pass
- All 29 commandRunner tests pass
- Verified exit codes are properly preserved
- Tested with various Docker commands

## Technical Details
The `script` command is a standard Unix utility that:
- Creates a pseudo-TTY session for the specified command
- Makes programs behave as if they're connected to a real terminal
- Properly propagates exit codes with the `-e` flag (Linux)
- Is universally available on Unix-like systems

This approach is standard practice for ensuring real-time output streaming in non-interactive environments.