### PR TITLE
Fix: Persist command output pane collapse state across tab navigation

### DIFF
--- a/packages/web/src/components/CommandButtonItem.test.js
+++ b/packages/web/src/components/CommandButtonItem.test.js
@@ -2,9 +2,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { ref, nextTick } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
 import CommandButtonItem from './CommandButtonItem.vue';
 
 describe('CommandButtonItem', () => {
+  // Set up a fresh Pinia instance before each test
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
   const mockButton = {
     id: 'btn-1',
     projectId: 'proj-1',
@@ -14,7 +20,7 @@ describe('CommandButtonItem', () => {
   };
 
   const mockRun = {
-    id: 'run-1',
+    runId: 'run-1',
     buttonId: 'btn-1',
     status: 'success',
     output: 'Tests passed\n✓ 42 tests completed',

--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -95,6 +95,7 @@
 <script setup>
 import { defineProps, defineEmits, ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
 import { ansiToHtml, stripAnsi } from '../utils/ansi.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 
 /**
  * Debounce with leading edge - first call is immediate, subsequent calls are debounced
@@ -145,8 +146,24 @@ const props = defineProps({
 
 const emit = defineEmits(['run', 'kill', 'send-to-canvas']);
 
-// Default to true only if command is running, false otherwise
-const showOutput = ref(props.run?.status === 'running');
+// Initialize store
+const commandButtonsStore = useCommandButtonsStore();
+
+// Use store to persist collapse state across tab navigation
+// Computed property syncs with store: get returns !isCollapsed, set updates store
+const showOutput = computed({
+  get() {
+    if (!props.run?.runId) {
+      return false;
+    }
+    return !commandButtonsStore.isOutputCollapsed(props.run.runId);
+  },
+  set(value) {
+    if (props.run?.runId) {
+      commandButtonsStore.setOutputCollapsed(props.run.runId, !value);
+    }
+  }
+});
 
 // Track if button click is in flight (prevents double-clicks)
 const isSubmitting = ref(false);

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -10,6 +10,7 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
   state: () => ({
     buttons: [],
     runs: {}, // runId -> { runId, buttonId, status, output, exitCode, outputTruncated }
+    collapsedStates: {}, // runId -> boolean (true = collapsed, false = expanded)
     loading: false,
     error: null,
     // Internal buffering state (not reactive to avoid extra renders)
@@ -30,6 +31,15 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
 
       // Return the first one (most recent)
       return runsForButton.length > 0 ? runsForButton[0] : null;
+    },
+    isOutputCollapsed: (state) => (runId) => {
+      // If user has set a preference, use it
+      if (state.collapsedStates[runId] !== undefined) {
+        return state.collapsedStates[runId];
+      }
+      // Otherwise, default based on status: collapsed for completed, expanded for running
+      const run = state.runs[runId];
+      return run?.status !== 'running';
     },
   },
 
@@ -333,6 +343,10 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
+    setOutputCollapsed(runId, isCollapsed) {
+      this.collapsedStates[runId] = isCollapsed;
+    },
+
     clearRun(runId) {
       // Clean up any pending timers/buffers
       if (this._flushTimers[runId]) {
@@ -341,6 +355,7 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
       delete this._outputBuffers[runId];
       delete this.runs[runId];
+      delete this.collapsedStates[runId];
     },
 
     clearAllRuns() {
@@ -351,6 +366,7 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       this._flushTimers = {};
       this._outputBuffers = {};
       this.runs = {};
+      this.collapsedStates = {};
     },
   },
 });


### PR DESCRIPTION
## Summary
Fixes a UX bug where command output panes lose their collapsed/expanded state when navigating away from the Commands tab and returning. The implementation uses Pinia store to persist user preferences throughout the session.

## Problem
When users manually expand or collapse command output panes, then navigate to another tab (Conversation, Canvas, etc.) and return to the Commands tab, all output panes reset to their default state:
- Running commands: expanded (correct)
- Completed commands: collapsed (loses user preference)

## Root Cause
The `showOutput` ref in `CommandButtonItem.vue` was a local component state that gets destroyed when the Commands tab unmounts. When remounting, it reinitializes to default values, forgetting user preferences.

## Solution
Implemented Pinia store-based state management:
1. **Store**: Added `collapsedStates` object to `commandButtons` store to track collapse state per runId
2. **Store**: Added `isOutputCollapsed` getter with smart defaults (running=expanded, completed=collapsed)
3. **Store**: Added `setOutputCollapsed` action and cleanup in `clearRun`/`clearAllRuns`
4. **Component**: Converted `showOutput` from `ref` to `computed` property backed by store
5. **Tests**: Added Pinia setup and fixed mock data to use `runId` instead of `id`

## Behavior
- **Default**: Running commands show expanded output, completed commands show collapsed output
- **User preference**: Manual toggles persist across tab navigation
- **Memory management**: Collapse states are cleaned up when runs are cleared

## Testing
- ✅ All 79 tests passing (22 component tests, 57 store tests)
- ✅ No linting errors
- ✅ Verified collapse state persists when navigating between tabs

## Files Modified
- `packages/web/src/stores/commandButtons.js` - Added collapse state tracking
- `packages/web/src/components/CommandButtonItem.vue` - Converted to computed property
- `packages/web/src/components/CommandButtonItem.test.js` - Fixed tests with Pinia setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)