### PR TITLE
fix: Reorder canvas list three-dot menu items

### DIFF
--- a/packages/web/src/components/CanvasFileList.vue
+++ b/packages/web/src/components/CanvasFileList.vue
@@ -54,15 +54,15 @@
         <Transition name="slide">
           <ul v-if="openMenuItemId === item.id" class="file-menu-items" role="menu">
             <li role="none">
-              <button class="menu-item" role="menuitem" @click.stop="handleMenuCopyContents(item)">
-                <span class="menu-item-icon">📋</span>
-                <span class="menu-item-text">Copy file contents</span>
-              </button>
-            </li>
-            <li role="none">
               <button class="menu-item" role="menuitem" @click.stop="handleMenuCopyFilename(item)">
                 <span class="menu-item-icon">📝</span>
                 <span class="menu-item-text">Copy filename</span>
+              </button>
+            </li>
+            <li role="none">
+              <button class="menu-item" role="menuitem" @click.stop="handleMenuCopyContents(item)">
+                <span class="menu-item-icon">📋</span>
+                <span class="menu-item-text">Copy file contents</span>
               </button>
             </li>
             <li role="none" class="menu-divider"></li>


### PR DESCRIPTION
## Summary
- Reordered the three-dot menu items in the canvas file list view to prioritize "Copy filename" action
- "Copy filename" is now the first menu item, followed by "Copy file contents"
- "Delete file" (trash) remains as the last action after a divider
- This improves UX by making the more frequently-used filename copying action more accessible

## Changes
- Modified `packages/web/src/components/CanvasFileList.vue` to swap the order of the first two menu items
- No functionality changes - purely a UI reordering improvement

## Test plan
- [x] Start dev server and navigate to a session with canvas items
- [x] Click the three-dot menu on any canvas item
- [x] Verify menu items appear in correct order: Copy filename → Copy file contents → Delete file
- [x] Test each action to ensure functionality is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)