### PR TITLE
Template chains: Add root session context variables

### DIFF
--- a/packages/server/src/services/templateTriggerService.js
+++ b/packages/server/src/services/templateTriggerService.js
@@ -8,24 +8,52 @@ import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 const liquid = new Liquid();
 
 /**
- * Render a template prompt with parent session context
+ * Get the root session (the original session that started a template chain)
+ * @param {Object} session - The current session
+ * @returns {Object} The root session (or the current session if it has no parent)
+ */
+export function getRootSession(session) {
+  let current = session;
+  while (current.parentSessionId) {
+    const parent = sessions.getById(current.parentSessionId);
+    if (!parent) break;
+    current = parent;
+  }
+  return current;
+}
+
+/**
+ * Render a template prompt with parent session and root session context
  * @param {string} templatePrompt - The Liquid template string
  * @param {Object} parentSession - The parent session object
- * @param {Object|null} summary - The parent session's summary
+ * @param {Object|null} parentSummary - The parent session's summary
+ * @param {Object} rootSession - The root session object
+ * @param {Object|null} rootSummary - The root session's summary
  * @returns {Promise<string>} The rendered prompt
  */
-export async function renderTemplatePrompt(templatePrompt, parentSession, summary) {
+export async function renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary) {
   const context = {
     parentSession: {
       id: parentSession.id,
       name: parentSession.name,
       status: parentSession.status,
-      summary: summary?.fullSummary || summary?.shortSummary || 'No summary available',
-      shortSummary: summary?.shortSummary || 'No summary available',
-      fullSummary: summary?.fullSummary || 'No summary available',
-      keyActions: summary?.keyActions || [],
-      filesModified: summary?.filesModified || [],
-      outcome: summary?.outcome || parentSession.status,
+      summary: parentSummary?.fullSummary || parentSummary?.shortSummary || 'No summary available',
+      shortSummary: parentSummary?.shortSummary || 'No summary available',
+      fullSummary: parentSummary?.fullSummary || 'No summary available',
+      keyActions: parentSummary?.keyActions || [],
+      filesModified: parentSummary?.filesModified || [],
+      outcome: parentSummary?.outcome || parentSession.status,
+    },
+    rootSession: {
+      id: rootSession.id,
+      name: rootSession.name,
+      status: rootSession.status,
+      summary: rootSummary?.fullSummary || rootSummary?.shortSummary || 'No summary available',
+      shortSummary: rootSummary?.shortSummary || 'No summary available',
+      fullSummary: rootSummary?.fullSummary || 'No summary available',
+      keyActions: rootSummary?.keyActions || [],
+      filesModified: rootSummary?.filesModified || [],
+      outcome: rootSummary?.outcome || rootSession.status,
     },
   };
 
@@ -65,10 +93,14 @@ export async function checkAndTriggerNextTemplate(sessionId) {
 
   try {
     // Get the parent session's summary for the template context
-    const summary = sessionSummaries.getBySessionId(sessionId);
+    const parentSummary = sessionSummaries.getBySessionId(sessionId);
 
-    // Render the template prompt with parent session context
-    const renderedPrompt = await renderTemplatePrompt(template.prompt, session, summary);
+    // Get the root session and its summary
+    const rootSession = getRootSession(session);
+    const rootSummary = sessionSummaries.getBySessionId(rootSession.id);
+
+    // Render the template prompt with parent and root session context
+    const renderedPrompt = await renderTemplatePrompt(template.prompt, session, parentSummary, rootSession, rootSummary);
 
     // Determine settings: use template overrides if set, otherwise inherit from parent session
     const thinkingEnabled = template.thinkingEnabled !== null ? template.thinkingEnabled : session.thinkingEnabled;

--- a/packages/server/src/services/templateTriggerService.test.js
+++ b/packages/server/src/services/templateTriggerService.test.js
@@ -15,7 +15,7 @@ vi.mock('./sessionManager.js', () => ({
 }));
 
 // Import after mocks are set up
-import { renderTemplatePrompt, checkAndTriggerNextTemplate } from './templateTriggerService.js';
+import { renderTemplatePrompt, checkAndTriggerNextTemplate, getRootSession } from './templateTriggerService.js';
 import { broadcastToProject } from '../websocket.js';
 import { runSession } from './sessionManager.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
@@ -29,12 +29,14 @@ describe('templateTriggerService', () => {
         name: 'Test Session',
         status: 'stopped',
       };
-      const summary = {
+      const parentSummary = {
         fullSummary: 'Built a new feature for user authentication.',
         shortSummary: 'Built auth feature',
       };
+      const rootSession = parentSession; // Same as parent for single-level
+      const rootSummary = parentSummary;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, summary);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary);
 
       expect(rendered).toBe('Review the work: Built a new feature for user authentication.');
     });
@@ -46,8 +48,9 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'stopped',
       };
