### PR TITLE
Refactor template management: dedicated detail view

### DIFF
--- a/packages/web/src/components/TemplatesPanel.vue
+++ b/packages/web/src/components/TemplatesPanel.vue
@@ -14,7 +14,7 @@
 
     <!-- Create Template Form -->
     <div v-if="showCreateForm" class="template-form card" data-testid="template-form">
-      <h3>{{ editingTemplate ? 'Edit Template' : 'Create Template' }}</h3>
+      <h3>Create Template</h3>
       <form @submit.prevent="handleSubmit">
         <div class="form-group">
           <label class="form-label">Name</label>
@@ -69,21 +69,11 @@
           </div>
         </div>
 
-        <div class="form-group">
-          <label class="form-label">Git Branch (Optional)</label>
-          <input
-            v-model="formData.gitBranch"
-            type="text"
-            class="form-input"
-            placeholder="Branch name"
-          />
-        </div>
-
         <div class="form-actions">
           <button type="button" class="btn" @click="cancelForm" data-testid="cancel-btn">Cancel</button>
           <button type="submit" class="btn btn-primary" :disabled="saving" data-testid="submit-btn">
             <span v-if="saving" class="loading-spinner"></span>
-            {{ editingTemplate ? 'Update' : 'Create' }}
+            Create
           </button>
         </div>
       </form>
@@ -101,22 +91,15 @@
       <div v-if="projectTemplates.length > 0" class="template-section">
         <h3 class="section-title">Project Templates</h3>
         <div class="templates-list">
-          <div v-for="template in projectTemplates" :key="template.id" class="template-card card" :data-testid="`template-card-${template.id}`">
+          <router-link
+            v-for="template in projectTemplates"
+            :key="template.id"
+            :to="`/projects/${projectId}/templates/${template.id}`"
+            class="template-card card"
+            :data-testid="`template-card-${template.id}`"
+          >
             <div class="template-header">
               <h4 class="template-name">{{ template.name }}</h4>
-              <div class="template-actions">
-                <button class="btn-icon" @click="editTemplate(template)" title="Edit" data-testid="edit-btn">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                  </svg>
-                </button>
-                <button class="btn-icon btn-icon-danger" @click="handleDelete(template)" title="Delete" data-testid="delete-btn">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                  </svg>
-                </button>
-              </div>
             </div>
             <p class="template-prompt">{{ truncatePrompt(template.prompt) }}</p>
             <div class="template-meta">
@@ -126,7 +109,7 @@
                 Chains to: {{ getTemplateName(template.nextTemplateId) }}
               </span>
             </div>
-          </div>
+          </router-link>
         </div>
       </div>
 
@@ -134,22 +117,15 @@
       <div v-if="globalTemplates.length > 0" class="template-section">
         <h3 class="section-title">Global Templates</h3>
         <div class="templates-list">
-          <div v-for="template in globalTemplates" :key="template.id" class="template-card card" :data-testid="`template-card-${template.id}`">
+          <router-link
+            v-for="template in globalTemplates"
+            :key="template.id"
+            :to="`/projects/${projectId}/templates/${template.id}`"
+            class="template-card card"
+            :data-testid="`template-card-${template.id}`"
+          >
             <div class="template-header">
               <h4 class="template-name">{{ template.name }}</h4>
-              <div class="template-actions">
-                <button class="btn-icon" @click="editTemplate(template)" title="Edit" data-testid="edit-btn">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                  </svg>
-                </button>
-                <button class="btn-icon btn-icon-danger" @click="handleDelete(template)" title="Delete" data-testid="delete-btn">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                  </svg>
-                </button>
-              </div>
             </div>
             <p class="template-prompt">{{ truncatePrompt(template.prompt) }}</p>
             <div class="template-meta">
@@ -160,7 +136,7 @@
                 Chains to: {{ getTemplateName(template.nextTemplateId) }}
               </span>
             </div>
-          </div>
+          </router-link>
         </div>
       </div>
 
@@ -188,7 +164,6 @@ const templatesStore = useTemplatesStore();
 const uiStore = useUiStore();
 
 const showCreateForm = ref(false);
