### PR TITLE
Remove session starred/unstarred toast notifications

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -466,8 +466,6 @@ async function handleArchive() {
 async function handleStar() {
   try {
     await sessionsStore.toggleSessionStar(sessionId);
-    const isNowStarred = sessionsStore.currentSession?.starred;
-    uiStore.success(isNowStarred ? 'Session starred' : 'Session unstarred');
   } catch (err) {
     uiStore.error(err.message);
   }


### PR DESCRIPTION
## Summary

Remove the success toast notifications that displayed when a session was starred or unstarred, addressing feature request #a520.

**Changes:**
- Removed the success toast in `handleStar()` function in SessionDetailView.vue
- Error handling remains in place to inform users if the operation fails
- Starring/unstarring functionality still works as expected - users can see starred status via the star icon

**Files Modified:**
- `packages/web/src/views/SessionDetailView.vue`

## Test Plan

- [x] Verified no other locations trigger the "Session starred/unstarred" toasts
- [x] Confirmed error handling still displays if toggle operation fails
- [x] Starring/unstarring functionality remains fully operational
- [x] No breaking changes to tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)