+      const rootSession = parentSession;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
 
       expect(rendered).toBe('Parent session ID: abc-123-def');
     });
@@ -59,8 +62,9 @@ describe('templateTriggerService', () => {
         name: 'Build login page',
         status: 'stopped',
       };
+      const rootSession = parentSession;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
 
       expect(rendered).toBe('Following up on: Build login page');
     });
@@ -72,8 +76,9 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'error',
       };
+      const rootSession = parentSession;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
 
       expect(rendered).toBe('Session ended with status: error');
     });
@@ -85,12 +90,14 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'stopped',
       };
-      const summary = {
+      const parentSummary = {
         shortSummary: 'Short summary only',
         fullSummary: null,
       };
+      const rootSession = parentSession;
+      const rootSummary = parentSummary;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, summary);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary);
 
       expect(rendered).toBe('Summary: Short summary only');
     });
@@ -102,8 +109,9 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'stopped',
       };
+      const rootSession = parentSession;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
 
       expect(rendered).toBe('Summary: No summary available');
     });
@@ -115,11 +123,13 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'stopped',
       };
-      const summary = {
+      const parentSummary = {
         keyActions: ['Added login form', 'Updated API', 'Fixed bug'],
       };
+      const rootSession = parentSession;
+      const rootSummary = parentSummary;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, summary);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary);
 
       expect(rendered).toBe('Added login form, Updated API, Fixed bug, ');
     });
@@ -131,11 +141,13 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'stopped',
       };
-      const summary = {
+      const parentSummary = {
         filesModified: ['src/login.js', 'src/api.js'],
       };
+      const rootSession = parentSession;
+      const rootSummary = parentSummary;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, summary);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary);
 
       expect(rendered).toBe('Modified: src/login.js, src/api.js');
     });
@@ -147,11 +159,13 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'stopped',
       };
-      const summary = {
+      const parentSummary = {
         outcome: 'partial',
       };
+      const rootSession = parentSession;
+      const rootSummary = parentSummary;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, summary);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary);
 
       expect(rendered).toBe('Outcome: partial');
     });
@@ -163,8 +177,9 @@ describe('templateTriggerService', () => {
         name: 'Test',
         status: 'error',
       };
+      const rootSession = parentSession;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
 
       expect(rendered).toBe('Outcome: error');
     });
@@ -184,11 +199,13 @@ Please review the above work.
         name: 'Build feature X',
         status: 'stopped',
       };
-      const summary = {
+      const parentSummary = {
         fullSummary: 'Implemented feature X with tests.',
       };
+      const rootSession = parentSession;
+      const rootSummary = parentSummary;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, summary);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, parentSummary, rootSession, rootSummary);
 
       expect(rendered).toContain('Review Session: Build feature X');
       expect(rendered).toContain('Status: stopped');
@@ -202,10 +219,120 @@ Please review the above work.
         name: 'Test',
         status: 'stopped',
       };
+      const rootSession = parentSession;
 
-      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null);
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
 
       expect(rendered).toBe('This is a static prompt with no variables.');