-const editingTemplate = ref(null);
 const saving = ref(false);
 
 const formData = ref({
@@ -197,7 +172,6 @@ const formData = ref({
   isGlobal: false,
   nextTemplateId: null,
   thinkingEnabled: false,
-  gitBranch: '',
 });
 
 const loading = computed(() => templatesStore.loading);
@@ -206,10 +180,6 @@ const globalTemplates = computed(() => templatesStore.globalTemplates);
 
 const availableNextTemplates = computed(() => {
   const all = [...templatesStore.projectTemplates, ...templatesStore.globalTemplates];
-  // Exclude the current template being edited
-  if (editingTemplate.value) {
-    return all.filter((t) => t.id !== editingTemplate.value.id);
-  }
   return all;
 });
 
@@ -241,9 +211,7 @@ function resetForm() {
     isGlobal: false,
     nextTemplateId: null,
     thinkingEnabled: false,
-    gitBranch: '',
   };
-  editingTemplate.value = null;
 }
 
 function openCreateForm() {
@@ -253,19 +221,6 @@ function openCreateForm() {
 function cancelForm() {
   showCreateForm.value = false;
   resetForm();
-}
-
-function editTemplate(template) {
-  editingTemplate.value = template;
-  formData.value = {
-    name: template.name,
-    prompt: template.prompt,
-    isGlobal: !template.projectId,
-    nextTemplateId: template.nextTemplateId || null,
-    thinkingEnabled: template.thinkingEnabled || false,
-    gitBranch: template.gitBranch || '',
-  };
-  showCreateForm.value = true;
 }
 
 async function handleSubmit() {
@@ -278,13 +233,9 @@ async function handleSubmit() {
       prompt: formData.value.prompt,
       nextTemplateId: formData.value.nextTemplateId || undefined,
       thinkingEnabled: formData.value.thinkingEnabled || undefined,
-      gitBranch: formData.value.gitBranch || undefined,
     };
 
-    if (editingTemplate.value) {
-      await templatesStore.updateTemplate(editingTemplate.value.id, data);
-      uiStore.success('Template updated');
-    } else if (formData.value.isGlobal) {
+    if (formData.value.isGlobal) {
       await templatesStore.createGlobalTemplate(data);
       uiStore.success('Global template created');
     } else {
@@ -297,17 +248,6 @@ async function handleSubmit() {
     uiStore.error(err.message);
   } finally {
     saving.value = false;
-  }
-}
-
-async function handleDelete(template) {
-  if (!confirm(`Delete template "${template.name}"?`)) return;
-
-  try {
-    await templatesStore.deleteTemplate(template.id);
-    uiStore.success('Template deleted');
-  } catch (err) {
-    uiStore.error(err.message);
   }
 }
 </script>
@@ -414,12 +354,18 @@ async function handleDelete(template) {
 
 .template-card {
   padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.template-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .template-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
   margin-bottom: 0.5rem;
 }
 
@@ -427,32 +373,7 @@ async function handleDelete(template) {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-}
-
-.template-actions {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.btn-icon {
-  background: none;
-  border: none;
-  padding: 0.25rem;
-  cursor: pointer;
-  color: var(--color-text-soft);
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.btn-icon:hover {
-  background: var(--color-bg-soft);
   color: var(--color-text);
-}
-
-.btn-icon-danger:hover {
-  color: var(--color-error);
 }
 
 .template-prompt {

--- a/packages/web/src/router.js
+++ b/packages/web/src/router.js
@@ -52,6 +52,11 @@ const routes = [
     component: () => import('./views/SessionListView.vue'),
   },
   {
+    path: '/projects/:projectId/templates/:templateId',
+    name: 'TemplateDetail',
+    component: () => import('./views/TemplateDetailView.vue'),
+  },
+  {
     path: '/projects/:id/sessions/new',
     name: 'NewSession',
     component: () => import('./views/NewSessionView.vue'),

--- a/packages/web/src/views/TemplateDetailView.vue
+++ b/packages/web/src/views/TemplateDetailView.vue
@@ -1,0 +1,457 @@
+<template>
+  <div class="container template-detail">
+    <div v-if="isLoading" class="loading-state">
+      <span class="loading-spinner"></span>
+      Loading...
+    </div>
+
+    <div v-else class="form-container">
+      <!-- Header -->
+      <div class="form-header">
+        <router-link :to="`/projects/${projectId}/templates`" class="btn btn-outline-secondary">
+          ← Back
+        </router-link>
+        <h2>Edit Template</h2>
+      </div>
+
+      <!-- Form -->
+      <form @submit.prevent="onSubmit" class="template-form">
+        <!-- Name Field -->
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input
+            id="name"
+            v-model="formData.name"
+            type="text"
+            class="form-input"
+            placeholder="Template name"
+            required
+          />
+        </div>
+
+        <!-- Prompt Field -->
+        <div class="form-group">
+          <label for="prompt">Prompt</label>
+          <textarea
+            id="prompt"
+            v-model="formData.prompt"
+            class="form-input form-textarea"
+            placeholder="Session prompt. Use {{parentSession.summary}} to reference parent session data."
+            rows="6"
+            required
+          ></textarea>
+          <p class="form-help">
+            Available variables: <code v-pre>{{parentSession.summary}}</code>, <code v-pre>{{parentSession.status}}</code>, <code v-pre>{{parentSession.name}}</code>, <code v-pre>{{rootSession.id}}</code>, <code v-pre>{{rootSession.name}}</code>, <code v-pre>{{rootSession.summary}}</code>, <code v-pre>{{rootSession.status}}</code>
+          </p>
+        </div>
+
+        <!-- Scope Field -->
+        <div class="form-group">
+          <label for="scope">Scope</label>
+          <select id="scope" v-model="formData.isGlobal" class="form-input" disabled>
+            <option :value="false">Project Only</option>
+            <option :value="true">Global (all projects)</option>
+          </select>
+          <p class="form-help">Scope cannot be changed after creation</p>
+        </div>
+
+        <!-- Next Template Field -->
+        <div class="form-group">
+          <label for="nextTemplate">Next Template (Optional)</label>
+          <select id="nextTemplate" v-model="formData.nextTemplateId" class="form-input">
+            <option :value="null">None</option>
+            <option v-for="t in availableNextTemplates" :key="t.id" :value="t.id">
+              {{ t.name }} {{ t.projectId ? '' : '(Global)' }}
+            </option>
+          </select>
+          <p class="form-help">Chain another template to run after this one completes.</p>
+        </div>
+
+        <!-- Thinking Enabled Checkbox -->
+        <div class="form-group form-group-checkbox">
+          <label for="thinkingEnabled" class="checkbox-label">
+            <input
+              id="thinkingEnabled"
+              v-model="formData.thinkingEnabled"
+              type="checkbox"
+              class="form-checkbox"
+            />
+            <span>Enable Extended Thinking</span>
+          </label>
+        </div>
+
+        <!-- Form Actions -->
+        <div class="form-actions">
+          <button type="button" class="btn btn-outline-secondary" @click="onCancel">
+            Cancel
+          </button>
+          <button type="button" class="btn btn-outline-danger" @click="onDelete">
+            Delete
+          </button>
+          <button type="submit" class="btn btn-primary" :disabled="isSaving">
+            {{ isSaving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+
+        <!-- Error Message -->
+        <div v-if="error" class="form-error-message">
+          {{ error }}
+        </div>
+      </form>
+    </div>
+
+    <!-- Delete Confirmation Dialog -->
+    <div v-if="showDeleteConfirm" class="modal-overlay" @click="showDeleteConfirm = false">
+      <div class="modal-dialog" @click.stop>
+        <div class="modal-header">
+          <h4>Delete Template</h4>
+        </div>
+        <div class="modal-body">
+          <p>Are you sure you want to delete "<strong>{{ formData.name }}</strong>"?</p>
+          <p>This action cannot be undone.</p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline-secondary" @click="showDeleteConfirm = false">
+            Cancel
+          </button>
+          <button class="btn btn-danger" @click="confirmDelete" :disabled="isDeleting">
+            {{ isDeleting ? 'Deleting...' : 'Delete' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useTemplatesStore } from '../stores/templates.js';
+import { useUiStore } from '../stores/ui.js';
+import { api } from '../api/index.js';
+
+const route = useRoute();
+const router = useRouter();
+const templatesStore = useTemplatesStore();
+const uiStore = useUiStore();
+
+const isLoading = ref(false);
+const isSaving = ref(false);
+const isDeleting = ref(false);
+const showDeleteConfirm = ref(false);
+const error = ref(null);
+
+const formData = ref({
+  name: '',
+  prompt: '',
+  isGlobal: false,
+  nextTemplateId: null,
+  thinkingEnabled: false,
+});
+
+const projectId = computed(() => route.params.projectId);
+const templateId = computed(() => route.params.templateId);
+
+const availableNextTemplates = computed(() => {
+  const all = [...templatesStore.projectTemplates, ...templatesStore.globalTemplates];
+  // Exclude the current template being edited
+  return all.filter((t) => t.id !== templateId.value);
+});
+
+const loadTemplate = async () => {
+  isLoading.value = true;
+  error.value = null;
+  try {
+    const template = await api.getTemplate(templateId.value);
+
+    if (template) {
+      formData.value = {
+        name: template.name,
+        prompt: template.prompt,
+        isGlobal: !template.projectId,
+        nextTemplateId: template.nextTemplateId || null,
+        thinkingEnabled: template.thinkingEnabled || false,
+      };
+    }
+  } catch (err) {
+    error.value = `Failed to load template: ${err.message}`;
+    uiStore.error(err.message);
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const onSubmit = async () => {
+  error.value = null;
+  isSaving.value = true;
+  try {
+    const data = {
+      name: formData.value.name,
+      prompt: formData.value.prompt,
+      nextTemplateId: formData.value.nextTemplateId || undefined,
+      thinkingEnabled: formData.value.thinkingEnabled || undefined,
+    };
+
+    await templatesStore.updateTemplate(templateId.value, data);
+    uiStore.success('Template updated');
+
+    router.push(`/projects/${projectId.value}/templates`);
+  } catch (err) {
+    error.value = err.message;
+    uiStore.error(err.message);
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const onCancel = () => {
+  router.back();
+};
+
+const onDelete = () => {
+  showDeleteConfirm.value = true;
+};
+
+const confirmDelete = async () => {
+  isDeleting.value = true;
+  error.value = null;
+  try {
+    await templatesStore.deleteTemplate(templateId.value);
+    uiStore.success('Template deleted');
+    showDeleteConfirm.value = false;
+
+    router.push(`/projects/${projectId.value}/templates`);
+  } catch (err) {
+    error.value = err.message;
+    uiStore.error(err.message);
+  } finally {
+    isDeleting.value = false;
+  }
+};
+
+onMounted(async () => {
+  await loadTemplate();
+});
+</script>
+
+<style scoped>
+.template-detail {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: var(--color-text-soft);
+}
+
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.form-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.form-header h2 {
+  margin: 0;
+  color: var(--color-text);
+  flex: 1;
+}
+
+.template-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 2rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-group label {
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.form-input {
+  padding: 0.75rem;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: border-color 0.2s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+}
+
+.form-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--color-bg-soft);
+}
+
+.form-input::placeholder {
+  color: var(--color-text-soft);
+}
+
+textarea.form-textarea {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  resize: vertical;
+  min-height: 120px;
+  line-height: 1.5;
+}
+
+.form-help {
+  font-size: 0.85rem;
+  color: var(--color-text-soft);
+  margin: 0;
+}
+
+.form-help code {
+  background: var(--color-bg-soft);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+.form-group-checkbox {
+  gap: 0.25rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.form-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+.form-error-message {
+  padding: 0.75rem;
+  background-color: rgba(248, 81, 73, 0.1);
+  border: 1px solid var(--color-error);
+  border-radius: var(--border-radius);
+  color: var(--color-error);
+  font-size: 0.9rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.form-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Modal Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-dialog {
+  background-color: var(--color-background-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  max-width: 400px;
+  width: 90%;
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.modal-header h4 {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.modal-body {
+  padding: 1.5rem 1rem;
+  color: var(--color-text-soft);
+}
+
+.modal-body p {
+  margin: 0.5rem 0;
+}
+
+.modal-footer {
+  padding: 1rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .template-detail {
+    padding: 1rem;
+  }
+
+  .form-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .template-form {
+    padding: 1.5rem 1rem;
+  }
+
+  .form-actions {
+    flex-direction: column-reverse;
+  }
+
+  .form-actions button {
+    width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary

This PR refactors template management by moving edit and delete functionality from inline actions to a dedicated detail page, improving UX and making the template list cleaner.

## Changes

- **Template cards now clickable**: Removed edit/delete icons from template cards, made entire card clickable with hover effects
- **New TemplateDetailView**: Created dedicated route and component for editing templates with full edit/delete functionality
- **Simplified create form**: Removed gitBranch field from template creation form
- **Better navigation**: Template cards use router-link for navigation to detail page

### Files Modified

- `packages/web/src/components/TemplatesPanel.vue` - Removed edit/delete buttons, made cards clickable links
- `packages/web/src/router.js` - Added new route for template detail view
- `packages/web/src/views/TemplateDetailView.vue` - New component with full edit/delete functionality

## Test Plan

- [ ] Verify clicking a template card navigates to the detail page
- [ ] Test editing template name, prompt, next template, and thinking enabled
- [ ] Test delete functionality with confirmation dialog
- [ ] Verify scope cannot be changed (disabled as designed)
- [ ] Test cancel and back navigation
- [ ] Verify template creation still works without gitBranch field
- [ ] Run E2E tests for template management

🤖 Generated with [Claude Code](https://claude.com/claude-code)