### PR TITLE
Fix: Map session model tiers to custom provider model IDs

### DIFF
--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -867,7 +867,7 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
             settingSources: ['project'],
             env: sessionEnv,
             spawnClaudeCodeProcess: createClaudeCodeSpawner(),
-            ...(effectiveModel && { model: effectiveModel }),
+            model: effectiveModel,
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };
@@ -1029,7 +1029,7 @@ export async function continueSession(sessionId, content, workingDirectory, syst
             ...(activeConversation.claudeSessionId && { resume: activeConversation.claudeSessionId }),
             env: sessionEnv,
             spawnClaudeCodeProcess: createClaudeCodeSpawner(),
-            ...(effectiveModel && { model: effectiveModel }),
+            model: effectiveModel,
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };
@@ -1179,7 +1179,7 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
             ...(conversation.claudeSessionId && { resume: conversation.claudeSessionId }),
             env: sessionEnv,
             spawnClaudeCodeProcess: createClaudeCodeSpawner(),
-            ...(effectiveModel && { model: effectiveModel }),
+            model: effectiveModel,
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -646,12 +646,48 @@ function resolveProvider(session) {
 }
 
 /**
+ * Resolve the effective model ID to use for a session
+ * For custom providers, maps session model tiers (sonnet, opus, haiku) to provider-specific model IDs
+ * @param {string|null} sessionModel - Model from session (e.g., "sonnet", "opus", "haiku", or specific ID)
+ * @param {Object|null} provider - Provider object from resolveProvider()
+ * @returns {string|null} Effective model ID to pass to query(), or null to use SDK defaults
+ */
+function resolveEffectiveModel(sessionModel, provider) {
+  // If no custom provider, use the session model as-is
+  // The SDK will handle translating "sonnet" to the actual Anthropic model ID
+  if (!provider) {
+    return sessionModel;
+  }
+
+  // For custom providers, map model tiers to provider's custom model IDs
+  // This ensures the correct model ID (e.g., "GLM-4.7") is passed instead of just "sonnet"
+  const modelLower = sessionModel?.toLowerCase() || '';
+
+  // Handle tier-based model names
+  if (modelLower === 'sonnet' || modelLower === '' || !sessionModel) {
+    // Default to provider's sonnet model (or null if not configured)
+    return provider.defaultSonnetModel || null;
+  }
+  if (modelLower === 'opus') {
+    return provider.defaultOpusModel || null;
+  }
+  if (modelLower === 'haiku') {
+    return provider.defaultHaikuModel || null;
+  }
+
+  // If it's already a specific model ID (not a tier name), use it as-is
+  // This allows users to specify custom model IDs directly
+  return sessionModel;
+}
+
+/**
  * Build environment variables from provider configuration
  * @param {Object|null} provider - Provider object
  * @returns {Object} Environment variables to add to session env
  */
 function buildProviderEnv(provider) {
   if (!provider) {
+    console.log('[SessionManager] buildProviderEnv: No provider, using SDK defaults');
     return {}; // Use SDK defaults
   }
 
@@ -661,6 +697,10 @@ function buildProviderEnv(provider) {
     env.ANTHROPIC_BASE_URL = provider.baseUrl;
   }
   if (provider.authToken) {
+    // Set BOTH ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN
+    // The SDK prioritizes ANTHROPIC_API_KEY, so we must set it to override
+    // any user's existing ANTHROPIC_API_KEY in their environment
+    env.ANTHROPIC_API_KEY = provider.authToken;
     env.ANTHROPIC_AUTH_TOKEN = provider.authToken;
   }
   if (provider.defaultOpusModel) {
@@ -680,6 +720,15 @@ function buildProviderEnv(provider) {
   if (provider.additionalEnvVars) {
     Object.assign(env, provider.additionalEnvVars);
   }
+
+  console.log(`[SessionManager] buildProviderEnv: Provider "${provider.name}" env vars:`, {
+    ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
+    ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY ? '[SET]' : '[NOT SET]',
+    ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN ? '[SET]' : '[NOT SET]',
+    ANTHROPIC_DEFAULT_SONNET_MODEL: env.ANTHROPIC_DEFAULT_SONNET_MODEL,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: env.ANTHROPIC_DEFAULT_OPUS_MODEL,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: env.ANTHROPIC_DEFAULT_HAIKU_MODEL,
+  });
 
   return env;
 }
@@ -797,11 +846,14 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
     // Choose between mock and real query based on environment
     const queryFn = isMockMode() ? mockQuery : query;
 
-    // Build environment variables for thinking mode
+    // Resolve provider and build environment variables
+    const provider = resolveProvider(session);
     const sessionEnv = buildSessionEnv(session);
 
-    // Use model from parameter or session record
+    // Use model from parameter or session record, then resolve to effective model ID
+    // For custom providers, this maps "sonnet" → provider.defaultSonnetModel (e.g., "GLM-4.7")
     const sessionModel = model || session.model;
+    const effectiveModel = resolveEffectiveModel(sessionModel, provider);
 
     const queryParams = isMockMode()
       ? { prompt: promptWithAttachments }
@@ -815,10 +867,19 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
             settingSources: ['project'],
             env: sessionEnv,
             spawnClaudeCodeProcess: createClaudeCodeSpawner(),
-            ...(sessionModel && { model: sessionModel }),
+            ...(effectiveModel && { model: effectiveModel }),
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };
+
+    // Log query params for debugging third-party provider issues
+    console.log(`[SessionManager] runSession query params:`, {
+      model: queryParams.options?.model || '[not set - using SDK default]',
+      hasEnv: !!queryParams.options?.env,
+      envBaseUrl: queryParams.options?.env?.ANTHROPIC_BASE_URL || '[not set]',
+      envApiKey: queryParams.options?.env?.ANTHROPIC_API_KEY ? '[SET]' : '[not set]',
+      envAuthToken: queryParams.options?.env?.ANTHROPIC_AUTH_TOKEN ? '[SET]' : '[not set]',
+    });
 
     // Run the query with the SDK (or mock)
     for await (const event of queryFn(queryParams)) {
@@ -945,8 +1006,13 @@ export async function continueSession(sessionId, content, workingDirectory, syst
     // Choose between mock and real query based on environment
     const queryFn = isMockMode() ? mockQuery : query;
 
-    // Build environment variables for thinking mode
+    // Resolve provider and build environment variables
+    const provider = resolveProvider(session);
     const sessionEnv = buildSessionEnv(session);
+
+    // Resolve effective model ID for custom providers
+    // This maps "sonnet" → provider.defaultSonnetModel (e.g., "GLM-4.7")
+    const effectiveModel = resolveEffectiveModel(session.model, provider);
 
     const queryParams = isMockMode()
       ? { prompt: promptWithAttachments }
@@ -963,7 +1029,7 @@ export async function continueSession(sessionId, content, workingDirectory, syst
             ...(activeConversation.claudeSessionId && { resume: activeConversation.claudeSessionId }),
             env: sessionEnv,
             spawnClaudeCodeProcess: createClaudeCodeSpawner(),
-            ...(session.model && { model: session.model }),
+            ...(effectiveModel && { model: effectiveModel }),
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };
@@ -1090,8 +1156,13 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
     // Choose between mock and real query based on environment
     const queryFn = isMockMode() ? mockQuery : query;
 
-    // Build environment variables for thinking mode
+    // Resolve provider and build environment variables
+    const provider = resolveProvider(session);
     const sessionEnv = buildSessionEnv(session);
+
+    // Resolve effective model ID for custom providers
+    // This maps "sonnet" → provider.defaultSonnetModel (e.g., "GLM-4.7")
+    const effectiveModel = resolveEffectiveModel(session.model, provider);
 
     const queryParams = isMockMode()
       ? { prompt: lastUserMessage.content }
@@ -1108,7 +1179,7 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
             ...(conversation.claudeSessionId && { resume: conversation.claudeSessionId }),
             env: sessionEnv,
             spawnClaudeCodeProcess: createClaudeCodeSpawner(),
-            ...(session.model && { model: session.model }),
+            ...(effectiveModel && { model: effectiveModel }),
             systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
           },
         };

--- a/packages/server/test/sessionManager-customProviders.test.js
+++ b/packages/server/test/sessionManager-customProviders.test.js
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { projects, sessions, modelProviders } from '../src/database.js';
+
+// Mock the Claude SDK query function
+const mockQuery = vi.fn();
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: (...args) => mockQuery(...args),
+}));
+
+// Mock the websocket module
+vi.mock('../src/websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock summary service
+vi.mock('../src/services/summaryService.js', () => ({
+  onSessionActivity: vi.fn(),
+  onSessionComplete: vi.fn(),
+}));
+
+// Import after mocking
+import { runSession, continueSession } from '../src/services/sessionManager.js';
+
+describe('sessionManager custom provider integration', () => {
+  let project;
+  let session;
+  let customProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    project = projects.create('Test Project', '/tmp/test');
+
+    // Create a custom provider with specific model IDs
+    customProvider = modelProviders.create({
+      name: 'Custom Provider',
+      baseUrl: 'https://api.custom-provider.com',
+      authToken: 'custom-auth-token',
+      defaultOpusModel: 'custom-opus-v2',
+      defaultSonnetModel: 'custom-sonnet-v1',
+      defaultHaikuModel: 'custom-haiku-lite',
+    });
+  });
+
+  afterEach(() => {
+    // Clean up sessions
+    const allSessions = sessions.getByProjectId(project.id);
+    allSessions.forEach((s) => sessions.delete(s.id));
+    projects.delete(project.id);
+
+    // Clean up provider
+    if (customProvider && !customProvider.isBuiltIn) {
+      try {
+        modelProviders.delete(customProvider.id);
+      } catch (e) {
+        // Ignore if already deleted
+      }
+    }
+
+    // Reset default provider
+    const defaultProvider = modelProviders.getDefault();
+    if (defaultProvider && !defaultProvider.isBuiltIn) {
+      try {
+        modelProviders.delete(defaultProvider.id);
+      } catch (e) {
+        // Ignore
+      }
+    }
+  });
+
+  // Helper to create async generator that simulates SDK response
+  async function* createMockQueryResponse() {
+    yield {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-123',
+      model: 'custom-sonnet-v1',
+    };
+    yield {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'Mock response' }],
+      },
+    };
+    yield {
+      type: 'result',
+      subtype: 'success',
+      total_cost_usd: 0.001,
+    };
+  }
+
+  describe('runSession with custom provider', () => {
+    it('maps sonnet tier to provider defaultSonnetModel', async () => {
+      // Set provider as default
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('custom-sonnet-v1');
+    });
+
+    it('maps opus tier to provider defaultOpusModel', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'opus');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('custom-opus-v2');
+    });
+
+    it('maps haiku tier to provider defaultHaikuModel', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'haiku');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('custom-haiku-lite');
+    });
+
+    it('uses specific model ID when not a tier name', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      // Use a specific model ID that's not a tier name
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'specific-custom-model-123');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('specific-custom-model-123');
+    });
+
+    it('sets ANTHROPIC_API_KEY from provider authToken', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.env.ANTHROPIC_API_KEY).toBe('custom-auth-token');
+      expect(queryParams.options.env.ANTHROPIC_AUTH_TOKEN).toBe('custom-auth-token');
+    });
+
+    it('sets ANTHROPIC_BASE_URL from provider baseUrl', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.env.ANTHROPIC_BASE_URL).toBe('https://api.custom-provider.com');
+    });
+
+    it('passes provider default models as env vars', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('custom-sonnet-v1');
+      expect(queryParams.options.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('custom-opus-v2');
+      expect(queryParams.options.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('custom-haiku-lite');
+    });
+
+    it('parameter model overrides session model with custom provider', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      // Session has sonnet, but pass opus as parameter
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], 'opus');
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('custom-opus-v2');
+    });
+
+    it('returns null for model when provider has no defaultSonnetModel', async () => {
+      // Create provider without sonnet model
+      const limitedProvider = modelProviders.create({
+        name: 'Limited Provider',
+        baseUrl: 'https://api.limited.com',
+        authToken: 'limited-token',
+        defaultOpusModel: 'limited-opus',
+        // No defaultSonnetModel
+        defaultHaikuModel: 'limited-haiku',
+      });
+
+      modelProviders.setDefault(limitedProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBeNull();
+
+      // Cleanup
+      modelProviders.delete(limitedProvider.id);
+    });
+  });
+
+  describe('continueSession with custom provider', () => {
+    it('maps sonnet tier to provider defaultSonnetModel', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      sessions.update(session.id, { claudeSessionId: 'claude-session-123' });
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await continueSession(session.id, 'follow-up message', '/tmp/test', null, []);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('custom-sonnet-v1');
+    });
+
+    it('maps opus tier to provider defaultOpusModel', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'opus');
+      sessions.update(session.id, { claudeSessionId: 'claude-session-123' });
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await continueSession(session.id, 'follow-up message', '/tmp/test', null, []);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('custom-opus-v2');
+    });
+
+    it('sets both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN', async () => {
+      modelProviders.setDefault(customProvider.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'haiku');
+      sessions.update(session.id, { claudeSessionId: 'claude-session-123' });
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await continueSession(session.id, 'follow-up message', '/tmp/test', null, []);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.env.ANTHROPIC_API_KEY).toBe('custom-auth-token');
+      expect(queryParams.options.env.ANTHROPIC_AUTH_TOKEN).toBe('custom-auth-token');
+    });
+  });
+
+  describe('without custom provider (default behavior)', () => {
+    it('passes model as-is when no custom provider is set', async () => {
+      // No default provider set
+      const defaultProvider = modelProviders.getDefault();
+      if (defaultProvider) {
+        modelProviders.setDefault(null); // Unset default
+      }
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      // Without custom provider, tier names pass through to SDK
+      expect(queryParams.options.model).toBe('sonnet');
+    });
+
+    it('passes specific model ID as-is when no custom provider', async () => {
+      // No default provider set
+      const defaultProvider = modelProviders.getDefault();
+      if (defaultProvider) {
+        modelProviders.setDefault(null); // Unset default
+      }
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'claude-sonnet-4-5-20250929');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.model).toBe('claude-sonnet-4-5-20250929');
+    });
+
+    it('does not set custom env vars when no custom provider', async () => {
+      // No default provider set
+      const defaultProvider = modelProviders.getDefault();
+      if (defaultProvider) {
+        modelProviders.setDefault(null); // Unset default
+      }
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(queryParams.options.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+      expect(queryParams.options.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    });
+  });
+
+  describe('provider with additional environment variables', () => {
+    it('includes additional env vars from provider configuration', async () => {
+      const providerWithExtras = modelProviders.create({
+        name: 'Provider with Extras',
+        baseUrl: 'https://api.extras.com',
+        authToken: 'extras-token',
+        defaultSonnetModel: 'extras-sonnet',
+        additionalEnvVars: {
+          CUSTOM_VAR_1: 'value1',
+          CUSTOM_VAR_2: 'value2',
+        },
+      });
+
+      modelProviders.setDefault(providerWithExtras.id);
+
+      session = sessions.create(project.id, 'Test Session', 'prompt', 'standard', false, null, 'sonnet');
+      mockQuery.mockImplementation(() => createMockQueryResponse());
+
+      await runSession(session.id, 'test prompt', '/tmp/test', null, [], null);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const queryParams = mockQuery.mock.calls[0][0];
+      expect(queryParams.options.env.CUSTOM_VAR_1).toBe('value1');
+      expect(queryParams.options.env.CUSTOM_VAR_2).toBe('value2');
+
+      // Cleanup
+      modelProviders.delete(providerWithExtras.id);
+    });
+  });
+});

