### PR TITLE
Simplify PR indicator to show only number in session list

### DIFF
--- a/packages/web/src/components/PrIndicators.vue
+++ b/packages/web/src/components/PrIndicators.vue
@@ -73,7 +73,7 @@ function extractPrDisplay() {
 }
 
 /**
- * Display PR text with repository context from URL
+ * Display PR text - just show the number
  */
 function displayPrText() {
   if (!props.prUrl) return 'PR';
@@ -81,8 +81,7 @@ function displayPrText() {
   const pr = extractPrDisplay();
   if (!pr.number) return 'PR';
 
-  const repo = pr.repo ? ` (${pr.owner}/${pr.repo})` : '';
-  return `PR ${pr.number}${repo}`;
+  return `PR ${pr.number}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Reverted the PR indicator display on the session list to show only the PR number (e.g., "PR 123") instead of the full repository path. This reduces UI clutter while preserving the tooltip that displays the full repository information on hover.

## Changes
- Modified `PrIndicators.vue` component to revert the `displayPrText()` function
- Shows concise PR number while maintaining full repo context in tooltip

## Test plan
- [ ] View session list and verify PR indicators show only the number
- [ ] Hover over PR indicators to confirm tooltip shows full repository information
- [ ] Verify PR indicator appears correctly for sessions with associated PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)