### PR TITLE
Fix quick response panel form submission issue

### DIFF
--- a/packages/web/src/components/QuickResponsesPanel.vue
+++ b/packages/web/src/components/QuickResponsesPanel.vue
@@ -4,6 +4,7 @@
     <div class="panel-header">
       <div class="header-left">
         <button
+          type="button"
           class="toggle-button"
           @click="toggleExpanded"
           :aria-expanded="isExpanded"
@@ -17,6 +18,7 @@
         <span class="panel-title">Quick Responses</span>
       </div>
       <button
+        type="button"
         class="settings-button"
         @click="$emit('openSettings')"
         title="Manage quick responses"
@@ -36,7 +38,7 @@
     <!-- Empty state (shown when expanded) -->
     <div v-else-if="!hasResponses && isExpanded" class="empty-state">
       <span class="empty-text">No quick responses yet</span>
-      <button class="add-button" @click="$emit('openSettings')">+ Add Quick Response</button>
+      <button type="button" class="add-button" @click="$emit('openSettings')">+ Add Quick Response</button>
     </div>
 
     <!-- Responses content (collapsible) -->


### PR DESCRIPTION
## Summary
Fixed quick response panel triggering form submission on NewSessionView by adding explicit `type=\"button\"` attributes to panel buttons.

## Problem
The quick response panel's toggle, settings, and add response buttons were missing explicit `type=\"button\"` attributes. When placed within a form context, HTML buttons default to `type=\"submit\"`, causing unintended form submissions when interacting with the panel.

## Solution
Added `type="button"` attributes to all three buttons in QuickResponsesPanel.vue:
- Toggle button
- Settings button  
- Add response button

## Testing
- QuickResponsesPanel tests: 23/23 passed ✅
- NewSessionView integration tests: 25/25 passed ✅
- All relevant tests passing

## Files Modified
- `packages/web/src/components/QuickResponsesPanel.vue`