### PR TITLE
Update system prompts for canvas and plan file behavior

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -206,15 +206,18 @@ export const PLAN_MODE_PROMPT = `## Plan Mode Active
 You are in PLAN mode. Before implementing any changes:
 
 1. **Analyze the Request**: Understand what the user is asking for
-2. **Create a Plan**: Write a detailed implementation plan with:
-   - Files that need to be created or modified
-   - Order of changes
-   - Key implementation decisions
-   - Potential risks or edge cases
-3. **Get Approval**: Present the plan and wait for user approval before proceeding
+2. **Create a Plan**: Write a detailed implementation plan to a file:
+   - Write your plan to: \`~/.claude/plans/<descriptive-name>.md\`
+   - Create the file using the Write tool
+   - Include in your plan:
+     - Files that need to be created or modified
+     - Order of changes
+     - Key implementation decisions
+     - Potential risks or edge cases
+3. **Get Approval**: Present the plan to the user by putting it on the canvas and wait for user approval before proceeding
 4. **Implement**: Only after approval, implement the changes step by step
 
-Do NOT start coding until you have presented a plan and received approval.
+CRITICAL: Do NOT start coding until you have presented a plan and received approval. Always write the plan file to \`~/.claude/plans/\` directory.
 
 `;
 

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -12,4 +12,13 @@ export const TOAST_DURATION = 5000;
 
 export const DEFAULT_SYSTEM_PROMPT = `You are Claude Code, an AI coding assistant. You help users with software engineering tasks including writing code, debugging, refactoring, and explaining code. You have full access to the shell and can execute any commands needed to assist the user. Be helpful, accurate, and thorough.
 
-IMPORTANT: Your working directory is already set correctly for this session. NEVER use \`cd\` to change to a hardcoded project path before running commands (e.g., \`cd /path/to/project && git status\`). This bypasses git worktree isolation and causes commands to run in the wrong directory. Always run commands directly without changing directory.`;
+IMPORTANT: Your working directory is already set correctly for this session. NEVER use \`cd\` to change to a hardcoded project path before running commands (e.g., \`cd /path/to/project && git status\`). This bypasses git worktree isolation and causes commands to run in the wrong directory. Always run commands directly without changing directory.
+
+## Canvas Behavior
+IMPORTANT: NEVER proactively put artifacts on the canvas unless the user explicitly requests it. Do not put images, markdown documents, code snippets, data visualizations, PDFs, or other artifacts on the canvas without being asked. Only use the canvas when the user specifically asks you to display or share something.
+
+## Plan Files
+When creating plan files or design documents, always write them to a temporary directory:
+- Use \`~/.claude/plans/<descriptive-name>.md\` for plan files
+- Use the Write tool to create these files
+- This keeps plans organized and separate from the main codebase`;


### PR DESCRIPTION
## Summary

This PR updates the system prompts to provide explicit guidance on two critical behaviors:

1. **Canvas Behavior**: Claude should never proactively put artifacts on the canvas unless explicitly requested by the user
2. **Plan File Organization**: When creating plan files, Claude should write them to `~/.claude/plans/` directory using the Write tool

## Changes

### 1. Updated `DEFAULT_SYSTEM_PROMPT` (packages/shared/src/constants.js)
- Added **Canvas Behavior** section clarifying that artifacts (images, markdown, code, visualizations, PDFs) should only be placed on canvas when explicitly requested
- Added **Plan Files** section instructing Claude to write plans to `~/.claude/plans/` directory and use the Write tool
- Both apply to all modes (standard, plan, yolo) and custom project prompts

### 2. Enhanced `PLAN_MODE_PROMPT` (packages/server/src/services/sessionManager.js)
- Updated "Create a Plan" step to explicitly require writing plan files to `~/.claude/plans/`
- Enhanced "Get Approval" step to specify presenting plan on canvas for approval
- Added CRITICAL note emphasizing no coding until plan is approved
- Makes the plan mode workflow more explicit and structured

## Benefits

- ✨ **Canvas Control**: Users won't see unexpected artifacts on canvas without their request
- 📋 **Plan Organization**: Plans are systematically written to a known temporary directory
- 🎯 **Workflow Clarity**: Plan mode instructions are more explicit about the expected process
- 🔄 **Consistency**: All system prompts follow the same rules across all modes
- 🚀 **No Breaking Changes**: All existing tests pass (1,659 server tests + 1,540 web tests)

## Files Modified

| File | Changes |
|------|---------|
| `packages/shared/src/constants.js` | +9 lines (Canvas Behavior + Plan Files sections) |
| `packages/server/src/services/sessionManager.js` | +3 lines (Enhanced plan mode instructions) |

## Testing

- ✅ ESLint: Passed (0 errors)
- ✅ Server Tests: 61 files, 1,659 tests passed
- ✅ Web Tests: 51 files, 1,540 tests passed
- ✅ No breaking changes

## How to Test

1. Create a new session and verify the default system prompt includes canvas behavior warnings
2. Create a new plan mode session and verify it mentions `~/.claude/plans/` directory
3. Run a test session to confirm Claude doesn't proactively add artifacts to canvas
4. Run a test in plan mode to confirm Claude writes plans to `~/.claude/plans/` and requests approval before implementing

## Checklist

- [x] Changes implement the design plan correctly
- [x] All relevant tests pass
- [x] Code follows project style guidelines
- [x] No breaking changes to existing functionality
- [x] Branch is up to date with main

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)