### PR TITLE
fix: Add per-mode state tracking for diff view expand/collapse

### DIFF
--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -33,11 +33,37 @@ describe('ChangesTab', () => {
   // Custom DiffViewer stub that properly exposes methods for refs
   const DiffViewerStub = defineComponent({
     name: 'DiffViewer',
-    props: ['files', 'expandAll'],
-    setup(props, { expose }) {
+    props: ['files', 'expandAll', 'externalExpandedState', 'defaultExpanded'],
+    emits: ['update:expandedState'],
+    setup(props, { expose, emit }) {
       expose({
-        collapseAll: () => {},
-        expandAll: () => {},
+        collapseAll: () => {
+          // When using external state, emit the update
+          if (props.externalExpandedState !== null && props.files) {
+            const newState = {};
+            props.files.forEach((file) => {
+              newState[file.displayPath] = false;
+            });
+            emit('update:expandedState', newState);
+          }
+        },
+        expandAll: () => {
+          // When using external state, emit the update
+          if (props.externalExpandedState !== null && props.files) {
+            const newState = {};
+            props.files.forEach((file) => {
+              newState[file.displayPath] = true;
+            });
+            emit('update:expandedState', newState);
+          }
+        },
+        isFileExpanded: (index) => {
+          if (props.externalExpandedState !== null && props.files && props.files[index]) {
+            const filePath = props.files[index].displayPath;
+            return props.externalExpandedState[filePath] ?? props.defaultExpanded;
+          }
+          return props.expandAll ?? true;
+        },
       });
       return () => null;
     },
@@ -832,6 +858,287 @@ describe('ChangesTab', () => {
 
       // In branch mode, fileCount should include branchDiff (2) + staged (1) = 3
       expect(wrapper.vm.fileCount).toBe(3);
+    });
+  });
+
+  describe('per-mode state management', () => {
+    const stagedDiffFixture = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const y = 2;`;
+
+    const twoFileDiffFixture = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const y = 2;
+diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,3 @@
+ const a = 1;
++const b = 2;`;
+
+    const branchDiffFixture = `diff --git a/feature.js b/feature.js
+index 1234567..abcdefg 100644
+--- a/feature.js
++++ b/feature.js
+@@ -1,2 +1,3 @@
+ const feature = 1;
++const newFeature = 2;`;
+
+    it('initializes modeState with local and branch entries', async () => {
+      api.getSessionChanges.mockResolvedValue({ staged: stagedDiffFixture, unstaged: '', untracked: '' });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.modeState).toBeDefined();
+      expect(wrapper.vm.modeState.local).toBeDefined();
+      expect(wrapper.vm.modeState.branch).toBeDefined();
+      expect(wrapper.vm.modeState.local.hasBeenViewed).toBe(true); // local is viewed on mount
+      expect(wrapper.vm.modeState.branch.hasBeenViewed).toBe(false);
+    });
+
+    it('marks mode as viewed when first switched to', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+        branchDiff: branchDiffFixture,
+      });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.modeState.branch.hasBeenViewed).toBe(false);
+
+      wrapper.vm.compareMode = 'branch';
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.modeState.branch.hasBeenViewed).toBe(true);
+    });
+
+    it('initializes files as collapsed on first view of a mode', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+        branchDiff: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // First view of local mode: files should be collapsed
+      const localState = wrapper.vm.modeState.local;
+      const expandedValues = Object.values(localState.expandedFiles);
+      expect(expandedValues.every((v) => v === false)).toBe(true);
+    });
+
+    it('preserves local mode state when switching to branch mode and back', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: twoFileDiffFixture,
+        unstaged: '',
+        untracked: '',
+        branchDiff: branchDiffFixture,
+      });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Update the state to have one file expanded
+      wrapper.vm.updateFileExpandedState('local', 'staged:file1.js', true);
+      wrapper.vm.updateFileExpandedState('local', 'staged:file2.js', false);
+
+      // Switch to branch mode
+      wrapper.vm.compareMode = 'branch';
+      await flushAll(wrapper);
+
+      // Switch back to local mode
+      wrapper.vm.compareMode = 'local';
+      await flushAll(wrapper);
+
+      // State should be preserved
+      expect(wrapper.vm.modeState.local.expandedFiles['staged:file1.js']).toBe(true);
+      expect(wrapper.vm.modeState.local.expandedFiles['staged:file2.js']).toBe(false);
+    });
+  });
+
+  describe('allExpanded computed property', () => {
+    const twoFileDiffFixture = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const y = 2;
+diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,3 @@
+ const a = 1;
++const b = 2;`;
+
+    it('returns false when all files are collapsed', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: twoFileDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // All files start collapsed on first view
+      expect(wrapper.vm.allExpanded).toBe(false);
+    });
+
+    it('returns false when some files are expanded and some collapsed', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: twoFileDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Expand one file, leave other collapsed
+      wrapper.vm.updateFileExpandedState('local', 'staged:file1.js', true);
+      wrapper.vm.updateFileExpandedState('local', 'staged:file2.js', false);
+
+      expect(wrapper.vm.allExpanded).toBe(false);
+    });
+
+    it('returns true when all files are expanded', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: twoFileDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Expand all files
+      wrapper.vm.updateFileExpandedState('local', 'staged:file1.js', true);
+      wrapper.vm.updateFileExpandedState('local', 'staged:file2.js', true);
+
+      expect(wrapper.vm.allExpanded).toBe(true);
+    });
+  });
+
+  describe('toggleAllFiles', () => {
+    const twoFileDiffFixture = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const y = 2;
+diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,3 @@
+ const a = 1;
++const b = 2;`;
+
+    it('expands all files when called and files are collapsed', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: twoFileDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Initially collapsed
+      expect(wrapper.vm.allExpanded).toBe(false);
+
+      wrapper.vm.toggleAllFiles();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.allExpanded).toBe(true);
+      // All files in state should be expanded
+      const localState = wrapper.vm.modeState.local;
+      Object.values(localState.expandedFiles).forEach((expanded) => {
+        expect(expanded).toBe(true);
+      });
+    });
+
+    it('collapses all files when called and files are expanded', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: twoFileDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Expand all first
+      wrapper.vm.toggleAllFiles();
+      await flushAll(wrapper);
+      expect(wrapper.vm.allExpanded).toBe(true);
+
+      // Now collapse all
+      wrapper.vm.toggleAllFiles();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.allExpanded).toBe(false);
+    });
+  });
+
+  describe('Expand All/Collapse All button text sync', () => {
+    const stagedDiffFixture = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const y = 2;`;
+
+    it('shows "Expand All" when files are collapsed', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const button = wrapper.find('.btn-link');
+      expect(button.text()).toBe('Expand All');
+    });
+
+    it('shows "Collapse All" when all files are expanded', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      wrapper.vm.toggleAllFiles(); // expand all
+      await flushAll(wrapper);
+
+      const button = wrapper.find('.btn-link');
+      expect(button.text()).toBe('Collapse All');
     });
   });
 });

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -48,7 +48,13 @@
       <!-- Branch diff section (only in branch compare mode) -->
       <div v-if="compareMode === 'branch' && branchDiffFiles.length > 0" class="diff-section">
         <h3>Changes vs {{ branchLabel }}</h3>
-        <DiffViewer ref="branchDiffViewer" :files="branchDiffFiles" />
+        <DiffViewer
+          ref="branchDiffViewer"
+          :files="branchDiffFiles"
+          :external-expanded-state="getExpandedStateForSection('branch')"
+          :default-expanded="false"
+          @update:expanded-state="handleExpandedStateUpdate('branch', $event)"
+        />
       </div>
 
       <!-- Local changes header (only show in branch mode when there are both branch and local changes) -->
@@ -62,17 +68,35 @@
       <!-- Diff sections: Only show when there are files -->
       <div v-if="stagedFiles.length > 0" class="diff-section">
         <h3>Staged Changes</h3>
-        <DiffViewer ref="stagedDiffViewer" :files="stagedFiles" />
+        <DiffViewer
+          ref="stagedDiffViewer"
+          :files="stagedFiles"
+          :external-expanded-state="getExpandedStateForSection('staged')"
+          :default-expanded="false"
+          @update:expanded-state="handleExpandedStateUpdate('staged', $event)"
+        />
       </div>
 
       <div v-if="unstagedFiles.length > 0" class="diff-section">
         <h3>Unstaged Changes</h3>
-        <DiffViewer ref="unstagedDiffViewer" :files="unstagedFiles" />
+        <DiffViewer
+          ref="unstagedDiffViewer"
+          :files="unstagedFiles"
+          :external-expanded-state="getExpandedStateForSection('unstaged')"
+          :default-expanded="false"
+          @update:expanded-state="handleExpandedStateUpdate('unstaged', $event)"
+        />
       </div>
 
       <div v-if="untrackedFiles.length > 0" class="diff-section">
         <h3>Untracked Files</h3>
-        <DiffViewer ref="untrackedDiffViewer" :files="untrackedFiles" />
+        <DiffViewer
+          ref="untrackedDiffViewer"
+          :files="untrackedFiles"
+          :external-expanded-state="getExpandedStateForSection('untracked')"
+          :default-expanded="false"
+          @update:expanded-state="handleExpandedStateUpdate('untracked', $event)"
+        />
       </div>
     </template>
   </div>
@@ -96,9 +120,21 @@ const unstaged = ref('');
 const untracked = ref('');
 const loading = ref(false);
 const error = ref(null);
-const allExpanded = ref(true);
 const compareMode = ref('local');
 const defaultBranch = ref(null);
+
+// Per-mode state tracking for expand/collapse
+// Keys in expandedFiles are "section:filepath", e.g., "staged:src/api.js"
+const modeState = ref({
+  local: {
+    hasBeenViewed: false,
+    expandedFiles: {},
+  },
+  branch: {
+    hasBeenViewed: false,
+    expandedFiles: {},
+  },
+});
 
 const branchDiffViewer = ref(null);
 const stagedDiffViewer = ref(null);
@@ -136,22 +172,101 @@ const branchLabel = computed(() => {
   return parts[parts.length - 1];
 });
 
+// Computed: allExpanded based on actual file states in current mode
+const allExpanded = computed(() => {
+  const currentState = modeState.value[compareMode.value];
+  if (!currentState.hasBeenViewed) return false; // First view = all collapsed
+
+  const expandedStates = Object.values(currentState.expandedFiles);
+  if (expandedStates.length === 0) return false;
+
+  return expandedStates.every((isExpanded) => isExpanded);
+});
+
+// Get expanded state for a specific section's files
+function getExpandedStateForSection(section) {
+  const currentMode = compareMode.value;
+  const state = modeState.value[currentMode];
+  const sectionState = {};
+
+  // Filter expandedFiles for this section
+  Object.entries(state.expandedFiles).forEach(([key, value]) => {
+    if (key.startsWith(`${section}:`)) {
+      const filePath = key.substring(section.length + 1);
+      sectionState[filePath] = value;
+    }
+  });
+
+  return sectionState;
+}
+
+// Update expanded state for a file
+function updateFileExpandedState(mode, key, isExpanded) {
+  modeState.value[mode].expandedFiles[key] = isExpanded;
+}
+
+// Handle state updates from DiffViewer
+function handleExpandedStateUpdate(section, newState) {
+  const currentMode = compareMode.value;
+  Object.entries(newState).forEach(([filePath, isExpanded]) => {
+    const key = `${section}:${filePath}`;
+    modeState.value[currentMode].expandedFiles[key] = isExpanded;
+  });
+}
+
+// Initialize state for files in a section (if not already initialized)
+function initializeFilesState(mode, section, files) {
+  const state = modeState.value[mode];
+  files.forEach((file) => {
+    const key = `${section}:${file.displayPath}`;
+    if (state.expandedFiles[key] === undefined) {
+      // Default to collapsed on first view
+      state.expandedFiles[key] = false;
+    }
+  });
+}
+
+// Initialize mode state after fetching changes
+function initializeModeState(mode) {
+  const state = modeState.value[mode];
+  if (!state.hasBeenViewed) {
+    state.hasBeenViewed = true;
+  }
+
+  // Initialize files based on mode
+  if (mode === 'branch') {
+    initializeFilesState(mode, 'branch', branchDiffFiles.value);
+  }
+  initializeFilesState(mode, 'staged', stagedFiles.value);
+  initializeFilesState(mode, 'unstaged', unstagedFiles.value);
+  initializeFilesState(mode, 'untracked', untrackedFiles.value);
+}
+
 // Emit file count whenever it changes
 watch(fileCount, (count) => emit('update:fileCount', count), { immediate: true });
 
 function toggleAllFiles() {
-  if (allExpanded.value) {
-    branchDiffViewer.value?.collapseAll();
-    stagedDiffViewer.value?.collapseAll();
-    unstagedDiffViewer.value?.collapseAll();
-    untrackedDiffViewer.value?.collapseAll();
-  } else {
+  const targetState = !allExpanded.value;
+  const currentMode = compareMode.value;
+
+  // Update all entries in current mode's expandedFiles
+  const state = modeState.value[currentMode];
+  Object.keys(state.expandedFiles).forEach((key) => {
+    state.expandedFiles[key] = targetState;
+  });
+
+  // Also call expand/collapse on viewers for immediate UI update
+  if (targetState) {
     branchDiffViewer.value?.expandAll();
     stagedDiffViewer.value?.expandAll();
     unstagedDiffViewer.value?.expandAll();
     untrackedDiffViewer.value?.expandAll();
+  } else {
+    branchDiffViewer.value?.collapseAll();
+    stagedDiffViewer.value?.collapseAll();
+    unstagedDiffViewer.value?.collapseAll();
+    untrackedDiffViewer.value?.collapseAll();
   }
-  allExpanded.value = !allExpanded.value;
 }
 
 async function fetchChanges() {
@@ -167,6 +282,9 @@ async function fetchChanges() {
     staged.value = changes.staged || '';
     unstaged.value = changes.unstaged || '';
     untracked.value = changes.untracked || '';
+
+    // Initialize mode state for the current mode after data is available
+    initializeModeState(compareMode.value);
   } catch (err) {
     error.value = err.message;
   } finally {
@@ -214,6 +332,11 @@ defineExpose({
   compareMode,
   defaultBranch,
   branchLabel,
+  modeState,
+  allExpanded,
+  toggleAllFiles,
+  updateFileExpandedState,
+  getExpandedStateForSection,
 });
 </script>
 

--- a/packages/web/src/components/DiffViewer.test.js
+++ b/packages/web/src/components/DiffViewer.test.js
@@ -282,4 +282,235 @@ index 1234567..abcdefg 100644
       expect(previewToggles.length).toBe(0);
     });
   });
+
+  describe('external state management', () => {
+    const twoFileDiff = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,2 @@
+ const x = 1;
++const y = 2;
+diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,2 @@
+ const a = 1;
++const b = 2;`;
+
+    it('accepts externalExpandedState prop', () => {
+      const files = parseDiff(twoFileDiff);
+      const externalState = { 'file1.js': true };
+
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: externalState,
+        },
+      });
+
+      expect(wrapper.props('externalExpandedState')).toEqual(externalState);
+    });
+
+    it('uses external state when provided', async () => {
+      const files = parseDiff(twoFileDiff);
+      const externalState = {
+        'file1.js': true, // expanded
+        'file2.js': false, // collapsed
+      };
+
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: externalState,
+        },
+      });
+
+      await flushAll(wrapper);
+
+      // Check that expansion matches external state
+      expect(wrapper.vm.isFileExpanded(0)).toBe(true);
+      expect(wrapper.vm.isFileExpanded(1)).toBe(false);
+    });
+
+    it('emits update:expandedState when file is toggled', async () => {
+      const files = parseDiff(twoFileDiff);
+      const externalState = { 'file1.js': true, 'file2.js': false };
+
+      // Track emitted events via a spy
+      const emitSpy = vi.fn();
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: externalState,
+          'onUpdate:expandedState': emitSpy,
+        },
+      });
+
+      await flushAll(wrapper);
+
+      // Click to toggle first file
+      const header = wrapper.find('.diff-file-header');
+      await header.trigger('click');
+      await flushAll(wrapper);
+
+      // Should emit state change
+      expect(emitSpy).toHaveBeenCalled();
+      const emittedState = emitSpy.mock.calls[0][0];
+      expect(emittedState['file1.js']).toBe(false);
+    });
+
+    it('falls back to internal state when externalExpandedState is null', async () => {
+      const files = parseDiff(twoFileDiff);
+
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: null,
+          expandAll: true, // default expand
+        },
+      });
+
+      await flushAll(wrapper);
+
+      // Should use internal state with expandAll default
+      expect(wrapper.vm.isFileExpanded(0)).toBe(true);
+    });
+  });
+
+  describe('defaultExpanded prop', () => {
+    const twoFileDiff = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,2 @@
+ const x = 1;
++const y = 2;
+diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,2 @@
+ const a = 1;
++const b = 2;`;
+
+    it('accepts defaultExpanded prop', () => {
+      const files = parseDiff(twoFileDiff);
+
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          defaultExpanded: false,
+        },
+      });
+
+      expect(wrapper.props('defaultExpanded')).toBe(false);
+    });
+
+    it('uses defaultExpanded for files not in external state', async () => {
+      const files = parseDiff(twoFileDiff);
+      // Only file1.js is in state, file2.js should use defaultExpanded
+      const externalState = { 'file1.js': true };
+
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: externalState,
+          defaultExpanded: false,
+        },
+      });
+
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.isFileExpanded(0)).toBe(true); // from externalState
+      expect(wrapper.vm.isFileExpanded(1)).toBe(false); // from defaultExpanded
+    });
+
+    it('initializes files as collapsed when defaultExpanded is false (no external state)', async () => {
+      const files = parseDiff(twoFileDiff);
+
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          defaultExpanded: false,
+        },
+      });
+
+      await flushAll(wrapper);
+
+      // With no external state and defaultExpanded: false, files should be collapsed
+      expect(wrapper.vm.isFileExpanded(0)).toBe(false);
+      expect(wrapper.vm.isFileExpanded(1)).toBe(false);
+    });
+  });
+
+  describe('expand/collapse all with external state', () => {
+    const twoFileDiff = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,2 @@
+ const x = 1;
++const y = 2;
+diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,2 @@
+ const a = 1;
++const b = 2;`;
+
+    it('expandAll emits update:expandedState with all files expanded', async () => {
+      const files = parseDiff(twoFileDiff);
+      const externalState = { 'file1.js': false, 'file2.js': false };
+
+      // Track emitted events via a spy
+      const emitSpy = vi.fn();
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: externalState,
+          'onUpdate:expandedState': emitSpy,
+        },
+      });
+
+      await flushAll(wrapper);
+
+      // Call expandAll exposed method
+      wrapper.vm.expandAll();
+      await flushAll(wrapper);
+
+      expect(emitSpy).toHaveBeenCalled();
+      const emittedState = emitSpy.mock.calls[0][0];
+      expect(emittedState['file1.js']).toBe(true);
+      expect(emittedState['file2.js']).toBe(true);
+    });
+
+    it('collapseAll emits update:expandedState with all files collapsed', async () => {
+      const files = parseDiff(twoFileDiff);
+      const externalState = { 'file1.js': true, 'file2.js': true };
+
+      // Track emitted events via a spy
+      const emitSpy = vi.fn();
+      const wrapper = mount(DiffViewer, {
+        props: {
+          files,
+          externalExpandedState: externalState,
+          'onUpdate:expandedState': emitSpy,
+        },
+      });
+
+      await flushAll(wrapper);
+
+      // Call collapseAll exposed method
+      wrapper.vm.collapseAll();
+      await flushAll(wrapper);
+
+      expect(emitSpy).toHaveBeenCalled();
+      const emittedState = emitSpy.mock.calls[0][0];
+      expect(emittedState['file1.js']).toBe(false);
+      expect(emittedState['file2.js']).toBe(false);
+    });
+  });
 });

