### PR TITLE
feat: Display committed changes vs branch in Changes tab

### DIFF
--- a/packages/server/src/services/diffService.js
+++ b/packages/server/src/services/diffService.js
@@ -151,21 +151,22 @@ export async function getChanges(directory) {
 
 /**
  * Get changes compared to a specific branch
- * Shows commits that are on current branch but not on the target branch
+ * Returns committed changes vs the target branch, plus any local uncommitted changes
  * @param {string} directory - The git repository directory
  * @param {string} branch - Branch to compare against (e.g., 'origin/main')
- * @returns {Promise<{staged: string, unstaged: string, untracked: string}>}
+ * @returns {Promise<{branchDiff: string, staged: string, unstaged: string, untracked: string}>}
  */
 export async function getChangesBranch(directory, branch) {
-  const [staged, unstaged, untrackedPaths] = await Promise.all([
-    gitService.getStagedDiffAgainstBranch(directory, branch),
-    gitService.getDiffAgainstBranch(directory, branch),
+  const [branchDiff, staged, unstaged, untrackedPaths] = await Promise.all([
+    gitService.getDiffBetweenRefs(directory, branch, 'HEAD'), // Committed changes vs branch
+    gitService.getStagedDiff(directory), // Actual staged changes (local)
+    gitService.getDiff(directory), // Actual unstaged changes (local)
     gitService.getUntrackedFiles(directory),
   ]);
 
   // Generate synthetic diffs for untracked files
   const untracked = await generateUntrackedDiffs(directory, untrackedPaths);
 
-  return { staged, unstaged, untracked };
+  return { branchDiff, staged, unstaged, untracked };
 }
 

--- a/packages/server/src/services/diffService.test.js
+++ b/packages/server/src/services/diffService.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import { getChanges, generateUntrackedDiffs } from './diffService.js';
+import { getChanges, getChangesBranch, generateUntrackedDiffs } from './diffService.js';
 import * as gitService from './gitService.js';
 import { mkdir, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
@@ -135,6 +135,172 @@ index 9876543..fedcba9 100644
 
       expect(result.staged).toBe(stagedDiff);
       expect(result.unstaged).toBe(unstagedDiff);
+    });
+  });
+
+  describe('getChangesBranch', () => {
+    it('returns branchDiff (committed changes vs branch) plus local changes', async () => {
+      gitService.getDiffBetweenRefs.mockResolvedValue('branch diff content');
+      gitService.getStagedDiff.mockResolvedValue('staged diff content');
+      gitService.getDiff.mockResolvedValue('unstaged diff content');
+      gitService.getUntrackedFiles.mockResolvedValue([]);
+
+      const result = await getChangesBranch('/test/dir', 'origin/main');
+
+      expect(result).toEqual({
+        branchDiff: 'branch diff content',
+        staged: 'staged diff content',
+        unstaged: 'unstaged diff content',
+        untracked: '',
+      });
+    });
+
+    it('calls correct git service functions with correct arguments', async () => {
+      gitService.getDiffBetweenRefs.mockResolvedValue('');
+      gitService.getStagedDiff.mockResolvedValue('');
+      gitService.getDiff.mockResolvedValue('');
+      gitService.getUntrackedFiles.mockResolvedValue([]);
+
+      await getChangesBranch('/my/project', 'origin/main');
+
+      expect(gitService.getDiffBetweenRefs).toHaveBeenCalledWith(
+        '/my/project',
+        'origin/main',
+        'HEAD'
+      );
+      expect(gitService.getStagedDiff).toHaveBeenCalledWith('/my/project');
+      expect(gitService.getDiff).toHaveBeenCalledWith('/my/project');
+      expect(gitService.getUntrackedFiles).toHaveBeenCalledWith('/my/project');
+    });
+
+    it('returns empty values when no changes exist', async () => {
+      gitService.getDiffBetweenRefs.mockResolvedValue('');
+      gitService.getStagedDiff.mockResolvedValue('');
+      gitService.getDiff.mockResolvedValue('');
+      gitService.getUntrackedFiles.mockResolvedValue([]);
+
+      const result = await getChangesBranch('/test/dir', 'origin/main');
+
+      expect(result).toEqual({
+        branchDiff: '',
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+    });
+
+    it('returns branchDiff with committed changes even when working tree is clean', async () => {
+      // This is the key scenario: all changes are committed, no local modifications
+      const branchDiff = `diff --git a/feature.js b/feature.js
+index 1234567..abcdefg 100644
+--- a/feature.js
++++ b/feature.js
+@@ -1,3 +1,4 @@
+ existing code
++new feature code
+ more code`;
+
+      gitService.getDiffBetweenRefs.mockResolvedValue(branchDiff);
+      gitService.getStagedDiff.mockResolvedValue(''); // No staged changes
+      gitService.getDiff.mockResolvedValue(''); // No unstaged changes
+      gitService.getUntrackedFiles.mockResolvedValue([]);
+
+      const result = await getChangesBranch('/test/dir', 'origin/main');
+
+      // Should show the committed changes in branchDiff, not in staged/unstaged
+      expect(result.branchDiff).toBe(branchDiff);
+      expect(result.staged).toBe('');
+      expect(result.unstaged).toBe('');
+    });
+
+    it('separates committed changes from local changes', async () => {
+      // branchDiff = committed changes on current branch vs target branch
+      const branchDiff = `diff --git a/committed.js b/committed.js
+index 1234567..abcdefg 100644
+--- a/committed.js
++++ b/committed.js
+@@ -1 +1,2 @@
+ committed line
++new committed line`;
+
+      // staged = actual git staged changes (git diff --cached)
+      const staged = `diff --git a/staged-file.js b/staged-file.js
+index 1234567..abcdefg 100644
+--- a/staged-file.js
++++ b/staged-file.js
+@@ -1 +1,2 @@
+ original
++staged change`;
+
+      // unstaged = actual git unstaged changes (git diff)
+      const unstaged = `diff --git a/working-file.js b/working-file.js
+index 1234567..abcdefg 100644
+--- a/working-file.js
++++ b/working-file.js
+@@ -1 +1,2 @@
+ original
++working change`;
+
+      gitService.getDiffBetweenRefs.mockResolvedValue(branchDiff);
+      gitService.getStagedDiff.mockResolvedValue(staged);
+      gitService.getDiff.mockResolvedValue(unstaged);
+      gitService.getUntrackedFiles.mockResolvedValue([]);
+
+      const result = await getChangesBranch('/test/dir', 'origin/main');
+
+      expect(result.branchDiff).toBe(branchDiff);
+      expect(result.staged).toBe(staged);
+      expect(result.unstaged).toBe(unstaged);
+    });
+
+    it('fetches all git info in parallel', async () => {
+      let branchDiffResolve;
+      let stagedResolve;
+      let unstagedResolve;
+      let untrackedResolve;
+
+      gitService.getDiffBetweenRefs.mockReturnValue(
+        new Promise((resolve) => {
+          branchDiffResolve = resolve;
+        })
+      );
+      gitService.getStagedDiff.mockReturnValue(
+        new Promise((resolve) => {
+          stagedResolve = resolve;
+        })
+      );
+      gitService.getDiff.mockReturnValue(
+        new Promise((resolve) => {
+          unstagedResolve = resolve;
+        })
+      );
+      gitService.getUntrackedFiles.mockReturnValue(
+        new Promise((resolve) => {
+          untrackedResolve = resolve;
+        })
+      );
+
+      const promise = getChangesBranch('/test/dir', 'origin/main');
+
+      // All should be called immediately (in parallel)
+      expect(gitService.getDiffBetweenRefs).toHaveBeenCalled();
+      expect(gitService.getStagedDiff).toHaveBeenCalled();
+      expect(gitService.getDiff).toHaveBeenCalled();
+      expect(gitService.getUntrackedFiles).toHaveBeenCalled();
+
+      // Resolve them
+      branchDiffResolve('branch');
+      stagedResolve('staged');
+      unstagedResolve('unstaged');
+      untrackedResolve([]);
+
+      const result = await promise;
+      expect(result).toEqual({
+        branchDiff: 'branch',
+        staged: 'staged',
+        unstaged: 'unstaged',
+        untracked: '',
+      });
     });
   });
 

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -380,3 +380,19 @@ export async function getStagedDiffAgainstBranch(directory, branch) {
     return '';
   }
 }
+
+/**
+ * Get diff between two git refs (e.g., comparing HEAD to origin/main)
+ * This shows the committed changes between two refs, ignoring working tree state
+ * @param {string} directory
+ * @param {string} fromRef - Base ref (e.g., 'origin/main')
+ * @param {string} toRef - Target ref (e.g., 'HEAD')
+ * @returns {Promise<string>}
+ */
+export async function getDiffBetweenRefs(directory, fromRef, toRef) {
+  try {
+    return await git(directory, `diff ${fromRef} ${toRef}`);
+  } catch {
+    return '';
+  }
+}

--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -5,7 +5,9 @@ import { nextTick, defineComponent } from 'vue';
 // Mock the API - MUST be before imports that use it
 vi.mock('../api/ApiClient.js', () => ({
   api: {
-    getSessionChanges: vi.fn().mockResolvedValue({ staged: '', unstaged: '', untracked: '' }),
+    getSessionChanges: vi
+      .fn()
+      .mockResolvedValue({ branchDiff: '', staged: '', unstaged: '', untracked: '' }),
     getSessionDefaultBranch: vi.fn().mockResolvedValue({ branch: null }),
   },
 }));
@@ -621,6 +623,215 @@ describe('ChangesTab', () => {
       await flushAll(wrapper);
 
       expect(wrapper.vm.fileCount).toBe(0);
+    });
+  });
+
+  describe('branchDiff feature', () => {
+    it('has branchDiff state', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff: '',
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // Verify branchDiff ref exists and defaults to empty string
+      expect(wrapper.vm.branchDiff).toBe('');
+    });
+
+    it('has branchDiffFiles computed property', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff: '',
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // Verify branchDiffFiles computed property exists
+      expect(wrapper.vm.branchDiffFiles).toBeDefined();
+      expect(wrapper.vm.branchDiffFiles).toEqual([]);
+    });
+
+    it('has hasLocalChanges computed property', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff: '',
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // Verify hasLocalChanges computed property exists
+      expect(wrapper.vm.hasLocalChanges).toBeDefined();
+      expect(wrapper.vm.hasLocalChanges).toBeFalsy();
+    });
+
+    it('parses branchDiff when present', async () => {
+      const branchDiff = [
+        'diff --git a/feature.js b/feature.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/feature.js',
+        '+++ b/feature.js',
+        '@@ -1,2 +1,3 @@',
+        ' const x = 1;',
+        '+const newFeature = 2;',
+      ].join('\n');
+
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff,
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.branchDiff).toBe(branchDiff);
+      expect(wrapper.vm.branchDiffFiles).toHaveLength(1);
+      expect(wrapper.vm.branchDiffFiles[0].displayPath).toBe('feature.js');
+    });
+
+    it('shows branchDiff as separate section from staged/unstaged', async () => {
+      const branchDiff = [
+        'diff --git a/committed.js b/committed.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/committed.js',
+        '+++ b/committed.js',
+        '@@ -1,2 +1,3 @@',
+        ' const x = 1;',
+        '+committed change',
+      ].join('\n');
+
+      const staged = [
+        'diff --git a/staged.js b/staged.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/staged.js',
+        '+++ b/staged.js',
+        '@@ -1,2 +1,3 @@',
+        ' const a = 1;',
+        '+local staged change',
+      ].join('\n');
+
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff,
+        staged,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // branchDiffFiles should contain committed changes
+      expect(wrapper.vm.branchDiffFiles).toHaveLength(1);
+      expect(wrapper.vm.branchDiffFiles[0].displayPath).toBe('committed.js');
+
+      // stagedFiles should contain local staged changes
+      expect(wrapper.vm.stagedFiles).toHaveLength(1);
+      expect(wrapper.vm.stagedFiles[0].displayPath).toBe('staged.js');
+    });
+
+    it('hasChanges is true when only branchDiff has content in branch mode', async () => {
+      const branchDiff = [
+        'diff --git a/feature.js b/feature.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/feature.js',
+        '+++ b/feature.js',
+        '@@ -1,2 +1,3 @@',
+        ' const x = 1;',
+        '+const y = 2;',
+      ].join('\n');
+
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff,
+        staged: '',
+        unstaged: '',
+        untracked: '',
+      });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // In local mode, hasChanges should be falsy (no local changes)
+      expect(wrapper.vm.compareMode).toBe('local');
+      expect(wrapper.vm.hasChanges).toBeFalsy();
+      expect(wrapper.vm.hasLocalChanges).toBeFalsy();
+
+      // Switch to branch mode
+      wrapper.vm.compareMode = 'branch';
+      await flushAll(wrapper);
+
+      // In branch mode, hasChanges should be truthy (branchDiff has content)
+      expect(wrapper.vm.hasChanges).toBeTruthy();
+      expect(wrapper.vm.hasLocalChanges).toBeFalsy();
+    });
+
+    it('fileCount includes branchDiff files in branch mode', async () => {
+      const branchDiff = [
+        'diff --git a/feature1.js b/feature1.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/feature1.js',
+        '+++ b/feature1.js',
+        '@@ -1,2 +1,3 @@',
+        ' const x = 1;',
+        '+const y = 2;',
+        'diff --git a/feature2.js b/feature2.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/feature2.js',
+        '+++ b/feature2.js',
+        '@@ -1,2 +1,3 @@',
+        ' const a = 1;',
+        '+const b = 2;',
+      ].join('\n');
+
+      const staged = [
+        'diff --git a/local.js b/local.js',
+        'index 1234567..abcdefg 100644',
+        '--- a/local.js',
+        '+++ b/local.js',
+        '@@ -1,2 +1,3 @@',
+        ' const z = 1;',
+        '+const w = 2;',
+      ].join('\n');
+
+      api.getSessionChanges.mockResolvedValue({
+        branchDiff,
+        staged,
+        unstaged: '',
+        untracked: '',
+      });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+
+      await flushAll(wrapper);
+
+      // In local mode, fileCount should only count local changes (1 staged)
+      expect(wrapper.vm.compareMode).toBe('local');
+      expect(wrapper.vm.fileCount).toBe(1);
+
+      // Switch to branch mode
+      wrapper.vm.compareMode = 'branch';
+      await nextTick();
+
+      // In branch mode, fileCount should include branchDiff (2) + staged (1) = 3
+      expect(wrapper.vm.fileCount).toBe(3);
     });
   });
 });

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -45,6 +45,20 @@
         <p v-else>No differences from {{ branchLabel }}.</p>
       </div>
 
