### PR TITLE
feat: Implement bulk canvas item operations

### DIFF
--- a/packages/server/src/api/canvas.js
+++ b/packages/server/src/api/canvas.js
@@ -394,4 +394,104 @@ router.delete('/:id/canvas/:itemId/permanent', (req, res) => {
   res.status(204).send();
 });
 
+// POST /api/sessions/:id/canvas/bulk-delete - Soft delete multiple items
+router.post('/:id/canvas/bulk-delete', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const { itemIds } = req.body;
+  if (!Array.isArray(itemIds)) {
+    return res.status(400).json({ error: 'itemIds must be an array' });
+  }
+
+  if (itemIds.length === 0) {
+    return res.json({ deletedCount: 0 });
+  }
+
+  // Verify all items belong to this session
+  for (const itemId of itemIds) {
+    const item = canvasItems.getById(itemId);
+    if (!item || item.sessionId !== req.params.id) {
+      return res.status(404).json({ error: `Item ${itemId} not found in session` });
+    }
+  }
+
+  const deletedCount = canvasItems.softDeleteBatch(itemIds);
+
+  // Broadcast each deleted item to session subscribers
+  itemIds.forEach(itemId => {
+    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId: req.params.id, itemId });
+  });
+
+  res.json({ deletedCount });
+});
+
+// POST /api/sessions/:id/canvas/bulk-recover - Recover multiple items from trash
+router.post('/:id/canvas/bulk-recover', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const { itemIds } = req.body;
+  if (!Array.isArray(itemIds)) {
+    return res.status(400).json({ error: 'itemIds must be an array' });
+  }
+
+  if (itemIds.length === 0) {
+    return res.json({ recoveredCount: 0 });
+  }
+
+  const recoveredCount = canvasItems.recoverBatch(itemIds);
+
+  // Broadcast each recovered item to session subscribers
+  itemIds.forEach(itemId => {
+    const item = canvasItems.getById(itemId);
+    if (item) {
+      broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_ADD, { item });
+    }
+  });
+
+  res.json({ recoveredCount });
+});
+
+// DELETE /api/sessions/:id/canvas/bulk-delete-permanent - Permanently delete multiple items from trash
+router.delete('/:id/canvas/bulk-delete-permanent', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const { itemIds } = req.body;
+  if (!Array.isArray(itemIds)) {
+    return res.status(400).json({ error: 'itemIds must be an array' });
+  }
+
+  if (itemIds.length === 0) {
+    return res.json({ deletedCount: 0 });
+  }
+
+  // Verify all items are in trash and belong to this session
+  for (const itemId of itemIds) {
+    const item = canvasItems.getById(itemId);
+    if (!item || item.sessionId !== req.params.id) {
+      return res.status(404).json({ error: `Item ${itemId} not found in session` });
+    }
+    if (!item.deletedAt) {
+      return res.status(400).json({ error: `Item ${itemId} is not in trash (cannot permanently delete active items)` });
+    }
+  }
+
+  const deletedCount = canvasItems.permanentDeleteBatch(itemIds);
+
+  // Broadcast each deleted item to session subscribers
+  itemIds.forEach(itemId => {
+    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId: req.params.id, itemId });
+  });
+
+  res.json({ deletedCount });
+});
+
 export default router;

--- a/packages/server/src/db/CanvasItemRepository.js
+++ b/packages/server/src/db/CanvasItemRepository.js
@@ -169,4 +169,66 @@ export class CanvasItemRepository extends BaseRepository {
       });
     }
   }
