### PR TITLE
Remove redundant output truncation warning from command button

### DIFF
--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -72,10 +72,6 @@
 
       <!-- Output Content (when expanded) -->
       <div v-if="showOutput" class="output-content">
-        <!-- Store truncation warning (2000 lines) -->
-        <div v-if="run.outputTruncated" class="output-truncated-warning">
-          ⚠️ Output truncated (showing last 2000 lines)
-        </div>
         <!-- Display truncation indicator (200 lines for performance) -->
         <div v-if="outputIsTruncatedForDisplay" class="output-display-truncated">
           ↑ Showing last 200 lines. Use Copy to get full output.
@@ -609,15 +605,6 @@ defineExpose({
   border: 1px solid var(--color-border);
   border-radius: 4px;
   position: relative;
-}
-
-.output-truncated-warning {
-  background-color: rgba(251, 191, 36, 0.15);
-  border: 1px solid rgba(251, 191, 36, 0.3);
-  color: var(--color-warning, #fbbf24);
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
-  font-size: 0.8rem;
 }
 
 .output-display-truncated {


### PR DESCRIPTION
## Summary
Successfully removed the redundant "Output truncated (showing last 2000 lines)" warning from the command button output UI. The store-level truncation warning was unnecessary since it appeared alongside the more practical display truncation indicator.

## Changes
- Removed redundant store truncation warning from CommandButtonItem.vue template
- Removed associated CSS styling for .output-truncated-warning
- Retained the helpful display truncation indicator "Showing last 200 lines..." which tells users they can copy the full output

## Files Modified
- `packages/web/src/components/CommandButtonItem.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)