### PR TITLE
Fix excessive spacing in Conversation Tab markdown

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -795,6 +795,11 @@ async function handleTemplateChange(templateId) {
   word-break: break-word;
 }
 
+/* Override pre-wrap for rendered markdown to prevent double line breaks */
+.message-content :deep(.markdown-viewer) {
+  white-space: normal;
+}
+
 .message-tools {
   margin-top: 0.75rem;
 }


### PR DESCRIPTION
## Summary

Fixes excessive vertical spacing and line breaks in the Conversation Tab markdown rendering. The issue was caused by conflicting CSS rules combined with markdown-it's `breaks: true` setting, resulting in double spacing compared to the Canvas tab.

## Root Cause

Two CSS rules were creating double spacing:
1. `.message-content` had `white-space: pre-wrap` (preserving all whitespace including newlines)
2. markdown-it's `breaks: true` setting was converting `\n` to `<br>` tags

This caused both the preserved whitespace AND the `<br>` tags to render, creating excessive gaps.

## Solution

Added a CSS override to reset `white-space: normal` specifically for MarkdownViewer components inside `.message-content`:

```css
.message-content :deep(.markdown-viewer) {
  white-space: normal;
}
```

This allows:
- **Plain text messages** to preserve intentional line breaks (still use pre-wrap)
- **Markdown messages** to render with proper HTML structure controlling spacing (white-space: normal)
- Alignment with Canvas tab rendering behavior

## Changes

- **packages/web/src/components/ConversationTab.vue**: Added CSS override for MarkdownViewer components

## Test Plan

- [ ] View markdown in Conversation tab and compare with Canvas tab
- [ ] Verify spacing is now consistent (compact lists, proper paragraph spacing)
- [ ] Verify plain text messages still preserve intentional line breaks
- [ ] Test edge cases: code blocks, inline code, nested lists, long text wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)