### PR TITLE
Add agent abstraction layer with call logging and metrics

### DIFF
--- a/packages/server/src/agents/AgentGateway.js
+++ b/packages/server/src/agents/AgentGateway.js
@@ -1,0 +1,64 @@
+import { ClaudeCodeAdapter } from './adapters/ClaudeCodeAdapter.js';
+
+/**
+ * Factory/registry for agent adapters.
+ * Session Manager uses this to get the appropriate adapter for a session's agent type.
+ */
+export class AgentGateway {
+  constructor() {
+    /** @type {Map<string, typeof import('./BaseAgent.js').BaseAgent>} */
+    this.adapters = new Map();
+    this._registerDefaultAdapters();
+  }
+
+  _registerDefaultAdapters() {
+    this.registerAdapter('claude-code', ClaudeCodeAdapter);
+  }
+
+  /**
+   * Register an adapter class for a given agent type.
+   * @param {string} agentType
+   * @param {typeof import('./BaseAgent.js').BaseAgent} AdapterClass
+   */
+  registerAdapter(agentType, AdapterClass) {
+    this.adapters.set(agentType, AdapterClass);
+  }
+
+  /**
+   * Create an agent instance for the given type.
+   * @param {string} agentType - e.g., 'claude-code'
+   * @param {import('./types.js').AgentConfig} [config]
+   * @returns {import('./BaseAgent.js').BaseAgent}
+   */
+  createAgent(agentType, config = {}) {
+    const AdapterClass = this.adapters.get(agentType);
+    if (!AdapterClass) {
+      throw new Error(
+        `Unknown agent type: "${agentType}". Available: ${this.getAvailableAgents().join(', ')}`
+      );
+    }
+    return new AdapterClass({ ...config, agentType });
+  }
+
+  /**
+   * @returns {string[]} List of registered agent type names
+   */
+  getAvailableAgents() {
+    return Array.from(this.adapters.keys());
+  }
+
+  /**
+   * Get capabilities for an agent type (uses a static check, no instantiation).
+   * @param {string} agentType
+   * @returns {Object|null}
+   */
+  getAgentCapabilities(agentType) {
+    const AdapterClass = this.adapters.get(agentType);
+    if (!AdapterClass) return null;
+    // Capabilities are static per adapter class
+    return new AdapterClass({}).getCapabilities();
+  }
+}
+
+// Singleton instance
+export const agentGateway = new AgentGateway();

--- a/packages/server/src/agents/AgentGateway.test.js
+++ b/packages/server/src/agents/AgentGateway.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the SDK so ClaudeCodeAdapter doesn't try to import the real one
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+}));
+
+import { AgentGateway } from './AgentGateway.js';
+import { ClaudeCodeAdapter } from './adapters/ClaudeCodeAdapter.js';
+import { BaseAgent } from './BaseAgent.js';
+
+describe('AgentGateway', () => {
+  it('creates a ClaudeCodeAdapter for "claude-code" type', () => {
+    const gateway = new AgentGateway();
+    const agent = gateway.createAgent('claude-code');
+    expect(agent).toBeInstanceOf(ClaudeCodeAdapter);
+  });
+
+  it('throws descriptive error for unknown agent type', () => {
+    const gateway = new AgentGateway();
+    expect(() => gateway.createAgent('nonexistent')).toThrow(
+      'Unknown agent type: "nonexistent". Available: claude-code'
+    );
+  });
+
+  it('registers and creates custom adapter classes', () => {
+    class CustomAdapter extends BaseAgent {
+      async *execute(_params) {
+        yield { type: 'custom' };
+      }
+    }
+
+    const gateway = new AgentGateway();
+    gateway.registerAdapter('custom', CustomAdapter);
+    const agent = gateway.createAgent('custom');
+    expect(agent).toBeInstanceOf(CustomAdapter);
+  });
+
+  it('lists all registered agent types', () => {
+    const gateway = new AgentGateway();
+    expect(gateway.getAvailableAgents()).toEqual(['claude-code']);
+
+    class FakeAdapter extends BaseAgent {}
+    gateway.registerAdapter('fake', FakeAdapter);
+    expect(gateway.getAvailableAgents()).toEqual(['claude-code', 'fake']);
+  });
+
+  it('returns capabilities for registered agent types', () => {
+    const gateway = new AgentGateway();
+    const capabilities = gateway.getAgentCapabilities('claude-code');
+    expect(capabilities).toEqual({
+      streaming: true,
+      thinking: true,
+      toolUse: true,
+      resume: true,
+    });
+  });
+
+  it('returns null capabilities for unknown agent type', () => {
+    const gateway = new AgentGateway();
+    expect(gateway.getAgentCapabilities('nonexistent')).toBeNull();
+  });
+
+  it('passes config to created agent', () => {
+    const gateway = new AgentGateway();
+    const agent = gateway.createAgent('claude-code', { model: 'test-model' });
+    expect(agent.config).toEqual({ model: 'test-model', agentType: 'claude-code' });
+  });
+});

--- a/packages/server/src/agents/BaseAgent.js
+++ b/packages/server/src/agents/BaseAgent.js
@@ -1,0 +1,41 @@
+/**
+ * Base agent interface. All adapters must implement `execute()` which returns
+ * an async generator of SDK events.
+ */
+export class BaseAgent {
+  constructor(config = {}) {
+    this.config = config;
+  }
+
+  /**
+   * Execute a query and yield events as an async generator.
+   * This mirrors the SDK's `query()` contract: callers consume with `for await...of`.
+   *
+   * @param {import('./types.js').AgentQueryParams} queryParams - { prompt, options? }
+   * @returns {AsyncGenerator<Object>} - Yields raw SDK events
+   */
+  async *execute(_queryParams) { // eslint-disable-line require-yield
+    throw new Error('execute() must be implemented by adapter');
+  }
+
+  /**
+   * Check if agent supports session resumption via `options.resume`
+   * @returns {boolean}
+   */
+  supportsResume() {
+    return false;
+  }
+
+  /**
+   * Get agent capabilities
+   * @returns {{ streaming: boolean, thinking: boolean, toolUse: boolean, resume: boolean }}
+   */
+  getCapabilities() {
+    return {
+      streaming: false,
+      thinking: false,
+      toolUse: false,
+      resume: false,
+    };
+  }
+}

--- a/packages/server/src/agents/BaseAgent.test.js
+++ b/packages/server/src/agents/BaseAgent.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { BaseAgent } from './BaseAgent.js';
+
+describe('BaseAgent', () => {
+  it('throws when execute() is called on base class', async () => {
+    const agent = new BaseAgent();
+    const gen = agent.execute({ prompt: 'test' });
+    await expect(gen.next()).rejects.toThrow('execute() must be implemented by adapter');
+  });
+
+  it('returns false for supportsResume() by default', () => {
+    const agent = new BaseAgent();
+    expect(agent.supportsResume()).toBe(false);
+  });
+
+  it('returns all-false capabilities by default', () => {
+    const agent = new BaseAgent();
+    expect(agent.getCapabilities()).toEqual({
+      streaming: false,
+      thinking: false,
+      toolUse: false,
+      resume: false,
+    });
+  });
+
+  it('stores config passed to constructor', () => {
+    const config = { agentType: 'test', model: 'test-model' };
+    const agent = new BaseAgent(config);
+    expect(agent.config).toEqual(config);
+  });
+
+  it('defaults config to empty object', () => {
+    const agent = new BaseAgent();
+    expect(agent.config).toEqual({});
+  });
+});

--- a/packages/server/src/agents/LoggingAgentWrapper.js
+++ b/packages/server/src/agents/LoggingAgentWrapper.js
@@ -1,0 +1,68 @@
+import { agentCallLogger } from '../services/agentCallLogger.js';
+
+/**
+ * Decorator that wraps a BaseAgent's execute() to log call start/end/errors.
+ * The wrapper is transparent to the consumer -- it yields the same events.
+ */
+export class LoggingAgentWrapper {
+  /**
+   * @param {import('./BaseAgent.js').BaseAgent} agent - The agent to wrap
+   */
+  constructor(agent) {
+    this.agent = agent;
+  }
+
+  /**
+   * Wraps agent.execute() with logging.
+   * @param {import('./types.js').AgentQueryParams} queryParams
+   * @param {import('./types.js').AgentCallMeta} meta - Logging metadata (sessionId, callType, etc.)
+   * @returns {AsyncGenerator<Object>} Same events as the inner agent
+   */
+  async *execute(queryParams, meta) {
+    const callId = agentCallLogger.startCall(meta);
+
+    try {
+      for await (const event of this.agent.execute(queryParams)) {
+        // Capture final usage from 'result' events
+        if (event.type === 'result' && event.subtype !== 'error') {
+          const modelUsageEntry = event.modelUsage
+            ? Object.values(event.modelUsage)[0]
+            : null;
+          if (modelUsageEntry || event.usage) {
+            agentCallLogger.updateUsage(callId, {
+              inputTokens:
+                modelUsageEntry?.inputTokens || event.usage?.input_tokens || 0,
+              outputTokens:
+                modelUsageEntry?.outputTokens || event.usage?.output_tokens || 0,
+              thinkingTokens: 0, // Not exposed in result event
+              cacheReadInputTokens:
+                modelUsageEntry?.cacheReadInputTokens ||
+                event.usage?.cache_read_input_tokens ||
+                0,
+              cacheCreationInputTokens:
+                modelUsageEntry?.cacheCreationInputTokens ||
+                event.usage?.cache_creation_input_tokens ||
+                0,
+            });
+          }
+        }
+
+        yield event;
+      }
+
+      agentCallLogger.completeCall(callId, { success: true });
+    } catch (error) {
+      agentCallLogger.completeCall(callId, { success: false, error });
+      throw error;
+    }
+  }
+
+  // Proxy capability methods
+  supportsResume() {
+    return this.agent.supportsResume();
+  }
+
+  getCapabilities() {
+    return this.agent.getCapabilities();
+  }
+}

