### PR TITLE
Hide file upload button when viewing trash in Canvas

### DIFF
--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -8,7 +8,7 @@
   >
     <!-- Upload header -->
     <div class="canvas-header">
-      <label v-if="!shouldShowViewer" class="btn btn-primary" :class="{ disabled: uploading }">
+      <label v-if="!shouldShowViewer && !showTrash" class="btn btn-primary" :class="{ disabled: uploading }">
         {{ uploading ? 'Uploading...' : 'Upload File' }}
         <input
           type="file"


### PR DESCRIPTION
## Summary
Removes the file upload button from the trash list view in the canvas tab by adding a condition to check the trash state.

## Changes
- Updated `CanvasTab.vue` to add `&& !showTrash` condition to the upload button visibility check
- This ensures the upload button is only shown when viewing the active canvas, not the trash

## Testing
- ✅ All 1765 tests passed
- Change verified in file

## Files Modified
- `packages/web/src/components/CanvasTab.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)