+
+  /**
+   * Soft delete multiple items atomically
+   * @param {string[]} itemIds - Array of item IDs to soft delete
+   * @returns {number} Count of items actually deleted
+   */
+  softDeleteBatch(itemIds) {
+    if (!itemIds || itemIds.length === 0) {
+      return 0;
+    }
+
+    const now = Date.now();
+    const placeholders = itemIds.map(() => '?').join(',');
+
+    const updateStmt = this.db.prepare(
+      `UPDATE canvas_items SET deleted_at = ? WHERE id IN (${placeholders}) AND deleted_at IS NULL`
+    );
+
+    const result = updateStmt.run(now, ...itemIds);
+    return result.changes || 0;
+  }
+
+  /**
+   * Recover multiple items atomically
+   * @param {string[]} itemIds - Array of item IDs to recover
+   * @returns {number} Count of items actually recovered
+   */
+  recoverBatch(itemIds) {
+    if (!itemIds || itemIds.length === 0) {
+      return 0;
+    }
+
+    const placeholders = itemIds.map(() => '?').join(',');
+
+    const updateStmt = this.db.prepare(
+      `UPDATE canvas_items SET deleted_at = NULL WHERE id IN (${placeholders}) AND deleted_at IS NOT NULL`
+    );
+
+    const result = updateStmt.run(...itemIds);
+    return result.changes || 0;
+  }
+
+  /**
+   * Permanently delete multiple items atomically
+   * @param {string[]} itemIds - Array of item IDs to permanently delete (must be from trash)
+   * @returns {number} Count of items actually deleted
+   */
+  permanentDeleteBatch(itemIds) {
+    if (!itemIds || itemIds.length === 0) {
+      return 0;
+    }
+
+    // Only allow permanent deletion of items that are in trash (deleted_at IS NOT NULL)
+    const placeholders = itemIds.map(() => '?').join(',');
+
+    const deleteStmt = this.db.prepare(
+      `DELETE FROM canvas_items WHERE id IN (${placeholders}) AND deleted_at IS NOT NULL`
+    );
+
+    const result = deleteStmt.run(...itemIds);
+    return result.changes || 0;
+  }
 }

--- a/packages/web/src/api/ApiClient.js
+++ b/packages/web/src/api/ApiClient.js
@@ -442,6 +442,36 @@ export class ApiClient {
     return this.#request('DELETE', `/sessions/${sessionId}/canvas/${itemId}/permanent`);
   }
 
