### PR TITLE
fix: Await canvas fetch to ensure tab indicator shows correct count

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -353,7 +353,9 @@ onMounted(async () => {
   // (Issue: conversations were only loaded when ConversationTab became visible)
   await sessionsStore.fetchConversations(sessionId);
   await sessionsStore.fetchWorkLogs(sessionId);
-  canvasStore.fetchItems(sessionId);
+  // Await canvas fetch to ensure indicator shows correct count immediately.
+  // This catches items added before/during WebSocket subscription establishment.
+  await canvasStore.fetchItems(sessionId);
   todosStore.fetchTodos(sessionId);
 
   // Fetch summary for PR indicators (don't await, not critical)


### PR DESCRIPTION
## Summary

- Fix canvas tab indicator not updating when Claude adds items to the canvas via the API
- Await the initial canvas fetch to ensure indicator captures all items before/during WebSocket subscription establishment

## Problem

When Claude added items to the canvas via `POST /api/sessions/:id/canvas`, the canvas tab indicator in SessionDetailView didn't update until the user navigated to the Canvas tab.

Root cause: A race condition where items could be added before the WebSocket subscription was fully established on the server. The subscription message was sent but not yet processed when the broadcast occurred.

## Solution

Await the initial `canvasStore.fetchItems()` call in SessionDetailView's `onMounted`. This ensures the indicator shows the correct count immediately, capturing items added before/during subscription establishment.

## Test plan

- [ ] Open a session in the browser
- [ ] Have Claude add an item to the canvas via the API
- [ ] Verify the canvas tab indicator updates without navigating to the Canvas tab
- [ ] Verify all existing tests pass (`yarn workspace @claudetools/web test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)