### PR TITLE
Update resize icon in ResizableTextarea to diagonal grip lines

### DIFF
--- a/packages/web/src/components/ResizableTextarea.vue
+++ b/packages/web/src/components/ResizableTextarea.vue
@@ -13,7 +13,7 @@
       aria-hidden="true"
     >
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-        <path d="M10 6L14 10M6 10L14 10M10 14L14 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M14 10L10 14M14 6L6 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
       </svg>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Updated the resize icon in ResizableTextarea from an arrow indicator to classic diagonal grip lines for better UX. This change makes the resize affordance more universally recognizable to users.

## Changes

- **File Modified**: `packages/web/src/components/ResizableTextarea.vue`
- **Change**: Replaced arrow-based resize indicator (`M10 6L14 10M6 10L14 10M10 14L14 10`) with classic diagonal grip lines (`M14 10L10 14M14 6L6 14`)

## Why This Change

The classic diagonal grip lines pattern is universally recognized across:
- macOS native applications
- Windows native applications  
- VS Code and popular desktop apps
- Most web applications

This makes the resize control more intuitive and discoverable without requiring visual learning.

## Testing

Please verify that:
- [ ] The resize indicator displays correctly in the textarea
- [ ] The icon is visible with adequate contrast
- [ ] The resize functionality works as expected
- [ ] The icon renders properly at different zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)