### PR TITLE
Remove Projects and Sessions top navigation links

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -5,10 +5,6 @@
         <router-link to="/" class="logo">
           <img src="/logo.png" alt="ClaudeTools.io Logo" class="logo-image" />
         </router-link>
-        <nav class="nav">
-          <router-link to="/" class="nav-link">Projects</router-link>
-          <router-link to="/sessions/active" class="nav-link">Sessions</router-link>
-        </nav>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
Removed the 'Projects' and 'Sessions' top navigation links from the application header. The header now displays only the ClaudeTools.io logo, simplifying the UI while maintaining all core functionality.

## Changes
- Removed `<nav>` element from `packages/web/src/App.vue` (lines 8-11)
- Removed router-links for Projects and Sessions pages
- Header retains the logo as the sole navigational element

## Rationale
This simplification removes top-level navigation to Projects and Sessions pages as part of streamlining the application experience. Users can still access sessions through other means if needed.

## Testing
- E2E tests verified no functionality was broken
- All existing tests pass
- Header renders correctly with logo only

## Files Modified
- `packages/web/src/App.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)