### PR TITLE
Fix misleading updating indicator in token count display

### DIFF
--- a/packages/web/src/components/ConversationPanel.vue
+++ b/packages/web/src/components/ConversationPanel.vue
@@ -38,11 +38,6 @@
         <div v-if="!isExpanded" class="cost-display" @click="isExpanded = true" title="Billable Token Equivalent - weighted token cost where output tokens are 5x and cache varies">
           <span class="cost-label">Cost:</span>
           <span class="cost-value">{{ formattedBillableTokens }}</span>
-          <span v-if="isUpdating" class="updating-indicator">
-            <span class="dot"></span>
-            <span class="dot"></span>
-            <span class="dot"></span>
-          </span>
         </div>
 
         <!-- Toggle expand button -->
@@ -73,11 +68,6 @@
       <div class="bte-header" title="Billable Token Equivalent - weighted token cost where output tokens are 5x and cache varies">
         <span class="bte-label">Cost:</span>
         <span class="bte-value">{{ formattedBillableTokens }}</span>
-        <span v-if="isUpdating" class="updating-indicator">
-          <span class="dot"></span>
-          <span class="dot"></span>
-          <span class="dot"></span>
-        </span>
       </div>
 
       <div class="token-grid">
@@ -170,7 +160,6 @@ const isSessionRunning = computed(() => {
 
 const formattedTokens = computed(() => sessionsStore.formattedTokens);
 const formattedBillableTokens = computed(() => sessionsStore.formattedBillableTokens);
-const isUpdating = computed(() => sessionsStore.isUsageUpdating);
 
 // Raw token values for weighted calculations
 const inputTokens = computed(() => {
@@ -527,37 +516,4 @@ defineExpose({
   background: var(--color-background-soft);
 }
 
-/* Updating indicator */
-.updating-indicator {
-  display: flex;
-  gap: 2px;
-  align-items: center;
-}
-
-.updating-indicator .dot {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background-color: var(--color-accent, var(--color-primary));
-  animation: pulse 1.4s ease-in-out infinite;
-}
-
-.updating-indicator .dot:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.updating-indicator .dot:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes pulse {
-  0%, 80%, 100% {
-    opacity: 0.3;
-    transform: scale(0.8);
-  }
-  40% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
 </style>


### PR DESCRIPTION
## Summary

Fixed a bug where an animated 'writing/updating' icon appeared next to the token count indicator in the session detail view, even when Claude wasn't actively writing. The icon should never appear since the token count only displays when the session is idle.

## Changes

- Removed updating indicator spans from both collapsed and expanded token cost displays
- Removed isUpdating computed property that was no longer needed
- Cleaned up associated CSS styles including pulse animation keyframes
- Component now has cleaner appearance without unnecessary animations

## Logical Issue Fixed

The ConversationPanel component only renders when `!isSessionRunning`, yet it had an updating indicator controlled by `isUsageUpdating` flag. This created a logical inconsistency where the indicator could theoretically appear when it shouldn't. By removing the indicator entirely, we eliminate this unnecessary complexity.

## Test Plan

- [x] Syntax checks and linting passed
- Verify token count display appears correctly in session detail view
- Confirm no visual artifacts or updating indicators appear when session is idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)