--- a/packages/server/src/agents/LoggingAgentWrapper.test.js
+++ b/packages/server/src/agents/LoggingAgentWrapper.test.js
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LoggingAgentWrapper } from './LoggingAgentWrapper.js';
+
+// Mock the agentCallLogger service
+vi.mock('../services/agentCallLogger.js', () => ({
+  agentCallLogger: {
+    startCall: vi.fn(() => 'mock-call-id'),
+    updateUsage: vi.fn(),
+    completeCall: vi.fn(),
+  },
+}));
+
+import { agentCallLogger } from '../services/agentCallLogger.js';
+
+// Helper: create a mock agent that yields given events
+function createMockAgent(events, capabilities = {}) {
+  return {
+    async *execute(_queryParams) {
+      for (const event of events) {
+        yield event;
+      }
+    },
+    supportsResume() {
+      return capabilities.resume || false;
+    },
+    getCapabilities() {
+      return {
+        streaming: true,
+        thinking: true,
+        toolUse: true,
+        resume: true,
+        ...capabilities,
+      };
+    },
+  };
+}
+
+describe('LoggingAgentWrapper', () => {
+  const meta = {
+    sessionId: 'session-1',
+    conversationId: 'conv-1',
+    callType: 'runSession',
+    agentType: 'claude-code',
+    model: 'claude-sonnet-4-20250514',
+    promptLength: 500,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('yields all events from inner agent unchanged', async () => {
+    const events = [
+      { type: 'system', subtype: 'system.init' },
+      { type: 'assistant', message: { content: 'Hello' } },
+      { type: 'result', subtype: 'result.success' },
+    ];
+
+    const wrapper = new LoggingAgentWrapper(createMockAgent(events));
+    const collected = [];
+    for await (const event of wrapper.execute({ prompt: 'test' }, meta)) {
+      collected.push(event);
+    }
+
+    expect(collected).toEqual(events);
+  });
+
+  it('calls agentCallLogger.startCall() before first yield', async () => {
+    const events = [{ type: 'system' }];
+    const wrapper = new LoggingAgentWrapper(createMockAgent(events));
+
+    for await (const _event of wrapper.execute({ prompt: 'test' }, meta)) {
+      // By the time we get the first event, startCall should have been called
+      expect(agentCallLogger.startCall).toHaveBeenCalledWith(meta);
+    }
+  });
+
+  it('calls agentCallLogger.updateUsage() on result events with modelUsage', async () => {
+    const events = [
+      { type: 'system' },
+      {
+        type: 'result',
+        subtype: 'result.success',
+        modelUsage: {
+          'claude-sonnet-4-20250514': {
+            inputTokens: 1000,
+            outputTokens: 500,
+            cacheReadInputTokens: 300,
+            cacheCreationInputTokens: 100,
+          },
+        },
+      },
+    ];
+
+    const wrapper = new LoggingAgentWrapper(createMockAgent(events));
+    const collected = [];
+    for await (const event of wrapper.execute({ prompt: 'test' }, meta)) {
+      collected.push(event);
+    }
+
+    expect(agentCallLogger.updateUsage).toHaveBeenCalledWith('mock-call-id', {
+      inputTokens: 1000,
+      outputTokens: 500,
+      thinkingTokens: 0,
+      cacheReadInputTokens: 300,
+      cacheCreationInputTokens: 100,
+    });
+  });
+
+  it('calls agentCallLogger.updateUsage() on result events with usage field', async () => {
+    const events = [
+      {
+        type: 'result',
+        subtype: 'result.success',
+        usage: {
+          input_tokens: 800,
+          output_tokens: 400,
+          cache_read_input_tokens: 200,
+          cache_creation_input_tokens: 50,
+        },
+      },
+    ];
+
+    const wrapper = new LoggingAgentWrapper(createMockAgent(events));
+    for await (const _event of wrapper.execute({ prompt: 'test' }, meta)) {
+      // consume
+    }
+
+    expect(agentCallLogger.updateUsage).toHaveBeenCalledWith('mock-call-id', {
+      inputTokens: 800,
+      outputTokens: 400,
+      thinkingTokens: 0,
+      cacheReadInputTokens: 200,
+      cacheCreationInputTokens: 50,
+    });
+  });
+
+  it('does NOT call updateUsage on result.error events', async () => {
+    const events = [
+      {
+        type: 'result',
+        subtype: 'error',
+        error: { message: 'fail' },
+      },
+    ];
+
+    const wrapper = new LoggingAgentWrapper(createMockAgent(events));
+    for await (const _event of wrapper.execute({ prompt: 'test' }, meta)) {
+      // consume
+    }
+
+    expect(agentCallLogger.updateUsage).not.toHaveBeenCalled();
+  });
+
+  it('calls agentCallLogger.completeCall(success: true) after generator exhaustion', async () => {
+    const events = [{ type: 'system' }, { type: 'result', subtype: 'result.success' }];
+
+    const wrapper = new LoggingAgentWrapper(createMockAgent(events));
+    for await (const _event of wrapper.execute({ prompt: 'test' }, meta)) {
+      // consume
+    }
+
+    expect(agentCallLogger.completeCall).toHaveBeenCalledWith('mock-call-id', {
+      success: true,
+    });
+  });
+
+  it('calls agentCallLogger.completeCall(success: false, error) when inner agent throws', async () => {
+    const error = new Error('SDK crash');
+    const mockAgent = {
+      async *execute() {
+        yield { type: 'system' };
+        throw error;
+      },
+      supportsResume: () => false,
+      getCapabilities: () => ({}),
+    };
+
+    const wrapper = new LoggingAgentWrapper(mockAgent);
+
+    await expect(async () => {
+      for await (const _event of wrapper.execute({ prompt: 'test' }, meta)) {
+        // consume
+      }
+    }).rejects.toThrow('SDK crash');
+
+    expect(agentCallLogger.completeCall).toHaveBeenCalledWith('mock-call-id', {
+      success: false,
+      error,
+    });
+  });
+
+  it('does NOT swallow errors - re-throws after logging', async () => {
+    const mockAgent = {
+      async *execute() { // eslint-disable-line require-yield
+        throw new Error('original error');
+      },
+      supportsResume: () => false,
+      getCapabilities: () => ({}),
+    };
+
+    const wrapper = new LoggingAgentWrapper(mockAgent);
+
+    await expect(async () => {
+      for await (const _event of wrapper.execute({ prompt: 'test' }, meta)) {
+        // consume
+      }
+    }).rejects.toThrow('original error');
+  });
+
+  it('delegates supportsResume() to inner agent', () => {
+    const wrapper = new LoggingAgentWrapper(createMockAgent([], { resume: true }));
+    expect(wrapper.supportsResume()).toBe(true);
+
+    const wrapper2 = new LoggingAgentWrapper(createMockAgent([], { resume: false }));
+    expect(wrapper2.supportsResume()).toBe(false);
+  });
+
+  it('delegates getCapabilities() to inner agent', () => {
+    const caps = { streaming: true, thinking: false, toolUse: true, resume: false };
+    const wrapper = new LoggingAgentWrapper(createMockAgent([], caps));
+    expect(wrapper.getCapabilities()).toEqual(caps);
+  });
+});

--- a/packages/server/src/agents/adapters/ClaudeCodeAdapter.js
+++ b/packages/server/src/agents/adapters/ClaudeCodeAdapter.js
@@ -1,0 +1,33 @@
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { BaseAgent } from '../BaseAgent.js';
+
+/**
+ * Adapter for Claude Code SDK. Wraps the SDK's `query()` function
+ * which returns an async generator of events.
+ *
+ * The adapter does NOT transform events -- it passes through raw SDK events.
+ * Event handling remains in sessionManager's handleStreamEvent().
+ */
+export class ClaudeCodeAdapter extends BaseAgent {
+  /**
+   * Execute a query against the Claude Code SDK.
+   * @param {import('../types.js').AgentQueryParams} queryParams - { prompt, options? }
+   * @yields {Object} Raw SDK events (system, assistant, tool_result, stream_event, result)
+   */
+  async *execute(queryParams) {
+    yield* query(queryParams);
+  }
+
+  supportsResume() {
+    return true;
+  }
+
+  getCapabilities() {
+    return {
+      streaming: true,
+      thinking: true,
+      toolUse: true,
+      resume: true,
+    };
+  }
+}

--- a/packages/server/src/agents/adapters/ClaudeCodeAdapter.test.js
+++ b/packages/server/src/agents/adapters/ClaudeCodeAdapter.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the SDK before importing the adapter
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+}));
+
+import { ClaudeCodeAdapter } from './ClaudeCodeAdapter.js';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+describe('ClaudeCodeAdapter', () => {
+  it('calls SDK query() and yields all events', async () => {
+    const events = [
+      { type: 'system', subtype: 'system.init' },
+      { type: 'assistant', message: { content: 'Hello' } },
+      { type: 'result', subtype: 'result.success' },
+    ];
+
+    query.mockImplementation(async function* (_params) {
+      for (const event of events) {
+        yield event;
+      }
+    });
+
+    const adapter = new ClaudeCodeAdapter();
+    const collected = [];
+    for await (const event of adapter.execute({ prompt: 'test' })) {
+      collected.push(event);
+    }
+
+    expect(collected).toEqual(events);
+    expect(query).toHaveBeenCalledWith({ prompt: 'test' });
+  });
+
+  it('propagates errors from SDK query()', async () => {
+    query.mockImplementation(async function* () {
+      yield { type: 'system' };
+      throw new Error('SDK error');
+    });
+
+    const adapter = new ClaudeCodeAdapter();
+    const collected = [];
+    await expect(async () => {
+      for await (const event of adapter.execute({ prompt: 'test' })) {
+        collected.push(event);
+      }
+    }).rejects.toThrow('SDK error');
+
+    // Should have yielded the first event before error
+    expect(collected).toHaveLength(1);
+  });
+
+  it('works with abort controller (yields events until aborted)', async () => {
+    const controller = new AbortController();
+    const events = [
+      { type: 'system' },
+      { type: 'assistant' },
+      { type: 'result' },
+    ];
+
+    query.mockImplementation(async function* () {
+      for (const event of events) {
+        yield event;
+      }
+    });
+
+    const adapter = new ClaudeCodeAdapter();
+    const collected = [];
+    for await (const event of adapter.execute({ prompt: 'test', options: { abortController: controller } })) {
+      collected.push(event);
+      if (collected.length === 2) {
+        controller.abort();
+        break;
+      }
+    }
+
+    expect(collected).toHaveLength(2);
+  });
+
+  it('returns true for supportsResume()', () => {
+    const adapter = new ClaudeCodeAdapter();
+    expect(adapter.supportsResume()).toBe(true);
+  });
+
+  it('returns correct capabilities', () => {
+    const adapter = new ClaudeCodeAdapter();
+    expect(adapter.getCapabilities()).toEqual({
+      streaming: true,
+      thinking: true,
+      toolUse: true,
+      resume: true,
+    });
+  });
+});

