### PR TITLE
fix: Show Quick Responses panel even when empty

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -85,7 +85,7 @@
     <!-- Quick Responses Panel - shows above the input when not running -->
     <QuickResponsesPanel
       v-if="canSendMessage && !isDraft"
-      :show-empty="false"
+      :show-empty="true"
       @insert="handleQuickResponseInsert"
       @openSettings="quickResponseSettingsOpen = true"
     />

--- a/packages/web/src/components/QuickResponsesPanel.test.js
+++ b/packages/web/src/components/QuickResponsesPanel.test.js
@@ -90,4 +90,40 @@ describe('QuickResponsesPanel', () => {
       expect(mockStore.hasResponses).toBe(true);
     });
   });
+
+  describe('visibility', () => {
+    it('shows panel when showEmpty is true even with no responses', () => {
+      mockStore.hasResponses = false;
+      const wrapper = mountComponent({ showEmpty: true });
+      expect(wrapper.find('.quick-responses-panel').exists()).toBe(true);
+    });
+
+    it('hides panel when showEmpty is false and no responses', () => {
+      mockStore.hasResponses = false;
+      const wrapper = mountComponent({ showEmpty: false });
+      expect(wrapper.find('.quick-responses-panel').exists()).toBe(false);
+    });
+
+    it('shows panel when there are responses regardless of showEmpty', () => {
+      mockStore.hasResponses = true;
+      mockStore.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      const wrapper = mountComponent({ showEmpty: false });
+      expect(wrapper.find('.quick-responses-panel').exists()).toBe(true);
+    });
+
+    it('shows empty state message when no responses', () => {
+      mockStore.hasResponses = false;
+      const wrapper = mountComponent({ showEmpty: true });
+      expect(wrapper.find('.empty-state').exists()).toBe(true);
+      expect(wrapper.find('.empty-text').text()).toBe('No quick responses yet');
+    });
+
+    it('shows add button in empty state', () => {
+      mockStore.hasResponses = false;
+      const wrapper = mountComponent({ showEmpty: true });
+      const addButton = wrapper.find('.add-button');
+      expect(addButton.exists()).toBe(true);
+      expect(addButton.text()).toBe('+ Add Quick Response');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixed bug where Quick Responses panel was hidden when no quick responses existed
- Changed `show-empty` prop from `false` to `true` in ConversationTab
- Users can now discover and configure quick responses via the empty state UI

## Test plan
- [x] Added visibility tests to QuickResponsesPanel.test.js
- [ ] Verify panel shows with "No quick responses yet" message in empty state
- [ ] Verify "+ Add Quick Response" button opens settings dialog
- [ ] Verify panel still shows correctly when quick responses exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)