+    });
+
+    it('renders template with rootSession.id', async () => {
+      const templatePrompt = 'Root session ID: {{rootSession.id}}';
+      const parentSession = {
+        id: 'parent-456',
+        name: 'Parent',
+        status: 'stopped',
+      };
+      const rootSession = {
+        id: 'root-123',
+        name: 'Root',
+        status: 'stopped',
+      };
+
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
+
+      expect(rendered).toBe('Root session ID: root-123');
+    });
+
+    it('renders template with rootSession.name', async () => {
+      const templatePrompt = 'Root session name: {{rootSession.name}}';
+      const parentSession = {
+        id: 'parent-456',
+        name: 'Parent Session',
+        status: 'stopped',
+      };
+      const rootSession = {
+        id: 'root-123',
+        name: 'Original Session',
+        status: 'stopped',
+      };
+
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
+
+      expect(rendered).toBe('Root session name: Original Session');
+    });
+
+    it('renders template with rootSession.summary', async () => {
+      const templatePrompt = 'Root summary: {{rootSession.summary}}';
+      const parentSession = {
+        id: 'parent-456',
+        name: 'Parent',
+        status: 'stopped',
+      };
+      const rootSession = {
+        id: 'root-123',
+        name: 'Root',
+        status: 'stopped',
+      };
+      const rootSummary = {
+        fullSummary: 'This is the root session summary.',
+        shortSummary: 'Root summary',
+      };
+
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, rootSummary);
+
+      expect(rendered).toBe('Root summary: This is the root session summary.');
+    });
+
+    it('renders template with rootSession.status', async () => {
+      const templatePrompt = 'Root status: {{rootSession.status}}';
+      const parentSession = {
+        id: 'parent-456',
+        name: 'Parent',
+        status: 'stopped',
+      };
+      const rootSession = {
+        id: 'root-123',
+        name: 'Root',
+        status: 'completed',
+      };
+
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
+
+      expect(rendered).toBe('Root status: completed');
+    });
+
+    it('rootSession equals parentSession when there is no chain', async () => {
+      const templatePrompt = 'Parent: {{parentSession.id}}, Root: {{rootSession.id}}';
+      const parentSession = {
+        id: 'session-123',
+        name: 'Single Session',
+        status: 'stopped',
+      };
+      const rootSession = parentSession; // Same as parent for single-level
+
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
+
+      expect(rendered).toBe('Parent: session-123, Root: session-123');
+    });
+
+    it('rootSession differs from parentSession in multi-level chain', async () => {
+      const templatePrompt = 'Chain: {{rootSession.name}} -> {{parentSession.name}}';
+      const rootSession = {
+        id: 'root-123',
+        name: 'Root Session',
+        status: 'stopped',
+      };
+      const parentSession = {
+        id: 'parent-456',
+        name: 'Parent Session',
+        status: 'stopped',
+        parentSessionId: 'root-123',
+      };
+
+      const rendered = await renderTemplatePrompt(templatePrompt, parentSession, null, rootSession, null);
+
+      expect(rendered).toBe('Chain: Root Session -> Parent Session');
     });
   });
 
@@ -366,6 +493,59 @@ Please review the above work.
         expect.any(String),
         null
       );