--- a/packages/web/src/components/DiffViewer.vue
+++ b/packages/web/src/components/DiffViewer.vue
@@ -6,7 +6,7 @@
 
     <div v-for="(file, fileIndex) in files" :key="fileIndex" class="diff-file">
       <div class="diff-file-header" @click="toggleFile(fileIndex)">
-        <span class="diff-file-toggle">{{ expandedFiles[fileIndex] ? '▼' : '▶' }}</span>
+        <span class="diff-file-toggle">{{ isFileExpanded(fileIndex) ? '▼' : '▶' }}</span>
         <span class="diff-file-icon">
           <span v-if="file.isNew" class="file-badge file-badge-new">A</span>
           <span v-else-if="file.isDeleted" class="file-badge file-badge-deleted">D</span>
@@ -42,7 +42,7 @@
         </button>
       </div>
 
-      <div v-if="expandedFiles[fileIndex]" class="diff-file-content">
+      <div v-if="isFileExpanded(fileIndex)" class="diff-file-content">
         <!-- Markdown preview mode -->
         <div v-if="previewMode[fileIndex] && isMarkdownFile(file.displayPath)" class="markdown-preview-container">
           <div v-if="!file.isDeleted && !file.isNew" class="markdown-preview-split">
@@ -93,7 +93,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import MarkdownViewer from './MarkdownViewer.vue';
 import {
   isMarkdownFile,
@@ -111,19 +111,64 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  // External state management (keyed by file path)
+  externalExpandedState: {
+    type: Object,
+    default: null,
+  },
+  // Default expanded state for first-time viewing
+  // When undefined, falls back to expandAll prop behavior
+  defaultExpanded: {
+    type: Boolean,
+    default: undefined,
+  },
 });
