### PR TITLE
fix: Add explicit type='button' attributes to buttons in QuickResponsesPanel

### DIFF
--- a/packages/web/src/components/QuickResponsesPanel.vue
+++ b/packages/web/src/components/QuickResponsesPanel.vue
@@ -33,6 +33,7 @@
         <span class="section-label">Project</span>
         <div class="responses-row">
           <button
+            type="button"
             v-for="response in projectResponses"
             :key="response.id"
             @click="handleClick(response)"
@@ -51,6 +52,7 @@
         <span class="section-label">Global</span>
         <div class="responses-row">
           <button
+            type="button"
             v-for="response in globalResponses"
             :key="response.id"
             @click="handleClick(response)"


### PR DESCRIPTION
## Summary

This PR adds explicit `type="button"` attributes to buttons in the QuickResponsesPanel component. This is a semantic HTML fix that prevents potential default form submission behavior and improves accessibility.

## Changes

- Added `type="button"` to project responses buttons
- Added `type="button"` to global responses buttons

## Testing

These are minimal HTML semantic fixes. The functionality remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)