### PR TITLE
Reorder three-dot menu in CanvasFileViewer: 'Copy filename' to first position

### DIFF
--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -117,8 +117,8 @@ describe('CanvasFileViewer', () => {
 
       const menuItems = wrapper.findAll('.menu-item');
       expect(menuItems.length).toBe(3);
-      expect(menuItems[0].text()).toContain('Copy file contents');
-      expect(menuItems[1].text()).toContain('Copy filename');
+      expect(menuItems[0].text()).toContain('Copy filename');
+      expect(menuItems[1].text()).toContain('Copy file contents');
       expect(menuItems[2].text()).toContain('Delete file');
     });
 
@@ -132,7 +132,7 @@ describe('CanvasFileViewer', () => {
       await flushAll(wrapper);
 
       const menuItems = wrapper.findAll('.menu-item');
-      await menuItems[0].trigger('click');
+      await menuItems[1].trigger('click');
       await flushAll(wrapper);
 
       expect(mockClipboard.writeText).toHaveBeenCalledWith('File content here');
@@ -148,7 +148,7 @@ describe('CanvasFileViewer', () => {
       await flushAll(wrapper);
 
       const menuItems = wrapper.findAll('.menu-item');
-      await menuItems[1].trigger('click');
+      await menuItems[0].trigger('click');
       await flushAll(wrapper);
 
       expect(mockClipboard.writeText).toHaveBeenCalledWith('myfile.txt');

--- a/packages/web/src/components/CanvasFileViewer.vue
+++ b/packages/web/src/components/CanvasFileViewer.vue
@@ -70,24 +70,24 @@
                 <button
                   :class="['menu-item', { 'is-highlighted': menuHighlightedIndex === 0 }]"
                   role="menuitem"
-                  @click="handleMenuCopyContents"
+                  @click="handleMenuCopyFilename"
                   @mouseenter="menuHighlightedIndex = 0"
                   @mouseleave="menuHighlightedIndex = null"
                 >
-                  <span class="menu-item-icon">📋</span>
-                  <span class="menu-item-text">Copy file contents</span>
+                  <span class="menu-item-icon">📝</span>
+                  <span class="menu-item-text">Copy filename</span>
                 </button>
               </li>
               <li role="none">
                 <button
                   :class="['menu-item', { 'is-highlighted': menuHighlightedIndex === 1 }]"
                   role="menuitem"
-                  @click="handleMenuCopyFilename"
+                  @click="handleMenuCopyContents"
                   @mouseenter="menuHighlightedIndex = 1"
                   @mouseleave="menuHighlightedIndex = null"
                 >
-                  <span class="menu-item-icon">📝</span>
-                  <span class="menu-item-text">Copy filename</span>
+                  <span class="menu-item-icon">📋</span>
+                  <span class="menu-item-text">Copy file contents</span>
                 </button>
               </li>
               <li role="none" class="menu-divider"></li>
@@ -285,9 +285,9 @@ function handleMenuKeyDown(event) {
       event.preventDefault();
       if (menuHighlightedIndex.value !== null) {
         if (menuHighlightedIndex.value === 0) {
-          handleMenuCopyContents();
-        } else if (menuHighlightedIndex.value === 1) {
           handleMenuCopyFilename();
+        } else if (menuHighlightedIndex.value === 1) {
+          handleMenuCopyContents();
         } else if (menuHighlightedIndex.value === 2) {
           handleMenuDeleteAll();
         }


### PR DESCRIPTION
## Summary
Reordered the three-dot menu in CanvasFileViewer.vue to improve UX by placing the 'Copy filename' action first, making it more discoverable and frequently accessible.

## Changes
- Moved 'Copy filename' menu option to first position 
- Swapped menu item template order (lines 69-92)
- Updated keyboard navigation handler with new index mappings (lines 287-290)
- Updated all test cases to reflect the new menu structure
- Final menu order: Copy filename (1st), Copy file contents (2nd), Delete file (3rd)

## Testing
- Full test suite passes with no regressions
- All test cases updated to verify new menu configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)