### PR TITLE
Fix: Always show upload button in canvas view except trash

### DIFF
--- a/packages/web/src/components/CanvasTab.test.js
+++ b/packages/web/src/components/CanvasTab.test.js
@@ -210,7 +210,7 @@ describe('CanvasTab', () => {
       expect(uploadButton.text()).toContain('Upload File');
     });
 
-    it('hides upload button when viewing a single file', async () => {
+    it('shows upload button when viewing a single file', async () => {
       api.getCanvasItems.mockResolvedValue([
         { id: '1', filename: 'file1.png', createdAt: 1000 },
       ]);
@@ -219,12 +219,12 @@ describe('CanvasTab', () => {
 
       await flushAll(wrapper);
 
-      // With only one file, shouldShowViewer is true
+      // Upload button is now always visible, even when viewing a single file
       const uploadButton = wrapper.find('label.btn-primary');
-      expect(uploadButton.exists()).toBe(false);
+      expect(uploadButton.exists()).toBe(true);
     });
 
-    it('hides upload button when viewing a specific file in list', async () => {
+    it('shows upload button when viewing a specific file in list', async () => {
       api.getCanvasItems.mockResolvedValue([
         { id: '1', filename: 'file1.png', createdAt: 1000 },
         { id: '2', filename: 'file2.png', createdAt: 2000 },
@@ -236,9 +236,9 @@ describe('CanvasTab', () => {
 
       await flushAll(wrapper);
 
-      // With item query parameter, shouldShowViewer is true
+      // Upload button is now always visible, even when viewing a specific file
       const uploadButton = wrapper.find('label.btn-primary');
-      expect(uploadButton.exists()).toBe(false);
+      expect(uploadButton.exists()).toBe(true);
     });
 
     it('has hidden file input', async () => {

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -8,7 +8,7 @@
   >
     <!-- Upload header -->
     <div class="canvas-header">
-      <label v-if="!shouldShowViewer && !showTrash" class="btn btn-primary" :class="{ disabled: uploading }">
+      <label v-if="!showTrash" class="btn btn-primary" :class="{ disabled: uploading }">
         {{ uploading ? 'Uploading...' : 'Upload File' }}
         <input
           type="file"


### PR DESCRIPTION
## Summary

Fixed the missing file upload button in the canvas file list view. The button was being conditionally hidden by visibility logic that checked if a single file was being viewed.

## Changes

- **CanvasTab.vue**: Removed the `!shouldShowViewer` condition from the upload button's `v-if` directive, ensuring the button is always visible except in trash
- **CanvasTab.test.js**: Updated two tests to verify the new behavior where the upload button is consistently shown

## Testing

- All 1780 tests passing with 68 skipped
- No regressions detected
- Updated tests confirm upload button visibility behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)