### PR TITLE
Add copy session ID feature

### DIFF
--- a/packages/web/src/components/OverflowMenu.vue
+++ b/packages/web/src/components/OverflowMenu.vue
@@ -62,7 +62,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 
-const emit = defineEmits(['duplicate', 'archive', 'delete']);
+const emit = defineEmits(['duplicate', 'archive', 'copySessionId', 'delete']);
 
 const props = defineProps({
   ariaLabel: {
@@ -72,6 +72,10 @@ const props = defineProps({
   duplicateText: {
     type: String,
     default: 'Duplicate'
+  },
+  copySessionIdText: {
+    type: String,
+    default: null
   },
   archiveText: {
     type: String,
@@ -103,10 +107,16 @@ const archiveText = computed(() => {
   return props.isArchived ? 'Unarchive' : 'Archive';
 });
 
-const items = computed(() => [
-  { text: archiveText.value, icon: '📦', isDanger: false },
-  { text: props.duplicateText, icon: '⟳', isDanger: false }
-]);
+const items = computed(() => {
+  const baseItems = [
+    { text: archiveText.value, icon: '📦', isDanger: false },
+    { text: props.duplicateText, icon: '⟳', isDanger: false }
+  ];
+  if (props.copySessionIdText) {
+    baseItems.push({ text: props.copySessionIdText, icon: '📋', isDanger: false });
+  }
+  return baseItems;
+});
 
 function toggleMenu() {
   isOpen.value = !isOpen.value;
@@ -132,6 +142,9 @@ function handleItemClick(item, index) {
   } else if (index === 1) {
     // Second item is always Duplicate
     emit('duplicate');
+  } else if (index === 2 && props.copySessionIdText) {
+    // Third item is Copy Session ID (if provided)
+    emit('copySessionId');
   }
   closeMenu();
 }

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -31,7 +31,9 @@
           <OverflowMenu
             aria-label="Session actions"
             :is-archived="sessionsStore.currentSession.archived"
+            copy-session-id-text="Copy ID"
             @duplicate="handleDuplicate"
+            @copySessionId="handleCopySessionId"
             @archive="handleArchive"
             @delete="handleDelete"
           />
@@ -483,6 +485,29 @@ async function handleStar() {
     await sessionsStore.toggleSessionStar(sessionId);
   } catch (err) {
     uiStore.error(err.message);
+  }
+}
+
+async function handleCopySessionId() {
+  try {
+    await navigator.clipboard.writeText(sessionId);
+    uiStore.success(`Session ID copied to clipboard: ${sessionId}`);
+  } catch (err) {
+    // Fallback using textarea method for older browsers
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = sessionId;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      uiStore.success(`Session ID copied to clipboard: ${sessionId}`);
+    } catch (fallbackErr) {
+      console.error('Copy failed:', fallbackErr);
+      uiStore.error('Failed to copy session ID');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Successfully implemented a copy session ID feature in the overflow menu on the session detail view. Users can now copy the session ID to clipboard with a single click, with feedback shown via toast notification.

## Changes Made
- **OverflowMenu.vue**: Added support for optional `copySessionId` action in overflow menu
  - New `copySessionIdText` prop to customize button text
  - New `copySessionId` event emission
  - Conditional menu item rendering for copy option

- **SessionDetailView.vue**: Integrated copy session ID functionality
  - Added copy button to session overflow menu with "Copy ID" text
  - Implemented `handleCopySessionId()` function with:
    - Modern Clipboard API with fallback to `document.execCommand()` for older browsers
    - Success toast showing which session ID was copied
    - Error handling with user-friendly error message

## Testing
- All existing tests pass (1,780 tests across 60 files)
- Linting passes without errors
- Production build verified successful

## Implementation Details
The feature reuses established patterns from the codebase:
- Event emission pattern from OverflowMenu component
- Clipboard API pattern with fallback (consistent with existing copy implementations)
- Toast notification system for user feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)