### PR TITLE
Fix real-time command button status icon updates on session lists

### DIFF
--- a/packages/server/src/api/commandButtons.js
+++ b/packages/server/src/api/commandButtons.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { commandButtons, sessions, commandRuns } from '../database.js';
 import { CreateCommandButtonRequest, UpdateCommandButtonRequest } from '@claudetools/shared/contracts/commandButtons';
 import { commandRunner } from '../services/commandRunner.js';
-import { broadcastToSession } from '../websocket.js';
+import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 import { databaseManager } from '../db/DatabaseManager.js';
 
@@ -109,8 +109,16 @@ router.post('/run/:buttonId', (req, res) => {
         button.command,
         workingDirectory,
         (text) => {
-          // Broadcast output via WebSocket
+          // Broadcast output via WebSocket to session subscribers
           broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
+            sessionId,
+            runId,
+            buttonId,
+            output: text,
+          });
+          // Also broadcast to project subscribers for session list updates
+          broadcastToProject(session.projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
+            projectId: session.projectId,
             sessionId,
             runId,
             buttonId,
@@ -118,7 +126,7 @@ router.post('/run/:buttonId', (req, res) => {
           });
         },
         (exitCode, output) => {
-          // Broadcast completion via WebSocket
+          // Broadcast completion via WebSocket to session subscribers
           const status = exitCode === 0 ? 'success' : 'error';
           broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, {
             sessionId,
@@ -128,10 +136,28 @@ router.post('/run/:buttonId', (req, res) => {
             exitCode,
             output,
           });
+          // Also broadcast to project subscribers for session list updates
+          broadcastToProject(session.projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, {
+            projectId: session.projectId,
+            sessionId,
+            runId,
+            buttonId,
+            status,
+            exitCode,
+            output,
+          });
         },
         (message) => {
-          // Broadcast error via WebSocket
+          // Broadcast error via WebSocket to session subscribers
           broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+            sessionId,
+            runId,
+            buttonId,
+            error: message,
+          });
+          // Also broadcast to project subscribers for session list updates
+          broadcastToProject(session.projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+            projectId: session.projectId,
             sessionId,
             runId,
             buttonId,
@@ -143,6 +169,14 @@ router.post('/run/:buttonId', (req, res) => {
     } catch (error) {
       console.error(`Error running command button ${buttonId}:`, error);
       broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+        sessionId,
+        runId,
+        buttonId,
+        error: error.message,
+      });
+      // Also broadcast to project subscribers for session list updates
+      broadcastToProject(session.projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+        projectId: session.projectId,
         sessionId,
         runId,
         buttonId,

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -505,6 +505,37 @@ export function useProjectSubscription(projectId) {
     return () => off(WS_MESSAGE_TYPES.SESSION_SUMMARY_UPDATED, handler);
   };
 
+  // Command run handlers for real-time status icon updates on session lists
+  const onCommandRunOutput = (callback) => {
+    const handler = (msg) => {
+      if (msg.projectId === projectId) {
+        callback(msg.runId, msg.sessionId, msg.buttonId, msg.output);
+      }
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, handler);
+  };
+
+  const onCommandRunComplete = (callback) => {
+    const handler = (msg) => {
+      if (msg.projectId === projectId) {
+        callback(msg.runId, msg.sessionId, msg.buttonId, msg.exitCode, msg.output, msg.status);
+      }
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, handler);
+  };
+
+  const onCommandRunError = (callback) => {
+    const handler = (msg) => {
+      if (msg.projectId === projectId) {
+        callback(msg.runId, msg.sessionId, msg.buttonId, msg.error);
+      }
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, handler);
+  };
+
   // Auto-cleanup on unmount
   onUnmounted(() => {
     unsubscribe();
@@ -517,6 +548,9 @@ export function useProjectSubscription(projectId) {
     onSessionUpdated,
     onSessionDeleted,
     onSessionSummaryUpdated,
+    onCommandRunOutput,
+    onCommandRunComplete,
+    onCommandRunError,
   };
 }
 

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -23,6 +23,9 @@ let onSessionCreatedCallback = null;
 let onSessionUpdatedCallback = null;
 let onSessionDeletedCallback = null;
 let onSessionSummaryUpdatedCallback = null;
+let onCommandRunOutputCallback = null;
+let onCommandRunCompleteCallback = null;
+let onCommandRunErrorCallback = null;
 
 // Mock WebSocket composable
 vi.mock('../composables/useWebSocket.js', () => ({
@@ -43,6 +46,18 @@ vi.mock('../composables/useWebSocket.js', () => ({
     }),
     onSessionSummaryUpdated: vi.fn((cb) => {
       onSessionSummaryUpdatedCallback = cb;
+      return vi.fn();
+    }),
+    onCommandRunOutput: vi.fn((cb) => {
+      onCommandRunOutputCallback = cb;
+      return vi.fn();
+    }),
+    onCommandRunComplete: vi.fn((cb) => {
+      onCommandRunCompleteCallback = cb;
+      return vi.fn();
+    }),
+    onCommandRunError: vi.fn((cb) => {
+      onCommandRunErrorCallback = cb;
       return vi.fn();
     }),
   })),

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -314,8 +314,17 @@ watch(
     fetchSummaries();
 
     // Create new subscription for new project
-    const { subscribe, unsubscribe, onSessionCreated, onSessionUpdated, onSessionDeleted, onSessionSummaryUpdated } =
-      useProjectSubscription(newProjectId);
+    const {
+      subscribe,
+      unsubscribe,
+      onSessionCreated,
+      onSessionUpdated,
+      onSessionDeleted,
+      onSessionSummaryUpdated,
+      onCommandRunOutput,
+      onCommandRunComplete,
+      onCommandRunError,
+    } = useProjectSubscription(newProjectId);
 
     currentUnsubscribe = unsubscribe;
     subscribe();
@@ -351,6 +360,40 @@ watch(
         summaries[sessionId] = summary;
         loadingSummaries[sessionId] = false;
         summaryErrors[sessionId] = false;
+      })
+    );
+
+    // Handle command run output (for real-time status icon updates)
+    cleanups.push(
+      onCommandRunOutput((runId, sessionId, buttonId, output) => {
+        // Ensure run exists in store, create if needed
+        if (!commandButtonsStore.runs[runId]) {
+          commandButtonsStore.runs[runId] = {
+            runId,
+            buttonId,
+            sessionId,
+            status: 'running',
+            output: '',
+            exitCode: null,
+            startedAt: Date.now(),
+            outputTruncated: false,
+          };
+        }
+        commandButtonsStore.appendOutput(runId, output);
+      })
+    );
+
+    // Handle command run complete
+    cleanups.push(
+      onCommandRunComplete((runId, sessionId, buttonId, exitCode, output) => {
+        commandButtonsStore.completeRun(runId, exitCode, output);
+      })
+    );
+
+    // Handle command run error
+    cleanups.push(
+      onCommandRunError((runId, sessionId, buttonId, error) => {
+        commandButtonsStore.errorRun(runId, error);
       })
     );
   },


### PR DESCRIPTION
## Summary
- Fixed command button status icons not updating in real-time on session lists
- Added project-level WebSocket broadcasts for command run events
- Session list view now subscribes to and handles command run events

## Problem
Command button status icons on the session list (SessionListView.vue) weren't updating in real-time when:
- A command button is executed (status changes to "running")
- A command completes (status changes to "success" or "error")
- A command is killed

**Root cause:** Command run WebSocket events (`COMMAND_RUN_OUTPUT`, `COMMAND_RUN_COMPLETE`, `COMMAND_RUN_ERROR`) were only broadcast to session subscribers, but the session list view subscribes to project-level events only.

## Solution
1. **Server (`commandButtons.js`):** Also broadcast command run events to project level using `broadcastToProject()` in addition to the existing `broadcastToSession()` calls
2. **Client (`useWebSocket.js`):** Add `onCommandRunOutput`, `onCommandRunComplete`, `onCommandRunError` handlers to `useProjectSubscription()`
3. **Client (`SessionListView.vue`):** Subscribe to the new command run events and update the `commandButtonsStore` accordingly

## Test plan
- [x] All unit tests pass (SessionListView: 61, useWebSocket: 57, commandButtons: 43)
- [ ] Manual test: Open session list, start a command from another tab, verify status icon updates
- [ ] Manual test: Wait for command to complete, verify status icon updates to success/error

🤖 Generated with [Claude Code](https://claude.ai/code)