### PR TITLE
fix: Improve command button output performance with throttling and line limits

### DIFF
--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -51,6 +51,10 @@
 
       <!-- Output Content (when expanded) -->
       <div v-if="showOutput" class="output-content">
+        <!-- Truncation warning -->
+        <div v-if="run.outputTruncated" class="output-truncated-warning">
+          ⚠️ Output truncated (showing last 2000 lines)
+        </div>
         <div
           class="output-text"
           @scroll="onScroll"
@@ -486,6 +490,16 @@ defineExpose({
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: 4px;
+}
+
+.output-truncated-warning {
+  background-color: rgba(251, 191, 36, 0.15);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  color: var(--color-warning, #fbbf24);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
 }
 
 .output-text {

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -1,12 +1,19 @@
 import { defineStore } from 'pinia';
 import { api } from '../composables/useApi.js';
 
+// Performance: Limit output to prevent memory bloat and UI slowdown
+const MAX_OUTPUT_LINES = 2000;
+const OUTPUT_FLUSH_INTERVAL_MS = 100;
+
 export const useCommandButtonsStore = defineStore('commandButtons', {
   state: () => ({
     buttons: [],
-    runs: {}, // runId -> { runId, buttonId, status, output, exitCode }
+    runs: {}, // runId -> { runId, buttonId, status, output, exitCode, outputTruncated }
     loading: false,
     error: null,
+    // Internal buffering state (not reactive to avoid extra renders)
+    _outputBuffers: {}, // runId -> pending output string
+    _flushTimers: {}, // runId -> setTimeout id
   }),
 
   getters: {
@@ -93,6 +100,7 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
           output: response.output || '',
           exitCode: null,
           startedAt: Date.now(),
+          outputTruncated: false,
         };
 
         return runId;
@@ -118,15 +126,17 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
         const runs = await api.getActiveRuns(sessionId);
         // Restore runs to state (both running and recently completed)
         for (const run of runs) {
+          const { output, truncated } = this._truncateOutput(run.output || '');
           this.runs[run.runId] = {
             runId: run.runId,
             buttonId: run.buttonId,
             sessionId: sessionId,
             status: run.status || 'running',
-            output: run.output || '',
+            output,
             exitCode: run.exitCode !== undefined ? run.exitCode : null,
             startedAt: run.startedAt,
             completedAt: run.completedAt,
+            outputTruncated: truncated,
           };
         }
         return runs;
@@ -137,32 +147,104 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
-    // Handle WebSocket messages
-    appendOutput(runId, text) {
-      if (this.runs[runId]) {
-        // Use $patch to ensure reactivity
-        this.$patch({
-          runs: {
-            [runId]: {
-              ...this.runs[runId],
-              output: this.runs[runId].output + text,
-            },
+    /**
+     * Truncate output to MAX_OUTPUT_LINES, keeping only the most recent lines.
+     * Returns { output: string, truncated: boolean }
+     */
+    _truncateOutput(text) {
+      const lines = text.split('\n');
+      if (lines.length <= MAX_OUTPUT_LINES) {
+        return { output: text, truncated: false };
+      }
+      // Keep only the last MAX_OUTPUT_LINES
+      const truncatedLines = lines.slice(-MAX_OUTPUT_LINES);
+      return { output: truncatedLines.join('\n'), truncated: true };
+    },
+
+    /**
+     * Flush buffered output to the run state.
+     * Called on a timer to batch updates and reduce reactivity overhead.
+     */
+    _flushOutput(runId) {
+      const buffer = this._outputBuffers[runId];
+      if (!buffer || !this.runs[runId]) {
+        delete this._outputBuffers[runId];
+        delete this._flushTimers[runId];
+        return;
+      }
+
+      // Combine existing output with buffer
+      const combined = this.runs[runId].output + buffer;
+      const { output, truncated } = this._truncateOutput(combined);
+
+      // Update state in one batch
+      this.$patch({
+        runs: {
+          [runId]: {
+            ...this.runs[runId],
+            output,
+            outputTruncated: this.runs[runId].outputTruncated || truncated,
           },
-        });
+        },
+      });
+
+      // Clear the buffer
+      delete this._outputBuffers[runId];
+      delete this._flushTimers[runId];
+    },
+
+    /**
+     * Handle WebSocket output messages with throttling.
+     * Buffers output and flushes every OUTPUT_FLUSH_INTERVAL_MS to prevent
+     * excessive re-renders when output is streaming rapidly.
+     */
+    appendOutput(runId, text) {
+      if (!this.runs[runId]) {
+        return;
+      }
+
+      // Append to buffer
+      this._outputBuffers[runId] = (this._outputBuffers[runId] || '') + text;
+
+      // Schedule flush if not already scheduled
+      if (!this._flushTimers[runId]) {
+        this._flushTimers[runId] = setTimeout(() => {
+          this._flushOutput(runId);
+        }, OUTPUT_FLUSH_INTERVAL_MS);
+      }
+    },
+
+    /**
+     * Force flush any pending output immediately.
+     * Called before completing a run to ensure all output is displayed.
+     */
+    flushPendingOutput(runId) {
+      if (this._flushTimers[runId]) {
+        clearTimeout(this._flushTimers[runId]);
+        delete this._flushTimers[runId];
+      }
+      if (this._outputBuffers[runId]) {
+        this._flushOutput(runId);
       }
     },
 
     completeRun(runId, exitCode, output) {
       if (this.runs[runId]) {
-        // Use $patch to ensure reactivity
+        // Flush any pending buffered output first
+        this.flushPendingOutput(runId);
+
         // FIX: Only replace output if server has a more complete version
         // (longer output), otherwise keep the output we accumulated via
         // appendOutput calls. This prevents race conditions where the
         // completion message arrives before all streaming chunks.
-        const newOutput =
-          output && output.length > this.runs[runId].output.length
-            ? output
-            : this.runs[runId].output;
+        let newOutput = this.runs[runId].output;
+        let truncated = this.runs[runId].outputTruncated;
+
+        if (output && output.length > this.runs[runId].output.length) {
+          const result = this._truncateOutput(output);
+          newOutput = result.output;
+          truncated = result.truncated;
+        }
 
         this.$patch({
           runs: {
@@ -171,6 +253,7 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
               exitCode: exitCode,
               completedAt: Date.now(),
               output: newOutput,
+              outputTruncated: truncated,
               status: exitCode === 0 ? 'success' : 'error',
             },
           },
@@ -180,13 +263,19 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
 
     errorRun(runId, message) {
       if (this.runs[runId]) {
-        // Use $patch to ensure reactivity
+        // Flush any pending buffered output first
+        this.flushPendingOutput(runId);
+
+        const combined = this.runs[runId].output + `\n[Error] ${message}`;
+        const { output, truncated } = this._truncateOutput(combined);
+
         this.$patch({
           runs: {
             [runId]: {
               ...this.runs[runId],
               status: 'error',
-              output: this.runs[runId].output + `\n[Error] ${message}`,
+              output,
+              outputTruncated: this.runs[runId].outputTruncated || truncated,
             },
           },
         });
@@ -194,10 +283,22 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
     },
 
     clearRun(runId) {
+      // Clean up any pending timers/buffers
+      if (this._flushTimers[runId]) {
+        clearTimeout(this._flushTimers[runId]);
+        delete this._flushTimers[runId];
+      }
+      delete this._outputBuffers[runId];
       delete this.runs[runId];
     },
 
     clearAllRuns() {
+      // Clean up all pending timers
+      for (const runId of Object.keys(this._flushTimers)) {
+        clearTimeout(this._flushTimers[runId]);
+      }
+      this._flushTimers = {};
+      this._outputBuffers = {};
       this.runs = {};
     },
   },

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -332,6 +332,7 @@ describe('CommandButtons Store', () => {
 
       // WebSocket messages will use the same ID, so appendOutput should work
       store.appendOutput('server-generated-id', '\nmore output');
+      store.flushPendingOutput('server-generated-id'); // Flush throttled output
       expect(store.runs['server-generated-id'].output).toBe('initial output\nmore output');
     });
   });
@@ -350,18 +351,20 @@ describe('CommandButtons Store', () => {
             status: 'running',
             output: 'Initial ',
             exitCode: null,
+            outputTruncated: false,
           },
         };
 
         // Track if $patch was called
         const patchSpy = vi.spyOn(store, '$patch');
 
-        // Append output
+        // Append output (throttled - buffers until flush)
         store.appendOutput(runId, 'Hello ');
         store.appendOutput(runId, 'World');
+        store.flushPendingOutput(runId); // Flush to trigger $patch
 
-        // Verify $patch was called for each append
-        expect(patchSpy).toHaveBeenCalledTimes(2);
+        // Verify $patch was called once for the batched flush
+        expect(patchSpy).toHaveBeenCalledTimes(1);
 
         // Verify output was appended correctly
         expect(store.runs[runId].output).toBe('Initial Hello World');
@@ -445,10 +448,11 @@ describe('CommandButtons Store', () => {
     it('appendOutput adds text to existing run', () => {
       const store = useCommandButtonsStore();
       store.runs = {
-        'run-1': { runId: 'run-1', output: 'Hello ' },
+        'run-1': { runId: 'run-1', output: 'Hello ', outputTruncated: false },
       };
 
       store.appendOutput('run-1', 'World');
+      store.flushPendingOutput('run-1'); // Flush throttled output
 
       expect(store.runs['run-1'].output).toBe('Hello World');
     });


### PR DESCRIPTION
## Summary

- **Throttled output batching**: Buffer WebSocket output chunks and flush every 100ms instead of updating Vue state on every chunk. This reduces reactivity overhead from hundreds of updates per second to ~10.
- **Output line limits**: Cap output at 2000 lines, trimming oldest lines when exceeded. Prevents memory bloat and DOM slowdown with large outputs.
- **Truncation warning UI**: Shows warning banner when output is truncated so users know they're seeing partial output.

## Problem

The command button output tab had two issues:
1. Output stops showing after a while (memory exhaustion from unbounded output)
2. UI becomes sluggish during streaming (excessive Vue reactivity from per-chunk updates)

## Test plan

- [x] Unit tests pass (50 tests in commandButtons.test.js)
- [x] Full test suite passes (1340+ web tests, 1417+ server tests)
- [ ] Manual test: Run a command that generates rapid output (e.g., `seq 1 10000`) and verify UI stays responsive
- [ ] Manual test: Run a command that generates >2000 lines and verify truncation warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)