### PR TITLE
Move QuickResponsesPanel below prompt input in NewSessionView

### DIFF
--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -27,13 +27,6 @@
         </p>
       </div>
 
-      <!-- Quick Responses Panel - shows quick response templates above the prompt -->
-      <QuickResponsesPanel
-        :show-empty="true"
-        @insert="handleQuickResponseInsert"
-        @openSettings="quickResponseSettingsOpen = true"
-      />
-
       <div class="form-group">
         <ResizableTextarea
           id="prompt"
@@ -53,6 +46,13 @@
           />
         </div>
       </div>
+
+      <!-- Quick Responses Panel - shows quick response templates below the prompt -->
+      <QuickResponsesPanel
+        :show-empty="true"
+        @insert="handleQuickResponseInsert"
+        @openSettings="quickResponseSettingsOpen = true"
+      />
 
       <div class="form-group">
         <label class="form-label">Options</label>


### PR DESCRIPTION
## Summary
- Reordered the New Session view (`NewSessionView.vue`) so the `QuickResponsesPanel` appears **below** the prompt textarea instead of above it
- This change matches the layout pattern used in the Conversation Tab, providing a more consistent user experience
- Quick response templates are now more discoverable after users start typing their request

## Changes
- **File modified:** `packages/web/src/views/NewSessionView.vue`
- **Change:** Moved the `QuickResponsesPanel` component from lines 30-35 (above prompt) to lines 50-55 (below prompt)
- **Comment updated:** Changed "above the prompt" → "below the prompt"

### Before:
```
1. Start From Template selector
2. QuickResponsesPanel ← above prompt
3. Prompt textarea + attachments
4. Options row
```

### After:
```
1. Start From Template selector
2. Prompt textarea + attachments
3. QuickResponsesPanel ← below prompt
4. Options row
```

## Test plan
- [x] Verify the New Session view renders correctly with the new layout order
- [x] Confirm quick responses are still accessible and functional
- [x] Ensure the layout matches the Conversation Tab pattern
- [x] Test that quick response insertion still works properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)