### PR TITLE
Honor nextTemplateId in session creation request body

### DIFF
--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -277,6 +277,25 @@ router.post('/:id/sessions', uploadMiddleware('files', 10), handleUploadError, a
     }
   }
 
+  // Honor explicit nextTemplateId from request body
+  if (req.body.nextTemplateId !== undefined) {
+    // Explicit body value always wins (even over templateId-derived value).
+    // Allows callers to:
+    //   a) set a chain template without applying any template settings
+    //   b) apply a template's settings via templateId but chain to a *different* template
+    //   c) explicitly clear it by passing null
+    if (req.body.nextTemplateId === null) {
+      nextTemplateId = null;
+    } else {
+      // Validate that the referenced template actually exists
+      const nextTemplate = sessionTemplates.getById(req.body.nextTemplateId);
+      if (!nextTemplate) {
+        return res.status(400).json({ error: 'nextTemplateId references a non-existent template' });
+      }
+      nextTemplateId = req.body.nextTemplateId;
+    }
+  }
+
   // Extract scheduling fields from request
   const scheduledAt = req.body.scheduledAt ? parseInt(req.body.scheduledAt, 10) : undefined;
   const autoRescheduleEnabled = req.body.autoRescheduleEnabled === true || req.body.autoRescheduleEnabled === 'true';

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -266,6 +266,122 @@ describe('Projects API', () => {
         sessionTemplates.delete(minimalTemplate.id);
       });
     });
