### PR TITLE
Fix quick responses truncation in QuickResponsesPanel

### DIFF
--- a/packages/web/src/components/QuickResponsesPanel.vue
+++ b/packages/web/src/components/QuickResponsesPanel.vue
@@ -211,7 +211,7 @@ function handleClick(response) {
   cursor: pointer;
   transition: all 0.15s;
   border: 1px solid transparent;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .response-button:focus {
@@ -263,9 +263,7 @@ function handleClick(response) {
 }
 
 .button-label {
-  max-width: 150px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
 }
 
 /* Mobile responsiveness */


### PR DESCRIPTION
## Summary

Fix the issue where quick response text was being truncated with ellipsis instead of displaying the full message. This enables quick responses to wrap naturally and display complete text.

## Changes

- Changed `white-space: nowrap` to `white-space: normal` to allow text wrapping
- Removed `max-width: 150px`, `overflow: hidden`, and `text-overflow: ellipsis` constraints from `.button-label`
- Added `word-break: break-word` for better text wrapping behavior

## Test Plan

- [ ] Verify quick responses with long text display fully without truncation
- [ ] Confirm quick responses with short text still look good
- [ ] Test on mobile to ensure responsive behavior is maintained
- [ ] Click quick responses to verify they still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)