### PR TITLE
Remove branch name display from SessionDetailView

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -21,16 +21,6 @@
           </div>
           <div class="branch-line">
             <div class="branch-pr-indicators">
-              <span
-                v-if="sessionsStore.currentSession.gitBranch"
-                class="branch-indicator"
-                :title="sessionsStore.currentSession.gitBranch"
-              >
-                <svg class="branch-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                  <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.492 2.492 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z"/>
-                </svg>
-                {{ sessionsStore.currentSession.gitBranch }}
-              </span>
               <PrIndicators
                 v-if="sessionsStore.currentSession.prUrl"
                 :pr-url="sessionsStore.currentSession.prUrl"
@@ -572,27 +562,6 @@ function getTemplateName(templateId) {
   background: var(--color-warning, #f0ad4e);
   border-radius: 4px;
   white-space: nowrap;
-}
-
-.branch-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
-  font-family: var(--font-mono);
-  font-weight: 500;
-  color: var(--color-secondary, #8b5cf6);
-  background: var(--color-secondary-soft, rgba(139, 92, 246, 0.1));
-  border-radius: 4px;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.branch-icon {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
 }
 
 .tab-content {


### PR DESCRIPTION
## Summary

Successfully removed branch name display from the SessionDetailView.vue component. The session detail view no longer shows the branch indicator and associated styling.

## Changes

- Removed HTML branch indicator block (10 lines) from SessionDetailView.vue
- Removed .branch-indicator CSS styling rule (14 lines)
- Removed .branch-icon CSS styling rule (5 lines)
- Merged latest main branch with all conflicts resolved

## Files Modified

- `packages/web/src/views/SessionDetailView.vue`

## Test Plan

- [x] Build verification passed - no errors
- [x] Code changes reviewed
- [x] Merged main branch successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)