### PR TITLE
Automatically install dependencies in pw script

### DIFF
--- a/scripts/pw.sh
+++ b/scripts/pw.sh
@@ -138,6 +138,14 @@ print_error() {
     echo -e "${RED}✗${NC} $1" >&2
 }
 
+# Ensure dependencies are installed
+ensure_dependencies() {
+    if [ ! -d "$PROJECT_ROOT/node_modules" ]; then
+        print_info "Installing dependencies..."
+        cd "$PROJECT_ROOT" && yarn install
+    fi
+}
+
 # Ensure required directories exist
 ensure_directories() {
     mkdir -p "$PROJECT_ROOT/screenshots"
@@ -154,6 +162,7 @@ cmd_build() {
 
 # Run tests
 cmd_test() {
+    ensure_dependencies
     ensure_directories
 
     # Ensure server is running
@@ -207,6 +216,8 @@ cmd_screenshot() {
 
 # Run codegen
 cmd_codegen() {
+    ensure_dependencies
+
     # Ensure server is running to provide a default URL
     local SERVER_PORT
     SERVER_PORT=$(detect_or_start_server)
@@ -230,6 +241,7 @@ cmd_codegen() {
 
 # Interactive shell
 cmd_shell() {
+    ensure_dependencies
     ensure_directories
     print_info "Starting interactive shell..."
     docker compose -f "$COMPOSE_FILE" run --rm playwright shell
@@ -237,6 +249,7 @@ cmd_shell() {
 
 # Debug mode (headed browser)
 cmd_debug() {
+    ensure_dependencies
     ensure_directories
 
     if [ -z "$DISPLAY" ]; then


### PR DESCRIPTION
## Summary
- Added `ensure_dependencies()` function to pw.sh that checks for node_modules and runs `yarn install` if missing
- Integrated dependency check into all commands that start the server: test, codegen, debug, shell
- Prevents "vite: not found" and other missing dependency errors

## Test plan
- [x] Run `./scripts/pw.sh test` with missing node_modules - should install deps and run tests
- [x] Run `./scripts/pw.sh test` with existing node_modules - should skip install and run tests
- [x] Run `./scripts/pw.sh debug` - should install deps if needed
- [x] Run `./scripts/pw.sh codegen` - should install deps if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)