### PR TITLE
Fix streaming response text accumulation

### DIFF
--- a/packages/server/src/services/sessionManager.broadcasts.test.js
+++ b/packages/server/src/services/sessionManager.broadcasts.test.js
@@ -657,9 +657,10 @@ describe('sessionManager broadcasts', () => {
       const partialCalls = broadcastToSession.mock.calls.filter(
         (call) => call[1] === WS_MESSAGE_TYPES.SESSION_PARTIAL
       );
-      expect(partialCalls.length).toBe(2);
+      expect(partialCalls.length).toBe(3);
       expect(partialCalls[0][2].text).toBe('Hello ');
-      expect(partialCalls[1][2].text).toBe('world!');
+      expect(partialCalls[1][2].text).toBe('Hello world!');
+      expect(partialCalls[2][2].text).toBe(''); // Clear signal after complete message
 
       // Verify usage was streamed
       const usageUpdateCalls = broadcastToSession.mock.calls.filter(

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -14,6 +14,9 @@ const lastMessageIds = new Map();
 /** @type {Map<string, string>} Accumulate thinking content per session */
 const thinkingAccumulators = new Map();
 
+/** @type {Map<string, string>} Accumulate text content per session */
+const textAccumulators = new Map();
+
 /** @type {Map<string, { controller: AbortController }>} */
 const activeSessions = new Map();
 
@@ -684,6 +687,8 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
     }
     throw error;
   } finally {
+    textAccumulators.delete(sessionId);
+    thinkingAccumulators.delete(sessionId);
     activeSessions.delete(sessionId);
   }
 }
@@ -803,6 +808,8 @@ export async function continueSession(sessionId, content, workingDirectory, syst
     }
     throw error;
   } finally {
+    textAccumulators.delete(sessionId);
+    thinkingAccumulators.delete(sessionId);
     activeSessions.delete(sessionId);
   }
 }
@@ -925,6 +932,8 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
     }
     throw error;
   } finally {
+    textAccumulators.delete(sessionId);
+    thinkingAccumulators.delete(sessionId);
     activeSessions.delete(sessionId);
   }
 }
@@ -1070,6 +1079,12 @@ async function handleStreamEvent(sessionId, event) {
         // Broadcast message
         broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, { message });
 
+        // Clear partial text on client now that complete message has been sent
+        broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_PARTIAL, {
+          sessionId,
+          text: '',
+        });
+
         // Trigger debounced summary generation on new message
         summaryService.onSessionActivity(sessionId);
       }
@@ -1125,6 +1140,9 @@ async function handleStreamEvent(sessionId, event) {
     case 'stream_event': {
       // Handle message_start for initial usage (input tokens) - enables real-time token updates
       if (event.event?.type === 'message_start') {
+        // Clear text accumulator for fresh message
+        textAccumulators.delete(sessionId);
+
         const usage = event.event?.message?.usage;
         if (usage) {
           const conversationId = activeConversationIds.get(sessionId);
@@ -1158,9 +1176,14 @@ async function handleStreamEvent(sessionId, event) {
         const delta = event.event.delta;
 
         if (delta?.type === 'text_delta' && delta.text) {
+          // Accumulate text content
+          const current = textAccumulators.get(sessionId) || '';
+          const accumulated = current + delta.text;
+          textAccumulators.set(sessionId, accumulated);
+
           broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_PARTIAL, {
             sessionId,
-            text: delta.text,
+            text: accumulated,
           });
 
           // ISSUE 2: Estimate tokens from streamed content for real-time output token updates
@@ -1211,7 +1234,7 @@ async function handleStreamEvent(sessionId, event) {
         }
       }
 
-      // Handle content_block_stop - finalize accumulated thinking
+      // Handle content_block_stop - finalize accumulated thinking and text
       if (event.event?.type === 'content_block_stop') {
         const accumulated = thinkingAccumulators.get(sessionId);
         if (accumulated) {
@@ -1225,6 +1248,10 @@ async function handleStreamEvent(sessionId, event) {
             thinking: null,
           });
         }
+
+        // Clear text accumulator when content block finishes
+        // The text has been finalized into a message
+        textAccumulators.delete(sessionId);
       }
       break;
     }


### PR DESCRIPTION
## Summary

Fixed streaming response issues where conversation text appears mangled during streaming and partial text lingers after message completion.

**Root Cause**: The server was sending only text deltas (incremental changes) instead of accumulated full text, unlike the thinking functionality which already accumulates correctly.

## Changes

### Server-Side Fix in `packages/server/src/services/sessionManager.js`
- Added `textAccumulators` Map to track accumulated text per session (matching the working thinking pattern)
- Modified `text_delta` handler to accumulate full text before broadcasting in `SESSION_PARTIAL` messages
- Clear text accumulator on `content_block_stop` to prevent stale state
- Clear text accumulator on `message_start` for fresh messages
- Send empty string via `SESSION_PARTIAL` after complete message broadcast to clear client-side partial display
- Added text/thinking accumulator cleanup in all finally blocks to prevent memory leaks

### Test Updates
- Updated `sessionManager.broadcasts.test.js` to expect 3 partial calls (2 text deltas + 1 clear signal) instead of 2
- All 1753 tests passing, build successful

## Technical Details

This implementation mirrors the successful pattern already used for thinking accumulation:
1. **message_start**: Clear accumulator for new message
2. **text_delta**: Accumulate delta, broadcast full accumulated text
3. **content_block_stop**: Clear accumulator and send cleanup signal
4. **finally blocks**: Ensure cleanup regardless of how session ends

## Testing

✅ All 1753 server tests passing
✅ Build successful with no errors
✅ Test verified accumulation behavior: "Hello " → "Hello world!" (not just "world!")

🤖 Generated with [Claude Code](https://claude.com/claude-code)