### PR TITLE
Fix token counting bugs: remove duplicate handlers, fix fallback logic, add real-time getters

### DIFF
--- a/packages/web/src/components/ConversationSelector.vue
+++ b/packages/web/src/components/ConversationSelector.vue
@@ -104,8 +104,9 @@ function formatTokens(n) {
 }
 
 function getConversationTokens(conv) {
-  const total = (conv.inputTokens || 0) + (conv.outputTokens || 0);
-  return formatTokens(total);
+  // Use the store getter for real-time token updates during streaming
+  const tokens = sessionsStore.getConversationDisplayTokens(conv.id);
+  return formatTokens(tokens.total);
 }
 
 // Get display name for the active conversation

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -145,23 +145,21 @@ export const useSessionsStore = defineStore('sessions', {
         }
       }
 
-      // FINALIZED: Try conversation first, but fall back to session if conversation has no tokens
+      // FINALIZED: Use conversation tokens if available, otherwise show zeros
+      // Don't fall back to session aggregate - that shows sum of ALL conversations which is confusing
       let source = null;
 
       if (state.activeConversationId && state.conversations.length > 0) {
         const conv = state.conversations.find((c) => c.id === state.activeConversationId);
-        // Only use conversation if it actually has token data
-        if (conv && ((conv.inputTokens || 0) > 0 || (conv.outputTokens || 0) > 0)) {
+        if (conv) {
           source = conv;
         }
       }
 
-      // Fall back to session if no valid conversation data
+      // If no conversation data, return zeros instead of session aggregate
       if (!source) {
-        source = state.currentSession;
+        return { input: '0', output: '0', total: '0', cacheRead: '0', cacheCreation: '0' };
       }
-
-      if (!source) return { input: '0', output: '0', total: '0', cacheRead: '0', cacheCreation: '0' };
 
       return {
         input: format(source.inputTokens || 0),
@@ -199,6 +197,29 @@ export const useSessionsStore = defineStore('sessions', {
         return false;
       }
       return true;
+    },
+
+    /**
+     * Get tokens for a specific conversation, considering runningUsage if active
+     * Used by ConversationSelector to show real-time token updates in dropdown
+     */
+    getConversationDisplayTokens: (state) => (conversationId) => {
+      // If this conversation has active runningUsage, use that for real-time display
+      if (state.runningUsage && state.runningUsage.conversationId === conversationId) {
+        return {
+          inputTokens: state.runningUsage.inputTokens || 0,
+          outputTokens: state.runningUsage.outputTokens || 0,
+          total: (state.runningUsage.inputTokens || 0) + (state.runningUsage.outputTokens || 0),
+        };
+      }
+      // Otherwise use stored conversation data
+      const conv = state.conversations.find((c) => c.id === conversationId);
+      if (!conv) return { inputTokens: 0, outputTokens: 0, total: 0 };
+      return {
+        inputTokens: conv.inputTokens || 0,
+        outputTokens: conv.outputTokens || 0,
+        total: (conv.inputTokens || 0) + (conv.outputTokens || 0),
+      };
     },
   },
 

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -952,13 +952,16 @@ describe('Sessions Store', () => {
 
       it('formats small numbers as-is', () => {
         const store = useSessionsStore();
-        store.currentSession = {
-          id: 'session-1',
-          inputTokens: 500,
-          outputTokens: 250,
-          cacheReadInputTokens: 100,
-          cacheCreationInputTokens: 50,
-        };
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 500,
+            outputTokens: 250,
+            cacheReadInputTokens: 100,
+            cacheCreationInputTokens: 50,
+          },
+        ];
 
         const formatted = store.formattedTokens;
         expect(formatted.input).toBe('500');
@@ -970,11 +973,10 @@ describe('Sessions Store', () => {
 
       it('formats thousands with K suffix', () => {
         const store = useSessionsStore();
-        store.currentSession = {
-          id: 'session-1',
-          inputTokens: 5500,
-          outputTokens: 2500,
-        };
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 5500, outputTokens: 2500 },
+        ];
 
         const formatted = store.formattedTokens;
         expect(formatted.input).toBe('5.5K');
@@ -984,11 +986,10 @@ describe('Sessions Store', () => {
 
       it('formats millions with M suffix', () => {
         const store = useSessionsStore();
-        store.currentSession = {
-          id: 'session-1',
-          inputTokens: 1500000,
-          outputTokens: 500000,
-        };
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1500000, outputTokens: 500000 },
+        ];
 
         const formatted = store.formattedTokens;
         expect(formatted.input).toBe('1.5M');
@@ -998,11 +999,10 @@ describe('Sessions Store', () => {
 
       it('handles exactly 1000 tokens', () => {
         const store = useSessionsStore();
-        store.currentSession = {
-          id: 'session-1',
-          inputTokens: 1000,
-          outputTokens: 0,
-        };
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1000, outputTokens: 0 },
+        ];
 
         const formatted = store.formattedTokens;
         expect(formatted.input).toBe('1.0K');
@@ -1010,11 +1010,10 @@ describe('Sessions Store', () => {
 
       it('handles exactly 1000000 tokens', () => {
         const store = useSessionsStore();
-        store.currentSession = {
-          id: 'session-1',
-          inputTokens: 1000000,
-          outputTokens: 0,
-        };
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1000000, outputTokens: 0 },
+        ];
 
         const formatted = store.formattedTokens;
         expect(formatted.input).toBe('1.0M');
@@ -1048,15 +1047,18 @@ describe('Sessions Store', () => {
         expect(formatted.cacheCreation).toBe('100');
       });
 
-      it('falls back to session tokens when runningUsage is null', () => {
+      it('uses conversation tokens when runningUsage is null', () => {
         const store = useSessionsStore();
-        store.currentSession = {
-          id: 'session-1',
-          inputTokens: 5500,
-          outputTokens: 2500,
-          cacheReadInputTokens: 100,
-          cacheCreationInputTokens: 50,
-        };
+        store.activeConversationId = 'conv-1';
+        store.conversations = [
+          {
+            id: 'conv-1',
+            inputTokens: 5500,
+            outputTokens: 2500,
+            cacheReadInputTokens: 100,
+            cacheCreationInputTokens: 50,
+          },
+        ];
         store.runningUsage = null;
 
         const formatted = store.formattedTokens;
@@ -1189,9 +1191,10 @@ describe('Sessions Store', () => {
         expect(formatted.cacheCreation).toBe('2.5K');
       });
 
-      // Issue #324 - Improved fallback logic tests
-      describe('conversation/session fallback logic', () => {
-        it('falls back to session when conversation has zero tokens', () => {
+      // Issue #324 - No session fallback behavior (shows conversation data only)
+      // Bug fix: Don't fall back to session aggregate - that shows sum of ALL conversations which is confusing
+      describe('conversation-only display logic (no session fallback)', () => {
+        it('shows conversation zeros when conversation has zero tokens (no session fallback)', () => {
           const store = useSessionsStore();
           store.activeConversationId = 'conv-1';
           store.conversations = [
@@ -1213,12 +1216,12 @@ describe('Sessions Store', () => {
           store.runningUsage = null;
 
           const formatted = store.formattedTokens;
-          // Should use session data because conversation has zero tokens
-          expect(formatted.input).toBe('5.0K');
-          expect(formatted.output).toBe('2.5K');
-          expect(formatted.total).toBe('7.5K');
-          expect(formatted.cacheRead).toBe('500');
-          expect(formatted.cacheCreation).toBe('250');
+          // Should show conversation zeros, NOT session aggregate (that would be confusing)
+          expect(formatted.input).toBe('0');
+          expect(formatted.output).toBe('0');
+          expect(formatted.total).toBe('0');
+          expect(formatted.cacheRead).toBe('0');
+          expect(formatted.cacheCreation).toBe('0');
         });
 
         it('uses conversation data when it has non-zero tokens', () => {
@@ -1297,7 +1300,7 @@ describe('Sessions Store', () => {
           expect(formatted.total).toBe('500');
         });
 
-        it('falls back to session when activeConversationId is null', () => {
+        it('returns zeros when activeConversationId is null (no session fallback)', () => {
           const store = useSessionsStore();
           store.activeConversationId = null;
           store.conversations = [
@@ -1315,13 +1318,13 @@ describe('Sessions Store', () => {
           store.runningUsage = null;
 
           const formatted = store.formattedTokens;
-          // Should use session data because activeConversationId is null
-          expect(formatted.input).toBe('5.0K');
-          expect(formatted.output).toBe('2.5K');
-          expect(formatted.total).toBe('7.5K');
+          // Should return zeros, NOT session aggregate (that would show sum of ALL conversations)
+          expect(formatted.input).toBe('0');
+          expect(formatted.output).toBe('0');
+          expect(formatted.total).toBe('0');
         });
 
-        it('falls back to session when conversations array is empty', () => {
+        it('returns zeros when conversations array is empty (no session fallback)', () => {
           const store = useSessionsStore();
           store.activeConversationId = 'conv-1';
           store.conversations = [];
@@ -1333,13 +1336,13 @@ describe('Sessions Store', () => {
           store.runningUsage = null;
 
           const formatted = store.formattedTokens;
-          // Should use session data because conversations array is empty
-          expect(formatted.input).toBe('5.0K');
-          expect(formatted.output).toBe('2.5K');
-          expect(formatted.total).toBe('7.5K');
+          // Should return zeros, NOT session aggregate (that would show sum of ALL conversations)
+          expect(formatted.input).toBe('0');
+          expect(formatted.output).toBe('0');
+          expect(formatted.total).toBe('0');
         });
 
-        it('falls back to session when active conversation not found', () => {
+        it('returns zeros when active conversation not found (no session fallback)', () => {
           const store = useSessionsStore();
           store.activeConversationId = 'non-existent-conv';
           store.conversations = [
@@ -1357,20 +1360,20 @@ describe('Sessions Store', () => {
           store.runningUsage = null;
 
           const formatted = store.formattedTokens;
-          // Should use session data because active conversation not found
-          expect(formatted.input).toBe('5.0K');
-          expect(formatted.output).toBe('2.5K');
-          expect(formatted.total).toBe('7.5K');
+          // Should return zeros, NOT session aggregate (that would show sum of ALL conversations)
+          expect(formatted.input).toBe('0');
+          expect(formatted.output).toBe('0');
+          expect(formatted.total).toBe('0');
         });
 
-        it('prevents stale conversation data from overwriting session data during streaming', () => {
+        it('handles conversation with zero tokens before streaming starts', () => {
           const store = useSessionsStore();
-          // Simulate a race condition where conversation has stale data
+          // Simulate a new conversation that has no tokens yet
           store.activeConversationId = 'conv-1';
           store.conversations = [
             {
               id: 'conv-1',
-              inputTokens: 0, // Stale - hasn't been updated yet
+              inputTokens: 0, // New conversation - no usage yet
               outputTokens: 0,
             },
           ];
@@ -1382,10 +1385,10 @@ describe('Sessions Store', () => {
           store.runningUsage = null;
 
           const formatted = store.formattedTokens;
-          // Should fall back to session because conversation has zero tokens
-          expect(formatted.input).toBe('10.0K');
-          expect(formatted.output).toBe('5.0K');
-          expect(formatted.total).toBe('15.0K');
+          // Should show conversation zeros (no session fallback - that would be confusing)
+          expect(formatted.input).toBe('0');
+          expect(formatted.output).toBe('0');
+          expect(formatted.total).toBe('0');
 
           // Now simulate streaming updating the usage (with conversationId matching active conversation)
           store.runningUsage = {
@@ -1427,6 +1430,82 @@ describe('Sessions Store', () => {
         store.runningUsage = { inputTokens: 100, outputTokens: 50 };
 
         expect(store.isUsageUpdating).toBe(true);
+      });
+    });
+
+    describe('getConversationDisplayTokens getter', () => {
+      it('returns runningUsage data when conversation has active streaming', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1000, outputTokens: 500 },
+        ];
+        store.runningUsage = {
+          conversationId: 'conv-1',
+          inputTokens: 5000,
+          outputTokens: 2500,
+        };
+
+        const tokens = store.getConversationDisplayTokens('conv-1');
+        expect(tokens.inputTokens).toBe(5000);
+        expect(tokens.outputTokens).toBe(2500);
+        expect(tokens.total).toBe(7500);
+      });
+
+      it('returns stored conversation data when no runningUsage', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1000, outputTokens: 500 },
+        ];
+        store.runningUsage = null;
+
+        const tokens = store.getConversationDisplayTokens('conv-1');
+        expect(tokens.inputTokens).toBe(1000);
+        expect(tokens.outputTokens).toBe(500);
+        expect(tokens.total).toBe(1500);
+      });
+
+      it('returns stored conversation data when runningUsage is for different conversation', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1000, outputTokens: 500 },
+          { id: 'conv-2', inputTokens: 2000, outputTokens: 1000 },
+        ];
+        store.runningUsage = {
+          conversationId: 'conv-2',
+          inputTokens: 5000,
+          outputTokens: 2500,
+        };
+
+        const tokens = store.getConversationDisplayTokens('conv-1');
+        expect(tokens.inputTokens).toBe(1000);
+        expect(tokens.outputTokens).toBe(500);
+        expect(tokens.total).toBe(1500);
+      });
+
+      it('returns zeros for non-existent conversation', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1', inputTokens: 1000, outputTokens: 500 },
+        ];
+        store.runningUsage = null;
+
+        const tokens = store.getConversationDisplayTokens('non-existent');
+        expect(tokens.inputTokens).toBe(0);
+        expect(tokens.outputTokens).toBe(0);
+        expect(tokens.total).toBe(0);
+      });
+
+      it('handles conversation with undefined token values', () => {
+        const store = useSessionsStore();
+        store.conversations = [
+          { id: 'conv-1' }, // No token fields
+        ];
+        store.runningUsage = null;
+
+        const tokens = store.getConversationDisplayTokens('conv-1');
+        expect(tokens.inputTokens).toBe(0);
+        expect(tokens.outputTokens).toBe(0);
+        expect(tokens.total).toBe(0);
       });
     });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -175,7 +175,7 @@ function navigateToTab(tabId) {
   router.push(`/sessions/${route.params.id}/${tabId}`);
 }
 
-const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onUsageUpdate, onConversationUpdated, onChangesUpdate } =
+const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onConversationUpdated, onChangesUpdate } =
   useSessionSubscription(sessionId);
 
 let cleanups = [];
@@ -323,18 +323,8 @@ onMounted(async () => {
     })
   );
 
-  cleanups.push(
-    onUsageUpdate((msg) => {
-      if (msg.isFinal) {
-        // Pass conversationId for conversation-level usage tracking (Issue #175)
-        sessionsStore.finalizeUsage(msg.usage, msg.conversationId);
-      } else {
-        sessionsStore.updateRunningUsage(msg.usage, msg.conversationId);
-      }
-    })
-  );
-
   // Handle conversation updates for usage tracking (Issue #175)
+  // Note: onUsageUpdate is handled by ConversationTab to avoid duplicate registrations
   cleanups.push(
     onConversationUpdated((conversation) => {
       sessionsStore.updateConversation(conversation);


### PR DESCRIPTION
## Summary

- **Remove duplicate onUsageUpdate handler** from SessionDetailView.vue that was causing tokens to not update properly during Claude's streaming work
- **Fix formattedTokens fallback logic** to return zeros instead of session aggregate when conversation has no tokens (showing sum of ALL conversations was confusing)
- **Add getConversationDisplayTokens getter** to sessions store for real-time token updates using runningUsage during streaming
- **Update ConversationSelector.vue** to use new getter for live token display in the conversation dropdown

## Test plan

- [ ] Verify tokens update in real-time while Claude is working (streaming)
- [ ] Verify conversation dropdown displays correct per-conversation token totals
- [ ] Verify switching between conversations shows correct conversation-specific totals (not aggregate)
- [ ] Run `yarn workspace @claudetools/web test` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)