### PR TITLE
Fix session name wrapping in header

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -543,13 +543,13 @@ function getTemplateName(templateId) {
 
 .session-name {
   flex: 1;
-  min-width: 0; /* Critical: allows text-overflow to work in flexbox */
+  min-width: 0; /* Critical: allows wrapping to work in flexbox */
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
+  line-height: 1.4;
 }
 
 .branch-pr-indicators {
@@ -561,8 +561,10 @@ function getTemplateName(templateId) {
 
 @media (max-width: 768px) {
   .session-header-row {
-    /* Keep everything on one line - don't wrap */
-    min-height: 44px; /* Touch target minimum */
+    /* Allow flexbox to accommodate multi-line session names */
+    align-items: flex-start;
+    min-height: auto;
+    padding-top: 0.25rem; /* Align star button with first line of text */
   }
 
   .session-name {


### PR DESCRIPTION
## Summary

Successfully fixed session name wrapping on small screens by removing text truncation CSS and adding responsive layout adjustments to SessionDetailView.vue.

The solution involved:
- Removing `white-space: nowrap` and `text-overflow: ellipsis` CSS properties from the `.session-name` class
- Adding `word-break: break-word` for long names
- Updating mobile layout with `align-items: flex-start` and `min-height: auto` to accommodate multi-line text

Session names now fully display on small screens instead of being cut off, with proper layout adaptation for wrapped text.

## Changes Made

- Modified CSS in SessionDetailView.vue to enable text wrapping and responsive layout
- Added word-break and line-height properties for long session names
- Updated mobile media queries for proper alignment and sizing

## Test Plan

- [x] Ran E2E tests to verify responsive behavior across breakpoints
- [ ] Review the visual changes on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)