### PR TITLE
fix: Model selector visual update delay on click

### DIFF
--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -72,6 +72,12 @@ async function handleModelChange(id) {
   // Immediate visual feedback - update UI right away
   selectedModel.value = id;
 
+  // Force browser repaint by blurring the clicked button
+  // This ensures the 'active' class style change is rendered immediately
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur();
+  }
+
   if (props.sessionId) {
     // Session context: update store asynchronously
     togglingModel.value = true;


### PR DESCRIPTION
## Summary

- Fixes model selector buttons not showing selected state (blue background) immediately on click
- Issue was caused by browser repaint optimization batching DOM class changes with focus event handling
- Solution: Blur the clicked button after updating selection to force immediate browser repaint

## Test plan

- [ ] Navigate to New Session view
- [ ] Click different model buttons (Haiku, Sonnet, Opus)
- [ ] Verify background immediately fills with blue on click
- [ ] Navigate to Session Details view with a session
- [ ] Click different model buttons in the model row
- [ ] Verify immediate visual feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)