+      <!-- Branch diff section (only in branch compare mode) -->
+      <div v-if="compareMode === 'branch' && branchDiffFiles.length > 0" class="diff-section">
+        <h3>Changes vs {{ branchLabel }}</h3>
+        <DiffViewer ref="branchDiffViewer" :files="branchDiffFiles" />
+      </div>
+
+      <!-- Local changes header (only show in branch mode when there are both branch and local changes) -->
+      <div
+        v-if="compareMode === 'branch' && branchDiffFiles.length > 0 && hasLocalChanges"
+        class="local-changes-header"
+      >
+        <h3>Local Changes (uncommitted)</h3>
+      </div>
+
       <!-- Diff sections: Only show when there are files -->
       <div v-if="stagedFiles.length > 0" class="diff-section">
         <h3>Staged Changes</h3>
@@ -76,6 +90,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:fileCount']);
 
+const branchDiff = ref('');
 const staged = ref('');
 const unstaged = ref('');
 const untracked = ref('');
@@ -85,17 +100,35 @@ const allExpanded = ref(true);
 const compareMode = ref('local');
 const defaultBranch = ref(null);
 
+const branchDiffViewer = ref(null);
 const stagedDiffViewer = ref(null);
 const unstagedDiffViewer = ref(null);
 const untrackedDiffViewer = ref(null);
 