--- a/packages/server/src/agents/adapters/CodexAdapter.js
+++ b/packages/server/src/agents/adapters/CodexAdapter.js
@@ -1,0 +1,26 @@
+import { BaseAgent } from '../BaseAgent.js';
+
+/**
+ * Stub adapter for OpenAI Codex / future agents.
+ * When implemented, this would:
+ * 1. Transform AgentQueryParams into Codex API format
+ * 2. Call the Codex API
+ * 3. Yield events normalized to the SDK event format (system, assistant, tool_result, stream_event, result)
+ *
+ * Phase 7 note: A NormalizedEvent format should be introduced at this point,
+ * along with refactoring handleStreamEvent to consume normalized events.
+ */
+export class CodexAdapter extends BaseAgent {
+  async *execute(_queryParams) { // eslint-disable-line require-yield
+    throw new Error('CodexAdapter is not yet implemented');
+  }
+
+  getCapabilities() {
+    return {
+      streaming: true,
+      thinking: false, // Codex doesn't have explicit thinking
+      toolUse: true,
+      resume: false, // Codex may not support session resume
+    };
+  }
+}

--- a/packages/server/src/agents/adapters/CodexAdapter.test.js
+++ b/packages/server/src/agents/adapters/CodexAdapter.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { CodexAdapter } from './CodexAdapter.js';
+import { BaseAgent } from '../BaseAgent.js';
+
+describe('CodexAdapter', () => {
+  it('extends BaseAgent', () => {
+    const adapter = new CodexAdapter();
+    expect(adapter).toBeInstanceOf(BaseAgent);
+  });
+
+  it('throws "not yet implemented" from execute()', async () => {
+    const adapter = new CodexAdapter();
+    await expect(async () => {
+      for await (const _event of adapter.execute({ prompt: 'test' })) {
+        // consume
+      }
+    }).rejects.toThrow('CodexAdapter is not yet implemented');
+  });
+
+  it('returns false for supportsResume() (inherited default)', () => {
+    const adapter = new CodexAdapter();
+    expect(adapter.supportsResume()).toBe(false);
+  });
+
+  it('returns correct capabilities', () => {
+    const adapter = new CodexAdapter();
+    expect(adapter.getCapabilities()).toEqual({
+      streaming: true,
+      thinking: false,
+      toolUse: true,
+      resume: false,
+    });
+  });
+});

--- a/packages/server/src/agents/types.js
+++ b/packages/server/src/agents/types.js
@@ -1,0 +1,42 @@
+/**
+ * Agent abstraction layer type definitions.
+ *
+ * @typedef {Object} AgentConfig
+ * @property {string} agentType - 'claude-code' | 'codex' | etc.
+ * @property {string} [model] - Model identifier
+ * @property {Object} [providerConfig] - Provider-specific configuration
+ */
+
+/**
+ * @typedef {Object} AgentQueryParams
+ * @property {string} prompt - The prompt text (may include attachments/context)
+ * @property {AgentQueryOptions} [options] - SDK options (omitted in mock mode)
+ */
+
+/**
+ * @typedef {Object} AgentQueryOptions
+ * @property {string} cwd - Working directory
+ * @property {AbortController} abortController - Abort controller
+ * @property {boolean} includePartialMessages - Whether to include partial messages
+ * @property {string} permissionMode - 'default' | 'bypassPermissions'
+ * @property {string[]} settingSources - e.g., ['project']
+ * @property {string} [resume] - Claude session ID for resumption
+ * @property {Object} env - Environment variables
+ * @property {Function} spawnClaudeCodeProcess - Process spawner function
+ * @property {string} [model] - Model to use
+ * @property {string} systemPrompt - System prompt string
+ */
+
+/**
+ * Agent call metadata for logging purposes
+ * @typedef {Object} AgentCallMeta
+ * @property {string} sessionId
+ * @property {string} [conversationId]
+ * @property {string} callType - 'runSession' | 'continueSession' | 'continueSessionWithExistingMessage'
+ * @property {string} [agentType]
+ * @property {string} [model]
+ * @property {boolean} [isResume] - Whether this call uses SDK session resume
+ * @property {number} promptLength - Character length of prompt
+ */
+
+export {};

--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -9,6 +9,7 @@ import quickResponsesRouter from './quickResponses.js';
 import settingsRouter from './settings.js';
 import providersRouter from './providers.js';
 import commandsRouter from './commands.js';
+import metricsRouter from './metrics.js';
 
 const router = Router();
 
@@ -23,6 +24,9 @@ router.use('/commands', commandsRouter)
 
 // Canvas routes are nested under sessions
 router.use('/sessions', canvasRouter);
+
+// Metrics routes (agent call stats)
+router.use('/', metricsRouter);
 
 // Quick responses routes (nested under both projects and standalone)
 router.use('/', quickResponsesRouter);

--- a/packages/server/src/api/metrics.js
+++ b/packages/server/src/api/metrics.js
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { agentCallLogger } from '../services/agentCallLogger.js';
+import { agentCallLogs } from '../database.js';
+
+const router = Router();
+
+// GET /api/sessions/:sessionId/agent-stats
+// Returns aggregated stats for a session grouped by call_type
+router.get('/sessions/:sessionId/agent-stats', (req, res) => {
+  const stats = agentCallLogger.getSessionStats(req.params.sessionId);
+  res.json(stats);
+});
+
+// GET /api/sessions/:sessionId/agent-calls?limit=100&offset=0
+// Returns detailed call log entries for a session
+router.get('/sessions/:sessionId/agent-calls', (req, res) => {
+  const { limit = 100, offset = 0 } = req.query;
+  const calls = agentCallLogs.getBySessionId(req.params.sessionId, {
+    limit: parseInt(limit),
+    offset: parseInt(offset),
+  });
+  res.json(calls);
+});
+
+// GET /api/agent-stats?startDate=...&endDate=...
+// Returns global stats grouped by agent_type and call_type
+router.get('/agent-stats', (req, res) => {
+  const now = Date.now();
+  const start = req.query.startDate
+    ? parseInt(req.query.startDate)
+    : now - 7 * 24 * 60 * 60 * 1000;
+  const end = req.query.endDate ? parseInt(req.query.endDate) : now;
+  const stats = agentCallLogger.getGlobalStats(start, end);
+  res.json(stats);
+});
+
+export default router;

