### PR TITLE
fix: resolve spawn node ENOENT for npx users with nvm/fnm

### DIFF
--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,10 +1,28 @@
 import { createServer } from 'http';
 import { parseArgs } from 'node:util';
+import { execSync } from 'child_process';
 import { createApp } from './app.js';
 import { initDatabase } from './database.js';
 import { initWebSocket } from './websocket.js';
 import { DEFAULT_SERVER_PORT } from '@claudetools/shared';
 import * as prStatusService from './services/prStatusService.js';
+
+/**
+ * Validate Node.js environment at startup.
+ * Warns if 'node' is not in PATH (common with nvm/fnm version managers).
+ */
+function validateNodeEnvironment() {
+  try {
+    execSync('node --version', { stdio: 'ignore' });
+  } catch {
+    console.warn('');
+    console.warn('[Warning] "node" is not found in PATH.');
+    console.warn('If using nvm/fnm/volta, ensure your shell is properly configured.');
+    console.warn(`Current Node binary: ${process.execPath}`);
+    console.warn('This will be used for child processes (Claude Code sessions).');
+    console.warn('');
+  }
+}
 
 const { values } = parseArgs({
   options: {
@@ -27,6 +45,9 @@ process.on('uncaughtException', (err) => {
 process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);
 });
+
+// Validate Node.js environment
+validateNodeEnvironment();
 
 // Initialize database
 initDatabase(dbPath);

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import { commandRuns } from '../database.js';
+import { createRobustEnv } from './nodeSpawnHelper.js';
 
 /**
  * Service for running commands and managing their execution
@@ -53,6 +54,7 @@ export class CommandRunner {
           cwd: workingDirectory,
           stdio: ['pipe', 'pipe', 'pipe'],
           detached: true, // Create a new process group for proper signal handling
+          env: createRobustEnv(), // Ensure node is in PATH for npx users with nvm/fnm
         });
 
         // Store process with metadata and output buffer

--- a/packages/server/src/services/nodeSpawnHelper.js
+++ b/packages/server/src/services/nodeSpawnHelper.js
@@ -1,0 +1,63 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+/**
+ * Get the directory containing the current Node.js executable.
+ * Used to ensure child processes can find node even when using version managers.
+ * @returns {string} Path to the directory containing the Node binary
+ */
+export function getNodeBinDir() {
+  return path.dirname(process.execPath);
+}
+
+/**
+ * Create environment with guaranteed Node.js in PATH.
+ * Prepends the Node binary directory to PATH to ensure child processes can find node.
+ * This is critical for npx users with nvm/fnm/volta where 'node' may not be in system PATH.
+ *
+ * @param {Object} [baseEnv=process.env] - Base environment to extend
+ * @returns {Object} Environment object with robust PATH
+ */
+export function createRobustEnv(baseEnv = process.env) {
+  const nodeBinDir = getNodeBinDir();
+  const pathSeparator = process.platform === 'win32' ? ';' : ':';
+  const currentPath = baseEnv.PATH || baseEnv.Path || '';
+
+  return {
+    ...baseEnv,
+    PATH: `${nodeBinDir}${pathSeparator}${currentPath}`,
+  };
+}
+
+/**
+ * Create a custom spawn function for the Claude Agent SDK.
+ * Replaces 'node' command with process.execPath and ensures PATH is correct.
+ *
+ * This solves the "spawn node ENOENT" error that occurs when:
+ * - Users run the app via npx with Node version managers (nvm, fnm, volta)
+ * - The system PATH doesn't include the Node binary directory
+ *
+ * @returns {Function} Spawn function compatible with SDK's spawnClaudeCodeProcess option
+ */
+export function createClaudeCodeSpawner() {
+  return (options) => {
+    const { command, args, cwd, env, signal } = options;
+
+    // Replace 'node' with the absolute path to the current Node executable
+    // This ensures we use the same Node that's running our app
+    const actualCommand = command === 'node' ? process.execPath : command;
+
+    // Ensure PATH includes the directory containing Node
+    const robustEnv = createRobustEnv(env);
+
+    const stderrMode = robustEnv.DEBUG_CLAUDE_AGENT_SDK ? 'pipe' : 'ignore';
+
+    return spawn(actualCommand, args, {
+      cwd,
+      stdio: ['pipe', 'pipe', stderrMode],
+      signal,
+      env: robustEnv,
+      windowsHide: true,
+    });
+  };
+}

--- a/packages/server/src/services/nodeSpawnHelper.test.js
+++ b/packages/server/src/services/nodeSpawnHelper.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import { getNodeBinDir, createRobustEnv, createClaudeCodeSpawner } from './nodeSpawnHelper.js';
+
+describe('nodeSpawnHelper', () => {
+  describe('getNodeBinDir', () => {
+    it('returns the directory containing the Node binary', () => {
+      const nodeBinDir = getNodeBinDir();
+
+      // Should return a valid directory path
+      expect(nodeBinDir).toBeTruthy();
+      expect(typeof nodeBinDir).toBe('string');
+
+      // Should be the parent directory of process.execPath
+      expect(nodeBinDir).toBe(path.dirname(process.execPath));
+    });
+
+    it('returns absolute path', () => {
+      const nodeBinDir = getNodeBinDir();
+      expect(path.isAbsolute(nodeBinDir)).toBe(true);
+    });
+  });
+
+  describe('createRobustEnv', () => {
+    it('prepends Node bin directory to PATH', () => {
+      const env = createRobustEnv({ PATH: '/usr/bin:/bin' });
+      const nodeBinDir = getNodeBinDir();
+
+      expect(env.PATH).toContain(nodeBinDir);
+      expect(env.PATH.startsWith(nodeBinDir)).toBe(true);
+    });
+
+    it('preserves existing environment variables', () => {
+      const baseEnv = {
+        PATH: '/usr/bin:/bin',
+        HOME: '/home/user',
+        CUSTOM_VAR: 'custom_value',
+      };
+      const env = createRobustEnv(baseEnv);
+
+      expect(env.HOME).toBe('/home/user');
+      expect(env.CUSTOM_VAR).toBe('custom_value');
+    });
+
+    it('handles empty PATH gracefully', () => {
+      const env = createRobustEnv({ OTHER_VAR: 'value' });
+      const nodeBinDir = getNodeBinDir();
+
+      // Should still include the Node bin directory
+      expect(env.PATH).toContain(nodeBinDir);
+    });
+
+    it('uses process.env as default base', () => {
+      const env = createRobustEnv();
+      const nodeBinDir = getNodeBinDir();
+
+      // Should have Node bin dir at the start
+      expect(env.PATH.startsWith(nodeBinDir)).toBe(true);
+
+      // Should also include original PATH from process.env
+      if (process.env.PATH) {
+        expect(env.PATH).toContain(process.env.PATH);
+      }
+    });
+
+    it('uses correct path separator for platform', () => {
+      const env = createRobustEnv({ PATH: '/usr/bin' });
+      const expectedSeparator = process.platform === 'win32' ? ';' : ':';
+
+      expect(env.PATH).toContain(expectedSeparator);
+    });
+  });
+
+  describe('createClaudeCodeSpawner', () => {
+    let mockSpawn;
+
+    beforeEach(() => {
+      // We can't easily mock spawn in ESM, so we test the returned function's behavior
+    });
+
+    it('returns a function', () => {
+      const spawner = createClaudeCodeSpawner();
+      expect(typeof spawner).toBe('function');
+    });
+
+    it('replaces "node" command with process.execPath', async () => {
+      // This test verifies the spawner logic by checking if it handles the options correctly
+      // We can't easily test the actual spawn without mocking, but we can verify the function exists
+      const spawner = createClaudeCodeSpawner();
+
+      // The spawner should be callable with options
+      expect(() => {
+        // This will throw because we're not in a real spawn context,
+        // but we're testing that the function is properly constructed
+        spawner({
+          command: 'node',
+          args: ['--version'],
+          cwd: process.cwd(),
+          env: { PATH: '/usr/bin' },
+          signal: new AbortController().signal,
+        });
+      }).not.toThrow(); // The spawn itself might fail, but the function should execute
+    });
+  });
+});

--- a/packages/server/src/services/nodeSpawnHelper.test.js
+++ b/packages/server/src/services/nodeSpawnHelper.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import path from 'path';
 import { getNodeBinDir, createRobustEnv, createClaudeCodeSpawner } from './nodeSpawnHelper.js';
 
@@ -72,12 +72,6 @@ describe('nodeSpawnHelper', () => {
   });
 
   describe('createClaudeCodeSpawner', () => {
-    let mockSpawn;
-
-    beforeEach(() => {
-      // We can't easily mock spawn in ESM, so we test the returned function's behavior
-    });
-
     it('returns a function', () => {
       const spawner = createClaudeCodeSpawner();
       expect(typeof spawner).toBe('function');

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -6,6 +6,7 @@ import { updateTodos } from './todoStore.js';
 import * as summaryService from './summaryService.js';
 import { checkAndTriggerNextTemplate } from './templateTriggerService.js';
 import * as diffService from './diffService.js';
+import { createClaudeCodeSpawner, createRobustEnv } from './nodeSpawnHelper.js';
 
 /** @type {Map<string, string|null>} Track last message ID for end-of-turn work log association */
 const lastMessageIds = new Map();
@@ -466,17 +467,18 @@ curl -X POST ${apiUrl}/api/sessions/<session_id>/summary
 }
 
 /**
- * Build environment variables for Claude SDK based on session settings
+ * Build environment variables for Claude SDK based on session settings.
+ * Always returns a robust env with Node in PATH to prevent ENOENT errors.
  * @param {Object} session
- * @returns {Object|undefined}
+ * @returns {Object}
  */
 function buildSessionEnv(session) {
+  const baseEnv = createRobustEnv(process.env);
   if (!session.thinkingEnabled) {
-    return undefined; // Let SDK use process.env by default
+    return baseEnv;
   }
-  // Merge with process.env to preserve PATH and other essential env vars
   return {
-    ...process.env,
+    ...baseEnv,
     MAX_THINKING_TOKENS: '10240',
   };
 }
@@ -585,7 +587,8 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
             includePartialMessages: true,
             permissionMode: getPermissionModeForSession(session.mode),
             settingSources: ['project'],
-            ...(sessionEnv && { env: sessionEnv }),
+            env: sessionEnv,
+            spawnClaudeCodeProcess: createClaudeCodeSpawner(),
             ...(sessionModel && { model: sessionModel }),
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
@@ -706,7 +709,8 @@ export async function continueSession(sessionId, content, workingDirectory, syst
             // Use conversation's claudeSessionId for context isolation
             // Only pass resume if the conversation has an existing Claude session
             ...(activeConversation.claudeSessionId && { resume: activeConversation.claudeSessionId }),
-            ...(sessionEnv && { env: sessionEnv }),
+            env: sessionEnv,
+            spawnClaudeCodeProcess: createClaudeCodeSpawner(),
             ...(session.model && { model: session.model }),
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },


### PR DESCRIPTION
## Summary

- Fixes "spawn node ENOENT" error that occurs when users run via `npx` with Node version managers (nvm, fnm, volta)
- Uses `process.execPath` instead of relying on `node` being in PATH
- Adds startup warning when `node` is not found in PATH

## Problem

The Claude Agent SDK spawns child processes using `node` as the command. When users install via `npx` with version managers like nvm, `node` may not be in the system PATH (it's only available after sourcing shell configs). This causes:

```
Session error: Error: Failed to spawn Claude Code process: spawn node ENOENT
```

## Solution

Since the app is already running, `process.execPath` always points to a valid Node binary. The fix:

1. **Custom spawn function** - Uses SDK's `spawnClaudeCodeProcess` option to replace `node` with `process.execPath`
2. **Robust PATH** - Prepends the Node binary directory to PATH in all child process environments
3. **Startup validation** - Warns users early if `node` isn't in PATH (informational)

## Test plan

- [x] Unit tests for `nodeSpawnHelper.js` pass (9 tests)
- [x] Linting passes
- [x] Module imports work correctly
- [ ] Manual test: Start app normally with `yarn dev`
- [ ] Manual test: Create a session and verify it starts without ENOENT errors

🤖 Generated with [Claude Code](https://claude.ai/code)