### PR TITLE
Fix provider model IDs not reflected in model selector after update

### DIFF
--- a/packages/server/src/db/ModelProviderRepository.js
+++ b/packages/server/src/db/ModelProviderRepository.js
@@ -112,12 +112,26 @@ export class ModelProviderRepository extends BaseRepository {
   }
 
   /**
-   * Get all providers
-   * @returns {Array<Object>} - All providers
+   * Get all providers (always includes models)
+   * @returns {Array<Object>} - All providers with their models
    */
   getAll() {
     const rows = this.db.prepare('SELECT * FROM model_providers ORDER BY is_built_in DESC, name ASC').all();
-    return this.mapAll(rows);
+    return this.mapAll(rows).map(provider => ({
+      ...provider,
+      models: this.getModels(provider.id),
+    }));
+  }
+
+  /**
+   * Get a provider by ID (always includes models)
+   * @param {string} id - Provider ID
+   * @returns {Object|null} - Provider with its models, or null
+   */
+  getById(id) {
+    const provider = super.getById(id);
+    if (!provider) return null;
+    return { ...provider, models: this.getModels(id) };
   }
 
   /**

--- a/packages/web/src/components/ConversationTab.model-init.test.js
+++ b/packages/web/src/components/ConversationTab.model-init.test.js
@@ -75,7 +75,6 @@ vi.mock('../stores/providers.js', () => ({
       },
     ],
     fetchProviders: vi.fn().mockResolvedValue(undefined),
-    fetchProvidersWithModels: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 

--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -41,7 +41,6 @@ vi.mock('../stores/providers.js', () => ({
   useProvidersStore: vi.fn(() => ({
     providers: [],
     fetchProviders: vi.fn().mockResolvedValue(undefined),
-    fetchProvidersWithModels: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -1321,7 +1320,6 @@ describe.skip('ConversationTab - Model Selector Initialization', () => {
         },
       ],
       fetchProviders: vi.fn().mockResolvedValue(undefined),
-      fetchProvidersWithModels: vi.fn().mockResolvedValue(undefined),
     };
 
     vi.mocked(useSessionsStore).mockReturnValue(mockSessionsStore);

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -41,7 +41,7 @@ describe('ModelSelector', () => {
     ];
 
     // Mock the fetch method to prevent API calls
-    vi.spyOn(providersStore, 'fetchProvidersWithModels').mockResolvedValue();
+    vi.spyOn(providersStore, 'fetchProviders').mockResolvedValue();
   });
 
   const mountComponent = (props = {}, attrs = {}) => {

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -86,7 +86,7 @@ const hasInitialized = ref(false);
 onMounted(async () => {
   // Fetch if no providers OR if providers exist but don't have models loaded
   if (providersStore.providers.length === 0 || !providersHaveModels.value) {
-    await providersStore.fetchProvidersWithModels();
+    await providersStore.fetchProviders();
   }
 
   // Don't emit default - let parent component control model selection

--- a/packages/web/src/components/TemplatesPanel.vue
+++ b/packages/web/src/components/TemplatesPanel.vue
@@ -210,7 +210,7 @@ const availableNextTemplates = computed(() => {
 onMounted(async () => {
   // Ensure providers with models are loaded
   if (providersStore.providers.length === 0) {
-    await providersStore.fetchProvidersWithModels();
+    await providersStore.fetchProviders();
   }
   templatesStore.fetchProjectTemplates(props.projectId);
 });

--- a/packages/web/src/stores/providers.js
+++ b/packages/web/src/stores/providers.js
@@ -45,32 +45,6 @@ export const useProvidersStore = defineStore('providers', {
       }
     },
 
-    // Fetch providers with their models
-    async fetchProvidersWithModels() {
-      this.loading = true;
-      this.error = null;
-      try {
-        const providers = await api.getProviders();
-        // Fetch models for each provider
-        const providersWithModels = await Promise.all(
-          providers.map(async (provider) => {
-            try {
-              const models = await api.getProviderModels(provider.id);
-              return { ...provider, models };
-            } catch (err) {
-              console.error(`Failed to fetch models for provider ${provider.id}:`, err);
-              return { ...provider, models: [] };
-            }
-          })
-        );
-        this.providers = providersWithModels;
-      } catch (err) {
-        this.error = err.message;
-      } finally {
-        this.loading = false;
-      }
-    },
-
     async fetchProvider(id) {
       this.loading = true;
       this.error = null;

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -30,6 +30,7 @@ const TEST_PREFIX = `[TEST-${TEST_RUN_ID}] `;
 const createdResources = {
   projects: new Set<string>(),
   sessions: new Set<string>(),
+  providers: new Set<string>(),
 };
 
 /**
@@ -38,6 +39,7 @@ const createdResources = {
 function clearResourceTracking() {
   createdResources.projects.clear();
   createdResources.sessions.clear();
+  createdResources.providers.clear();
 }
 
 /**
@@ -59,6 +61,15 @@ export async function cleanupCreatedResources() {
       await fetch(`${API_URL}/api/projects/${projectId}`, { method: 'DELETE' });
     } catch (e) {
       // Ignore errors - project may already be deleted
+    }
+  }
+
+  // Then delete providers tracked by this test
+  for (const providerId of createdResources.providers) {
+    try {
+      await fetch(`${API_URL}/api/providers/${providerId}`, { method: 'DELETE' });
+    } catch (e) {
+      // Ignore errors - provider may already be deleted
     }
   }
 
@@ -328,6 +339,19 @@ export async function cleanupAll() {
     // Only delete test projects (prefixed with [TEST])
     if (project.name.startsWith(TEST_PREFIX)) {
       await fetch(`${API_URL}/api/projects/${project.id}`, { method: 'DELETE' });
+    }
+  }
+
+  // Delete all non-built-in providers whose names start with [TEST.
+  // This is safe here because cleanupAll() is only called from global-setup and
+  // global-teardown, which run sequentially (not in parallel with any workers).
+  const providersResponse = await fetch(`${API_URL}/api/providers`);
+  if (!providersResponse.ok) return;
+
+  const providers = await providersResponse.json();
+  for (const provider of providers) {
+    if (provider.name.startsWith('[TEST') && !provider.isBuiltIn) {
+      await fetch(`${API_URL}/api/providers/${provider.id}`, { method: 'DELETE' });
     }
   }
 }
@@ -751,7 +775,10 @@ export async function createProvider(data: {
     body: JSON.stringify(data),
   });
   if (!response.ok) throw new Error('Failed to create provider');
-  return response.json();
+  const provider = await response.json();
+  // Track for scoped cleanup
+  createdResources.providers.add(provider.id);
+  return provider;
 }
 
 /**
@@ -816,12 +843,15 @@ export async function testProviderConnection(id: string) {
 }
 
 /**
- * Cleanup all test providers (those with [TEST] prefix)
+ * Cleanup test providers created by this worker (those with TEST_PREFIX).
+ * Uses the per-worker TEST_PREFIX so parallel workers cannot accidentally
+ * delete each other's providers. For a broader sweep of all [TEST]-prefixed
+ * providers, use cleanupAll() (global setup/teardown only).
  */
 export async function cleanupProviders() {
   const providers = await getProviders();
   for (const provider of providers) {
-    // Only delete custom providers (those with [TEST] prefix) and not built-in ones
+    // Only delete custom providers (those with TEST_PREFIX) and not built-in ones
     if (provider.name.startsWith(TEST_PREFIX) && !provider.isBuiltIn) {
       await deleteProvider(provider.id);
     }

--- a/tests/e2e/provider-model-sync.spec.ts
+++ b/tests/e2e/provider-model-sync.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import {
+  cleanupCreatedResources,
+  createProvider,
+  updateProvider,
+  seedProject,
+  seedSession,
+} from './helpers';
+
+/**
+ * E2E test for provider model ID sync in the Model Selector
+ *
+ * Bug: When you update a third-party provider's model ID (e.g. defaultSonnetModel),
+ * the database updates correctly but the Model Selector still shows old model IDs.
+ *
+ * Root cause: There are two ways to fetch providers (with and without models).
+ * When the wrong fetch wins, models disappear from the store, causing stale data
+ * in the model selector.
+ *
+ * This test should FAIL before the fix and PASS after.
+ */
+test.describe('Provider Model Sync in Model Selector', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let provider: any;
+  let project: any;
+  let session: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+
+    // 1. Create a third-party provider with a known defaultSonnetModel
+    provider = await createProvider({
+      name: '[TEST] Sync Test Provider',
+      baseUrl: 'https://api.example.com',
+      authToken: 'test-token-sync',
+      defaultSonnetModel: 'test-model-v1',
+    });
+
+    // 2. Create a project and a draft session
+    project = await seedProject('Model Sync Test', '/tmp/model-sync-test');
+    session = await seedSession(project.id, {
+      prompt: 'Test prompt for model sync',
+      name: 'Model Sync Session',
+    });
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('model selector reflects updated provider model IDs after edit', async ({ page }) => {
+    // 3. Navigate to the session conversation tab
+    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.waitForLoadState('networkidle');
+
+    // 4. Wait for the model selector to load with providers
+    const modelSelect = page.locator('#model-select');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for our test provider's model to appear in the select options
+    await page.waitForFunction(() => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      if (!select) return false;
+      const options = Array.from(select.options);
+      return options.some(opt => opt.value === 'test-model-v1');
+    }, { timeout: 10000 });
+
+    // Verify test-model-v1 is present as an option
+    const v1Options = modelSelect.locator('option[value="test-model-v1"]');
+    expect(await v1Options.count()).toBeGreaterThanOrEqual(1);
+
+    // 5. Update the provider's defaultSonnetModel via API (reliable, avoids UI flakiness)
+    const updated = await updateProvider(provider.id, {
+      defaultSonnetModel: 'test-model-v2',
+    });
+    console.log('Provider updated - defaultSonnetModel:', updated.defaultSonnetModel);
+
+    // 6. Navigate to the providers settings page and back to force a fresh store refetch
+    //    (simulates the user flow: edit provider on settings page, then go back to session)
+    await page.goto('/settings/providers');
+    await page.waitForLoadState('networkidle');
+
+    // 7. Navigate back to the session conversation tab
+    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.waitForLoadState('networkidle');
+
+    // 8. Assert the model selector now contains test-model-v2 and NOT test-model-v1
+    const modelSelectAfter = page.locator('#model-select');
+    await expect(modelSelectAfter).toBeVisible({ timeout: 10000 });
+
+    // Wait for model selector to fully re-populate with providers+models
+    await page.waitForFunction(() => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      if (!select) return false;
+      return select.options.length > 1;
+    }, { timeout: 10000 });
+
+    // Collect all option values for debugging
+    const allOptionValues = await modelSelectAfter.locator('option').evaluateAll(
+      (options: HTMLOptionElement[]) => options.map(o => o.value)
+    );
+    console.log('Model selector options after update:', JSON.stringify(allOptionValues));
+
+    // The NEW model (test-model-v2) should be present
+    expect(allOptionValues).toContain('test-model-v2');
+
+    // The OLD model (test-model-v1) should be gone
+    expect(allOptionValues).not.toContain('test-model-v1');
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: Two separate fetch paths existed for providers — one that included models and one that didn't. When the wrong one won, the model selector showed stale model IDs even after a provider update.
- **Fix**: `ModelProviderRepository.getAll()` and `getById()` now always embed models, making `fetchProvidersWithModels()` redundant. Deleted it from the store and updated all callers to use `fetchProviders()`.
- **Regression test**: New Playwright E2E spec (`provider-model-sync.spec.ts`) creates a provider, updates its `defaultSonnetModel`, navigates back to the session, and asserts the model selector reflects the change — fails before this fix, passes after.
- **E2E test isolation**: Fixed a cross-worker race condition introduced while broadening `cleanupProviders()`. Now uses ID-based cleanup via `cleanupCreatedResources()` (matching the pattern used for projects/sessions) so parallel Playwright workers can't delete each other's providers mid-test.

## Test plan

- [x] `yarn workspace @claudetools/server test` — all passing
- [x] `yarn workspace @claudetools/web test` — all 2,267 tests passing
- [x] `./scripts/pw.sh test tests/e2e/provider-model-sync.spec.ts` — new test passes
- [x] `./scripts/pw.sh test tests/e2e/model-providers.spec.ts tests/e2e/provider-model-sync.spec.ts` — both specs pass together (verifies no cross-worker race)
- [x] Full E2E suite — 139/140 passing (1 pre-existing unrelated flaky test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)