### PR TITLE
Remove draft status message and show quick responses for draft sessions

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -72,11 +72,6 @@
     <!-- Todo drawer - only shows when todos exist -->
     <TodoDrawer />
 
-    <div v-if="isDraft" class="status-message status-draft">
-      <span class="draft-icon">📝</span>
-      This session is a draft. Edit your prompt and click "Start Session" to begin.
-    </div>
-
     <div v-if="isStopped && !isDraft" class="status-message status-stopped">
       <span class="stopped-icon">⏸</span>
       Session stopped - send a message to resume
@@ -84,7 +79,7 @@
 
     <!-- Quick Responses Panel - shows above the input when not running -->
     <QuickResponsesPanel
-      v-if="canSendMessage && !isDraft"
+      v-if="canSendMessage"
       :show-empty="true"
       @insert="handleQuickResponseInsert"
       @openSettings="quickResponseSettingsOpen = true"
@@ -1137,17 +1132,6 @@ async function handleTemplateChange(templateId) {
 }
 
 .stopped-icon {
-  font-size: 1rem;
-}
-
-.status-draft {
-  color: var(--color-info, #3b82f6);
-  background-color: rgba(59, 130, 246, 0.1);
-  border-radius: var(--border-radius);
-  margin-bottom: 0.5rem;
-}
-
-.draft-icon {
   font-size: 1rem;
 }
 

--- a/tests/e2e/draft-sessions.spec.ts
+++ b/tests/e2e/draft-sessions.spec.ts
@@ -35,10 +35,6 @@ test.describe('Draft Session Editing', () => {
     await page.goto(`/sessions/${session.id}`);
     await page.waitForLoadState('networkidle');
 
-    // Should show draft status
-    const draftBadge = page.locator('text=This session is a draft');
-    await expect(draftBadge).toBeVisible();
-
     // Should show "Edit your prompt..." placeholder
     const input = page.locator('textarea[placeholder*="Edit your prompt"]');
     await expect(input).toBeVisible();
@@ -272,10 +268,6 @@ test.describe('Draft Session Editing', () => {
     await page.goto(`/sessions/${session.id}`);
     await page.waitForLoadState('networkidle');
 
-    // Should show draft UI initially
-    const draftBadge = page.locator('text=This session is a draft');
-    await expect(draftBadge).toBeVisible();
-
     const input = page.locator('textarea[placeholder*="Edit your prompt"]');
     const startButton = page.locator('button:has-text("Start Session")');
 
@@ -295,7 +287,7 @@ test.describe('Draft Session Editing', () => {
     await page.waitForTimeout(3000);
 
     // Draft UI should be replaced with running/active UI
-    // The draft badge and edit prompt should be hidden
+    // The edit prompt and start button should be hidden
     // Messages should start appearing
   });
 


### PR DESCRIPTION
## Summary

- Remove the "This session is a draft. Edit your prompt and click "Start Session" to begin." message from the session detail view
- Enable quick responses panel to be visible when editing draft sessions
- Remove unused CSS styles associated with the draft status message
- Update E2E tests to reflect the removed draft status message

## Changes

- **ConversationTab.vue**: Removed draft status message div, enabled quick responses for drafts, removed unused CSS styles
- **draft-sessions.spec.ts**: Updated tests to remove assertions about the draft badge that no longer exists

## Test Plan

- Draft sessions can still be edited with the same prompt input and "Start Session" button
- Quick response actions are now available while editing draft prompts
- E2E tests should pass with the updated assertions (no longer checking for draft badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)