### PR TITLE
fix: Remove filename truncation in canvas list view

### DIFF
--- a/packages/web/src/components/CanvasFileList.vue
+++ b/packages/web/src/components/CanvasFileList.vue
@@ -514,10 +514,6 @@ defineExpose({
     flex: 1;
     min-width: 0;
     word-break: break-word;
-    max-width: 120px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .file-type {


### PR DESCRIPTION
## Summary
- Remove truncation styles (`max-width`, `overflow`, `text-overflow`, `white-space`) from canvas list view mobile media query
- Filenames now display fully with word-wrap, matching the canvas detail view behavior

## Test plan
- [ ] View canvas list on mobile viewport (< 640px width)
- [ ] Verify long filenames display fully with word wrapping
- [ ] Compare with canvas detail view to confirm consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)