### PR TITLE
Fix: Allow sending messages when session is in error state

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -247,7 +247,7 @@ router.post('/:id/message', upload.array('files', 10), handleUploadError, async 
     return res.status(400).json({ error: 'Content is required' });
   }
 
-  if (session.status !== 'waiting' && session.status !== 'stopped') {
+  if (session.status !== 'waiting' && session.status !== 'stopped' && session.status !== 'error') {
     return res.status(400).json({ error: 'Session is not waiting for input' });
   }
 

--- a/packages/server/test/file-attachments.test.js
+++ b/packages/server/test/file-attachments.test.js
@@ -558,6 +558,21 @@ describe('File Attachments API', () => {
       expect(response.body.success).toBe(true);
     });
 
+    it('accepts message when session is in error state', async () => {
+      sessions.update(session.id, { status: 'error' });
+
+      const response = await request(app)
+        .post(`/api/sessions/${session.id}/message`)
+        .field('content', 'Continuing from error')
+        .attach('files', Buffer.from('content'), {
+          filename: 'test.txt',
+          contentType: 'text/plain',
+        })
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+    });
+
     it('sends multiple files in a single message', async () => {
       const response = await request(app)
         .post(`/api/sessions/${session.id}/message`)


### PR DESCRIPTION
## Summary

Fixes the issue where users cannot send messages or comments when a session enters an error state. The frontend UI allows users to type and shows the send button, but the backend API was rejecting these messages, creating a confusing UX gap.

## Problem

When a Claude Code session encounters an error:
- The frontend displays an error banner with helpful text: "You can continue the conversation below, or try a different approach"
- The UI enables the message input form and send button
- However, when users click send, the API rejects with "Session is not waiting for input"

**Root Cause:** The backend validation only allowed messages in `'waiting'` and `'stopped'` states, not `'error'` state, despite the frontend supporting it.

## Solution

Added `'error'` to the valid session statuses that can receive messages in the POST `/api/sessions/:id/message` endpoint. This ensures:
- Frontend and backend validation are consistent
- Users can continue conversation after errors as the UI promises
- No breaking changes - only adds a new valid state

## Changes

- **packages/server/src/api/sessions.js**: Updated session status validation to accept `'error'` state
- **packages/server/test/file-attachments.test.js**: Added test case verifying messages can be sent in error state

## Test Plan

✅ New unit test added verifying messages accepted in error state  
✅ Existing tests pass (no regression)  
🔄 Manual testing: Create a session, trigger error, verify message send succeeds  
🔄 Verify error banner still displays  
🔄 Verify error badge and UI elements work correctly  

## Impact

- **Scope**: Small, targeted fix
- **Risk**: Very low - only adding valid state to existing validation
- **UX Improvement**: High - removes confusing behavior mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)