### PR TITLE
fix: Use session worktree directory for onSessionDeleted hook

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -804,8 +804,10 @@ router.delete('/:id', async (req, res) => {
   sessions.delete(req.params.id);
 
   // Execute on_session_deleted hook if configured (non-blocking)
+  // Use session's worktree directory if available, otherwise project directory
   if (project?.onSessionDeleted) {
-    executeHookAsync(project.onSessionDeleted, project.workingDirectory, {
+    const hookWorkingDirectory = session.gitWorktree || project.workingDirectory;
+    executeHookAsync(project.onSessionDeleted, hookWorkingDirectory, {
       sessionId: session.id,
       projectId: project.id,
       sessionName: session.name,

--- a/packages/server/test/session-hooks.test.js
+++ b/packages/server/test/session-hooks.test.js
@@ -3,6 +3,11 @@ import { mkdtemp, rm, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { projects, sessions } from '../src/database.js';
+import { executeHookAsync } from '../src/services/hookService.js';
+
+vi.mock('../src/services/hookService.js', () => ({
+  executeHookAsync: vi.fn(),
+}));
 
 describe('Session Lifecycle Hooks', () => {
   let tempDir;
@@ -137,6 +142,66 @@ describe('Session Lifecycle Hooks', () => {
 
       expect(retrievedProject.onSessionCreated).toBe('start.sh');
       expect(retrievedProject.onSessionDeleted).toBe('stop.sh');
+    });
+  });
+
+  describe('Hook working directory with worktrees', () => {
+    it('session stores gitWorktree path separately from project workingDirectory', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionDeleted: 'cleanup.sh',
+      });
+      const session = sessions.create(project.id, 'Worktree Session', 'Hello');
+
+      // Simulate worktree setup by updating session
+      const worktreePath = join(tempDir, '.worktrees', session.id);
+      sessions.update(session.id, {
+        gitWorktree: worktreePath,
+        gitBranch: 'feature-branch',
+      });
+
+      const retrieved = sessions.getById(session.id);
+      const retrievedProject = projects.getById(session.projectId);
+
+      // Session should have its own gitWorktree path
+      expect(retrieved.gitWorktree).toBe(worktreePath);
+      // Project still has original workingDirectory
+      expect(retrievedProject.workingDirectory).toBe(tempDir);
+      // These should be different - hooks should use session.gitWorktree when available
+      expect(retrieved.gitWorktree).not.toBe(retrievedProject.workingDirectory);
+    });
+
+    it('hook working directory should prefer session gitWorktree over project workingDirectory', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionDeleted: 'cleanup.sh',
+      });
+      const session = sessions.create(project.id, 'Worktree Session', 'Hello');
+
+      const worktreePath = join(tempDir, '.worktrees', session.id);
+      sessions.update(session.id, { gitWorktree: worktreePath });
+
+      const retrieved = sessions.getById(session.id);
+      const retrievedProject = projects.getById(session.projectId);
+
+      // This is the pattern that should be used in API routes when executing hooks:
+      // const hookWorkingDirectory = session.gitWorktree || project.workingDirectory;
+      const hookWorkingDirectory = retrieved.gitWorktree || retrievedProject.workingDirectory;
+
+      expect(hookWorkingDirectory).toBe(worktreePath);
+    });
+
+    it('hook working directory falls back to project when no gitWorktree', () => {
+      const project = projects.create('Test', tempDir, null, {
+        onSessionDeleted: 'cleanup.sh',
+      });
+      const session = sessions.create(project.id, 'Regular Session', 'Hello');
+
+      const retrieved = sessions.getById(session.id);
+      const retrievedProject = projects.getById(session.projectId);
+
+      // No gitWorktree set, should use project directory
+      const hookWorkingDirectory = retrieved.gitWorktree || retrievedProject.workingDirectory;
+
+      expect(hookWorkingDirectory).toBe(tempDir);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed `onSessionDeleted` hook to use `session.gitWorktree` when available instead of always using `project.workingDirectory`
- This prevents files created by deletion hooks from leaking into the main repository when sessions run in worktree mode
- Added tests documenting the expected worktree/hook working directory behavior

## Test plan
- [x] Run `yarn workspace @claudetools/server test test/session-hooks.test.js` - all 16 tests pass
- [ ] Create a session with worktree mode, configure an `onSessionDeleted` hook that creates a file, delete the session, verify file is created in worktree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)