+  /**
+   * Soft delete multiple canvas items (move to trash)
+   * @param {string} sessionId - Session ID
+   * @param {string[]} itemIds - Array of canvas item IDs
+   * @returns {Promise<Object>} - { deletedCount: number }
+   */
+  async bulkDeleteCanvasItems(sessionId, itemIds) {
+    return this.#request('POST', `/sessions/${sessionId}/canvas/bulk-delete`, { itemIds });
+  }
+
+  /**
+   * Recover multiple canvas items from trash
+   * @param {string} sessionId - Session ID
+   * @param {string[]} itemIds - Array of canvas item IDs
+   * @returns {Promise<Object>} - { recoveredCount: number }
+   */
+  async bulkRecoverCanvasItems(sessionId, itemIds) {
+    return this.#request('POST', `/sessions/${sessionId}/canvas/bulk-recover`, { itemIds });
+  }
+
+  /**
+   * Permanently delete multiple canvas items from trash
+   * @param {string} sessionId - Session ID
+   * @param {string[]} itemIds - Array of canvas item IDs
+   * @returns {Promise<Object>} - { deletedCount: number }
+   */
+  async bulkPermanentlyDeleteCanvasItems(sessionId, itemIds) {
+    return this.#request('DELETE', `/sessions/${sessionId}/canvas/bulk-delete-permanent`, { itemIds });
+  }
+
   // Git
 
   /**

--- a/packages/web/src/components/CanvasFileList.vue
+++ b/packages/web/src/components/CanvasFileList.vue
@@ -1,11 +1,41 @@
 <template>
   <div class="canvas-file-list">
+    <!-- Header with select all checkbox -->
+    <div class="list-header" v-if="showSelectionUI">
+      <input
+        type="checkbox"
+        class="select-all-checkbox"
+        :checked="isAllSelected"
+        :indeterminate="isPartialSelection"
+        @change="toggleSelectAll"
+        :disabled="isOperationInProgress"
+        aria-label="Select all items"
+      />
+      <span class="header-label">Items</span>
+      <span class="selection-count" v-if="selectedCount > 0">
+        {{ selectedCount }} selected
+      </span>
+    </div>
+
     <div
       v-for="item in items"
       :key="item.id"
       class="file-row"
-      @click="$emit('select', item.id)"
+      :class="{ selected: isItemSelected(item.id) }"
+      @click="handleRowClick(item.id)"
     >
+      <!-- Checkbox for selection -->
+      <input
+        v-if="showSelectionUI"
+        type="checkbox"
+        class="item-checkbox"
+        :checked="isItemSelected(item.id)"
+        @change="toggleItemSelection(item.id)"
+        @click.stop
+        :disabled="isOperationInProgress"
+        :aria-label="`Select ${item.filename || 'item'}`"
+      />
+
       <span class="file-icon">{{ getTypeIcon(item.type) }}</span>
       <span class="file-name">{{ item.filename || item.label || 'Untitled' }}</span>
 
@@ -33,16 +63,54 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { useCanvasStore } from '../stores/canvas.js';
+
+const canvasStore = useCanvasStore();
 
 defineProps({
   items: {
     type: Array,
     required: true,
   },
+  showSelectionUI: {
+    type: Boolean,
+    default: true,
+  },
 });
 
-defineEmits(['select']);
+const emit = defineEmits(['select']);
+
+const isOperationInProgress = computed(() => canvasStore.bulkOperationInProgress);
+const selectedCount = computed(() => canvasStore.selectedItemCount);
+const isAllSelected = computed(() => canvasStore.isAllItemsSelected);
+const isPartialSelection = computed(() => canvasStore.isPartialSelection);
+
+function isItemSelected(itemId) {
+  return canvasStore.selectedItemIds.has(itemId);
+}
+
+function toggleItemSelection(itemId) {
+  canvasStore.toggleItemSelection(itemId);
+}
+
+function toggleSelectAll() {
+  if (isAllSelected.value) {
+    canvasStore.deselectAllItems();
+  } else {
+    canvasStore.selectAllItems();
+  }
+}
+
+function handleRowClick(itemId) {
+  // Only emit select if item not already selected, or if shift/ctrl not held
+  if (!isItemSelected(itemId) || !canvasStore.selectedItemCount) {
+    // Clear selection when clicking item
+    canvasStore.deselectAllItems();
+    // Emit select to parent to view the item
+    emit('select', itemId);
+  }
+}
 
 const copiedItemId = ref(null);
 
@@ -212,6 +280,67 @@ function formatRelativeTime(timestamp) {
   100% { transform: scale(1); opacity: 1; }
 }
 
+/* List header styles for selection UI */
+.list-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.select-all-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.select-all-checkbox:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.header-label {
+  flex: 1;
+}
+
+.selection-count {
+  color: var(--color-text-soft);
+  font-size: 0.85rem;
+  font-weight: normal;
+  margin-left: auto;
+}
+
+/* Checkbox styles */
+.item-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.item-checkbox:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Selected row styling */
+.file-row.selected {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.file-row.selected:hover {
+  background: rgba(34, 197, 94, 0.15);
+}
+
 /* Mobile styles */
 @media (max-width: 640px) {
   .file-row {
@@ -226,6 +355,16 @@ function formatRelativeTime(timestamp) {
   .copy-button {
     min-width: 2.75rem;
     min-height: 2.75rem;
+  }
+
+  .item-checkbox {
+    width: 16px;
+    height: 16px;
+  }
+
+  .select-all-checkbox {
+    width: 16px;
+    height: 16px;
   }
 }
 </style>

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -31,6 +31,38 @@
       <span v-if="isDragOver" class="drag-hint">Drop file to upload</span>
     </div>
 
+    <!-- Bulk action toolbar -->
+    <div v-if="canvasStore.selectedItemCount > 0 && !showTrash" class="bulk-action-toolbar">
+      <div class="toolbar-left">
+        <span class="selection-info">
+          {{ canvasStore.selectedItemCount }} item{{ canvasStore.selectedItemCount > 1 ? 's' : '' }} selected
+        </span>
+      </div>
+      <div class="toolbar-right">
+        <button
+          class="btn btn-sm"
+          @click="handleSelectAll"
+          :disabled="canvasStore.bulkOperationInProgress"
+        >
+          {{ canvasStore.isAllItemsSelected ? 'Deselect All' : 'Select All' }}
+        </button>
+        <button
+          class="btn btn-sm btn-danger"
+          @click="handleBulkDelete"
+          :disabled="canvasStore.bulkOperationInProgress"
+        >
+          {{ canvasStore.bulkOperationInProgress ? 'Deleting...' : 'Delete Selected' }}
+        </button>
+        <button
+          class="btn btn-sm btn-secondary"
+          @click="handleCancelSelection"
+          :disabled="canvasStore.bulkOperationInProgress"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+
     <!-- Trash view -->
     <CanvasTrash
       v-if="showTrash"
@@ -249,6 +281,32 @@ async function uploadFile(file) {
     uploading.value = false;
   }
 }
+
+// Bulk action handlers
+async function handleBulkDelete() {
+  const count = canvasStore.selectedItemCount;
+  if (!confirm(`Delete ${count} item${count > 1 ? 's' : ''}?`)) return;
+
+  try {
+    const itemIds = Array.from(canvasStore.selectedItemIds);
+    await canvasStore.bulkDeleteItems(props.sessionId, itemIds);
+    uiStore.success(`${count} item${count > 1 ? 's' : ''} deleted`);
+  } catch (err) {
+    uiStore.error(err.message);
+  }
+}
+
+function handleSelectAll() {
+  if (canvasStore.isAllItemsSelected) {
+    canvasStore.deselectAllItems();
+  } else {
+    canvasStore.selectAllItems();
+  }
+}
+
+function handleCancelSelection() {
+  canvasStore.deselectAllItems();
+}
 </script>
 
 <style scoped>
@@ -334,6 +392,65 @@ async function uploadFile(file) {
   opacity: 0.8;
 }
 
+/* Bulk action toolbar styles */
+.bulk-action-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: var(--border-radius);
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.selection-info {
+  color: var(--color-text);
+  font-weight: 500;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.btn-danger {
+  background-color: var(--color-error);
+  color: white;
+  border-color: var(--color-error);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background-color: #dc2626;
+  border-color: #dc2626;
+}
+
+.btn-secondary {
+  background-color: var(--color-background-mute);
+  color: var(--color-text-soft);
+  border-color: var(--color-border);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: var(--color-background-soft);
+  color: var(--color-text);
+}
+
 /* Mobile styles */
 @media (max-width: 640px) {
   .canvas-header {
@@ -348,6 +465,24 @@ async function uploadFile(file) {
 
   .drag-hint {
     display: none;
+  }
+
+  .bulk-action-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-left {
+    justify-content: center;
+  }
+
+  .toolbar-right {
+    justify-content: center;
+  }
+
+  .toolbar-right .btn {
+    flex: 1;
+    min-height: 44px;
   }
 }
 

--- a/packages/web/src/components/CanvasTrash.vue
+++ b/packages/web/src/components/CanvasTrash.vue
@@ -21,36 +21,89 @@
       <p class="empty-state-hint">Deleted files will appear here for recovery.</p>
     </div>
 
-    <div v-else class="trash-list">
-      <div
-        v-for="item in groupedItems"
-        :key="item.id"
-        class="trash-row"
-      >
-        <span class="file-icon">{{ getTypeIcon(item.type) }}</span>
-        <div class="file-info">
-          <span class="file-name">{{ item.filename || item.label || 'Untitled' }}</span>
-          <span class="file-meta">
-            {{ item.versionCount }} version{{ item.versionCount > 1 ? 's' : '' }}
-            &bull; Deleted {{ formatRelativeTime(item.deletedAt) }}
+    <div v-else>
+      <!-- Bulk action toolbar for trash -->
+      <div v-if="canvasStore.selectedItemCount > 0" class="bulk-action-toolbar">
+        <div class="toolbar-left">
+          <span class="selection-info">
+            {{ canvasStore.selectedItemCount }} item{{ canvasStore.selectedItemCount > 1 ? 's' : '' }} selected
           </span>
         </div>
-
-        <div class="trash-actions">
+        <div class="toolbar-right">
+          <button
+            class="btn btn-sm"
+            @click="handleSelectAll"
+            :disabled="canvasStore.bulkOperationInProgress"
+          >
+            {{ canvasStore.isAllItemsSelected ? 'Deselect All' : 'Select All' }}
+          </button>
           <button
             class="btn btn-sm btn-success"
-            @click="handleRecover(item.filename)"
-            :disabled="recovering === item.filename"
+            @click="handleBulkRecover"
+            :disabled="canvasStore.bulkOperationInProgress"
           >
-            {{ recovering === item.filename ? 'Recovering...' : 'Recover' }}
+            {{ canvasStore.bulkOperationInProgress ? 'Recovering...' : 'Recover Selected' }}
           </button>
           <button
             class="btn btn-sm btn-danger"
-            @click="handlePermanentDelete(item)"
-            :disabled="deleting === item.id"
+            @click="handleBulkPermanentDelete"
+            :disabled="canvasStore.bulkOperationInProgress"
           >
-            Delete Forever
+            {{ canvasStore.bulkOperationInProgress ? 'Deleting...' : 'Delete Forever' }}
           </button>
+          <button
+            class="btn btn-sm btn-secondary"
+            @click="handleCancelSelection"
+            :disabled="canvasStore.bulkOperationInProgress"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+
+      <div class="trash-list">
+        <div
+          v-for="item in groupedItems"
+          :key="item.id"
+          class="trash-row"
+          :class="{ selected: isItemSelected(item.id) }"
+        >
+          <!-- Checkbox for selection -->
+          <input
+            type="checkbox"
+            class="item-checkbox"
+            :checked="isItemSelected(item.id)"
+            @change="toggleItemSelection(item.id)"
+            @click.stop
+            :disabled="canvasStore.bulkOperationInProgress"
+            :aria-label="`Select ${item.filename || 'item'}`"
+          />
+
+          <span class="file-icon">{{ getTypeIcon(item.type) }}</span>
+          <div class="file-info">
+            <span class="file-name">{{ item.filename || item.label || 'Untitled' }}</span>
+            <span class="file-meta">
+              {{ item.versionCount }} version{{ item.versionCount > 1 ? 's' : '' }}
+              &bull; Deleted {{ formatRelativeTime(item.deletedAt) }}
+            </span>
+          </div>
+
+          <div class="trash-actions">
+            <button
+              class="btn btn-sm btn-success"
+              @click="handleRecover(item.filename)"
+              :disabled="recovering === item.filename || canvasStore.selectedItemCount > 0"
+            >
+              {{ recovering === item.filename ? 'Recovering...' : 'Recover' }}
+            </button>
+            <button
+              class="btn btn-sm btn-danger"
+              @click="handlePermanentDelete(item)"
+              :disabled="deleting === item.id || canvasStore.selectedItemCount > 0"
+            >
+              Delete Forever
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -141,6 +194,54 @@ function formatRelativeTime(timestamp) {
   if (hours > 0) return `${hours}h ago`;
   if (minutes > 0) return `${minutes}m ago`;
   return 'just now';
+}
+
+// Selection helpers
+function isItemSelected(itemId) {
+  return canvasStore.selectedItemIds.has(itemId);
+}
+
+function toggleItemSelection(itemId) {
+  canvasStore.toggleItemSelection(itemId);
+}
+
+function handleSelectAll() {
+  if (canvasStore.isAllItemsSelected) {
+    canvasStore.deselectAllItems();
+  } else {
+    canvasStore.selectAllItems();
+  }
+}
+
+function handleCancelSelection() {
+  canvasStore.deselectAllItems();
+}
+
+// Bulk action handlers
+async function handleBulkRecover() {
+  const count = canvasStore.selectedItemCount;
+  if (!confirm(`Recover ${count} item${count > 1 ? 's' : ''}?`)) return;
+
+  try {
+    const itemIds = Array.from(canvasStore.selectedItemIds);
+    await canvasStore.bulkRecoverItems(props.sessionId, itemIds);
+    uiStore.success(`${count} item${count > 1 ? 's' : ''} recovered`);
+  } catch (err) {
+    uiStore.error(err.message);
+  }
+}
+
+async function handleBulkPermanentDelete() {
+  const count = canvasStore.selectedItemCount;
+  if (!confirm(`Permanently delete ${count} item${count > 1 ? 's' : ''}? This cannot be undone.`)) return;
+
+  try {
+    const itemIds = Array.from(canvasStore.selectedItemIds);
+    await canvasStore.bulkPermanentlyDeleteItems(props.sessionId, itemIds);
+    uiStore.success(`${count} item${count > 1 ? 's' : ''} permanently deleted`);
+  } catch (err) {
+    uiStore.error(err.message);
+  }
 }
 </script>
 
@@ -260,6 +361,78 @@ function formatRelativeTime(timestamp) {
   background: rgba(248, 81, 73, 0.1);
 }
 
+/* Checkbox styles */
+.item-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.item-checkbox:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Selected row styling */
+.trash-row.selected {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.trash-row.selected:hover {
+  background: rgba(34, 197, 94, 0.15);
+}
+
+/* Bulk action toolbar styles */
+.bulk-action-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: var(--border-radius);
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.selection-info {
+  color: var(--color-text);
+  font-weight: 500;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.btn-secondary {
+  background-color: var(--color-background-mute);
+  color: var(--color-text-soft);
+  border: 1px solid var(--color-border);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: var(--color-background-soft);
+  color: var(--color-text);
+}
+
 /* Mobile */
 @media (max-width: 640px) {
   .trash-row {
@@ -272,6 +445,29 @@ function formatRelativeTime(timestamp) {
   }
 
   .trash-actions .btn {
+    flex: 1;
+    min-height: 44px;
+  }
+
+  .item-checkbox {
+    width: 16px;
+    height: 16px;
+  }
+
+  .bulk-action-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-left {
+    justify-content: center;
+  }
+
+  .toolbar-right {
+    justify-content: center;
+  }
+
+  .toolbar-right .btn {
     flex: 1;
     min-height: 44px;
   }

--- a/packages/web/src/stores/canvas.js
+++ b/packages/web/src/stores/canvas.js
@@ -7,9 +7,25 @@ export const useCanvasStore = defineStore('canvas', {
     trashedItems: [],
     loading: false,
     error: null,
+    selectedItemIds: new Set(),
+    bulkOperationInProgress: false,
   }),
 
   getters: {
+    selectedItemCount: (state) => state.selectedItemIds.size,
+
+    isAllItemsSelected: (state) => {
+      return state.items.length > 0 && state.selectedItemIds.size === state.items.length;
+    },
+
+    isPartialSelection: (state) => {
+      return state.selectedItemIds.size > 0 && state.selectedItemIds.size < state.items.length;
+    },
+
+    selectedItems: (state) => {
+      return state.items.filter(item => state.selectedItemIds.has(item.id));
+    },
+
     // Group items by filename, return latest of each with version info
     groupedItems: (state) => {
       const groups = {};
@@ -151,6 +167,100 @@ export const useCanvasStore = defineStore('canvas', {
       } catch (err) {
         this.error = err.message;
         throw err;
+      }
+    },
+
+    // Selection actions
+    toggleItemSelection(itemId) {
+      if (this.selectedItemIds.has(itemId)) {
+        this.selectedItemIds.delete(itemId);
+      } else {
+        this.selectedItemIds.add(itemId);
+      }
+    },
+
+    selectAllItems() {
+      for (const item of this.items) {
+        this.selectedItemIds.add(item.id);
+      }
+    },
+
+    deselectAllItems() {
+      this.selectedItemIds.clear();
+    },
+
+    // Bulk delete items (soft delete - move to trash)
+    async bulkDeleteItems(sessionId, itemIds) {
+      this.bulkOperationInProgress = true;
+      this.error = null;
+      try {
+        const result = await api.bulkDeleteCanvasItems(sessionId, itemIds);
+
+        // Remove from active items
+        const deletedIds = new Set(itemIds);
+        this.items = this.items.filter((i) => !deletedIds.has(i.id));
+
+        // Clear selection
+        this.selectedItemIds.clear();
+
+        return result;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      } finally {
+        this.bulkOperationInProgress = false;
+      }
+    },
+
+    // Bulk recover items from trash
+    async bulkRecoverItems(sessionId, itemIds) {
+      this.bulkOperationInProgress = true;
+      this.error = null;
+      try {
+        const result = await api.bulkRecoverCanvasItems(sessionId, itemIds);
+
+        // Get the items from trash before removing
+        const recoveredIds = new Set(itemIds);
+        const recoveredItems = this.trashedItems.filter((i) => recoveredIds.has(i.id));
+
+        // Remove from trash
+        this.trashedItems = this.trashedItems.filter((i) => !recoveredIds.has(i.id));
+
+        // Add back to active items
+        this.items.unshift(...recoveredItems);
+
+        // Clear selection
+        this.selectedItemIds.clear();
+
+        return result;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      } finally {
+        this.bulkOperationInProgress = false;
+      }
+    },
+
+    // Bulk permanently delete items from trash
+    async bulkPermanentlyDeleteItems(sessionId, itemIds) {
+      this.bulkOperationInProgress = true;
+      this.error = null;
+      try {
+        const result = await api.bulkPermanentlyDeleteCanvasItems(sessionId, itemIds);
+
+        // Remove from trash
+        const deletedIds = new Set(itemIds);
+        this.trashedItems = this.trashedItems.filter((i) => !deletedIds.has(i.id));
+
+        // Clear selection
+        this.selectedItemIds.clear();
+
+        return result;
+      } catch (err) {
+        this.error = err.message;
+        throw err;
+      } finally {
+        this.bulkOperationInProgress = false;
       }
     },
   },


### PR DESCRIPTION
## Summary
Implements bulk operations for canvas items, allowing users to select and perform actions on multiple items at once. Includes soft delete (trash), recover from trash, and permanent deletion.

## Changes
- **Backend API endpoints** for bulk delete, recover, and permanent delete with atomic transactions
- **Selection UI** with checkboxes in CanvasFileList and CanvasTrash components
- **Bulk action toolbar** in CanvasTab and CanvasTrash with action buttons
- **Canvas store updates** for managing item selection and bulk operations
- **ApiClient methods** for bulk delete, recover, and permanent delete operations
- **CanvasItemRepository** batch operations for efficient database updates

## Test plan
- [ ] Select individual items using checkboxes
- [ ] Use "Select All" to select all items in the current view
- [ ] Verify "Deselect All" clears all selections
- [ ] Bulk delete selected items and verify they move to trash
- [ ] Bulk recover items from trash and verify they return to main canvas
- [ ] Bulk permanently delete items from trash
- [ ] Verify WebSocket broadcasts for bulk operations
- [ ] Test with mixed scenarios (select some, deselect some, etc.)
- [ ] Verify UI disables during operations
- [ ] Test on mobile view

🤖 Generated with [Claude Code](https://claude.com/claude-code)