### PR TITLE
fix: Update Changes tab indicator in real-time during active sessions

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -208,6 +208,8 @@ function startPolling() {
       await sessionsStore.fetchSession(sessionId, false);
       await sessionsStore.fetchMessages(sessionId, false);
       await sessionsStore.fetchWorkLogs(sessionId);
+      // Check for file changes during active session so the Changes tab indicator updates
+      checkForChanges();
     } else {
       // Session no longer actively processing, stop polling
       stopPolling();


### PR DESCRIPTION
## Summary
- Add `checkForChanges()` to the existing polling loop in `SessionDetailView.vue`
- The Changes tab indicator (orange dot + file count) now updates every 2 seconds while Claude is actively processing
- Fixes issue where changes made by Claude didn't show in the indicator until manually navigating to the Changes tab

## Test plan
- [ ] Start a session that creates or modifies files
- [ ] While Claude is working, observe the Changes tab indicator from the Conversation tab
- [ ] Verify the indicator updates within ~2 seconds of file changes
- [ ] Verify no performance regression (polling already exists, this just adds a git diff call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)