### PR TITLE
Fix iOS Safari viewport offset handling for browser chrome

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -34,6 +34,10 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue';
 import ToastContainer from './components/ToastContainer.vue';
+import { useVisualViewport } from './composables/useVisualViewport.js';
+
+// Initialize visual viewport tracking for iOS Safari browser chrome offset
+useVisualViewport();
 
 const headerRef = ref(null);
 let resizeObserver = null;
@@ -87,6 +91,7 @@ onUnmounted(() => {
 <style scoped>
 .app {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -99,7 +104,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   position: sticky;
-  top: 0;
+  top: var(--viewport-offset-top, 0px);
   z-index: 100;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 

--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -5,6 +5,9 @@
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
   --safe-area-inset-right: env(safe-area-inset-right, 0px);
 
+  /* Visual viewport offset for iOS Safari browser chrome (URL bar, tab bar) */
+  --viewport-offset-top: 0px;
+
   --color-background: #0d1117;
   --color-background-soft: #161b22;
   --color-background-mute: #21262d;
@@ -52,6 +55,7 @@ body {
   color: var(--color-text);
   line-height: 1.6;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 a {
@@ -268,7 +272,7 @@ input, textarea, select {
   /* Sticky positioning - accounts for header + safe area on iOS */
   position: -webkit-sticky; /* Safari prefix */
   position: sticky;
-  top: var(--header-height-computed, 51px);
+  top: calc(var(--header-height-computed, 51px) + var(--viewport-offset-top, 0px));
   background-color: var(--color-background);
   z-index: 99;
   padding: 0.5rem 0.5rem 0 0.5rem; /* Add horizontal padding to prevent cut-off */

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -1,0 +1,72 @@
+import { onMounted, onUnmounted } from 'vue';
+
+/**
+ * Vue composable that tracks the visual viewport offset and updates CSS variables.
+ * This is needed for iOS Safari, where the browser chrome (URL bar + tab bar) can
+ * physically overlap sticky-positioned elements when expanded.
+ *
+ * Sets --viewport-offset-top CSS variable on document.documentElement, which can be
+ * used to offset sticky elements: top: calc(var(--header-height) + var(--viewport-offset-top))
+ *
+ * On browsers without visualViewport API, this no-ops and --viewport-offset-top remains 0px.
+ */
+export function useVisualViewport() {
+  let rafId = null;
+
+  /**
+   * Update the CSS variable with the current visual viewport offset.
+   * Throttled using requestAnimationFrame to prevent jitter.
+   */
+  function updateViewportOffset() {
+    if (rafId) {
+      return;
+    }
+
+    rafId = requestAnimationFrame(() => {
+      if (window.visualViewport) {
+        const offsetTop = window.visualViewport.offsetTop || 0;
+        document.documentElement.style.setProperty('--viewport-offset-top', `${offsetTop}px`);
+      }
+      rafId = null;
+    });
+  }
+
+  /**
+   * Handle visual viewport resize and scroll events.
+   */
+  function handleViewportChange() {
+    updateViewportOffset();
+  }
+
+  onMounted(() => {
+    // Check if visualViewport API is supported
+    if (!window.visualViewport) {
+      return;
+    }
+
+    // Set initial value
+    updateViewportOffset();
+
+    // Listen for viewport changes (scroll and resize events)
+    window.visualViewport.addEventListener('scroll', handleViewportChange);
+    window.visualViewport.addEventListener('resize', handleViewportChange);
+  });
+
+  onUnmounted(() => {
+    // Clean up event listeners
+    if (window.visualViewport) {
+      window.visualViewport.removeEventListener('scroll', handleViewportChange);
+      window.visualViewport.removeEventListener('resize', handleViewportChange);
+    }
+
+    // Cancel any pending raf
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  });
+
+  return {
+    updateViewportOffset,
+  };
+}

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -808,7 +808,7 @@ onUnmounted(() => {
   position: -webkit-sticky; /* Safari prefix */
   position: sticky;
   /* Default for phones/small screens */
-  top: 51px;
+  top: calc(var(--header-height-computed, 51px) + var(--viewport-offset-top, 0px));
   background-color: var(--color-background);
   z-index: 99;
   padding: 0.5rem 0.5rem 0 0.5rem;
@@ -817,7 +817,7 @@ onUnmounted(() => {
 /* iPad and larger screens - account for safe area */
 @media (min-width: 768px) {
   .tabs {
-    top: 80px;
+    top: calc(var(--header-height-computed, 80px) + var(--viewport-offset-top, 0px));
   }
 }
 

--- a/packages/web/src/views/SettingsView.vue
+++ b/packages/web/src/views/SettingsView.vue
@@ -45,7 +45,7 @@ h1 {
   position: -webkit-sticky; /* Safari prefix */
   position: sticky;
   /* Default for phones/small screens */
-  top: 51px;
+  top: calc(var(--header-height-computed, 51px) + var(--viewport-offset-top, 0px));
   background-color: var(--color-background);
   z-index: 99;
   padding: 0.5rem 0.5rem 0 0.5rem;
@@ -54,7 +54,7 @@ h1 {
 /* iPad and larger screens - account for safe area */
 @media (min-width: 768px) {
   .tabs {
-    top: 80px;
+    top: calc(var(--header-height-computed, 80px) + var(--viewport-offset-top, 0px));
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes iOS Safari layout issues caused by dynamic browser chrome (URL bar, tab bar)
- Adds Visual Viewport API tracking to detect when browser chrome appears/disappears
- Updates all sticky positioning to account for viewport offset

## Changes
- **New**: `useVisualViewport` composable to track viewport changes via Visual Viewport API
- **Updated**: Use `100dvh` instead of `100vh` for mobile viewport height (better mobile handling)
- **Updated**: Add `--viewport-offset-top` CSS variable for dynamic offset tracking
- **Updated**: All sticky elements (header, tabs, etc.) now use `calc()` to account for viewport offset

## Test Plan
- [ ] Test on iOS Safari to verify browser chrome no longer causes layout shifts
- [ ] Test on desktop browsers to ensure no regressions
- [ ] Test on Android browsers to verify compatibility
- [ ] Check sticky positioning behavior on Session List and Settings views

## Context
The Visual Viewport API is needed for iOS Safari because the browser chrome
(URL bar, tab bar) can dynamically appear and disappear while scrolling, causing
layout issues with sticky elements. The new composable tracks these changes and
updates CSS custom properties to adjust positioning in real-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)