### PR TITLE
fix: Token usage UI not updating during streaming

### DIFF
--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -24,6 +24,10 @@ vi.mock('../composables/useWebSocket.js', () => ({
     onWorkLog: vi.fn(() => vi.fn()),
     onWorkLogsAssociated: vi.fn(() => vi.fn()),
     onThinkingPartial: vi.fn(() => vi.fn()),
+    onConversationCreated: vi.fn(() => vi.fn()),
+    onConversationUpdated: vi.fn(() => vi.fn()),
+    onConversationDeleted: vi.fn(() => vi.fn()),
+    onUsageUpdate: vi.fn(() => vi.fn()),
   })),
 }));
 

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -304,6 +304,7 @@ const {
   onConversationCreated,
   onConversationUpdated,
   onConversationDeleted,
+  onUsageUpdate,
 } = useSessionSubscription(props.sessionId);
 let unsubPartial = null;
 let unsubMessage = null;
@@ -313,6 +314,7 @@ let unsubThinkingPartial = null;
 let unsubConvCreated = null;
 let unsubConvUpdated = null;
 let unsubConvDeleted = null;
+let unsubUsage = null;
 
 function handleScroll() {
   if (!messagesContainer.value) return;
@@ -362,8 +364,12 @@ onMounted(async () => {
     messagesContainer.value.addEventListener('scroll', handleScroll);
   }
 
-  // Fetch conversations for this session
-  await sessionsStore.fetchConversations(props.sessionId);
+  // Only fetch conversations if not already loaded for this session
+  // This prevents overwriting updated data (e.g., token counts during streaming)
+  if (sessionsStore.conversations.length === 0 ||
+      sessionsStore.conversations[0]?.sessionId !== props.sessionId) {
+    await sessionsStore.fetchConversations(props.sessionId);
+  }
 
   // Fetch quick responses for the project
   if (sessionsStore.currentSession?.projectId) {
@@ -439,6 +445,15 @@ onMounted(async () => {
     }
   });
 
+  // Subscribe to usage updates - Critical fix for token count display during streaming
+  unsubUsage = onUsageUpdate((msg) => {
+    if (msg.isFinal) {
+      sessionsStore.finalizeUsage(msg.usage, msg.conversationId);
+    } else {
+      sessionsStore.updateRunningUsage(msg.usage, msg.conversationId);
+    }
+  });
+
   // Fetch initial work logs
   await sessionsStore.fetchWorkLogs(props.sessionId);
 
@@ -455,6 +470,7 @@ onUnmounted(() => {
   if (unsubConvCreated) unsubConvCreated();
   if (unsubConvUpdated) unsubConvUpdated();
   if (unsubConvDeleted) unsubConvDeleted();
+  if (unsubUsage) unsubUsage();
   if (debounceTimer) clearTimeout(debounceTimer);
   if (draftSaveTimer) clearTimeout(draftSaveTimer);
   if (inputSyncTimer) clearTimeout(inputSyncTimer);

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -137,9 +137,21 @@ export const useSessionsStore = defineStore('sessions', {
         };
       }
 
-      // FINALIZED: Use active conversation tokens if available, fallback to session
-      const conv = state.conversations.find((c) => c.id === state.activeConversationId);
-      const source = conv || state.currentSession;
+      // FINALIZED: Try conversation first, but fall back to session if conversation has no tokens
+      let source = null;
+
+      if (state.activeConversationId && state.conversations.length > 0) {
+        const conv = state.conversations.find((c) => c.id === state.activeConversationId);
+        // Only use conversation if it actually has token data
+        if (conv && ((conv.inputTokens || 0) > 0 || (conv.outputTokens || 0) > 0)) {
+          source = conv;
+        }
+      }
+
+      // Fall back to session if no valid conversation data
+      if (!source) {
+        source = state.currentSession;
+      }
 
       if (!source) return { input: '0', output: '0', total: '0', cacheRead: '0', cacheCreation: '0' };
 

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -1186,6 +1186,229 @@ describe('Sessions Store', () => {
         expect(formatted.cacheRead).toBe('5.0K');
         expect(formatted.cacheCreation).toBe('2.5K');
       });
+
+      // Issue #324 - Improved fallback logic tests
+      describe('conversation/session fallback logic', () => {
+        it('falls back to session when conversation has zero tokens', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = 'conv-1';
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+            cacheReadInputTokens: 500,
+            cacheCreationInputTokens: 250,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use session data because conversation has zero tokens
+          expect(formatted.input).toBe('5.0K');
+          expect(formatted.output).toBe('2.5K');
+          expect(formatted.total).toBe('7.5K');
+          expect(formatted.cacheRead).toBe('500');
+          expect(formatted.cacheCreation).toBe('250');
+        });
+
+        it('uses conversation data when it has non-zero tokens', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = 'conv-1';
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 1000,
+              outputTokens: 500,
+              cacheReadInputTokens: 200,
+              cacheCreationInputTokens: 100,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use conversation data because it has non-zero tokens
+          expect(formatted.input).toBe('1.0K');
+          expect(formatted.output).toBe('500');
+          expect(formatted.total).toBe('1.5K');
+          expect(formatted.cacheRead).toBe('200');
+          expect(formatted.cacheCreation).toBe('100');
+        });
+
+        it('uses conversation when only inputTokens are non-zero', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = 'conv-1';
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 1000,
+              outputTokens: 0,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use conversation data because inputTokens is non-zero
+          expect(formatted.input).toBe('1.0K');
+          expect(formatted.output).toBe('0');
+          expect(formatted.total).toBe('1.0K');
+        });
+
+        it('uses conversation when only outputTokens are non-zero', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = 'conv-1';
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 0,
+              outputTokens: 500,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use conversation data because outputTokens is non-zero
+          expect(formatted.input).toBe('0');
+          expect(formatted.output).toBe('500');
+          expect(formatted.total).toBe('500');
+        });
+
+        it('falls back to session when activeConversationId is null', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = null;
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 1000,
+              outputTokens: 500,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use session data because activeConversationId is null
+          expect(formatted.input).toBe('5.0K');
+          expect(formatted.output).toBe('2.5K');
+          expect(formatted.total).toBe('7.5K');
+        });
+
+        it('falls back to session when conversations array is empty', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = 'conv-1';
+          store.conversations = [];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use session data because conversations array is empty
+          expect(formatted.input).toBe('5.0K');
+          expect(formatted.output).toBe('2.5K');
+          expect(formatted.total).toBe('7.5K');
+        });
+
+        it('falls back to session when active conversation not found', () => {
+          const store = useSessionsStore();
+          store.activeConversationId = 'non-existent-conv';
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 1000,
+              outputTokens: 500,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 5000,
+            outputTokens: 2500,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should use session data because active conversation not found
+          expect(formatted.input).toBe('5.0K');
+          expect(formatted.output).toBe('2.5K');
+          expect(formatted.total).toBe('7.5K');
+        });
+
+        it('prevents stale conversation data from overwriting session data during streaming', () => {
+          const store = useSessionsStore();
+          // Simulate a race condition where conversation has stale data
+          store.activeConversationId = 'conv-1';
+          store.conversations = [
+            {
+              id: 'conv-1',
+              inputTokens: 0, // Stale - hasn't been updated yet
+              outputTokens: 0,
+            },
+          ];
+          store.currentSession = {
+            id: 'session-1',
+            inputTokens: 10000,
+            outputTokens: 5000,
+          };
+          store.runningUsage = null;
+
+          const formatted = store.formattedTokens;
+          // Should fall back to session because conversation has zero tokens
+          expect(formatted.input).toBe('10.0K');
+          expect(formatted.output).toBe('5.0K');
+          expect(formatted.total).toBe('15.0K');
+
+          // Now simulate streaming updating the usage
+          store.runningUsage = {
+            inputTokens: 10000,
+            outputTokens: 7500,
+          };
+
+          const streamingFormatted = store.formattedTokens;
+          // Should use running usage during streaming
+          expect(streamingFormatted.input).toBe('10.0K');
+          expect(streamingFormatted.output).toBe('7.5K');
+          expect(streamingFormatted.total).toBe('17.5K');
+
+          // After streaming ends, conversation gets updated
+          store.runningUsage = null;
+          store.conversations[0].inputTokens = 10000;
+          store.conversations[0].outputTokens = 7500;
+
+          const finalFormatted = store.formattedTokens;
+          // Should use updated conversation data
+          expect(finalFormatted.input).toBe('10.0K');
+          expect(finalFormatted.output).toBe('7.5K');
+          expect(finalFormatted.total).toBe('17.5K');
+        });
+      });
     });
 
     describe('isUsageUpdating getter', () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -249,7 +249,13 @@ onMounted(async () => {
     uiStore.error('Failed to subscribe to session updates');
   }
 
-  // STEP 2: Register all handlers IMMEDIATELY (before fetching data)
+  // STEP 1.5: Fetch critical data BEFORE registering handlers
+  // This ensures conversations array is populated when usage updates arrive
+  // and prevents handlers from trying to access empty conversation lists
+  await sessionsStore.fetchSession(sessionId);
+  await sessionsStore.fetchConversations(sessionId);
+
+  // STEP 2: Register all handlers (data is now ready)
   // This ensures we don't miss any updates that arrive while data is being fetched
   cleanups.push(
     onStatus((status) => {
@@ -347,12 +353,8 @@ onMounted(async () => {
     })
   );
 
-  // STEP 3: Now fetch data (handlers are ready to receive updates)
-  await sessionsStore.fetchSession(sessionId);
+  // STEP 3: Now fetch remaining data (handlers are ready to receive updates)
   await sessionsStore.fetchMessages(sessionId);
-  // Load conversations proactively so token updates are available immediately
-  // (Issue: conversations were only loaded when ConversationTab became visible)
-  await sessionsStore.fetchConversations(sessionId);
   await sessionsStore.fetchWorkLogs(sessionId);
   // Await canvas fetch to ensure indicator shows correct count immediately.
   // This catches items added before/during WebSocket subscription establishment.


### PR DESCRIPTION
## Summary

Implements the changes from PR #324 with comprehensive tests. This PR addresses two critical issues:
1. **Token count doesn't update until Claude's turn ends** - Users had to leave the conversation tab and return to see updates
2. **Token count shows zero during streaming** - Even when Claude is actively generating, the UI showed 0 tokens

## Changes

### 1. Add onUsageUpdate handler to ConversationTab
- TokenUsagePanel now receives live token updates during streaming
- Previously only SessionDetailView had the handler

### 2. Improve formattedTokens getter fallback logic
- Only use conversation data if it has actual token counts
- Fall back to session data if conversation has zero tokens
- Prevents showing stale or empty data

### 3. Prevent conversation re-fetch from overwriting data
- Only fetch conversations if not already loaded for session
- Prevents new fetch calls from overwriting updated token counts
- Fixes race condition where stale DB values overwrite live updates

### 4. Reorder data fetching in SessionDetailView
- Fetch session and conversations BEFORE registering handlers
- Ensures data is ready when usage updates arrive during streaming
- Handlers no longer try to access empty conversation arrays

## Tests Added

Added 8 comprehensive tests for the improved fallback logic:
- Falls back to session when conversation has zero tokens
- Uses conversation data when it has non-zero tokens
- Uses conversation when only inputTokens are non-zero
- Uses conversation when only outputTokens are non-zero
- Falls back to session when activeConversationId is null
- Falls back to session when conversations array is empty
- Falls back to session when active conversation not found
- Prevents stale conversation data from overwriting session data during streaming

## Test plan

- [x] All 1297 web package tests pass
- [x] All 155 session store tests pass
- [ ] Start a new session and observe token count during streaming
- [ ] Verify token count shows non-zero values in real-time
- [ ] Verify final token count is correct after turn completes
- [ ] Switch tabs (to Changes, Canvas) and back - tokens should persist
- [ ] Create a new conversation and verify token tracking works
- [ ] Test with multiple conversations in same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)