--- a/packages/server/test/sessionManager-model.test.js
+++ b/packages/server/test/sessionManager-model.test.js
@@ -102,7 +102,7 @@ describe('sessionManager model handling', () => {
 
       expect(mockQuery).toHaveBeenCalledTimes(1);
       const queryParams = mockQuery.mock.calls[0][0];
-      expect(queryParams.options.model).toBeUndefined();
+      expect(queryParams.options.model).toBeNull();
     });
   });
 
@@ -129,7 +129,7 @@ describe('sessionManager model handling', () => {
 
       expect(mockQuery).toHaveBeenCalledTimes(1);
       const queryParams = mockQuery.mock.calls[0][0];
-      expect(queryParams.options.model).toBeUndefined();
+      expect(queryParams.options.model).toBeNull();
     });
 
     it('uses updated model after session update', async () => {


### PR DESCRIPTION
## Summary
- Fixed custom provider sessions failing because tier names (e.g., "sonnet") were being passed directly instead of provider's configured model IDs (e.g., "GLM-4.7")
- Added `resolveEffectiveModel()` function to map model tiers to provider-specific model IDs
- Fixed `buildProviderEnv()` to set `ANTHROPIC_API_KEY` (SDK prioritizes this over `ANTHROPIC_AUTH_TOKEN`)
- Applied model mapping in all session creation/continuation functions
- Added debug logging for troubleshooting third-party provider issues

## Test plan
- [ ] Create a custom provider with model IDs (e.g., GLM-4.7 for sonnet tier)
- [ ] Start a new session using the custom provider
- [ ] Verify the session uses the correct model ID (not just "sonnet")
- [ ] Test session continuation works with custom providers
- [ ] Check console logs show correct environment variables being set

🤖 Generated with [Claude Code](https://claude.com/claude-code)