+
+    describe('with nextTemplateId', () => {
+      it('sets nextTemplateId when provided without templateId', async () => {
+        // Create a template to reference
+        const template = sessionTemplates.create({
+          name: 'Chain Template',
+          prompt: 'Chain prompt',
+          projectId: projectId,
+          thinkingEnabled: true,
+          gitBranch: 'feature/chain',
+          gitMode: 'worktree',
+        });
+
+        const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+          prompt: 'Test prompt',
+          nextTemplateId: template.id,
+        });
+
+        expect(res.status).toBe(201);
+
+        const session = sessions.getById(res.body.id);
+        expect(session.nextTemplateId).toBe(template.id);
+        // Template settings should NOT be applied (no templateId was provided)
+        expect(session.thinkingEnabled).toBe(false); // system default
+
+        // Clean up
+        sessionTemplates.delete(template.id);
+      });
+
+      it('validates nextTemplateId references an existing template', async () => {
+        const fakeUUID = '00000000-0000-4000-8000-000000000000';
+
+        const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+          prompt: 'Test prompt',
+          nextTemplateId: fakeUUID,
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('nextTemplateId references a non-existent template');
+      });
+
+      it('allows nextTemplateId to be null', async () => {
+        const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+          prompt: 'Test prompt',
+          nextTemplateId: null,
+        });
+
+        expect(res.status).toBe(201);
+
+        const session = sessions.getById(res.body.id);
+        expect(session.nextTemplateId).toBeNull();
+      });
+
+      it('explicit nextTemplateId overrides templateId-derived value', async () => {
+        // Create two templates
+        const templateA = sessionTemplates.create({
+          name: 'Template A',
+          prompt: 'Prompt A',
+          projectId: projectId,
+          thinkingEnabled: true,
+          gitBranch: 'feature/a',
+          gitMode: 'worktree',
+        });
+        const templateB = sessionTemplates.create({
+          name: 'Template B',
+          prompt: 'Prompt B',
+          projectId: projectId,
+        });
+
+        const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+          prompt: 'Test prompt',
+          templateId: templateA.id,
+          nextTemplateId: templateB.id,
+        });
+
+        expect(res.status).toBe(201);
+
+        const session = sessions.getById(res.body.id);
+        // Template A's settings should be applied
+        expect(session.thinkingEnabled).toBe(true);
+        // But nextTemplateId should be B, not A
+        expect(session.nextTemplateId).toBe(templateB.id);
+
+        // Clean up
+        sessionTemplates.delete(templateA.id);
+        sessionTemplates.delete(templateB.id);
+      });
+
+      it('explicit null nextTemplateId clears templateId-derived value', async () => {
+        const template = sessionTemplates.create({
+          name: 'Template With Chain',
+          prompt: 'Prompt',
+          projectId: projectId,
+          thinkingEnabled: true,
+          gitBranch: 'feature/chain',
+          gitMode: 'worktree',
+        });
+
+        const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+          prompt: 'Test prompt',
+          templateId: template.id,
+          nextTemplateId: null,
+        });
+
+        expect(res.status).toBe(201);
+
+        const session = sessions.getById(res.body.id);
+        // Template settings should be applied
+        expect(session.thinkingEnabled).toBe(true);
+        // But nextTemplateId should be null (explicitly cleared)
+        expect(session.nextTemplateId).toBeNull();
+
+        // Clean up
+        sessionTemplates.delete(template.id);
+      });
+    });
   });
 
   describe('GET /api/projects', () => {

--- a/tests/e2e/session-nextTemplateId.spec.ts
+++ b/tests/e2e/session-nextTemplateId.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedProjectTemplate,
+  getSession,
+  cleanupCreatedResources,
+  getAPIURL,
+} from './helpers';
+
+const API_URL = getAPIURL();
+
+test.describe('Session Creation - nextTemplateId', () => {
+  let project: any;
+  let templateA: any;
+  let templateB: any;
+
+  test.beforeEach(async () => {
+    project = await seedProject('NextTemplate Test', '/tmp/test');
+    templateA = await seedProjectTemplate(project.id, {
+      name: 'Template A',
+      prompt: 'Prompt A',
+      thinkingEnabled: true,
+      gitBranch: 'feature/a',
+    });
+    templateB = await seedProjectTemplate(project.id, {
+      name: 'Template B',
+      prompt: 'Prompt B',
+    });
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('sets nextTemplateId when provided without templateId', async () => {
+    const response = await fetch(`${API_URL}/api/projects/${project.id}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Test with nextTemplateId only',
+        nextTemplateId: templateA.id,
+        startImmediately: false,
+      }),
+    });
+
+    expect(response.ok).toBe(true);
+    const session = await response.json();
+
+    // Verify nextTemplateId is set
+    const fetchedSession = await getSession(session.id);
+    expect(fetchedSession.nextTemplateId).toBe(templateA.id);
+    // Template settings should NOT be applied (no templateId)
+    expect(fetchedSession.thinkingEnabled).toBe(false);
+  });
+
+  test('explicit nextTemplateId overrides templateId-derived value', async () => {
+    const response = await fetch(`${API_URL}/api/projects/${project.id}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Test with both templateId and nextTemplateId',
+        templateId: templateA.id,
+        nextTemplateId: templateB.id,
+        startImmediately: false,
+      }),
+    });
+
+    expect(response.ok).toBe(true);
+    const session = await response.json();
+
+    // Verify template A's settings were applied
+    const fetchedSession = await getSession(session.id);
+    expect(fetchedSession.thinkingEnabled).toBe(true);
+    // But nextTemplateId should point to B, not A
+    expect(fetchedSession.nextTemplateId).toBe(templateB.id);
+  });
+
+  test('returns 400 for non-existent nextTemplateId', async () => {
+    const response = await fetch(`${API_URL}/api/projects/${project.id}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Test with bad nextTemplateId',
+        nextTemplateId: '00000000-0000-4000-8000-000000000000',
+        startImmediately: false,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('nextTemplateId references a non-existent template');
+  });
+
+  test('explicit null nextTemplateId clears templateId-derived value', async () => {
+    const response = await fetch(`${API_URL}/api/projects/${project.id}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Test clearing nextTemplateId',
+        templateId: templateA.id,
+        nextTemplateId: null,
+        startImmediately: false,
+      }),
+    });
+
+    expect(response.ok).toBe(true);
+    const session = await response.json();
+
+    // Template A's settings should be applied
+    const fetchedSession = await getSession(session.id);
+    expect(fetchedSession.thinkingEnabled).toBe(true);
+    // But nextTemplateId should be null
+    expect(fetchedSession.nextTemplateId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- The `POST /api/projects/:id/sessions` endpoint now reads `nextTemplateId` from the request body, allowing callers to set a template chain pointer independently of `templateId`
- Explicit body value always wins over the `templateId`-derived value, enabling scenarios like applying one template's settings while chaining to a different template, or explicitly clearing the chain with `null`
- Validates that non-null `nextTemplateId` references an existing template, returning 400 if not found

## Test plan
- [x] 5 new unit tests in `projects.test.js` covering all scenarios (set without templateId, validation, null, override, clear)
- [x] 4 new E2E tests in `session-nextTemplateId.spec.ts` exercising the full HTTP stack
- [x] All 59 existing unit tests continue to pass
- [x] All E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)