### PR TITLE
Fix dynamic model provider updates to replace existing models

### DIFF
--- a/packages/server/src/db/ModelProviderRepository.js
+++ b/packages/server/src/db/ModelProviderRepository.js
@@ -91,22 +91,23 @@ export class ModelProviderRepository extends BaseRepository {
    */
   #syncDefaultModels(providerId, { defaultOpusModel, defaultSonnetModel, defaultHaikuModel }) {
     const now = Date.now();
-    const insertModel = this.db.prepare(
-      `INSERT OR IGNORE INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
+    // Use REPLACE to update existing models when default model IDs change
+    const upsertModel = this.db.prepare(
+      `INSERT OR REPLACE INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`
     );
 
     if (defaultOpusModel) {
       const modelId = `${providerId}-opus`;
-      insertModel.run(modelId, providerId, defaultOpusModel, 'Opus', 'Most capable model', 'opus', now);
+      upsertModel.run(modelId, providerId, defaultOpusModel, 'Opus', 'Most capable model', 'opus', now);
     }
     if (defaultSonnetModel) {
       const modelId = `${providerId}-sonnet`;
-      insertModel.run(modelId, providerId, defaultSonnetModel, 'Sonnet', 'Balanced model', 'sonnet', now);
+      upsertModel.run(modelId, providerId, defaultSonnetModel, 'Sonnet', 'Balanced model', 'sonnet', now);
     }
     if (defaultHaikuModel) {
       const modelId = `${providerId}-haiku`;
-      insertModel.run(modelId, providerId, defaultHaikuModel, 'Haiku', 'Fast & lightweight model', 'haiku', now);
+      upsertModel.run(modelId, providerId, defaultHaikuModel, 'Haiku', 'Fast & lightweight model', 'haiku', now);
     }
   }
 

--- a/packages/server/src/db/ModelProviderRepository.test.js
+++ b/packages/server/src/db/ModelProviderRepository.test.js
@@ -203,6 +203,64 @@ describe('ModelProviderRepository', () => {
       // Cleanup
       repo.delete(provider.id);
     });
+
+    it('updates existing provider_models entry when default model changes', () => {
+      // Create provider with initial model
+      const provider = repo.create({
+        name: 'Model Update Test',
+        baseUrl: 'https://api.test.com',
+        authToken: 'token',
+        defaultSonnetModel: 'old-sonnet-v1',
+      });
+
+      // Verify initial model was created
+      let models = repo.getModels(provider.id);
+      expect(models.some((m) => m.modelId === 'old-sonnet-v1')).toBe(true);
+
+      // Update to new model - this should UPDATE the existing entry, not ignore it
+      repo.update(provider.id, {
+        defaultSonnetModel: 'new-sonnet-v2',
+      });
+
+      // Verify the model was updated (not ignored)
+      models = repo.getModels(provider.id);
+      const sonnetModel = models.find((m) => m.tier === 'sonnet');
+
+      expect(sonnetModel).toBeDefined();
+      expect(sonnetModel.modelId).toBe('new-sonnet-v2');
+      // Old model should no longer exist
+      expect(models.some((m) => m.modelId === 'old-sonnet-v1')).toBe(false);
+
+      // Cleanup
+      repo.delete(provider.id);
+    });
+
+    it('updates multiple default models in single update', () => {
+      const provider = repo.create({
+        name: 'Multi Update Test',
+        baseUrl: 'https://api.test.com',
+        authToken: 'token',
+        defaultSonnetModel: 'sonnet-v1',
+        defaultOpusModel: 'opus-v1',
+        defaultHaikuModel: 'haiku-v1',
+      });
+
+      // Update all three models at once
+      repo.update(provider.id, {
+        defaultSonnetModel: 'sonnet-v2',
+        defaultOpusModel: 'opus-v2',
+        defaultHaikuModel: 'haiku-v2',
+      });
+
+      const models = repo.getModels(provider.id);
+
+      expect(models.find((m) => m.tier === 'sonnet').modelId).toBe('sonnet-v2');
+      expect(models.find((m) => m.tier === 'opus').modelId).toBe('opus-v2');
+      expect(models.find((m) => m.tier === 'haiku').modelId).toBe('haiku-v2');
+
+      // Cleanup
+      repo.delete(provider.id);
+    });
   });
 
   describe('delete', () => {


### PR DESCRIPTION
## Summary

Fixed a bug in `ModelProviderRepository` that prevented updates to custom provider models from being reflected in the application. The issue was that the `#syncDefaultModels` method used `INSERT OR IGNORE`, which silently ignored updates to existing model rows when a provider's model IDs changed.

## Changes

- Changed `INSERT OR IGNORE` to `INSERT OR REPLACE` in `ModelProviderRepository.js` to properly update existing provider_models records when default model IDs change
- Added comprehensive test coverage:
  - Test for updating a single provider model when the default model ID changes
  - Test for updating multiple default models in a single update

## Test Results

All 33 existing tests pass with the new test coverage included.

## How to Test

1. Create a custom model provider (e.g., z.ai)
2. Update the provider's model to a newly released version
3. Verify the new model appears in the application's model selector

Before the fix, the update would be silently ignored (due to INSERT OR IGNORE).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)