### PR TITLE
Fix: Show 'Compare to main' toggle when there are no local changes

### DIFF
--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -216,12 +216,15 @@ describe('ChangesTab', () => {
 
   it('displays empty state when no changes', async () => {
     api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+    api.getSessionDefaultBranch.mockResolvedValue({ branch: null });
 
     const wrapper = mountComponent();
 
     await flushAll(wrapper);
 
-    expect(wrapper.text()).toContain('No git changes to show');
+    // Toolbar should NOT show when there are no changes and no defaultBranch
+    expect(wrapper.find('.changes-toolbar').exists()).toBe(false);
+    expect(wrapper.text()).toContain('No local git changes to show');
   });
 
   it('displays untracked files when present', async () => {
@@ -295,12 +298,13 @@ describe('ChangesTab', () => {
 
   it('handles null staged/unstaged values', async () => {
     api.getSessionChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+    api.getSessionDefaultBranch.mockResolvedValue({ branch: null });
 
     const wrapper = mountComponent();
 
     await flushAll(wrapper);
 
-    expect(wrapper.text()).toContain('No git changes to show');
+    expect(wrapper.text()).toContain('No local git changes to show');
   });
 
   describe('branch comparison feature', () => {
@@ -461,6 +465,74 @@ describe('ChangesTab', () => {
       await nextTick();
 
       expect(wrapper.vm.branchLabel).toBe('master');
+    });
+
+    it('shows toolbar with compare button when no local changes but defaultBranch exists', async () => {
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // Toolbar should show when there's a defaultBranch, even without local changes
+      const toolbar = wrapper.find('.changes-toolbar');
+      expect(toolbar.exists()).toBe(true);
+
+      // Should have both mode toggle buttons
+      const buttons = toolbar.findAll('button');
+      expect(buttons.length).toBeGreaterThanOrEqual(2);
+      expect(toolbar.text()).toContain('Local Changes');
+      expect(toolbar.text()).toContain('Compare to main');
+
+      // Should NOT show the Expand/Collapse button when there are no changes
+      expect(toolbar.text()).not.toContain('Expand All');
+      expect(toolbar.text()).not.toContain('Collapse All');
+    });
+
+    it('allows switching to branch compare mode when no local changes', async () => {
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // Clear the mock to track the new call
+      api.getSessionChanges.mockClear();
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+
+      // Click the "Compare to main" button
+      const compareButton = wrapper.findAll('.toggle-button')[1];
+      await compareButton.trigger('click');
+      await flushAll(wrapper);
+
+      // Should have called API with 'branch' compare mode
+      expect(api.getSessionChanges).toHaveBeenCalledWith('test-session', 'branch', 'origin/main');
+      expect(wrapper.vm.compareMode).toBe('branch');
+    });
+
+    it('displays mode-aware empty state message', async () => {
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // Start in local mode
+      expect(wrapper.vm.compareMode).toBe('local');
+      expect(wrapper.text()).toContain('No local git changes to show');
+
+      // Clear the mock and switch to branch mode
+      api.getSessionChanges.mockClear();
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+
+      wrapper.vm.compareMode = 'branch';
+      await flushAll(wrapper);
+
+      // Empty message should change for branch mode
+      expect(wrapper.text()).toContain('No differences from main');
     });
   });
 

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -9,12 +9,9 @@
       {{ error }}
     </div>
 
-    <div v-else-if="!hasChanges" class="empty-state">
-      <p>No git changes to show.</p>
-    </div>
-
     <template v-else>
-      <div class="changes-toolbar">
+      <!-- Toolbar: Show when there are changes OR a default branch exists -->
+      <div v-if="hasChanges || defaultBranch" class="changes-toolbar">
         <div class="mode-toggle">
           <button
             class="toggle-button"
@@ -37,11 +34,18 @@
             Compare to {{ branchLabel }}
           </button>
         </div>
-        <button class="btn-link" @click="toggleAllFiles" :disabled="loading">
+        <button v-if="hasChanges" class="btn-link" @click="toggleAllFiles" :disabled="loading">
           {{ allExpanded ? 'Collapse All' : 'Expand All' }}
         </button>
       </div>
 
+      <!-- Empty state: Show when no changes in current mode -->
+      <div v-if="!hasChanges" class="empty-state">
+        <p v-if="compareMode === 'local'">No local git changes to show.</p>
+        <p v-else>No differences from {{ branchLabel }}.</p>
+      </div>
+
+      <!-- Diff sections: Only show when there are files -->
       <div v-if="stagedFiles.length > 0" class="diff-section">
         <h3>Staged Changes</h3>
         <DiffViewer ref="stagedDiffViewer" :files="stagedFiles" />


### PR DESCRIPTION
## Summary

This PR fixes an issue where the "Compare to main branch" toggle in the Changes tab was only visible when there were local changes. Users can now access branch comparison mode even without uncommitted modifications.

## Changes

### Template Restructuring (`ChangesTab.vue`)
- Moved the toolbar outside the exclusive `v-else` block
- Changed visibility condition to: `v-if="hasChanges || defaultBranch"`
- Made "Expand All/Collapse All" button only appear when there are actual changes to expand
- The toolbar now shows in two scenarios:
  1. When there are local changes (staged, unstaged, or untracked files)
  2. When a default branch is available for comparison

### Mode-Aware Empty State
- Empty state message now changes based on the selected compare mode:
  - **Local mode**: "No local git changes to show."
  - **Branch mode**: "No differences from {branch}."
- This provides clearer context to users about what they're viewing

### Test Coverage
- Updated existing test "displays empty state when no changes" 
- Added 3 new comprehensive tests:
  1. "shows toolbar with compare button when no local changes but defaultBranch exists"
  2. "allows switching to branch compare mode when no local changes"
  3. "displays mode-aware empty state message"

## Test Plan

✅ All tests pass:
- 25 ChangesTab component tests
- 1340 web package tests  
- 1411 server package tests
- **Total: 2751+ tests passing**

## User Impact

**Before**: Users with no local changes could not see the toolbar to switch to branch comparison mode, limiting their ability to compare branches without having uncommitted modifications.

**After**: Users can always access the "Compare to main branch" feature when a default branch is available, improving the workflow for comparing branches.

## Files Changed
- `packages/web/src/components/ChangesTab.vue` - Template restructuring
- `packages/web/src/components/ChangesTab.test.js` - Test updates and new test cases