### PR TITLE
Hide 'Claude is working...' text on extremely small screens (≤360px)

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -1608,4 +1608,11 @@ async function handleBranchCreate({ messageId, prompt }) {
     display: none;
   }
 }
+
+/* Hide "Claude is working..." text on extremely small screens */
+@media (max-width: 360px) {
+  .running-title {
+    display: none;
+  }
+}
 </style>

--- a/packages/web/src/components/LiveWorkLogPanel.vue
+++ b/packages/web/src/components/LiveWorkLogPanel.vue
@@ -164,4 +164,11 @@ defineExpose({
     animation: none;
   }
 }
+
+/* Hide "Claude is working..." text on extremely small screens */
+@media (max-width: 360px) {
+  .live-title {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary

Successfully implemented CSS media queries to hide the "Claude is working..." text on screens 360px or smaller, improving responsive design for ultra-compact devices while maintaining spinner visibility.

## Changes

- **ConversationTab.vue**: Added media query to hide `.running-title` on screens ≤360px
- **LiveWorkLogPanel.vue**: Added media query to hide `.live-title` on screens ≤360px

## Test Plan

- [x] Unit tests passing (17/17)
- [x] Linter validation successful
- [x] No regressions introduced
- [ ] Manually test on small screen devices
- [ ] Verify spinner still displays on all screen sizes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)