### PR TITLE
fix: Duplicated sessions not having summaries updated

### DIFF
--- a/packages/server/src/db/SessionSummaryRepository.js
+++ b/packages/server/src/db/SessionSummaryRepository.js
@@ -171,6 +171,10 @@ export class SessionSummaryRepository extends BaseRepository {
 
   /**
    * Duplicates the session summary from one session to another.
+   * Note: PR-related fields (prMerged, prState, hasMergeConflicts, ciStatus, ciFailures)
+   * are NOT copied because the duplicated session is a fresh start and may create
+   * its own PR. Copying prMerged=true would prevent the summary from ever being
+   * regenerated (see summaryService.generateSummary skip logic).
    * @param {string} sourceSessionId - Source session ID
    * @param {string} targetSessionId - Target session ID
    */
@@ -185,11 +189,7 @@ export class SessionSummaryRepository extends BaseRepository {
         filesModified: summary.filesModified,
         outcome: summary.outcome,
         messageCount: summary.messageCount,
-        prMerged: summary.prMerged,
-        prState: summary.prState,
-        hasMergeConflicts: summary.hasMergeConflicts,
-        ciStatus: summary.ciStatus,
-        ciFailures: summary.ciFailures,
+        // PR-related fields intentionally omitted - see note above
       });
     }
   }

--- a/packages/server/src/db/SessionSummaryRepository.test.js
+++ b/packages/server/src/db/SessionSummaryRepository.test.js
@@ -471,7 +471,9 @@ describe('SessionSummaryRepository', () => {
       expect(repo.getBySessionId(targetSessionId)).toBeNull();
     });
 
-    it('should preserve all summary fields including PR and CI data', () => {
+    it('should NOT copy PR and CI data (allows summary regeneration for duplicated sessions)', () => {
+      // See summaryService.generateSummary: if prMerged=true, summary regeneration is skipped.
+      // Duplicated sessions should be able to have their summaries regenerated.
       const targetSessionId = databaseManager.generateId();
       const now = Date.now();
       databaseManager.get().prepare(
@@ -491,11 +493,12 @@ describe('SessionSummaryRepository', () => {
       repo.duplicateForSession(sessionId, targetSessionId);
 
       const targetSummary = repo.getBySessionId(targetSessionId);
-      expect(targetSummary.prMerged).toBe(true);
-      expect(targetSummary.prState).toBe('merged');
-      expect(targetSummary.hasMergeConflicts).toBe(false);
-      expect(targetSummary.ciStatus).toBe('passed');
-      expect(targetSummary.ciFailures).toEqual(['test1']);
+      // PR-related fields should NOT be copied
+      expect(targetSummary.prMerged).toBeNull();
+      expect(targetSummary.prState).toBeNull();
+      expect(targetSummary.hasMergeConflicts).toBeNull();
+      expect(targetSummary.ciStatus).toBeNull();
+      expect(targetSummary.ciFailures).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed issue where duplicated sessions never had their summaries updated
- Root cause: `prMerged` flag was copied during duplication, triggering early return in `generateSummary()`
- Solution: Omit PR-related fields (prMerged, prState, hasMergeConflicts, ciStatus, ciFailures) when duplicating session summaries

## Test plan
- [x] Verify `SessionSummaryRepository.duplicateForSession()` no longer copies PR-related fields
- [x] Verify existing tests pass (1531 tests)
- [ ] Manual test: Duplicate a session that had a merged PR, continue it, verify summary updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)