### PR TITLE
Fix: Canvas delete should remove all versions of a file

### DIFF
--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -200,11 +200,11 @@ async function handleDeleteAll(filename) {
 
 async function handleDeleteItem(item) {
   const filename = item.filename || item.id;
-  if (!confirm(`Delete "${filename}"?`)) return;
+  if (!confirm(`Delete all versions of "${filename}"?`)) return;
 
   try {
-    await canvasStore.deleteItem(props.sessionId, item.id);
-    uiStore.success('Item deleted');
+    await canvasStore.deleteGroup(props.sessionId, filename);
+    uiStore.success('All versions deleted');
   } catch (err) {
     uiStore.error(err.message);
   }

--- a/packages/web/src/stores/canvas.test.js
+++ b/packages/web/src/stores/canvas.test.js
@@ -160,6 +160,49 @@ describe('Canvas Store', () => {
       expect(store.items[0].id).toBe('3');
     });
 
+    it('moves all versions to trash when deleting multi-version file', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'report.md', createdAt: 1000 },
+        { id: '2', filename: 'report.md', createdAt: 2000 },
+        { id: '3', filename: 'report.md', createdAt: 3000 },
+      ];
+
+      const deletedItems = [
+        { id: '1', filename: 'report.md', deletedAt: 4000 },
+        { id: '2', filename: 'report.md', deletedAt: 4001 },
+        { id: '3', filename: 'report.md', deletedAt: 4002 },
+      ];
+
+      api.deleteCanvasItem
+        .mockResolvedValueOnce(deletedItems[0])
+        .mockResolvedValueOnce(deletedItems[1])
+        .mockResolvedValueOnce(deletedItems[2]);
+
+      await store.deleteGroup('session-1', 'report.md');
+
+      expect(store.items).toHaveLength(0);
+      expect(store.trashedItems).toHaveLength(3);
+      // Check that all versions are in trash (order doesn't matter)
+      expect(store.trashedItems.map(item => item.id).sort()).toEqual(['1', '2', '3']);
+      expect(store.trashedItems.every(item => item.filename === 'report.md')).toBe(true);
+    });
+
+    it('moves single item to trash when deleting one-version file', async () => {
+      const store = useCanvasStore();
+      const singleItem = { id: '1', filename: 'single.txt', createdAt: 1000 };
+      store.items = [singleItem];
+
+      const deletedItem = { id: '1', filename: 'single.txt', deletedAt: 2000 };
+      api.deleteCanvasItem.mockResolvedValue(deletedItem);
+
+      await store.deleteGroup('session-1', 'single.txt');
+
+      expect(store.items).toHaveLength(0);
+      expect(store.trashedItems).toHaveLength(1);
+      expect(store.trashedItems[0]).toEqual(deletedItem);
+    });
+
   });
 
   describe('removeItem action', () => {

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -5,6 +5,7 @@ import {
   seedCanvasItem,
   cleanupAll,
   getCanvasItems,
+  getAllCanvasItems,
   getCanvasTrash,
   deleteCanvasItem,
   navigateAndWait,
@@ -125,5 +126,50 @@ test.describe('Canvas Trash & Soft Delete', () => {
     const trashedItems = await getCanvasTrash(session.id);
     expect(items.length).toBe(0);
     expect(trashedItems.length).toBe(0);
+  });
+
+  test('deleting from list view removes all versions', async ({ page }) => {
+    // Create two versions of the same file
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Version 1',
+      label: 'MultiVersion',
+      filename: 'report.txt',
+    });
+
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Version 2',
+      label: 'MultiVersion',
+      filename: 'report.txt',
+    });
+
+    // Verify we have 2 items via API (using getAllCanvasItems to get all versions)
+    const itemsBefore = await getAllCanvasItems(session.id);
+    expect(itemsBefore.length).toBe(2);
+
+    await navigateAndWait(page, `/sessions/${session.id}/canvas`);
+
+    // Handle confirmation dialog
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Click the context menu button for the file (first .btn-menu)
+    await page.locator('.btn-menu').first().click();
+
+    // Click "Delete file" in the menu
+    await page.locator('.menu-item.is-danger').filter({ hasText: 'Delete file' }).click();
+
+    // Wait for deletion to complete
+    await page.waitForTimeout(500);
+
+    // Verify both versions are gone from the list view via API
+    const itemsAfter = await getAllCanvasItems(session.id);
+    expect(itemsAfter.length).toBe(0);
+
+    // Verify both versions are in trash via API
+    const trashedItems = await getCanvasTrash(session.id);
+    expect(trashedItems.length).toBe(2);
+    expect(trashedItems[0].filename).toBe('report.txt');
+    expect(trashedItems[1].filename).toBe('report.txt');
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -229,6 +229,12 @@ export async function getCanvasItems(sessionId: string) {
   return response.json();
 }
 
+export async function getAllCanvasItems(sessionId: string) {
+  const response = await fetch(`${API_URL}/api/sessions/${sessionId}/canvas/all`);
+  if (!response.ok) return [];
+  return response.json();
+}
+
 export async function getCanvasTrash(sessionId: string) {
   const response = await fetch(`${API_URL}/api/sessions/${sessionId}/canvas-trash`);
   if (!response.ok) return [];


### PR DESCRIPTION
## Summary

Fixes a bug where deleting a file from the canvas **list view** only removed the most recent version, while the user expected all versions to be removed.

## Problem

When a file had multiple versions (e.g., `report.md` with 3 versions), clicking "Delete" from the list view context menu would only delete the latest version. The other versions would remain, creating inconsistency with the detail view's "Delete All Versions" action.

## Root Cause

In `CanvasTab.vue`, the list-view delete handler (`handleDeleteItem`) called `canvasStore.deleteItem()`, which deletes a **single item by ID**. It should call `canvasStore.deleteGroup()`, which deletes **all versions by filename** — the same behavior used by the detail-view's "Delete All" action.

## Changes

### Frontend (`packages/web/src/components/CanvasTab.vue`)
- Updated `handleDeleteItem` to call `canvasStore.deleteGroup(props.sessionId, filename)` instead of `deleteItem(props.sessionId, item.id)`
- Updated confirmation dialog: "Delete all versions of..." (matches detail view wording)
- Updated success message: "All versions deleted"

### Tests
- **Unit tests** (`packages/web/src/stores/canvas.test.js`): Added tests for multi-version and single-version delete scenarios
- **E2E test** (`tests/e2e/canvas.spec.ts`): Added test that creates 2 versions, deletes from list view, and verifies both are removed
- **Helper** (`tests/e2e/helpers.ts`): Added `getAllCanvasItems()` to fetch all versions (existing helper only returns latest)

## Test Plan

✅ All unit tests pass (23 canvas store tests)
✅ All E2E tests pass (4 canvas tests)
✅ New E2E test covers the full flow:
- Create 2 versions of the same file
- Delete from list view
- Verify both versions are removed and moved to trash

## Why This is Safe

- `deleteGroup()` is already used by the detail-view's "Delete All Versions" action and is proven to work
- For files with only one version, `deleteGroup` finds one item and deletes it — same as `deleteItem`
- Soft-delete is used throughout, so items go to trash and can be recovered
- No backend changes required — uses existing API endpoints

## Related

This aligns list-view delete behavior with the existing detail-view "Delete All Versions" action.