### PR TITLE
Fix submit button visibility in Quick Response dialog

### DIFF
--- a/packages/web/src/components/QuickResponseDialog.vue
+++ b/packages/web/src/components/QuickResponseDialog.vue
@@ -442,9 +442,9 @@ async function handleSubmit() {
 }
 
 .btn-primary {
-  background: var(--color-accent);
-  border: 1px solid var(--color-accent);
-  color: var(--color-background);
+  background: var(--color-accent, #22d3ee);
+  border: 1px solid var(--color-accent, #22d3ee);
+  color: var(--color-background, #0d1117);
 }
 
 .btn-primary:hover:not(:disabled) {


### PR DESCRIPTION
## Summary

Fixed the invisible Submit button on the Add Quick Response modal. The button's CSS styling was broken due to a missing fallback value for an undefined CSS variable.

## Root Cause

The `.btn-primary` button styling in `QuickResponseDialog.vue` was using `var(--color-accent)` without a fallback, but the `--color-accent` CSS variable is not defined in the global CSS. This resulted in:
- Transparent background (undefined variable)
- Transparent border (undefined variable)  
- Dark text color on dark modal background

The button became invisible.

## Solution

Added CSS fallback values to the `.btn-primary` rule, matching the pattern used elsewhere in the codebase:
- `var(--color-accent, #22d3ee)` for background and border
- `var(--color-background, #0d1117)` for text color

The fallback uses the standard cyan accent color (#22d3ee) that's used throughout the UI.

## Test Plan

- [x] Unit tests for QuickResponseDialog component pass
- Visual testing recommended:
  1. Open Quick Response settings
  2. Click "Add Quick Response"
  3. Verify the cyan "Save Quick Response" button is visible
  4. Verify button is disabled with empty form, enabled when valid
  5. Test submitting a quick response

## Files Changed

- `packages/web/src/components/QuickResponseDialog.vue` - Added CSS fallback values

🤖 Generated with [Claude Code](https://claude.com/claude-code)