### PR TITLE
Fix iPad UX zoom issues

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>ClaudeTools.io</title>
   </head>
   <body>

--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -34,6 +34,18 @@
   padding: 0;
 }
 
+/* Prevent double-tap and pinch zoom on iOS/iPadOS */
+html {
+  touch-action: manipulation;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+/* Ensure interactive elements also respect this */
+button, a, input, select, textarea {
+  touch-action: manipulation;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   background-color: var(--color-background);


### PR DESCRIPTION
## Summary

Fixed iPad UX problems where double-clicking or orientation changes caused unwanted zoom behavior on the ClaudeTools.io application.

## Changes

- **Updated viewport meta tag** in `packages/web/index.html`:
  - Added `maximum-scale=1.0` to prevent zoom scaling
  - Added `user-scalable=no` to disable user pinch zoom
  
- **Added CSS touch-action rules** in `packages/web/src/assets/main.css`:
  - Applied `touch-action: manipulation` to `html` element to disable double-tap zoom
  - Applied same rule to interactive elements (`button`, `a`, `input`, `select`, `textarea`)
  - Preserves normal scrolling functionality
  
- **Implemented text-size-adjust properties**:
  - Added `-webkit-text-size-adjust: 100%` for WebKit browsers
  - Added `text-size-adjust: 100%` for standard support
  - Prevents text scaling on orientation changes

## Test Plan

- [ ] Test on iPad with double-tap to verify zoom is disabled
- [ ] Test device orientation changes to ensure no unwanted zoom
- [ ] Verify scrolling functionality still works normally
- [ ] Test on iOS Safari and other browsers to confirm accessibility
- [ ] Check desktop browsers to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)