+const branchDiffFiles = computed(() => parseDiff(branchDiff.value));
 const stagedFiles = computed(() => parseDiff(staged.value));
 const unstagedFiles = computed(() => parseDiff(unstaged.value));
 const untrackedFiles = computed(() => parseDiff(untracked.value));
-const hasChanges = computed(() => staged.value || unstaged.value || untracked.value);
-const fileCount = computed(
-  () => stagedFiles.value.length + unstagedFiles.value.length + untrackedFiles.value.length
-);
+const hasLocalChanges = computed(() => staged.value || unstaged.value || untracked.value);
+const hasChanges = computed(() => {
+  if (compareMode.value === 'branch') {
+    return branchDiff.value || hasLocalChanges.value;
+  }
+  return hasLocalChanges.value;
+});
+const fileCount = computed(() => {
+  if (compareMode.value === 'branch') {
+    // In branch mode, count branch diff files + local changes
+    return (
+      branchDiffFiles.value.length +
+      stagedFiles.value.length +
+      unstagedFiles.value.length +
+      untrackedFiles.value.length
+    );
+  }
+  // In local mode, only count local changes
+  return stagedFiles.value.length + unstagedFiles.value.length + untrackedFiles.value.length;
+});
 const branchLabel = computed(() => {
   if (!defaultBranch.value) return 'branch';
   // Extract branch name from 'origin/main' or 'origin/master'
@@ -108,10 +141,12 @@ watch(fileCount, (count) => emit('update:fileCount', count), { immediate: true }
 
 function toggleAllFiles() {
   if (allExpanded.value) {
+    branchDiffViewer.value?.collapseAll();
     stagedDiffViewer.value?.collapseAll();
     unstagedDiffViewer.value?.collapseAll();
     untrackedDiffViewer.value?.collapseAll();
   } else {
+    branchDiffViewer.value?.expandAll();
     stagedDiffViewer.value?.expandAll();
     unstagedDiffViewer.value?.expandAll();
     untrackedDiffViewer.value?.expandAll();
@@ -128,6 +163,7 @@ async function fetchChanges() {
       compareMode.value,
       compareMode.value === 'branch' ? defaultBranch.value : null
     );
+    branchDiff.value = changes.branchDiff || '';
     staged.value = changes.staged || '';
     unstaged.value = changes.unstaged || '';
     untracked.value = changes.untracked || '';
@@ -162,12 +198,15 @@ onMounted(() => {
 // Expose for testing
 defineExpose({
   fetchChanges,
+  branchDiff,
   staged,
   unstaged,
   untracked,
   loading,
   error,
   hasChanges,
+  hasLocalChanges,
+  branchDiffFiles,
   stagedFiles,
   unstagedFiles,
   untrackedFiles,
@@ -289,5 +328,20 @@ defineExpose({
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
   color: var(--color-text-soft);
+}
+
+.local-changes-header {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.local-changes-header h3 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-soft);
+  margin: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

This PR enhances the Changes tab in the session detail view to separately display:
1. **Committed changes** - Changes that exist on the current branch but not on the base branch
2. **Local uncommitted changes** - Staged, unstaged, and untracked files

When in branch compare mode, the Changes tab now shows a dedicated "Changes vs [branch]" section for committed changes, followed by a "Local Changes (uncommitted)" header before showing the local changes.

## Changes Made

- **diffService.js**: Updated `getChangesBranch()` to return `branchDiff` field with committed changes
- **gitService.js**: Added/enhanced diff methods for branch comparison
- **ChangesTab.vue**: 
  - Added branch diff display section
  - Improved file count calculation to include branch diff files
  - Added "Local Changes" header to clarify distinction
- **Tests**: Added comprehensive test coverage for new functionality

## Test Plan

- [ ] Run unit tests: `yarn test`
- [ ] Test Changes tab displays branch diff correctly when in branch compare mode
- [ ] Verify file count includes branch diff files
- [ ] Verify "Local Changes (uncommitted)" header appears appropriately
- [ ] Test that all diff sections collapse/expand together

🤖 Generated with [Claude Code](https://claude.com/claude-code)