### PR TITLE
Fix ModelSelector not showing options when providers loaded without models

### DIFF
--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -50,9 +50,17 @@ const providersStore = useProvidersStore();
 const uiStore = useUiStore();
 const togglingModel = ref(false);
 
+// Check if providers have models loaded
+// Providers may have been fetched without models (e.g., from ProvidersView)
+const providersHaveModels = computed(() => {
+  return providersStore.providers.length > 0 &&
+    providersStore.providers.some(p => p.models && p.models.length > 0);
+});
+
 // Fetch providers with models on mount
 onMounted(async () => {
-  if (providersStore.providers.length === 0) {
+  // Fetch if no providers OR if providers exist but don't have models loaded
+  if (providersStore.providers.length === 0 || !providersHaveModels.value) {
     await providersStore.fetchProvidersWithModels();
   }
 });


### PR DESCRIPTION
## Summary
- Fixed the model select dropdown showing no options on the session detail view
- Root cause: `ProvidersView.vue` calls `fetchProviders()` which loads providers without models, and `ModelSelector.vue` only fetched with models if `providers.length === 0`
- Now checks if any provider has models attached before deciding to fetch

## Test plan
- [ ] Navigate to a session detail view
- [ ] Verify the model dropdown shows available models (Haiku, Sonnet, Opus)
- [ ] Navigate to Providers view first, then to a session - verify models still show
- [ ] All 70 test files and 2088 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)