### PR TITLE
Fix: Remove hardcoded model validation to allow custom models

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -916,10 +916,6 @@ router.patch('/:id', (req, res) => {
     updateData.nextTemplateId = nextTemplateId;
   }
   if (model !== undefined) {
-    const validModels = ['claude-sonnet-4-5-20250929', 'claude-opus-4-5-20251101', 'claude-haiku-4-5-20251001'];
-    if (!validModels.includes(model)) {
-      return res.status(400).json({ error: 'Invalid model. Must be one of: ' + validModels.join(', ') });
-    }
     updateData.model = model;
   }
   // PR URL - allow setting, updating, or clearing (null or empty string clears it)


### PR DESCRIPTION
## Summary

Fixed custom model selection validation error by removing hardcoded model list from sessions.js. All 1997 tests passed.

## Problem

User reported a model selection validation error when attempting to use custom models. Investigation identified a hardcoded list of 3 models in `packages/server/src/api/sessions.js` (lines 918-924) that conflicted with the existing custom provider infrastructure.

## Solution

Removed the hardcoded model validation check entirely, deferring to Claude API runtime validation. This allows the provider_models schema and custom provider infrastructure to work as intended.

## Changes

- Removed hardcoded model validation list from `packages/server/src/api/sessions.js`

## Testing

✅ Full test suite: 1997 tests passed (no regressions)
✅ E2E model provider tests: All passed