### PR TITLE
Implement worktree inheritance for child sessions in template chaining

### DIFF
--- a/packages/server/src/services/templateTriggerService.js
+++ b/packages/server/src/services/templateTriggerService.js
@@ -94,15 +94,28 @@ export async function checkAndTriggerNextTemplate(sessionId) {
       nextTemplateId: template.nextTemplateId || null,
     });
 
-    // Setup git environment (branch checkout or worktree creation)
-    const { workingDirectory, gitWorktree } = await setupGitForSession({
-      projectDir: project.workingDirectory,
-      gitMode: gitMode,
-      gitBranch: gitBranch,
-      sessionId: newSession.id,
-    });
+    // Determine working directory: inherit from parent if it has a worktree
+    let workingDirectory;
+    let gitWorktree = null;
 
-    // Update session with worktree path if created
+    if (session.gitWorktree) {
+      // Parent is in a worktree - child should run in the same worktree
+      workingDirectory = session.gitWorktree;
+      gitWorktree = session.gitWorktree;
+      console.log(`Template trigger: Inheriting parent worktree: ${gitWorktree}`);
+    } else {
+      // Parent is not in a worktree - set up git environment normally
+      const gitSetup = await setupGitForSession({
+        projectDir: project.workingDirectory,
+        gitMode: gitMode,
+        gitBranch: gitBranch,
+        sessionId: newSession.id,
+      });
+      workingDirectory = gitSetup.workingDirectory;
+      gitWorktree = gitSetup.gitWorktree;
+    }
+
+    // Update session with worktree path if set
     if (gitWorktree) {
       sessions.update(newSession.id, { gitWorktree });
     }


### PR DESCRIPTION
## Summary

- Modified template trigger service to inherit parent session's git worktree for child sessions
- Child sessions created via `nextTemplateId` now run in the same git context as their parent
- Maintains environment continuity allowing children to see uncommitted changes from parent sessions
- Avoids creating redundant worktrees when chaining templates

## Implementation Details

When a template triggers a child session:
- If the parent session has a `gitWorktree`, the child inherits it directly
- If the parent is in the main repository (no worktree), normal git setup proceeds
- This ensures proper context inheritance while maintaining backward compatibility

## Test Plan

- [x] Run existing test suite to verify no regressions (21/21 tests pass)
- [ ] Manually test template chaining with worktree-based parent sessions
- [ ] Verify child sessions can see parent's uncommitted changes
- [ ] Test mixed scenarios (worktree parent → child, non-worktree parent → child)

🤖 Generated with [Claude Code](https://claude.com/claude-code)