### PR TITLE
Fix model field in ProjectEditView - convert text input to dropdown select

### DIFF
--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -161,15 +161,18 @@
 
         <div class="form-group">
           <label class="form-label" for="defaultModel">Model</label>
-          <input
+          <select
             id="defaultModel"
             v-model="defaultModel"
-            type="text"
             class="form-input"
-            placeholder="e.g., claude-opus-4"
-          />
+          >
+            <option value="">Use system default (Opus 4.5)</option>
+            <option v-for="model in CLAUDE_MODELS" :key="model.id" :value="model.id">
+              {{ model.name }} - {{ model.description }}
+            </option>
+          </select>
           <p class="form-help">
-            Specify a default Claude model for sessions. Leave empty to use the session's default.
+            Choose the default Claude model for new sessions in this project.
           </p>
         </div>
 
@@ -274,6 +277,7 @@ import { useUiStore } from '../stores/ui.js';
 import PathChooser from '../components/PathChooser.vue';
 import QuickResponseSettings from '../components/QuickResponseSettings.vue';
 import { DEFAULT_SYSTEM_PROMPT as defaultSystemPrompt } from '@claudetools/shared/constants';
+import { CLAUDE_MODELS } from '@claudetools/shared/types';
 
 const route = useRoute();
 const router = useRouter();


### PR DESCRIPTION
## Summary
Convert the model field in the Edit Project's "Session Defaults" section from a text input to a dropdown (select) control. Users can now choose from available Claude models, and the selected model is pre-selected when creating new sessions.

## Changes
- Import `CLAUDE_MODELS` constant from `@claudetools/shared/types`
- Replace text input with select dropdown in ProjectEditView.vue (lines 164-173)
- Display all 3 Claude models: Sonnet 4.5, Opus 4.5, Haiku 4.5
- Add "Use system default (Opus 4.5)" option for empty selection
- Update help text to reflect new dropdown functionality

## Test Plan
- [ ] Open Edit Project view in web UI
- [ ] Navigate to Session Defaults section
- [ ] Verify model field is now a dropdown with all 3 models visible
- [ ] Select a model and save the project
- [ ] Create a new session and verify the selected model is pre-selected
- [ ] Verify "Use system default (Opus 4.5)" option works when empty
- [ ] Verify dropdown styling matches other select fields in the form

## Technical Details
- No backend changes required - uses existing defaultModel field
- Integrates with existing project defaults store (defaultsStore.updateDefaults)
- Data persistence through existing save logic (handleSubmit)
- Dropdown styling provided by existing form-input CSS class

🤖 Generated with [Claude Code](https://claude.com/claude-code)