### PR TITLE
Change conversation tab label from singular to plural

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -211,7 +211,7 @@ const canArchive = computed(() => {
 
 const tabs = computed(() => [
   { id: 'summary', label: 'Summary' },
-  { id: 'conversation', label: 'Conversation' },
+  { id: 'conversation', label: 'Conversations' },
   { id: 'changes', label: changesFileCount.value > 0 ? `Changes (${changesFileCount.value})` : 'Changes' },
   { id: 'canvas', label: canvasItemCount.value > 0 ? `Canvas (${canvasItemCount.value})` : 'Canvas' },
   { id: 'commands', label: 'Commands' }


### PR DESCRIPTION
## Summary

Successfully pluralized the 'Conversation' tab label to 'Conversations' in the session detail view component.

## Changes

- Updated the conversation tab label from 'Conversation' to 'Conversations' in `SessionDetailView.vue`
- Tab ID remains singular for routing consistency

## Files Modified

- `packages/web/src/views/SessionDetailView.vue`

## Test Plan

- [ ] Navigate to a session detail page
- [ ] Verify the conversation tab now displays as "Conversations"
- [ ] Verify the tab functionality still works correctly
- [ ] Verify no routing or navigation is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)