### PR TITLE
feat: Return only latest canvas file versions in list endpoint

### DIFF
--- a/packages/server/src/api/canvas.js
+++ b/packages/server/src/api/canvas.js
@@ -282,13 +282,18 @@ router.post('/:id/canvas', upload.single('file'), handleUploadError, (req, res) 
 });
 
 // GET /api/sessions/:id/canvas - List canvas items
+// Returns only latest version of each file (no version metadata exposed)
 router.get('/:id/canvas', (req, res) => {
   const session = sessions.getById(req.params.id);
   if (!session) {
     return res.status(404).json({ error: 'Session not found' });
   }
 
-  const items = canvasItems.getBySessionId(req.params.id);
+  // Get only latest versions (one per filename)
+  const items = canvasItems.getLatestVersionsBySessionId(req.params.id);
+
+  // Return items without version metadata
+  // (content/data are included for frontend to display items)
   res.json(items);
 });
 

--- a/packages/server/src/api/canvas.test.js
+++ b/packages/server/src/api/canvas.test.js
@@ -952,6 +952,185 @@ describe('Canvas API', () => {
     });
   });
 
+  describe('HTTP GET /api/sessions/:id/canvas (List Endpoint)', () => {
+    let app;
+    let projectId;
+    let sessionId;
+
+    beforeEach(() => {
+      app = express();
+      app.use(express.json());
+      app.use('/api/sessions', canvasRouter);
+
+      // Create project and session
+      const project = projects.create('Test Project', '/tmp/test');
+      projectId = project.id;
+
+      const now = Date.now();
+      const id = databaseManager.generateId();
+      databaseManager.get().prepare(
+        'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      ).run(id, projectId, 'Test Session', 'running', 'standard', now, now);
+      sessionId = id;
+    });
+
+    it('returns only latest version of each file (no duplicates)', async () => {
+      // Create multiple versions of the same file
+      canvasItems.create(sessionId, { type: 'text', content: 'Version 1', filename: 'test.txt' });
+      canvasItems.create(sessionId, { type: 'text', content: 'Version 2', filename: 'test.txt' });
+      canvasItems.create(sessionId, { type: 'text', content: 'Version 3', filename: 'test.txt' });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      // Should only return 1 item (latest version)
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].filename).toBe('test.txt');
+    });
+
+    it('returns latest version for multiple files', async () => {
+      // Create multiple versions of different files
+      canvasItems.create(sessionId, { type: 'text', content: 'A v1', filename: 'a.txt' });
+      canvasItems.create(sessionId, { type: 'text', content: 'A v2', filename: 'a.txt' });
+      canvasItems.create(sessionId, { type: 'markdown', content: '# B v1', filename: 'b.md' });
+      canvasItems.create(sessionId, { type: 'markdown', content: '# B v2', filename: 'b.md' });
+      canvasItems.create(sessionId, { type: 'markdown', content: '# B v3', filename: 'b.md' });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      // Should return 2 items (one per filename)
+      expect(res.body).toHaveLength(2);
+      const filenames = res.body.map(i => i.filename).sort();
+      expect(filenames).toEqual(['a.txt', 'b.md']);
+    });
+
+    it('includes content field for text-based types', async () => {
+      canvasItems.create(sessionId, { type: 'text', content: 'Hello World', filename: 'test.txt' });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].content).toBe('Hello World');
+    });
+
+    it('includes data field for image type', async () => {
+      const base64Image = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+      canvasItems.create(sessionId, { type: 'image', data: base64Image, mimeType: 'image/png', filename: 'pixel.png' });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].data).toBe(base64Image);
+    });
+
+    it('does not include version or totalVersions fields in response', async () => {
+      canvasItems.create(sessionId, { type: 'text', content: 'V1', filename: 'test.txt' });
+      canvasItems.create(sessionId, { type: 'text', content: 'V2', filename: 'test.txt' });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0]).not.toHaveProperty('version');
+      expect(res.body[0]).not.toHaveProperty('totalVersions');
+    });
+
+    it('includes all standard fields in response', async () => {
+      canvasItems.create(sessionId, {
+        type: 'markdown',
+        content: '# Title',
+        filename: 'readme.md',
+        mimeType: 'text/markdown'
+      });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      const item = res.body[0];
+
+      // Should include these fields
+      expect(item).toHaveProperty('id');
+      expect(item).toHaveProperty('sessionId');
+      expect(item).toHaveProperty('type');
+      expect(item).toHaveProperty('mimeType');
+      expect(item).toHaveProperty('filename');
+      expect(item).toHaveProperty('content');
+      expect(item).toHaveProperty('createdAt');
+      expect(item).toHaveProperty('deletedAt');
+
+      // Should NOT include version metadata
+      expect(item).not.toHaveProperty('version');
+      expect(item).not.toHaveProperty('totalVersions');
+    });
+
+    it('includes width and height for images', async () => {
+      canvasItems.create(sessionId, {
+        type: 'image',
+        data: 'base64data',
+        mimeType: 'image/png',
+        filename: 'pic.png',
+        width: 800,
+        height: 600
+      });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body[0].width).toBe(800);
+      expect(res.body[0].height).toBe(600);
+    });
+
+    it('returns empty array when no items exist', async () => {
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('excludes soft-deleted items', async () => {
+      const item1 = canvasItems.create(sessionId, { type: 'text', content: 'Active', filename: 'active.txt' });
+      const item2 = canvasItems.create(sessionId, { type: 'text', content: 'Deleted', filename: 'deleted.txt' });
+
+      canvasItems.softDelete(item2.id);
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].id).toBe(item1.id);
+    });
+
+    it('returns items ordered by createdAt descending', async () => {
+      const first = canvasItems.create(sessionId, { type: 'text', content: 'First', filename: 'a.txt' });
+      const second = canvasItems.create(sessionId, { type: 'text', content: 'Second', filename: 'b.txt' });
+      const third = canvasItems.create(sessionId, { type: 'text', content: 'Third', filename: 'c.txt' });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(3);
+      // Verify newest first
+      expect(res.body[0].createdAt).toBeGreaterThanOrEqual(res.body[2].createdAt);
+
+      // Verify all items are present
+      const ids = res.body.map(i => i.id);
+      expect(ids).toContain(first.id);
+      expect(ids).toContain(second.id);
+      expect(ids).toContain(third.id);
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app).get('/api/sessions/nonexistent-session/canvas');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain('Session not found');
+    });
+  });
+
   describe('HTTP POST /api/sessions/:id/canvas (Inline Content Mode)', () => {
     let app;
     let projectId;
@@ -1274,18 +1453,17 @@ describe('Canvas API', () => {
     describe('recover file (POST /:id/canvas-trash/recover-file/:filename)', () => {
       it('recovers all versions of a file', async () => {
         // Create multiple versions
-        await request(app).post(`/api/sessions/${sessionId}/canvas`)
+        const v1 = await request(app).post(`/api/sessions/${sessionId}/canvas`)
           .send({ type: 'text', content: 'V1', filename: 'multi.txt' });
-        await request(app).post(`/api/sessions/${sessionId}/canvas`)
+        const v2 = await request(app).post(`/api/sessions/${sessionId}/canvas`)
           .send({ type: 'text', content: 'V2', filename: 'multi.txt' });
-        await request(app).post(`/api/sessions/${sessionId}/canvas`)
+        const v3 = await request(app).post(`/api/sessions/${sessionId}/canvas`)
           .send({ type: 'text', content: 'V3', filename: 'multi.txt' });
 
-        // Get all items and delete them
-        let listRes = await request(app).get(`/api/sessions/${sessionId}/canvas`);
-        for (const item of listRes.body) {
-          await request(app).delete(`/api/sessions/${sessionId}/canvas/${item.id}`);
-        }
+        // Delete all versions individually (list endpoint only shows latest version now)
+        await request(app).delete(`/api/sessions/${sessionId}/canvas/${v1.body.id}`);
+        await request(app).delete(`/api/sessions/${sessionId}/canvas/${v2.body.id}`);
+        await request(app).delete(`/api/sessions/${sessionId}/canvas/${v3.body.id}`);
 
         // Verify trash has 3 items
         let trashRes = await request(app).get(`/api/sessions/${sessionId}/canvas-trash`);
@@ -1298,9 +1476,10 @@ describe('Canvas API', () => {
         expect(recoverRes.status).toBe(200);
         expect(recoverRes.body.recovered).toBe(3);
 
-        // Verify all are back in canvas list
-        listRes = await request(app).get(`/api/sessions/${sessionId}/canvas`);
-        expect(listRes.body).toHaveLength(3);
+        // Verify latest version is back in canvas list (list only shows latest version)
+        let listRes = await request(app).get(`/api/sessions/${sessionId}/canvas`);
+        expect(listRes.body).toHaveLength(1);
+        expect(listRes.body[0].content).toBe('V3'); // Latest version
 
         // Verify trash is empty
         trashRes = await request(app).get(`/api/sessions/${sessionId}/canvas-trash`);

--- a/packages/server/src/db/CanvasItemRepository.js
+++ b/packages/server/src/db/CanvasItemRepository.js
@@ -73,6 +73,32 @@ export class CanvasItemRepository extends BaseRepository {
   }
 
   /**
+   * Get only the latest version of each file for a session (for agent-facing API)
+   * Returns one item per unique filename, always the newest version
+   * @param {string} sessionId
+   * @returns {Array} Array of latest canvas items (one per filename)
+   */
+  getLatestVersionsBySessionId(sessionId) {
+    // Use a subquery to get the max rowid (which is unique and auto-incrementing) for each filename
+    // rowid is more reliable than created_at since items can have identical timestamps
+    const rows = this.db
+      .prepare(
+        `SELECT ci.*
+         FROM canvas_items ci
+         INNER JOIN (
+           SELECT filename, MAX(rowid) as max_rowid
+           FROM canvas_items
+           WHERE session_id = ? AND deleted_at IS NULL
+           GROUP BY filename
+         ) latest ON ci.filename = latest.filename AND ci.rowid = latest.max_rowid
+         WHERE ci.session_id = ? AND ci.deleted_at IS NULL
+         ORDER BY ci.created_at DESC`
+      )
+      .all(sessionId, sessionId);
+    return this.mapAll(rows);
+  }
+
+  /**
    * Get all versions of a file by filename, ordered newest first
    * @param {string} sessionId
    * @param {string} filename

--- a/packages/server/src/db/CanvasItemRepository.test.js
+++ b/packages/server/src/db/CanvasItemRepository.test.js
@@ -184,6 +184,133 @@ describe('CanvasItemRepository', () => {
     });
   });
 
+  describe('getLatestVersionsBySessionId', () => {
+    it('returns empty array when no items exist', () => {
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+      expect(items).toEqual([]);
+    });
+
+    it('returns only the latest version of each file', () => {
+      // Create multiple versions of test.txt
+      repo.create(sessionId, { type: 'text', content: 'Version 1', filename: 'test.txt' });
+      repo.create(sessionId, { type: 'text', content: 'Version 2', filename: 'test.txt' });
+      const v3 = repo.create(sessionId, { type: 'text', content: 'Version 3', filename: 'test.txt' });
+
+      // Create multiple versions of another.md
+      repo.create(sessionId, { type: 'markdown', content: '# V1', filename: 'another.md' });
+      const v2md = repo.create(sessionId, { type: 'markdown', content: '# V2', filename: 'another.md' });
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      // Should only return 2 items (one per filename)
+      expect(items).toHaveLength(2);
+
+      // Find the returned items by filename
+      const txtItem = items.find(i => i.filename === 'test.txt');
+      const mdItem = items.find(i => i.filename === 'another.md');
+
+      // Should be the latest versions
+      expect(txtItem.id).toBe(v3.id);
+      expect(txtItem.content).toBe('Version 3');
+      expect(mdItem.id).toBe(v2md.id);
+      expect(mdItem.content).toBe('# V2');
+    });
+
+    it('returns items with no duplicates', () => {
+      // Create 5 versions of the same file
+      repo.create(sessionId, { type: 'text', content: 'V1', filename: 'shared.txt' });
+      repo.create(sessionId, { type: 'text', content: 'V2', filename: 'shared.txt' });
+      repo.create(sessionId, { type: 'text', content: 'V3', filename: 'shared.txt' });
+      repo.create(sessionId, { type: 'text', content: 'V4', filename: 'shared.txt' });
+      repo.create(sessionId, { type: 'text', content: 'V5', filename: 'shared.txt' });
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      // Should only return 1 item
+      expect(items).toHaveLength(1);
+      expect(items[0].content).toBe('V5'); // Latest version
+    });
+
+    it('returns items ordered by createdAt descending', () => {
+      const i1 = repo.create(sessionId, { type: 'text', content: 'First', filename: 'a.txt' });
+      const i2 = repo.create(sessionId, { type: 'text', content: 'Second', filename: 'b.txt' });
+      const i3 = repo.create(sessionId, { type: 'text', content: 'Third', filename: 'c.txt' });
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      expect(items).toHaveLength(3);
+      expect(items[0].createdAt).toBeGreaterThanOrEqual(items[2].createdAt);
+
+      // Verify all expected items are returned
+      const ids = items.map(i => i.id);
+      expect(ids).toContain(i1.id);
+      expect(ids).toContain(i2.id);
+      expect(ids).toContain(i3.id);
+    });
+
+    it('does not return items from other sessions', () => {
+      // Create another session
+      const project = projectRepo.create('Another Project', '/tmp/another');
+      const now = Date.now();
+      const otherId = databaseManager.generateId();
+      databaseManager.get().prepare(
+        'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      ).run(otherId, project.id, 'Other Session', 'running', 'standard', now, now);
+
+      repo.create(sessionId, { type: 'text', content: 'Session 1', filename: 'shared.txt' });
+      repo.create(otherId, { type: 'text', content: 'Session 2', filename: 'shared.txt' });
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].content).toBe('Session 1');
+    });
+
+    it('excludes soft-deleted items', () => {
+      const v1 = repo.create(sessionId, { type: 'text', content: 'V1', filename: 'test.txt' });
+      const v2 = repo.create(sessionId, { type: 'text', content: 'V2', filename: 'test.txt' });
+
+      // Soft delete the latest version
+      repo.softDelete(v2.id);
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      // Should return v1 now (since v2 is deleted)
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe(v1.id);
+      expect(items[0].content).toBe('V1');
+    });
+
+    it('excludes files with all versions deleted', () => {
+      const v1 = repo.create(sessionId, { type: 'text', content: 'V1', filename: 'deleted.txt' });
+      const v2 = repo.create(sessionId, { type: 'text', content: 'V2', filename: 'deleted.txt' });
+      repo.create(sessionId, { type: 'text', content: 'Active', filename: 'active.txt' });
+
+      // Delete all versions of deleted.txt
+      repo.softDelete(v1.id);
+      repo.softDelete(v2.id);
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      // Should only return active.txt
+      expect(items).toHaveLength(1);
+      expect(items[0].filename).toBe('active.txt');
+    });
+
+    it('works with various file types', () => {
+      repo.create(sessionId, { type: 'image', data: 'imagedata', filename: 'pic.png', mimeType: 'image/png' });
+      repo.create(sessionId, { type: 'pdf', data: 'pdfdata', filename: 'doc.pdf', mimeType: 'application/pdf' });
+      repo.create(sessionId, { type: 'markdown', content: '# Title', filename: 'readme.md' });
+      repo.create(sessionId, { type: 'json', data: '{"key":"value"}', filename: 'data.json' });
+      repo.create(sessionId, { type: 'code', content: 'console.log()', filename: 'script.js' });
+
+      const items = repo.getLatestVersionsBySessionId(sessionId);
+
+      expect(items).toHaveLength(5);
+      expect(items.map(i => i.type).sort()).toEqual(['code', 'image', 'json', 'markdown', 'pdf']);
+    });
+  });
+
   describe('getAllVersionsByFilename', () => {
     it('returns empty array when no items with filename exist', () => {
       const items = repo.getAllVersionsByFilename(sessionId, 'nonexistent.txt');


### PR DESCRIPTION
## Summary
Improved the canvas list endpoint to return only the latest version of each file, eliminating duplicate versions from the response while keeping full version history available via the file history endpoint.

## Changes
- Add `getLatestVersionsBySessionId()` method to CanvasItemRepository for efficient retrieval of latest file versions only
- Update `GET /api/sessions/:id/canvas` endpoint to use the new method
- Version and totalVersions metadata no longer exposed in list response (content/data fields are included for frontend display)
- Comprehensive test coverage for new functionality including edge cases

## Why This Matters
- **Simpler client state**: Frontend receives one canonical version per file instead of managing duplicates
- **Cleaner API contract**: Version history is still available via dedicated endpoints, just not in the main list
- **Better performance**: No duplicate data transmitted for multi-version files
- **Maintains flexibility**: Version history implementation remains intact for when clients need it

## Test Coverage
✅ New `getLatestVersionsBySessionId()` unit tests covering:
- Latest version selection for single and multiple files
- No duplicates in results
- Ordering by createdAt
- Session isolation
- Soft-deleted items handling
- Various file types

✅ New list endpoint tests covering:
- Response format and fields
- Deduplication behavior
- Soft-deleted exclusion
- Non-existent session handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)