### PR TITLE
Fix sub-navigation cutoff by updating header height CSS variable

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -20,7 +20,7 @@
   --color-info: #58a6ff;
   --border-radius: 6px;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
-  --header-height: 3rem;
+  --header-height: 51px; /* 40px logo + 10px padding (5px top/bottom) + 1px border */
 
   /* Combined header height with safe area for sticky positioning */
   --header-height-with-safe-area: calc(var(--header-height) + var(--safe-area-inset-top));


### PR DESCRIPTION
## Summary
Fixed sub-navigation tabs being cut off at the top when scrolling. The --header-height CSS variable (48px) didn't match actual header dimensions (~51px), causing sticky-positioned tabs to be positioned behind the header. Updated the variable to 51px with detailed comments explaining the calculation (40px logo + 10px padding + 1px border).

## Changes
- Updated `--header-height` in `packages/web/src/assets/main.css` from `3rem` (48px) to `51px`
- Added comments explaining the measurement breakdown for future reference

## Testing
Visual verification of sub-navigation alignment when scrolling through conversation history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)