### PR TITLE
fix: Remove stale .server-port file on server startup

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -29,6 +29,9 @@ PORT_FILE=".server-port"
 MAIN_PORT=5000
 WORKTREE_PORT_START=5001
 
+# Clean up stale port file from previous runs
+rm -f "$PORT_FILE"
+
 # -----------------------------------------------------------------------------
 # Detect if we're in a git worktree
 #


### PR DESCRIPTION
## Summary

Ensures that any existing `.server-port` file from previous server instances is cleaned up before the new port assignment logic runs. This prevents tools from reading stale port data.

## Problem

When the `start-server.sh` script runs, any existing `.server-port` file may be stale from a previous server instance. This could cause issues if:

1. A previous server crashed without cleanup
2. The file contains an old/incorrect port number
3. Tools reading the file get stale data during the brief window before the new port is written

## Solution

Added a single `rm -f "$PORT_FILE"` command near the beginning of `scripts/start-server.sh` (after variable definitions) to remove the stale file before any port selection logic runs.

## Technical Details

- **File modified:** `scripts/start-server.sh`
- **Change:** Added `rm -f "$PORT_FILE"` on line 33
- **Why rm -f:** The `-f` flag suppresses errors if the file doesn't exist, making this operation safe and idempotent
- **Location:** After variable definitions (`PORT_FILE`, `MAIN_PORT`, `WORKTREE_PORT_START`) and before the `is_worktree()` function

## Testing

- [x] Change verified in file
- [x] No breaking changes
- [x] Safe to merge (rm -f is idempotent)
- [x] Branch pushed to remote

## Related

This addresses the server startup script improvements needed for reliable port management across worktree instances.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)