### PR TITLE
fix: Ensure draft session prompt updates UI immediately on start

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -639,8 +639,9 @@ async function handleStart() {
 
   restarting.value = true;
   try {
-    // Pass the current prompt to the start API
-    await api.startSession(props.sessionId, currentValue);
+    // Pass the current prompt to the start method via the store
+    // This ensures the UI updates immediately via Vue reactivity
+    await sessionsStore.startSession(props.sessionId, currentValue);
     uiStore.success('Session started');
     // Clear localStorage draft on successful start
     localStorage.removeItem(STORAGE_KEY);

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -304,10 +304,10 @@ export const useSessionsStore = defineStore('sessions', {
       }
     },
 
-    async startSession(id) {
+    async startSession(id, prompt = undefined) {
       this.error = null;
       try {
-        const result = await api.startSession(id);
+        const result = await api.startSession(id, prompt);
         // Update session status to starting
         if (this.currentSession?.id === id) {
           this.currentSession.status = 'starting';


### PR DESCRIPTION
## Summary
- Fixed draft session UI to update immediately when starting a session with a prompt
- Changed to pass prompt through the store's `startSession` method instead of the API directly
- Ensures Vue reactivity immediately reflects the session status change
- Clears localStorage draft on successful session start

## Test Plan
- [ ] Create a new draft session with a prompt
- [ ] Click "Start" to begin the session
- [ ] Verify the UI updates immediately to show "starting" status
- [ ] Verify localStorage draft is cleared after successful start
- [ ] Verify the prompt was passed to the session correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)