### PR TITLE
Fix sub nav horizontal scrolling on session detail view

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -259,15 +259,6 @@ input, textarea, select {
   background-color: var(--color-background);
   z-index: 99;
   padding: 0.5rem 0.5rem 0 0.5rem; /* Add horizontal padding to prevent cut-off */
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
-  /* Hide scrollbar but keep functionality */
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-
-.tabs::-webkit-scrollbar {
-  display: none;
 }
 
 .tab {


### PR DESCRIPTION
## Summary

Fixed sub nav horizontal scrolling issue by removing `overflow-x: auto` from `.tabs` CSS class that was interfering with page scrolling gestures on the session detail view.

## Problem

The sub nav on the session detail view was slightly scrollable due to the `.tabs` container having `overflow-x: auto` enabled in `packages/web/src/assets/main.css`. This unintended horizontal scrolling interfered with normal page scrolling behavior.

## Solution

Removed all horizontal overflow properties from the `.tabs` CSS class:
- Removed `overflow-x: auto`
- Removed `-webkit-overflow-scrolling: touch` (iOS smooth scrolling)
- Removed scrollbar hiding rules (`-ms-overflow-style`, `scrollbar-width`, `::-webkit-scrollbar`)

The mobile dropdown functionality remains intact via the separate select element.

## Changes

- **packages/web/src/assets/main.css** - Removed horizontal scrolling and scrollbar hiding CSS properties from .tabs

## Testing

✅ Mobile dropdown functionality verified to remain intact
✅ Horizontal scrolling removed from sub nav
✅ Page scrolling gestures no longer interfered with

🤖 Generated with [Claude Code](https://claude.com/claude-code)