--- a/packages/server/src/api/metrics.test.js
+++ b/packages/server/src/api/metrics.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, agentCallLogs } from '../db/index.js';
+import metricsRouter from './metrics.js';
+
+describe('Metrics API', () => {
+  let app;
+  let projectId;
+  let sessionId;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api', metricsRouter);
+
+    // Create a project and session for test data
+    const project = projects.create('Test', '/tmp');
+    projectId = project.id;
+    const session = sessions.create(projectId, 'Test session', 'hello', 'standard');
+    sessionId = session.id;
+  });
+
+  describe('GET /api/sessions/:sessionId/agent-stats', () => {
+    it('returns empty array when no calls logged', async () => {
+      const res = await request(app).get(`/api/sessions/${sessionId}/agent-stats`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns aggregated stats grouped by call_type', async () => {
+      // Create two call log entries with different call types
+      agentCallLogs.create({
+        id: 'call-1',
+        sessionId,
+        conversationId: null,
+        agentType: 'claude-code',
+        model: 'claude-sonnet-4-20250514',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+      agentCallLogs.complete('call-1', {
+        success: true,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+
+      agentCallLogs.create({
+        id: 'call-2',
+        sessionId,
+        conversationId: null,
+        agentType: 'claude-code',
+        model: 'claude-sonnet-4-20250514',
+        callType: 'continueSession',
+        promptLength: 200,
+      });
+      agentCallLogs.complete('call-2', {
+        success: true,
+        inputTokens: 2000,
+        outputTokens: 800,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/agent-stats`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+
+      const runStat = res.body.find((s) => s.call_type === 'runSession');
+      expect(runStat).toBeTruthy();
+      expect(runStat.call_count).toBe(1);
+      expect(runStat.total_input_tokens).toBe(1000);
+      expect(runStat.total_output_tokens).toBe(500);
+
+      const continueStat = res.body.find((s) => s.call_type === 'continueSession');
+      expect(continueStat).toBeTruthy();
+      expect(continueStat.call_count).toBe(1);
+    });
+  });
+
+  describe('GET /api/sessions/:sessionId/agent-calls', () => {
+    it('returns empty array when no calls exist', async () => {
+      const res = await request(app).get(`/api/sessions/${sessionId}/agent-calls`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns detailed call log entries for a session', async () => {
+      agentCallLogs.create({
+        id: 'call-a',
+        sessionId,
+        conversationId: null,
+        agentType: 'claude-code',
+        model: 'claude-sonnet-4-20250514',
+        callType: 'runSession',
+        promptLength: 500,
+      });
+
+      const res = await request(app).get(`/api/sessions/${sessionId}/agent-calls`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].id).toBe('call-a');
+      expect(res.body[0].callType).toBe('runSession');
+      expect(res.body[0].promptLength).toBe(500);
+    });
+
+    it('respects limit and offset query params', async () => {
+      // Create 3 calls
+      for (let i = 0; i < 3; i++) {
+        agentCallLogs.create({
+          id: `call-${i}`,
+          sessionId,
+          conversationId: null,
+          agentType: 'claude-code',
+          model: null,
+          callType: 'runSession',
+          promptLength: 100,
+        });
+      }
+
+      const res = await request(app).get(
+        `/api/sessions/${sessionId}/agent-calls?limit=2&offset=1`
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+  });
+
+  describe('GET /api/agent-stats', () => {
+    it('returns global stats (empty when no calls)', async () => {
+      const res = await request(app).get('/api/agent-stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns global stats grouped by agent_type and call_type', async () => {
+      agentCallLogs.create({
+        id: 'global-1',
+        sessionId,
+        conversationId: null,
+        agentType: 'claude-code',
+        model: null,
+        callType: 'runSession',
+        promptLength: 100,
+      });
+      agentCallLogs.complete('global-1', {
+        success: true,
+        inputTokens: 500,
+        outputTokens: 200,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+
+      const res = await request(app).get('/api/agent-stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].agent_type).toBe('claude-code');
+      expect(res.body[0].call_type).toBe('runSession');
+      expect(res.body[0].call_count).toBe(1);
+    });
+
+    it('accepts startDate and endDate query parameters', async () => {
+      agentCallLogs.create({
+        id: 'dated-1',
+        sessionId,
+        conversationId: null,
+        agentType: 'claude-code',
+        model: null,
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      // Query with future dates → should find nothing
+      const futureStart = Date.now() + 100000;
+      const futureEnd = futureStart + 100000;
+      const res = await request(app).get(
+        `/api/agent-stats?startDate=${futureStart}&endDate=${futureEnd}`
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+  });
+});

--- a/packages/server/src/database.js
+++ b/packages/server/src/database.js
@@ -22,6 +22,7 @@ export {
   // Kept for any code that still imports ModelProviderRepository by name
   ModelProviderRepository,
   SettingsRepository,
+  AgentCallLogRepository,
   // Singleton instances
   databaseManager,
   projects,
@@ -41,6 +42,7 @@ export {
   quickResponses,
   modelProviders,
   settings,
+  agentCallLogs,
   // Legacy functions
   initDatabase,
   getDatabase,

--- a/packages/server/src/db/AgentCallLogRepository.js
+++ b/packages/server/src/db/AgentCallLogRepository.js
@@ -1,0 +1,164 @@
+import { BaseRepository } from './BaseRepository.js';
+
+function mapRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    conversationId: row.conversation_id,
+    agentType: row.agent_type,
+    model: row.model,
+    callType: row.call_type,
+    promptLength: row.prompt_length,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    thinkingTokens: row.thinking_tokens,
+    cacheReadTokens: row.cache_read_tokens,
+    cacheWriteTokens: row.cache_write_tokens,
+    totalTokens: row.total_tokens,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    durationMs: row.duration_ms,
+    status: row.status,
+    errorMessage: row.error_message,
+    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    createdAt: row.created_at,
+  };
+}
+
+export class AgentCallLogRepository extends BaseRepository {
+  constructor() {
+    super('agent_call_logs', mapRow);
+  }
+
+  /**
+   * Create a new call log entry
+   */
+  create({ id, sessionId, conversationId, agentType, model, callType, promptLength }) {
+    const now = Date.now();
+    this.db
+      .prepare(
+        `INSERT INTO agent_call_logs (id, session_id, conversation_id, agent_type, model, call_type, prompt_length, started_at, status, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)`
+      )
+      .run(id, sessionId, conversationId, agentType, model, callType, promptLength, now, now);
+    return this.getById(id);
+  }
+
+  /**
+   * Update usage tokens during streaming
+   */
+  updateUsage(
+    id,
+    { inputTokens, outputTokens, thinkingTokens, cacheReadTokens, cacheWriteTokens }
+  ) {
+    this.db
+      .prepare(
+        `UPDATE agent_call_logs SET
+        input_tokens = COALESCE(?, input_tokens),
+        output_tokens = COALESCE(?, output_tokens),
+        thinking_tokens = COALESCE(?, thinking_tokens),
+        cache_read_tokens = COALESCE(?, cache_read_tokens),
+        cache_write_tokens = COALESCE(?, cache_write_tokens),
+        status = 'streaming'
+      WHERE id = ?`
+      )
+      .run(inputTokens, outputTokens, thinkingTokens, cacheReadTokens, cacheWriteTokens, id);
+  }
+
+  /**
+   * Mark a call as completed or errored
+   */
+  complete(
+    id,
+    { success, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, errorMessage }
+  ) {
+    const now = Date.now();
+    const row = this.db.prepare('SELECT started_at FROM agent_call_logs WHERE id = ?').get(id);
+    const durationMs = row ? now - row.started_at : null;
+    const totalTokens = (inputTokens || 0) + (outputTokens || 0);
+
+    this.db
+      .prepare(
+        `UPDATE agent_call_logs SET
+        input_tokens = COALESCE(?, input_tokens),
+        output_tokens = COALESCE(?, output_tokens),
+        cache_read_tokens = COALESCE(?, cache_read_tokens),
+        cache_write_tokens = COALESCE(?, cache_write_tokens),
+        total_tokens = ?,
+        completed_at = ?,
+        duration_ms = ?,
+        status = ?,
+        error_message = ?
+      WHERE id = ?`
+      )
+      .run(
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        totalTokens,
+        now,
+        durationMs,
+        success ? 'completed' : 'error',
+        errorMessage || null,
+        id
+      );
+  }
+
+  /**
+   * Get all call logs for a session
+   */
+  getBySessionId(sessionId, { limit = 100, offset = 0 } = {}) {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM agent_call_logs WHERE session_id = ?
+      ORDER BY started_at DESC LIMIT ? OFFSET ?`
+      )
+      .all(sessionId, limit, offset);
+    return this.mapAll(rows);
+  }
+
+  /**
+   * Get aggregated stats for a session, grouped by call_type
+   */
+  getSessionStats(sessionId) {
+    return this.db
+      .prepare(
+        `SELECT
+        call_type,
+        COUNT(*) as call_count,
+        SUM(input_tokens) as total_input_tokens,
+        SUM(output_tokens) as total_output_tokens,
+        SUM(total_tokens) as total_tokens,
+        AVG(duration_ms) as avg_duration_ms,
+        SUM(duration_ms) as total_duration_ms
+      FROM agent_call_logs
+      WHERE session_id = ?
+      GROUP BY call_type`
+      )
+      .all(sessionId);
+  }
+
+  /**
+   * Get global stats grouped by agent_type within a date range
+   */
+  getGlobalStats(startDate, endDate) {
+    return this.db
+      .prepare(
+        `SELECT
+        agent_type,
+        call_type,
+        COUNT(*) as call_count,
+        SUM(total_tokens) as total_tokens,
+        SUM(input_tokens) as total_input_tokens,
+        SUM(output_tokens) as total_output_tokens,
+        AVG(duration_ms) as avg_duration_ms
+      FROM agent_call_logs
+      WHERE started_at >= ? AND started_at <= ?
+      GROUP BY agent_type, call_type
+      ORDER BY total_tokens DESC`
+      )
+      .all(startDate, endDate);
+  }
+}

--- a/packages/server/src/db/AgentCallLogRepository.test.js
+++ b/packages/server/src/db/AgentCallLogRepository.test.js
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AgentCallLogRepository } from './AgentCallLogRepository.js';
+import { ProjectRepository } from './ProjectRepository.js';
+import { databaseManager } from './DatabaseManager.js';
+
+describe('AgentCallLogRepository', () => {
+  // Uses global setup from test/setup.js (in-memory DB per test)
+  let repo;
+  let projectRepo;
+  let sessionId;
+
+  beforeEach(() => {
+    repo = new AgentCallLogRepository();
+    projectRepo = new ProjectRepository();
+
+    // Create a project and session for testing
+    const project = projectRepo.create('Test Project', '/tmp/test');
+    const now = Date.now();
+    const id = databaseManager.generateId();
+    databaseManager.get().prepare(
+      'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, project.id, 'Test Session', 'running', 'standard', now, now);
+    sessionId = id;
+  });
+
+  describe('constructor', () => {
+    it('creates repository instance', () => {
+      expect(repo).toBeInstanceOf(AgentCallLogRepository);
+      expect(repo.tableName).toBe('agent_call_logs');
+    });
+  });
+
+  describe('create', () => {
+    it('creates a call log entry and returns mapped object', () => {
+      const callId = databaseManager.generateId();
+      const entry = repo.create({
+        id: callId,
+        sessionId,
+        conversationId: 'conv-1',
+        agentType: 'claude-code',
+        model: 'claude-sonnet-4-20250514',
+        callType: 'runSession',
+        promptLength: 500,
+      });
+
+      expect(entry.id).toBe(callId);
+      expect(entry.sessionId).toBe(sessionId);
+      expect(entry.conversationId).toBe('conv-1');
+      expect(entry.agentType).toBe('claude-code');
+      expect(entry.model).toBe('claude-sonnet-4-20250514');
+      expect(entry.callType).toBe('runSession');
+      expect(entry.promptLength).toBe(500);
+      expect(entry.status).toBe('pending');
+      expect(entry.startedAt).toBeTypeOf('number');
+      expect(entry.createdAt).toBeTypeOf('number');
+      expect(entry.inputTokens).toBe(0);
+      expect(entry.outputTokens).toBe(0);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns mapped object with camelCase properties', () => {
+      const callId = databaseManager.generateId();
+      repo.create({
+        id: callId,
+        sessionId,
+        agentType: 'claude-code',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      const retrieved = repo.getById(callId);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved.sessionId).toBe(sessionId);
+      expect(retrieved.agentType).toBe('claude-code');
+      expect(retrieved.callType).toBe('runSession');
+    });
+
+    it('returns null for non-existent ID', () => {
+      expect(repo.getById('non-existent')).toBeNull();
+    });
+  });
+
+  describe('updateUsage', () => {
+    it('updates token columns and sets status to streaming', () => {
+      const callId = databaseManager.generateId();
+      repo.create({
+        id: callId,
+        sessionId,
+        agentType: 'claude-code',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      repo.updateUsage(callId, {
+        inputTokens: 1000,
+        outputTokens: 500,
+        thinkingTokens: 200,
+        cacheReadTokens: 300,
+        cacheWriteTokens: 100,
+      });
+
+      const updated = repo.getById(callId);
+      expect(updated.inputTokens).toBe(1000);
+      expect(updated.outputTokens).toBe(500);
+      expect(updated.thinkingTokens).toBe(200);
+      expect(updated.cacheReadTokens).toBe(300);
+      expect(updated.cacheWriteTokens).toBe(100);
+      expect(updated.status).toBe('streaming');
+    });
+  });
+
+  describe('complete', () => {
+    it('with success sets status, completed_at, duration_ms, total_tokens', () => {
+      const callId = databaseManager.generateId();
+      repo.create({
+        id: callId,
+        sessionId,
+        agentType: 'claude-code',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      repo.complete(callId, {
+        success: true,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 300,
+        cacheWriteTokens: 100,
+      });
+
+      const completed = repo.getById(callId);
+      expect(completed.status).toBe('completed');
+      expect(completed.completedAt).toBeTypeOf('number');
+      expect(completed.durationMs).toBeTypeOf('number');
+      expect(completed.durationMs).toBeGreaterThanOrEqual(0);
+      expect(completed.totalTokens).toBe(1500); // 1000 + 500
+      expect(completed.inputTokens).toBe(1000);
+      expect(completed.outputTokens).toBe(500);
+    });
+
+    it('with error sets status to error and error_message', () => {
+      const callId = databaseManager.generateId();
+      repo.create({
+        id: callId,
+        sessionId,
+        agentType: 'claude-code',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      repo.complete(callId, {
+        success: false,
+        errorMessage: 'Connection timeout',
+      });
+
+      const completed = repo.getById(callId);
+      expect(completed.status).toBe('error');
+      expect(completed.errorMessage).toBe('Connection timeout');
+      expect(completed.completedAt).toBeTypeOf('number');
+    });
+  });
+
+  describe('getBySessionId', () => {
+    it('returns calls ordered by started_at DESC with limit/offset', () => {
+      // Create multiple call logs
+      for (let i = 0; i < 5; i++) {
+        repo.create({
+          id: databaseManager.generateId(),
+          sessionId,
+          agentType: 'claude-code',
+          callType: 'runSession',
+          promptLength: 100 * (i + 1),
+        });
+      }
+
+      const all = repo.getBySessionId(sessionId);
+      expect(all).toHaveLength(5);
+
+      // Test limit
+      const limited = repo.getBySessionId(sessionId, { limit: 3 });
+      expect(limited).toHaveLength(3);
+
+      // Test offset
+      const offset = repo.getBySessionId(sessionId, { limit: 2, offset: 2 });
+      expect(offset).toHaveLength(2);
+    });
+
+    it('returns empty array for session with no calls', () => {
+      const calls = repo.getBySessionId('nonexistent');
+      expect(calls).toEqual([]);
+    });
+  });
+
+  describe('getSessionStats', () => {
+    it('returns correct aggregation grouped by call_type', () => {
+      // Create entries with different call types
+      const id1 = databaseManager.generateId();
+      const id2 = databaseManager.generateId();
+      const id3 = databaseManager.generateId();
+
+      repo.create({ id: id1, sessionId, agentType: 'claude-code', callType: 'runSession', promptLength: 100 });
+      repo.create({ id: id2, sessionId, agentType: 'claude-code', callType: 'continueSession', promptLength: 200 });
+      repo.create({ id: id3, sessionId, agentType: 'claude-code', callType: 'continueSession', promptLength: 300 });
+
+      repo.complete(id1, { success: true, inputTokens: 100, outputTokens: 50 });
+      repo.complete(id2, { success: true, inputTokens: 200, outputTokens: 100 });
+      repo.complete(id3, { success: true, inputTokens: 300, outputTokens: 150 });
+
+      const stats = repo.getSessionStats(sessionId);
+      expect(stats).toHaveLength(2); // runSession, continueSession
+
+      const runStats = stats.find(s => s.call_type === 'runSession');
+      expect(runStats.call_count).toBe(1);
+      expect(runStats.total_input_tokens).toBe(100);
+      expect(runStats.total_output_tokens).toBe(50);
+
+      const continueStats = stats.find(s => s.call_type === 'continueSession');
+      expect(continueStats.call_count).toBe(2);
+      expect(continueStats.total_input_tokens).toBe(500); // 200 + 300
+      expect(continueStats.total_output_tokens).toBe(250); // 100 + 150
+    });
+  });
+
+  describe('getGlobalStats', () => {
+    it('filters by date range and groups by agent_type and call_type', () => {
+      const id1 = databaseManager.generateId();
+      repo.create({ id: id1, sessionId, agentType: 'claude-code', callType: 'runSession', promptLength: 100 });
+      repo.complete(id1, { success: true, inputTokens: 100, outputTokens: 50 });
+
+      const now = Date.now();
+      const stats = repo.getGlobalStats(now - 60000, now + 60000);
+      expect(stats.length).toBeGreaterThanOrEqual(1);
+
+      const claudeStats = stats.find(s => s.agent_type === 'claude-code');
+      expect(claudeStats).toBeDefined();
+      expect(claudeStats.call_count).toBe(1);
+    });
+
+    it('returns empty array when no calls in range', () => {
+      const id1 = databaseManager.generateId();
+      repo.create({ id: id1, sessionId, agentType: 'claude-code', callType: 'runSession', promptLength: 100 });
+
+      // Use a range far in the past
+      const stats = repo.getGlobalStats(0, 1000);
+      expect(stats).toEqual([]);
+    });
+  });
+
+  describe('delete (CASCADE)', () => {
+    it('deletes call logs when session is deleted', () => {
+      const id1 = databaseManager.generateId();
+      repo.create({ id: id1, sessionId, agentType: 'claude-code', callType: 'runSession', promptLength: 100 });
+
+      expect(repo.getById(id1)).not.toBeNull();
+
+      // Delete the session (should cascade to agent_call_logs)
+      databaseManager.get().prepare('DELETE FROM sessions WHERE id = ?').run(sessionId);
+
+      expect(repo.getById(id1)).toBeNull();
+    });
+  });
+});

--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -470,6 +470,43 @@ export class DatabaseManager {
 
     // Migrate built-in models to 4.6 versions
     this.#updateBuiltInModels();
+
+    // Add agent_type column to sessions table (defaults to 'claude-code')
+    const agentTypeTableInfo = this.#db.prepare('PRAGMA table_info(sessions)').all();
+    const agentTypeColumns = agentTypeTableInfo.map((col) => col.name);
+
+    if (!agentTypeColumns.includes('agent_type')) {
+      this.#db.exec("ALTER TABLE sessions ADD COLUMN agent_type TEXT DEFAULT 'claude-code'");
+    }
+
+    // Create agent_call_logs table if it doesn't exist
+    // (new installs get the table from schema.sql; this handles existing databases)
+    this.#db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_call_logs (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        conversation_id TEXT,
+        agent_type TEXT NOT NULL,
+        model TEXT,
+        call_type TEXT NOT NULL,
+        prompt_length INTEGER,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        thinking_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        total_tokens INTEGER DEFAULT 0,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        duration_ms INTEGER,
+        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'streaming', 'completed', 'error')),
+        error_message TEXT,
+        metadata TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+      );
+      CREATE INDEX IF NOT EXISTS idx_agent_call_logs_session ON agent_call_logs(session_id);
+      CREATE INDEX IF NOT EXISTS idx_agent_call_logs_started ON agent_call_logs(started_at);
+    `);
   }
 
   /**

--- a/packages/server/src/db/DatabaseManager.test.js
+++ b/packages/server/src/db/DatabaseManager.test.js
@@ -460,6 +460,163 @@ describe('DatabaseManager', () => {
     });
   });
 
+  describe('agent_type column migration', () => {
+    it('sessions table has agent_type column with default claude-code', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(sessions)').all();
+      const agentTypeColumn = columns.find((col) => col.name === 'agent_type');
+
+      expect(agentTypeColumn).toBeDefined();
+      expect(agentTypeColumn.type).toBe('TEXT');
+      expect(agentTypeColumn.dflt_value).toBe("'claude-code'");
+    });
+
+    it('new sessions default to claude-code agent_type', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-agent', 'Test Project', '/tmp', now, now);
+      db.prepare('INSERT INTO sessions (id, project_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('sess-agent', 'proj-agent', 'Test Session', 'running', now, now);
+
+      const session = db.prepare('SELECT agent_type FROM sessions WHERE id = ?').get('sess-agent');
+      expect(session.agent_type).toBe('claude-code');
+    });
+
+    it('allows setting a custom agent_type', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-agent2', 'Test Project', '/tmp', now, now);
+      db.prepare("INSERT INTO sessions (id, project_id, name, status, agent_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
+        .run('sess-agent2', 'proj-agent2', 'Test Session', 'running', 'codex', now, now);
+
+      const session = db.prepare('SELECT agent_type FROM sessions WHERE id = ?').get('sess-agent2');
+      expect(session.agent_type).toBe('codex');
+    });
+  });
+
+  describe('agent_call_logs table migration', () => {
+    it('agent_call_logs table exists', () => {
+      const db = manager.get();
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all().map(t => t.name);
+      expect(tables).toContain('agent_call_logs');
+    });
+
+    it('has all expected columns', () => {
+      const db = manager.get();
+      const columns = db.prepare('PRAGMA table_info(agent_call_logs)').all().map(c => c.name);
+
+      expect(columns).toContain('id');
+      expect(columns).toContain('session_id');
+      expect(columns).toContain('conversation_id');
+      expect(columns).toContain('agent_type');
+      expect(columns).toContain('model');
+      expect(columns).toContain('call_type');
+      expect(columns).toContain('prompt_length');
+      expect(columns).toContain('input_tokens');
+      expect(columns).toContain('output_tokens');
+      expect(columns).toContain('thinking_tokens');
+      expect(columns).toContain('cache_read_tokens');
+      expect(columns).toContain('cache_write_tokens');
+      expect(columns).toContain('total_tokens');
+      expect(columns).toContain('started_at');
+      expect(columns).toContain('completed_at');
+      expect(columns).toContain('duration_ms');
+      expect(columns).toContain('status');
+      expect(columns).toContain('error_message');
+      expect(columns).toContain('metadata');
+      expect(columns).toContain('created_at');
+    });
+
+    it('has indexes on session_id and started_at', () => {
+      const db = manager.get();
+      const indexes = db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='agent_call_logs'").all().map(i => i.name);
+
+      expect(indexes).toContain('idx_agent_call_logs_session');
+      expect(indexes).toContain('idx_agent_call_logs_started');
+    });
+
+    it('enforces foreign key to sessions table', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      // Inserting with a non-existent session_id should fail due to FK constraint
+      expect(() => {
+        db.prepare(
+          `INSERT INTO agent_call_logs (id, session_id, agent_type, call_type, started_at, status, created_at)
+           VALUES (?, ?, ?, ?, ?, 'pending', ?)`
+        ).run('call-fk', 'nonexistent-session', 'claude-code', 'runSession', now, now);
+      }).toThrow();
+    });
+
+    it('status column defaults to pending and respects CHECK constraint', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      // Create project and session
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-acl', 'Test', '/tmp', now, now);
+      db.prepare('INSERT INTO sessions (id, project_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('sess-acl', 'proj-acl', 'Test Session', 'running', now, now);
+
+      // Insert a call log row
+      db.prepare(
+        `INSERT INTO agent_call_logs (id, session_id, agent_type, call_type, started_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('call-status', 'sess-acl', 'claude-code', 'runSession', now, now);
+
+      const row = db.prepare('SELECT status FROM agent_call_logs WHERE id = ?').get('call-status');
+      expect(row.status).toBe('pending');
+
+      // Valid status values
+      expect(() => {
+        db.prepare('UPDATE agent_call_logs SET status = ? WHERE id = ?').run('streaming', 'call-status');
+      }).not.toThrow();
+
+      expect(() => {
+        db.prepare('UPDATE agent_call_logs SET status = ? WHERE id = ?').run('completed', 'call-status');
+      }).not.toThrow();
+
+      expect(() => {
+        db.prepare('UPDATE agent_call_logs SET status = ? WHERE id = ?').run('error', 'call-status');
+      }).not.toThrow();
+
+      // Invalid status should throw
+      expect(() => {
+        db.prepare('UPDATE agent_call_logs SET status = ? WHERE id = ?').run('invalid', 'call-status');
+      }).toThrow();
+    });
+
+    it('cascades delete when session is deleted', () => {
+      const db = manager.get();
+      const now = Date.now();
+
+      // Create project, session, and call log
+      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('proj-cascade', 'Test', '/tmp', now, now);
+      db.prepare('INSERT INTO sessions (id, project_id, name, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run('sess-cascade', 'proj-cascade', 'Test Session', 'running', now, now);
+      db.prepare(
+        `INSERT INTO agent_call_logs (id, session_id, agent_type, call_type, started_at, status, created_at)
+         VALUES (?, ?, ?, ?, ?, 'pending', ?)`
+      ).run('call-cascade', 'sess-cascade', 'claude-code', 'runSession', now, now);
+
+      // Verify call log exists
+      const before = db.prepare('SELECT * FROM agent_call_logs WHERE id = ?').get('call-cascade');
+      expect(before).toBeTruthy();
+
+      // Delete the session
+      db.prepare('DELETE FROM sessions WHERE id = ?').run('sess-cascade');
+
+      // Call log should be cascaded
+      const after = db.prepare('SELECT * FROM agent_call_logs WHERE id = ?').get('call-cascade');
+      expect(after).toBeUndefined();
+    });
+  });
+
   describe('conversation_messages model column migration', () => {
     it('has model column with TEXT type', () => {
       const db = manager.get();

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -24,6 +24,7 @@ export { SettingsRepository } from './SettingsRepository.js';
 // ProviderRepository replaces ModelProviderRepository; keep the old name exported for any leftover imports
 export { ProviderRepository } from './ProviderRepository.js';
 export { ProviderRepository as ModelProviderRepository } from './ProviderRepository.js';
+export { AgentCallLogRepository } from './AgentCallLogRepository.js';
 
 // Singleton instances
 import { ProjectRepository } from './ProjectRepository.js';
@@ -42,6 +43,7 @@ import { CommandRunRepository } from './CommandRunRepository.js';
 import { QuickResponseRepository } from './QuickResponseRepository.js';
 import { SettingsRepository } from './SettingsRepository.js';
 import { ProviderRepository } from './ProviderRepository.js';
+import { AgentCallLogRepository } from './AgentCallLogRepository.js';
 
 export const projects = new ProjectRepository();
 export const projectDefaults = new ProjectDefaultsRepository();
@@ -59,6 +61,7 @@ export const commandRuns = new CommandRunRepository();
 export const quickResponses = new QuickResponseRepository();
 export const settings = new SettingsRepository();
 export const modelProviders = new ProviderRepository();
+export const agentCallLogs = new AgentCallLogRepository();
 
 // SessionRepository needs to be instantiated after messages is available
 import { SessionRepository } from './SessionRepository.js';

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -281,3 +281,41 @@ CREATE INDEX IF NOT EXISTS idx_command_runs_status ON command_runs(status);
 CREATE INDEX IF NOT EXISTS idx_quick_responses_project ON quick_responses(project_id);
 CREATE INDEX IF NOT EXISTS idx_quick_responses_sort ON quick_responses(project_id, sort_order);
 CREATE INDEX IF NOT EXISTS idx_provider_models_provider ON provider_models(provider_id);
+
+-- Agent call logs (metrics and analytics for agent interactions)
+CREATE TABLE IF NOT EXISTS agent_call_logs (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  conversation_id TEXT,
+  agent_type TEXT NOT NULL,
+  model TEXT,
+
+  -- Request info
+  call_type TEXT NOT NULL,       -- 'runSession' | 'continueSession' | 'continueSessionWithExistingMessage'
+  prompt_length INTEGER,
+
+  -- Response token info (updated during streaming and finalized at result)
+  input_tokens INTEGER DEFAULT 0,
+  output_tokens INTEGER DEFAULT 0,
+  thinking_tokens INTEGER DEFAULT 0,
+  cache_read_tokens INTEGER DEFAULT 0,
+  cache_write_tokens INTEGER DEFAULT 0,
+  total_tokens INTEGER DEFAULT 0,
+
+  -- Timing
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  duration_ms INTEGER,
+
+  -- Status
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'streaming', 'completed', 'error')),
+  error_message TEXT,
+
+  -- Metadata (JSON blob for extensibility)
+  metadata TEXT,
+
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_call_logs_session ON agent_call_logs(session_id);
+CREATE INDEX IF NOT EXISTS idx_agent_call_logs_started ON agent_call_logs(started_at);

--- a/packages/server/src/services/agentCallLogger.js
+++ b/packages/server/src/services/agentCallLogger.js
@@ -1,0 +1,79 @@
+import { nanoid } from 'nanoid';
+import { agentCallLogs } from '../database.js';
+
+/**
+ * Service for logging agent calls with in-memory tracking for active calls.
+ * Uses AgentCallLogRepository for persistence.
+ */
+export class AgentCallLogger {
+  constructor() {
+    /** @type {Map<string, Object>} Active (in-flight) calls */
+    this.activeCalls = new Map();
+  }
+
+  /**
+   * Start logging a new agent call.
+   * @param {import('../agents/types.js').AgentCallMeta} meta
+   * @returns {string} callId
+   */
+  startCall(meta) {
+    const callId = nanoid();
+    agentCallLogs.create({
+      id: callId,
+      sessionId: meta.sessionId,
+      conversationId: meta.conversationId || null,
+      agentType: meta.agentType || 'claude-code',
+      model: meta.model || null,
+      callType: meta.callType,
+      promptLength: meta.promptLength || 0,
+    });
+    this.activeCalls.set(callId, { id: callId, ...meta });
+    return callId;
+  }
+
+  /**
+   * Update token counts during streaming (called from handleStreamEvent on result events)
+   */
+  updateUsage(callId, usage) {
+    if (!this.activeCalls.has(callId)) return;
+    agentCallLogs.updateUsage(callId, {
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      thinkingTokens: usage.thinkingTokens,
+      cacheReadTokens: usage.cacheReadInputTokens,
+      cacheWriteTokens: usage.cacheCreationInputTokens,
+    });
+  }
+
+  /**
+   * Mark call as completed or errored.
+   */
+  completeCall(callId, { success, usage, error }) {
+    agentCallLogs.complete(callId, {
+      success,
+      inputTokens: usage?.inputTokens,
+      outputTokens: usage?.outputTokens,
+      cacheReadTokens: usage?.cacheReadInputTokens,
+      cacheWriteTokens: usage?.cacheCreationInputTokens,
+      errorMessage: error?.message,
+    });
+    this.activeCalls.delete(callId);
+  }
+
+  /**
+   * Get session stats (delegates to repository)
+   */
+  getSessionStats(sessionId) {
+    return agentCallLogs.getSessionStats(sessionId);
+  }
+
+  /**
+   * Get global stats (delegates to repository)
+   */
+  getGlobalStats(startDate, endDate) {
+    return agentCallLogs.getGlobalStats(startDate, endDate);
+  }
+}
+
+// Singleton
+export const agentCallLogger = new AgentCallLogger();

--- a/packages/server/src/services/agentCallLogger.test.js
+++ b/packages/server/src/services/agentCallLogger.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AgentCallLogger } from './agentCallLogger.js';
+
+// Mock nanoid
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'mock-call-id-' + Math.random().toString(36).slice(2, 8)),
+}));
+
+// Mock the database module
+vi.mock('../database.js', () => ({
+  agentCallLogs: {
+    create: vi.fn(),
+    updateUsage: vi.fn(),
+    complete: vi.fn(),
+    getSessionStats: vi.fn(() => [{ call_type: 'runSession', call_count: 1 }]),
+    getGlobalStats: vi.fn(() => []),
+  },
+}));
+
+import { agentCallLogs } from '../database.js';
+
+describe('AgentCallLogger', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = new AgentCallLogger();
+    vi.clearAllMocks();
+  });
+
+  describe('startCall', () => {
+    it('creates a log entry and returns callId', () => {
+      const meta = {
+        sessionId: 'session-1',
+        conversationId: 'conv-1',
+        callType: 'runSession',
+        agentType: 'claude-code',
+        model: 'claude-sonnet-4-20250514',
+        promptLength: 500,
+      };
+
+      const callId = logger.startCall(meta);
+
+      expect(callId).toBeTruthy();
+      expect(agentCallLogs.create).toHaveBeenCalledWith({
+        id: callId,
+        sessionId: 'session-1',
+        conversationId: 'conv-1',
+        agentType: 'claude-code',
+        model: 'claude-sonnet-4-20250514',
+        callType: 'runSession',
+        promptLength: 500,
+      });
+      expect(logger.activeCalls.has(callId)).toBe(true);
+    });
+
+    it('defaults agentType to claude-code when not provided', () => {
+      const meta = {
+        sessionId: 'session-1',
+        callType: 'runSession',
+        promptLength: 100,
+      };
+
+      logger.startCall(meta);
+
+      expect(agentCallLogs.create).toHaveBeenCalledWith(
+        expect.objectContaining({ agentType: 'claude-code' })
+      );
+    });
+  });
+
+  describe('updateUsage', () => {
+    it('persists token updates for active calls', () => {
+      const callId = logger.startCall({
+        sessionId: 'session-1',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      logger.updateUsage(callId, {
+        inputTokens: 1000,
+        outputTokens: 500,
+        thinkingTokens: 200,
+        cacheReadInputTokens: 300,
+        cacheCreationInputTokens: 100,
+      });
+
+      expect(agentCallLogs.updateUsage).toHaveBeenCalledWith(callId, {
+        inputTokens: 1000,
+        outputTokens: 500,
+        thinkingTokens: 200,
+        cacheReadTokens: 300,
+        cacheWriteTokens: 100,
+      });
+    });
+
+    it('is a no-op for unknown callId', () => {
+      logger.updateUsage('unknown-call', { inputTokens: 1000 });
+      expect(agentCallLogs.updateUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('completeCall', () => {
+    it('with success persists final state and removes from activeCalls', () => {
+      const callId = logger.startCall({
+        sessionId: 'session-1',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      logger.completeCall(callId, {
+        success: true,
+        usage: {
+          inputTokens: 1000,
+          outputTokens: 500,
+          cacheReadInputTokens: 300,
+          cacheCreationInputTokens: 100,
+        },
+      });
+
+      expect(agentCallLogs.complete).toHaveBeenCalledWith(callId, {
+        success: true,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 300,
+        cacheWriteTokens: 100,
+        errorMessage: undefined,
+      });
+      expect(logger.activeCalls.has(callId)).toBe(false);
+    });
+
+    it('with error persists error_message', () => {
+      const callId = logger.startCall({
+        sessionId: 'session-1',
+        callType: 'runSession',
+        promptLength: 100,
+      });
+
+      const error = new Error('Connection timeout');
+      logger.completeCall(callId, { success: false, error });
+
+      expect(agentCallLogs.complete).toHaveBeenCalledWith(callId, {
+        success: false,
+        inputTokens: undefined,
+        outputTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+        errorMessage: 'Connection timeout',
+      });
+      expect(logger.activeCalls.has(callId)).toBe(false);
+    });
+  });
+
+  describe('getSessionStats', () => {
+    it('delegates to repository correctly', () => {
+      const result = logger.getSessionStats('session-1');
+      expect(agentCallLogs.getSessionStats).toHaveBeenCalledWith('session-1');
+      expect(result).toEqual([{ call_type: 'runSession', call_count: 1 }]);
+    });
+  });
+
+  describe('getGlobalStats', () => {
+    it('delegates to repository correctly', () => {
+      logger.getGlobalStats(1000, 2000);
+      expect(agentCallLogs.getGlobalStats).toHaveBeenCalledWith(1000, 2000);
+    });
+  });
+});

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -1,4 +1,3 @@
-import { query } from '@anthropic-ai/claude-agent-sdk';
 import { sessions, messages, workLogs, attachments, conversations, modelProviders } from '../database.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES, DEFAULT_SERVER_PORT, DEFAULT_SYSTEM_PROMPT } from '@claudetools/shared';
@@ -8,6 +7,8 @@ import { checkAndTriggerNextTemplate } from './templateTriggerService.js';
 import * as diffService from './diffService.js';
 import { createClaudeCodeSpawner, createRobustEnv } from './nodeSpawnHelper.js';
 import { schedulerService } from './schedulerService.js';
+import { agentGateway } from '../agents/AgentGateway.js';
+import { LoggingAgentWrapper } from '../agents/LoggingAgentWrapper.js';
 
 /** @type {Map<string, string|null>} Track last message ID for end-of-turn work log association */
 const lastMessageIds = new Map();
@@ -97,6 +98,26 @@ function updateTurnUsage(conversationId, usage, eventType) {
 
 /** Check if mock mode is enabled (for E2E testing) */
 const isMockMode = () => process.env.MOCK_CLAUDE === 'true';
+
+/**
+ * Create the agent for a session, using gateway + logging.
+ * In mock mode, returns a mock agent that delegates to mockQuery.
+ *
+ * @param {string} agentType - The agent type (e.g., 'claude-code')
+ * @returns {{ execute: (queryParams: any, meta?: any) => AsyncGenerator }}
+ */
+function createAgentForSession(agentType = 'claude-code') {
+  if (isMockMode()) {
+    // Mock mode: return a fake "agent" that delegates to mockQuery
+    return {
+      async *execute(queryParams) {
+        yield* mockQuery(queryParams);
+      },
+    };
+  }
+  const baseAgent = agentGateway.createAgent(agentType);
+  return new LoggingAgentWrapper(baseAgent);
+}
 
 /**
  * Get the base API URL for canvas and session operations.
@@ -963,8 +984,9 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
     // Build prompt with attachment context
     const promptWithAttachments = buildPromptWithAttachments(prompt, fileAttachments);
 
-    // Choose between mock and real query based on environment
-    const queryFn = isMockMode() ? mockQuery : query;
+    // Create agent via gateway (or mock agent in mock mode)
+    const agentType = session.agentType || 'claude-code';
+    const agent = createAgentForSession(agentType);
 
     // Derive provider from the model ID (returns null for Anthropic/SDK defaults)
     const provider = resolveProviderFromModel(model);
@@ -996,8 +1018,18 @@ export async function runSession(sessionId, prompt, workingDirectory, systemProm
       envAuthToken: queryParams.options?.env?.ANTHROPIC_AUTH_TOKEN ? '[SET]' : '[not set]',
     });
 
-    // Run the query with the SDK (or mock)
-    for await (const event of queryFn(queryParams)) {
+    // Logging metadata for agent call tracking
+    const agentCallMeta = {
+      sessionId,
+      conversationId: activeConversation.id,
+      callType: 'runSession',
+      agentType,
+      model,
+      promptLength: promptWithAttachments.length,
+    };
+
+    // Run the query with the agent (SDK via gateway, or mock)
+    for await (const event of agent.execute(queryParams, agentCallMeta)) {
       if (controller.signal.aborted) break;
 
       await handleStreamEvent(sessionId, event);
@@ -1124,8 +1156,9 @@ export async function continueSession(sessionId, content, workingDirectory, syst
     sessions.update(sessionId, { status: 'running' });
     broadcastSessionStatus(sessionId, 'running');
 
-    // Choose between mock and real query based on environment
-    const queryFn = isMockMode() ? mockQuery : query;
+    // Create agent via gateway (or mock agent in mock mode)
+    const agentType = session.agentType || 'claude-code';
+    const agent = createAgentForSession(agentType);
 
     // Derive provider from the model ID (returns null for Anthropic/SDK defaults)
     const provider = resolveProviderFromModel(model);
@@ -1195,8 +1228,19 @@ export async function continueSession(sessionId, content, workingDirectory, syst
           },
         };
 
+    // Logging metadata for agent call tracking
+    const agentCallMeta = {
+      sessionId,
+      conversationId: activeConversation.id,
+      callType: 'continueSession',
+      agentType,
+      model,
+      isResume: canResume,
+      promptLength: promptWithContext.length,
+    };
+
     // Resume the session with the new message
-    for await (const event of queryFn(queryParams)) {
+    for await (const event of agent.execute(queryParams, agentCallMeta)) {
       if (controller.signal.aborted) break;
 
       await handleStreamEvent(sessionId, event);
@@ -1317,8 +1361,9 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
     // Use the existing user message content as the prompt
     // Note: We do NOT create a new user message here - it already exists
 
-    // Choose between mock and real query based on environment
-    const queryFn = isMockMode() ? mockQuery : query;
+    // Create agent via gateway (or mock agent in mock mode)
+    const agentType = session.agentType || 'claude-code';
+    const agent = createAgentForSession(agentType);
 
     // Derive provider from the model ID (returns null for Anthropic/SDK defaults)
     const provider = resolveProviderFromModel(model);
@@ -1381,8 +1426,19 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
           },
         };
 
+    // Logging metadata for agent call tracking
+    const agentCallMeta = {
+      sessionId,
+      conversationId: conversationId,
+      callType: 'continueSessionWithExistingMessage',
+      agentType,
+      model,
+      isResume: canResume,
+      promptLength: promptWithContext.length,
+    };
+
     // Run the query
-    for await (const event of queryFn(queryParams)) {
+    for await (const event of agent.execute(queryParams, agentCallMeta)) {
       if (controller.signal.aborted) break;
 
       await handleStreamEvent(sessionId, event);


### PR DESCRIPTION
## Summary
- Introduces a gateway/adapter pattern (`BaseAgent` → `AgentGateway` → `ClaudeCodeAdapter`) to decouple `sessionManager.js` from the Claude Code SDK, enabling future multi-agent support (e.g., Codex)
- Adds automatic call logging via `LoggingAgentWrapper` that tracks every agent interaction with timing, token usage, and error status in a new `agent_call_logs` SQLite table
- Exposes 3 new metrics API endpoints (`/api/sessions/:id/agent-stats`, `/api/sessions/:id/agent-calls`, `/api/agent-stats`) for analytics and debugging

## Test plan
- [x] All 48 new unit tests pass (BaseAgent, ClaudeCodeAdapter, AgentGateway, AgentCallLogRepository, AgentCallLogger, LoggingAgentWrapper)
- [x] All 2348 existing tests pass with zero regressions (86 test files)
- [x] Lint passes cleanly
- [ ] E2E tests via `./scripts/pw.sh test` (mock mode preserved through `createAgentForSession()` helper)
- [ ] Manual smoke test: create session, continue session, verify agent_call_logs populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)