+
+const emit = defineEmits(['update:expandedState']);
 
 const expandedFiles = ref({});
 const previewMode = ref({});
 const copiedFileIndex = ref(null);
 
-// Initialize expanded state
+// Check if using external state management
+// External state is in use when the prop is a non-null object
+const useExternalState = computed(
+  () => props.externalExpandedState !== null && typeof props.externalExpandedState === 'object'
+);
+
+// Get the effective expanded state for a file
+function isFileExpanded(index) {
+  const file = props.files[index];
+  if (!file) return false;
+
+  if (useExternalState.value) {
+    // Use external state if available, fall back to defaultExpanded
+    const filePath = file.displayPath;
+    return props.externalExpandedState[filePath] ?? props.defaultExpanded;
+  }
+  // Use internal state
+  return expandedFiles.value[index] ?? props.expandAll;
+}
+
+// Determine the default expanded state for new files
+// Priority: defaultExpanded prop (if provided) > expandAll prop
+function getDefaultExpandedState() {
+  // If externalExpandedState is provided, this shouldn't be used
+  // Otherwise, use defaultExpanded if explicitly set, otherwise fall back to expandAll
+  if (props.defaultExpanded !== undefined) {
+    return props.defaultExpanded;
+  }
+  return props.expandAll;
+}
+
+// Initialize expanded state (only for internal state mode)
 watch(
   () => props.files,
   (newFiles) => {
     newFiles.forEach((file, index) => {
-      if (expandedFiles.value[index] === undefined) {
-        expandedFiles.value[index] = props.expandAll;
+      // Only initialize internal state if not using external state
+      if (!useExternalState.value && expandedFiles.value[index] === undefined) {
+        expandedFiles.value[index] = getDefaultExpandedState();
       }
       // Initialize preview mode to true for markdown files (preview by default)
       if (previewMode.value[index] === undefined) {
@@ -135,7 +180,21 @@ watch(
 );
 
 function toggleFile(index) {
-  expandedFiles.value[index] = !expandedFiles.value[index];
+  const file = props.files[index];
+  if (!file) return;
+
+  const filePath = file.displayPath;
+  const currentState = isFileExpanded(index);
+  const newState = !currentState;
+
+  if (useExternalState.value) {
+    // Emit state update to parent
+    const updatedState = { ...props.externalExpandedState, [filePath]: newState };
+    emit('update:expandedState', updatedState);
+  } else {
+    // Update internal state
+    expandedFiles.value[index] = newState;
+  }
 }
 
 function togglePreview(index) {
@@ -173,20 +232,39 @@ async function copyFilePath(filePath, fileIndex) {
 }
 
 function collapseAllFiles() {
-  props.files.forEach((_, index) => {
-    expandedFiles.value[index] = false;
-  });
+  if (useExternalState.value) {
+    // Emit state update with all files collapsed
+    const newState = {};
+    props.files.forEach((file) => {
+      newState[file.displayPath] = false;
+    });
+    emit('update:expandedState', newState);
+  } else {
+    props.files.forEach((_, index) => {
+      expandedFiles.value[index] = false;
+    });
+  }
 }
 
 function expandAllFiles() {
-  props.files.forEach((_, index) => {
-    expandedFiles.value[index] = true;
-  });
+  if (useExternalState.value) {
+    // Emit state update with all files expanded
+    const newState = {};
+    props.files.forEach((file) => {
+      newState[file.displayPath] = true;
+    });
+    emit('update:expandedState', newState);
+  } else {
+    props.files.forEach((_, index) => {
+      expandedFiles.value[index] = true;
+    });
+  }
 }
 
 defineExpose({
   collapseAll: collapseAllFiles,
   expandAll: expandAllFiles,
+  isFileExpanded,
 });
 
 


### PR DESCRIPTION
## Summary

Fixes the diff view state synchronization issue where expand/collapse state was lost when switching between "Local Changes" and "Compare to main" modes in the Changes tab.

### Issues Fixed
- **State lost on mode switch**: Manually collapsed files would re-expand when switching modes and back
- **Button out of sync**: Collapse All/Expand All button text didn't reflect actual UI state after manual toggles
- **No per-mode memory**: Each mode should remember its own expand/collapse state independently

### Key Changes
- Add `modeState` ref to `ChangesTab.vue` for per-mode expand/collapse tracking with structure: `{ local: { hasBeenViewed, expandedFiles }, branch: { hasBeenViewed, expandedFiles } }`
- Add `externalExpandedState` prop to `DiffViewer.vue` for external state control
- Convert `allExpanded` to computed property that reflects actual file states
- Update `toggleAllFiles` to sync both modeState and DiffViewer components
- Initialize files as **collapsed** by default on first view of a mode

### Key Behaviors
- **First-time viewing a mode**: All diffs start collapsed
- **Returning to a previously viewed mode**: Exact expand/collapse state is restored
- **Collapse All/Expand All button**: Always reflects the true state of the current view
- **Independent mode states**: Local and branch modes maintain separate expand/collapse memories

## Test plan
- [x] All existing tests pass (1323 tests)
- [x] Added 16+ new test cases covering:
  - Per-mode state management initialization and persistence
  - `allExpanded` computed property behavior
  - `toggleAllFiles` expand/collapse functionality
  - Button text synchronization
  - External state management in DiffViewer
  - `defaultExpanded` prop behavior
  - Expand/collapse all with external state
- [ ] Manual testing: Open Changes tab → collapse some files → switch to "Compare to main" → switch back → verify state preserved
- [ ] Manual testing: Click "Collapse All" → manually expand one file → verify button shows "Expand All"

🤖 Generated with [Claude Code](https://claude.com/claude-code)