### PR TITLE
fix: Keep command button output pane closed by default when command starts

### DIFF
--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -346,18 +346,17 @@ watch(
 );
 
 /**
- * Watch for run status changes to start/stop the timer and auto-expand output
+ * Watch for run status changes to start/stop the timer
  *
- * When status changes to 'running', start the timer and expand the output pane
- * so users can see the live output immediately.
+ * When status changes to 'running', start the elapsed time timer.
  * When status changes away from 'running', stop the timer.
+ * Note: Output pane remains collapsed by default; user can expand manually.
  */
 watch(
   () => props.run?.status,
   (newStatus) => {
     if (newStatus === 'running') {
       startTimer();
-      showOutput.value = true;
     } else {
       stopTimer();
     }


### PR DESCRIPTION
## Summary

- Removes the automatic expansion of the output pane when a command button's status changes to 'running'
- Output pane now stays collapsed by default, allowing users to manually expand it if they want to monitor command output

## Test plan

- [ ] Click a command button to start a command
- [ ] Verify output pane remains collapsed (not auto-expanded)
- [ ] Click to expand the output pane
- [ ] Verify output streams correctly when expanded
- [ ] Verify output can be collapsed again
- [ ] Run unit tests: `yarn workspace @claudetools/web test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)