### PR TITLE
Remove project path display from session list view

### DIFF
--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -10,9 +10,6 @@
             </svg>
           </a>
         </div>
-        <p v-if="projectsStore.currentProject" class="project-path">
-          {{ projectsStore.currentProject.workingDirectory }}
-        </p>
       </div>
       <router-link v-if="activeTab === 'sessions'" :to="`/projects/${route.params.id}/sessions/new`" class="btn btn-primary">
         New Session
@@ -622,13 +619,6 @@ onUnmounted(() => {
   stroke-linejoin: round;
 }
 
-.project-path {
-  margin: 0.25rem 0 0;
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  font-family: var(--font-mono);
-}
-
 .tabs {
   display: flex;
   gap: 0;
@@ -735,10 +725,6 @@ onUnmounted(() => {
   .page-header .btn {
     width: 100%;
     justify-content: center;
-  }
-
-  .project-path {
-    word-break: break-all;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

Removed the project working directory path from the session list view UI to simplify the interface. The session list now displays only the project name and optional repository link.

## Changes Made

- Removed project path HTML element from SessionListView.vue template
- Deleted .project-path CSS styling rules
- Removed mobile responsive styles for project-path

## Test Plan

- [ ] Verify session list view displays project name and repo link without path
- [ ] Check responsive behavior on mobile devices
- [ ] Ensure no console errors in browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)