### PR TITLE
Improve Canvas Tab UX: hide upload button in detail view, add breadcrumb navigation

### DIFF
--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -76,16 +76,12 @@ describe('CanvasFileViewer', () => {
       expect(wrapper.find('.viewer-filename').text()).toBe('My Label');
     });
 
-    it('shows back button when showBackButton is true', () => {
-      const wrapper = mountComponent({ showBackButton: true });
+    it('always shows breadcrumb navigation', () => {
+      const wrapper = mountComponent();
 
-      expect(wrapper.find('.btn-back').exists()).toBe(true);
-    });
-
-    it('hides back button when showBackButton is false', () => {
-      const wrapper = mountComponent({ showBackButton: false });
-
-      expect(wrapper.find('.btn-back').exists()).toBe(false);
+      expect(wrapper.find('.breadcrumb-back').exists()).toBe(true);
+      expect(wrapper.find('.breadcrumb-separator').exists()).toBe(true);
+      expect(wrapper.find('.breadcrumb-back').text()).toBe('← Canvas');
     });
   });
 

--- a/packages/web/src/components/CanvasFileViewer.vue
+++ b/packages/web/src/components/CanvasFileViewer.vue
@@ -3,19 +3,18 @@
     <!-- Header -->
     <div class="viewer-header">
       <div class="viewer-header-left">
+        <!-- Breadcrumb navigation - always visible -->
+        <button
+          class="breadcrumb-back"
+          @click="handleBack"
+        >
+          ← Canvas
+        </button>
+        <span class="breadcrumb-separator">/</span>
         <span class="viewer-filename">{{ item.label || item.filename || 'Untitled' }}</span>
       </div>
 
       <div class="viewer-header-right">
-        <!-- Back button -->
-        <button
-          v-if="showBackButton"
-          class="btn-back"
-          @click="$emit('back')"
-        >
-          &#8249; Back
-        </button>
-
         <!-- Version dropdown -->
         <details
           v-if="versions.length > 1"
@@ -226,6 +225,11 @@ async function copyToClipboard(text) {
   }
 }
 
+// Navigation functions
+function handleBack() {
+  emit('back');
+}
+
 // Menu functions
 function toggleMenu() {
   menuOpen.value = !menuOpen.value;
@@ -403,20 +407,26 @@ function selectVersion(itemId) {
   flex-shrink: 0;
 }
 
-.btn-back {
+.breadcrumb-back {
   background: none;
-  border: 1px solid var(--color-border);
-  color: var(--color-text);
-  padding: 0.4rem 0.75rem;
-  border-radius: var(--border-radius);
+  border: none;
+  color: var(--color-primary);
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0;
   white-space: nowrap;
-  min-height: 36px;
+  transition: text-decoration 0.15s ease;
 }
 
-.btn-back:hover {
-  background: var(--color-background-mute);
+.breadcrumb-back:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-separator {
+  color: var(--color-text-soft);
+  margin: 0 0.5rem;
+  font-size: 0.875rem;
 }
 
 .viewer-filename {
@@ -700,11 +710,12 @@ function selectVersion(itemId) {
     gap: 0.5rem;
   }
 
-  .btn-back {
-    min-height: 44px;
-    padding: 0.5rem 0.75rem;
-    white-space: nowrap;
-    flex-shrink: 0;
+  .breadcrumb-back {
+    font-size: 0.875rem;
+  }
+
+  .breadcrumb-separator {
+    margin: 0 0.25rem;
   }
 
   .viewer-filename {

--- a/packages/web/src/components/CanvasTab.test.js
+++ b/packages/web/src/components/CanvasTab.test.js
@@ -210,7 +210,7 @@ describe('CanvasTab', () => {
       expect(uploadButton.text()).toContain('Upload File');
     });
 
-    it('shows upload button when viewing a single file', async () => {
+    it('shows upload button in list view with single file (not auto-opened)', async () => {
       api.getCanvasItems.mockResolvedValue([
         { id: '1', filename: 'file1.png', createdAt: 1000 },
       ]);
@@ -219,12 +219,13 @@ describe('CanvasTab', () => {
 
       await flushAll(wrapper);
 
-      // Upload button is now always visible, even when viewing a single file
+      // With the new behavior, single files show in list view (not auto-opened)
+      // So upload button should be visible
       const uploadButton = wrapper.find('label.btn-primary');
       expect(uploadButton.exists()).toBe(true);
     });
 
-    it('shows upload button when viewing a specific file in list', async () => {
+    it('hides upload button when viewing a specific file in list', async () => {
       api.getCanvasItems.mockResolvedValue([
         { id: '1', filename: 'file1.png', createdAt: 1000 },
         { id: '2', filename: 'file2.png', createdAt: 2000 },
@@ -236,9 +237,9 @@ describe('CanvasTab', () => {
 
       await flushAll(wrapper);
 
-      // Upload button is now always visible, even when viewing a specific file
+      // Upload button should be hidden when viewing a specific file
       const uploadButton = wrapper.find('label.btn-primary');
-      expect(uploadButton.exists()).toBe(true);
+      expect(uploadButton.exists()).toBe(false);
     });
 
     it('has hidden file input', async () => {

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -6,8 +6,8 @@
     @dragleave="handleDragLeave"
     @drop.prevent="handleDrop"
   >
-    <!-- Upload header -->
-    <div class="canvas-header">
+    <!-- Upload header - only show in list view -->
+    <div v-if="!shouldShowViewer || !selectedItem" class="canvas-header">
       <label v-if="!showTrash" class="btn btn-primary" :class="{ disabled: uploading }">
         {{ uploading ? 'Uploading...' : 'Upload File' }}
         <input
@@ -154,7 +154,7 @@ const selectedVersions = computed(() => {
 });
 
 const shouldShowViewer = computed(() => {
-  return groupedItems.value.length === 1 || selectedItemId.value !== null;
+  return selectedItemId.value !== null;
 });
 
 const showBackButton = computed(() => {


### PR DESCRIPTION
## Summary
- Hide upload header when viewing individual files to prevent confusing UX
- Add breadcrumb navigation (← Canvas / filename) with clickable back link for clear navigation context
- Update viewer logic to always show file list first instead of auto-opening single files when only one file exists
- Enhance mobile and desktop CSS styling for breadcrumb navigation

## Test plan
- ✅ All unit tests passing
- Test file upload and verify upload header is hidden when viewing file details
- Test breadcrumb back link functionality and navigation
- Verify file list always shows initially, even with single file
- Test breadcrumb styling on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)