### PR TITLE
Fix race condition where streamed messages disappear after session continuation

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -654,7 +654,11 @@ watch(
 );
 
 // Re-fetch messages and work logs when session status changes from running to waiting/completed
-// This ensures the UI shows the correct messages after Claude's turn ends
+// This ensures the UI shows the correct messages after Claude's turn ends.
+// Note: fetchMessages() uses a smart merge strategy that preserves any messages
+// already in the store (delivered via WebSocket) that aren't yet in the API response.
+// This prevents a race condition where messages disappear if the database write
+// hasn't completed before the status change triggers this refetch.
 watch(
   () => sessionsStore.currentSession?.status,
   async (newStatus, oldStatus) => {

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -763,7 +763,22 @@ export const useSessionsStore = defineStore('sessions', {
       try {
         const fetchedMessages = await api.getSessionMessages(sessionId);
         console.log(`[STORE] fetchMessages: session ${sessionId}, received ${fetchedMessages.length} messages, activeConversationId: ${this.activeConversationId}`);
-        this.messages = fetchedMessages;
+
+        // Smart merge: preserve any messages that were added via WebSocket but not yet in API response
+        // This prevents a race condition where WebSocket delivers a message before the server has
+        // persisted it, causing fetchMessages to overwrite the store with stale data
+        const fetchedIds = new Set(fetchedMessages.map(m => m.id));
+        const newMessages = this.messages.filter(m =>
+          m.sessionId === sessionId && !fetchedIds.has(m.id)
+        );
+
+        if (newMessages.length > 0) {
+          console.log(`[STORE] fetchMessages: merging ${fetchedMessages.length} fetched + ${newMessages.length} WebSocket-delivered messages`);
+          this.messages = [...fetchedMessages, ...newMessages];
+        } else {
+          this.messages = fetchedMessages;
+        }
+
         console.log(`[STORE] fetchMessages: updated store with ${this.messages.length} messages`);
       } catch (err) {
         this.error = err.message;
@@ -956,7 +971,12 @@ export const useSessionsStore = defineStore('sessions', {
     },
 
     addMessage(message) {
-      this.messages.push(message);
+      // Prevent duplicate additions (can happen if WebSocket delivers message multiple times
+      // or if fetchMessages returns the message while we're also receiving it via WebSocket)
+      const exists = this.messages.some(m => m.id === message.id);
+      if (!exists) {
+        this.messages.push(message);
+      }
     },
 
     async fetchWorkLogs(sessionId) {


### PR DESCRIPTION
## Summary

Fixed a race condition bug where the first response from Claude would stream then disappear when streaming completed after continuing a session.

### Root Cause

`fetchMessages()` could run before the database commit completes when session status changes from running to waiting/completed, overwriting WebSocket-delivered messages with stale data. This caused messages to temporarily appear then vanish.

### Solution

Implemented Option A (Smart Merge) strategy:
1. Modified `fetchMessages()` to merge WebSocket-delivered messages with fetched data
2. Added duplicate detection in `addMessage()` to prevent multiple additions
3. Added detailed comments explaining the race condition prevention

### Test Results

All 2047 tests pass with these changes.

## Changes

- `packages/web/src/stores/sessions.js` - Smart merge in fetchMessages(), duplicate check in addMessage()
- `packages/web/src/components/ConversationTab.vue` - Updated comments explaining the fix

## Test Plan

- ✅ All 2047 unit tests pass
- Messages now persist correctly when continuing a session
- No regressions in message streaming behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)