### PR TITLE
fix: Show file count in Changes tab indicator on initial load

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -124,6 +124,7 @@ import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription, ensureSubscribed } from '../composables/useWebSocket.js';
 import { useModelInfo } from '../composables/useModelInfo.js';
 import { api } from '../composables/useApi.js';
+import { parseDiff } from '../utils/diffParser.js';
 import ConversationTab from '../components/ConversationTab.vue';
 import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
@@ -185,6 +186,11 @@ async function checkForChanges() {
   try {
     const changes = await api.getSessionChanges(sessionId);
     hasChanges.value = !!(changes.staged || changes.unstaged || changes.untracked);
+    // Count files from the diff responses so the tab shows the count immediately
+    const stagedFiles = parseDiff(changes.staged || '');
+    const unstagedFiles = parseDiff(changes.unstaged || '');
+    const untrackedFiles = parseDiff(changes.untracked || '');
+    changesFileCount.value = stagedFiles.length + unstagedFiles.length + untrackedFiles.length;
   } catch (error) {
     // Silently fail - changes indicator is not critical
     console.error('Failed to check for changes:', error);


### PR DESCRIPTION
## Summary
- The Changes tab was showing the orange dot indicator when changes existed, but the file count (e.g., "Changes (3)") only appeared after visiting the tab
- Updated `checkForChanges()` to also parse diff responses using `parseDiff` and count files
- Now `changesFileCount` is populated on initial load alongside `hasChanges`

## Test plan
- [ ] Open a session that has uncommitted git changes
- [ ] Verify the Changes tab shows both the orange indicator AND the file count (e.g., "Changes (3)") without visiting the tab first
- [ ] Verify visiting the Changes tab still works correctly
- [ ] Verify the count updates when Claude makes changes and returns to waiting status

🤖 Generated with [Claude Code](https://claude.com/claude-code)