### PR TITLE
Remove .claude/plans from git history and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ temp/
 
 # Git worktrees
 .worktrees/
+
+# Claude plans (generated during sessions)
+.claude/plans/


### PR DESCRIPTION
## Summary

Completely removed `.claude/plans` directory from git history and excluded it from future tracking.

### Changes Made

- Updated `.gitignore` to exclude `.claude/plans` directory (generated during Claude Code sessions)
- Removed directory from git cache and working tree
- Rewrote git history using `filter-branch` to remove all historical references across 1,296+ commits
- Force pushed all branches to remote repository

### Why This Change?

The `.claude/plans` directory was being generated during Claude Code sessions and committed to git. This clutters the repository and shouldn't be version controlled. Moving it to `.gitignore` prevents future commits while cleaning up the git history.

### Verification

✅ Clean git history confirmed  
✅ `.claude/plans` no longer tracked in git  
✅ All branches force pushed successfully  
✅ Directory properly added to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)