### PR TITLE
Fix session count display in SessionCard

### DIFF
--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -58,9 +58,9 @@
               ⚠ {{ workflowStatus.errorCount }} error
             </span>
 
-            <!-- Session count (always show for root sessions with children, or show when no actionable statuses) -->
+            <!-- Session count (only show when there are multiple sessions) -->
             <span
-              v-if="!isChild && (workflowStatus.totalCount > 1 || (workflowStatus.runningCount === 0 && workflowStatus.scheduledCount === 0 && workflowStatus.errorCount === 0))"
+              v-if="!isChild && workflowStatus.totalCount > 1"
               class="session-count"
             >
               {{ workflowStatus.totalCount }} {{ workflowStatus.totalCount === 1 ? 'session' : 'sessions' }}


### PR DESCRIPTION
## Summary

Fixed session count display in SessionCard.vue to hide '1 session' text when only one session exists.

The session list and archived session list views were incorrectly displaying a session count line even when there was only one session. This has been fixed by simplifying the visibility condition to only show the count when there are multiple sessions.

## Changes

- **packages/web/src/components/SessionCard.vue**: Simplified the v-if condition for the session count display (lines 62-67)
  - Changed from showing count when `totalCount > 1 OR no actionable statuses`
  - To showing count only when `totalCount > 1`
  - This removes the fallback that was displaying "1 session" unnecessarily

## Testing

The fix applies to both:
- Regular session list view
- Archived session list view

Both views use the same SessionCard component, so this change fixes both in one place.

## Test Plan

- [ ] Verify session count is hidden when viewing a single session
- [ ] Verify session count is shown when viewing multiple sessions
- [ ] Test in both regular and archived session list views

🤖 Generated with [Claude Code](https://claude.com/claude-code)