### PR TITLE
fix: Allow file names to wrap in Changes tab on small screens

### DIFF
--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -280,10 +280,9 @@ function getLinePrefix(type) {
 
 .diff-file-path {
   flex: 1;
+  min-width: 0;
   color: var(--color-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
 }
 
 .diff-file-stats {


### PR DESCRIPTION
## Summary
- Remove truncation styles (`white-space: nowrap`, `text-overflow: ellipsis`, `overflow: hidden`) from file path display in Changes tab
- Add `word-break: break-word` and `min-width: 0` so long file paths wrap naturally on narrow screens
- Improves usability on mobile and small screen devices

## Test plan
- [ ] View Changes tab with files that have long paths
- [ ] Resize browser to narrow width
- [ ] Verify file names wrap instead of being truncated
- [ ] Confirm copy button and stats remain accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)