+    });
+
+    it('getRootSession walks up a multi-level chain correctly', () => {
+      // Create a 3-level chain: A -> B -> C
+      // A is the root (no parent)
+      const sessionA = sessions.create(projectId, 'Session A', 'Prompt A', 'standard');
+
+      // B is child of A
+      const sessionB = sessions.create(projectId, 'Session B', 'Prompt B', 'standard');
+      sessions.update(sessionB.id, { parentSessionId: sessionA.id });
+
+      // C is child of B
+      const sessionC = sessions.create(projectId, 'Session C', 'Prompt C', 'standard');
+      sessions.update(sessionC.id, { parentSessionId: sessionB.id });
+
+      // Get the updated sessions
+      const updatedB = sessions.getById(sessionB.id);
+      const updatedC = sessions.getById(sessionC.id);
+
+      // From C, getRootSession should return A
+      const rootFromC = getRootSession(updatedC);
+      expect(rootFromC.id).toBe(sessionA.id);
+      expect(rootFromC.name).toBe('Session A');
+
+      // From B, getRootSession should return A
+      const rootFromB = getRootSession(updatedB);
+      expect(rootFromB.id).toBe(sessionA.id);
+      expect(rootFromB.name).toBe('Session A');
+
+      // From A, getRootSession should return A (itself)
+      const rootFromA = getRootSession(sessionA);
+      expect(rootFromA.id).toBe(sessionA.id);
+      expect(rootFromA.name).toBe('Session A');
+    });
+
+    it('getRootSession handles orphaned chains gracefully', () => {
+      // Create a chain where the middle session gets deleted
+      const sessionA = sessions.create(projectId, 'Session A', 'Prompt A', 'standard');
+      const sessionB = sessions.create(projectId, 'Session B', 'Prompt B', 'standard');
+      sessions.update(sessionB.id, { parentSessionId: sessionA.id });
+      const sessionC = sessions.create(projectId, 'Session C', 'Prompt C', 'standard');
+      sessions.update(sessionC.id, { parentSessionId: sessionB.id });
+
+      // Delete session A (the root)
+      sessions.delete(sessionA.id);
+
+      // Get updated C
+      const updatedC = sessions.getById(sessionC.id);
+
+      // From C, getRootSession should return B (the deepest valid ancestor)
+      const root = getRootSession(updatedC);
+      expect(root.id).toBe(sessionB.id);
+      expect(root.name).toBe('Session B');
     });
   });
 });

--- a/packages/web/src/components/TemplatesPanel.vue
+++ b/packages/web/src/components/TemplatesPanel.vue
@@ -37,7 +37,7 @@
             required
           ></textarea>
           <p class="form-help">
-            Available variables: <code v-pre>{{parentSession.summary}}</code>, <code v-pre>{{parentSession.status}}</code>, <code v-pre>{{parentSession.name}}</code>
+            Available variables: <code v-pre>{{parentSession.summary}}</code>, <code v-pre>{{parentSession.status}}</code>, <code v-pre>{{parentSession.name}}</code>, <code v-pre>{{rootSession.id}}</code>, <code v-pre>{{rootSession.name}}</code>, <code v-pre>{{rootSession.summary}}</code>, <code v-pre>{{rootSession.status}}</code>
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Successfully implemented root session template variables to enable template chains to reference the original ancestor session. This allows deeply nested template chains to access context from the session that initiated the chain, not just the immediate parent session.

### What Changed

Added comprehensive support for root session context variables in template chains:
- New `getRootSession()` helper function to traverse parent session chains
- Updated template rendering logic to include root session context variables (`id`, `name`, `summary`, `status`)
- Enhanced template context to provide both parent and root session information
- Updated UI help text to document the new root session variables

### Implementation Details

**Files Modified:**
- `packages/server/src/services/templateTriggerService.js` - Core template chain logic
- `packages/server/src/services/templateTriggerService.test.js` - Comprehensive test coverage
- `packages/web/src/components/TemplatesPanel.vue` - UI documentation updates

**Key Changes:**
- Implemented `getRootSession()` to find the original session in a chain
- Extended `renderTemplatePrompt()` to accept and render root session context
- Updated `checkAndTriggerNextTemplate()` to fetch and pass root session data
- Added test coverage for edge cases: single-level chains, deep chains, orphaned sessions
- Verified no regressions: all 29 tests passed, full server suite (1966 tests) passed

### Test Results

✅ Template chain unit tests: 29/29 passed  
✅ Full server test suite: 1966/1966 passed  
✅ Linter: No errors

### Root Session Variables Available in Templates

When crafting template prompts, you can now reference the root session:
- `rootSession.id` - ID of the original session
- `rootSession.name` - Name of the original session  
- `rootSession.status` - Status of the original session
- `rootSession.summary` - Full summary of the original session
- `rootSession.shortSummary` - Short summary of the original session
- `rootSession.fullSummary` - Full summary of the original session
- `rootSession.outcome` - Outcome status of the original session

Plus all existing parent session variables remain available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)