### PR TITLE
Add mobile-friendly dropdown navigation to project session list

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -21,34 +21,47 @@
 
     <!-- Tabs -->
     <div class="tabs">
-      <button
-        class="tab"
-        :class="{ active: activeTab === 'sessions' }"
-        @click="activeTab = 'sessions'"
-      >
-        Sessions
-      </button>
-      <button
-        class="tab"
-        :class="{ active: activeTab === 'archived' }"
-        @click="handleArchivedTabClick"
-      >
-        Archived
-      </button>
-      <button
-        class="tab"
-        :class="{ active: activeTab === 'templates' }"
-        @click="activeTab = 'templates'"
-      >
-        Templates
-      </button>
-      <button
-        class="tab"
-        :class="{ active: activeTab === 'commands' }"
-        @click="activeTab = 'commands'"
-      >
-        Commands
-      </button>
+      <!-- Desktop tabs -->
+      <div class="tabs-desktop">
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'sessions' }"
+          @click="activeTab = 'sessions'"
+        >
+          Sessions
+        </button>
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'archived' }"
+          @click="handleArchivedTabClick"
+        >
+          Archived
+        </button>
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'templates' }"
+          @click="activeTab = 'templates'"
+        >
+          Templates
+        </button>
+        <button
+          class="tab"
+          :class="{ active: activeTab === 'commands' }"
+          @click="activeTab = 'commands'"
+        >
+          Commands
+        </button>
+      </div>
+
+      <!-- Mobile dropdown -->
+      <div class="tabs-mobile">
+        <select :value="activeTab" @change="handleTabChange($event.target.value)" class="tab-select">
+          <option value="sessions">Sessions</option>
+          <option value="archived">Archived</option>
+          <option value="templates">Templates</option>
+          <option value="commands">Commands</option>
+        </select>
+      </div>
     </div>
 
     <!-- Status Filters -->
@@ -175,6 +188,15 @@ const toggleFilter = (status) => {
     sessionsStore.setStatusFilter(status);
   }
 };
+
+// Handle tab change from mobile dropdown
+function handleTabChange(tab) {
+  if (tab === 'archived') {
+    handleArchivedTabClick();
+  } else {
+    activeTab.value = tab;
+  }
+}
 
 // Statuses that count as "idle" (not actively running)
 const IDLE_STATUSES = ['waiting', 'stopped', 'error'];


### PR DESCRIPTION
## Summary

- Project session list tabs (Sessions, Archived, Templates, Commands) now switch to a dropdown at 640px screen width
- Uses the same responsive pattern already implemented in SessionDetailView
- Includes special handling for Archived tab's lazy-loading behavior

## Test plan

- [ ] Verify tabs work normally on desktop (above 640px)
- [ ] Verify dropdown appears on mobile (below 640px)
- [ ] Verify selecting from dropdown switches tabs correctly
- [ ] Verify Archived tab lazy-loading works from both desktop tabs and mobile dropdown
- [ ] Verify all four tabs are accessible on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)