### PR TITLE
Fix critical race condition in command button data loading on direct navigation

### DIFF
--- a/packages/web/src/components/CommandButtonsPanel.test.js
+++ b/packages/web/src/components/CommandButtonsPanel.test.js
@@ -304,17 +304,21 @@ describe('CommandButtonsPanel', () => {
     expect(deleteButtonFn).toHaveBeenCalledWith('test-project', '1');
   });
 
-  it('fetches buttons on mount', async () => {
+  it('does not fetch buttons on mount (parent handles fetching)', async () => {
+    // The parent SessionListView handles fetching buttons, so the component
+    // should not fetch on mount. Instead, it should display data from the store.
     const fetchButtons = vi.fn().mockResolvedValue(undefined);
     const mockStore = {
-      buttons: [],
+      buttons: [
+        { id: '1', label: 'Test', command: 'npm test', sortOrder: 1 },
+      ],
       loading: false,
       error: null,
       fetchButtons,
     };
     vi.mocked(useCommandButtonsStore).mockReturnValue(mockStore);
 
-    mount(CommandButtonsPanel, {
+    const wrapper = mount(CommandButtonsPanel, {
       props: { projectId: 'test-project' },
       global: {
         stubs: {
@@ -324,6 +328,9 @@ describe('CommandButtonsPanel', () => {
     });
 
     await flushPromises();
-    expect(fetchButtons).toHaveBeenCalledWith('test-project');
+    // fetchButtons should NOT be called by the component
+    expect(fetchButtons).not.toHaveBeenCalled();
+    // But it should display the data from the store
+    expect(wrapper.text()).toContain('Test');
   });
 });

--- a/packages/web/src/components/CommandButtonsPanel.vue
+++ b/packages/web/src/components/CommandButtonsPanel.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script setup>
-import { defineProps, ref, onMounted } from 'vue';
+import { defineProps, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 
@@ -119,10 +119,6 @@ const confirmDelete = async () => {
     }
   }
 };
-
-onMounted(async () => {
-  await commandButtonsStore.fetchButtons(props.projectId);
-});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Fixed a critical bug where direct navigation to the command button list configuration view displayed a data loading error, while sub-navigation allowed the data to load successfully.

### Root Cause
Race condition between SessionListView (with immediate watcher) and CommandButtonsPanel (with onMounted fetch) both calling `fetchButtons()` simultaneously, causing the data fetch to be interrupted.

### Solution
Removed the redundant `onMounted` fetch from CommandButtonsPanel.vue since the parent component (SessionListView) already handles data fetching. This eliminates the race condition while maintaining the same functionality.

### Changes
- **packages/web/src/components/CommandButtonsPanel.vue** - Removed redundant onMounted hook and fetchButtons() call
- **packages/web/src/components/CommandButtonsPanel.test.js** - Updated test to reflect new behavior

### Testing
- ✅ All 9 CommandButtonsPanel tests passing
- ✅ All 1,682 web package tests passing
- ✅ Direct navigation scenario works correctly
- ✅ Browser refresh scenario works correctly
- ✅ Sub-navigation scenario still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)