### PR TITLE
Improve encryption test isolation to prevent touching real ~/.claudetools directory

### DIFF
--- a/packages/server/src/services/encryption.js
+++ b/packages/server/src/services/encryption.js
@@ -9,14 +9,16 @@ const IV_LENGTH = 12; // 96 bits is recommended for GCM
 const SEPARATOR = ':';
 const PARTS_COUNT = 3;
 
+// Allow tests to override the key directory so they never touch the real ~/.claudetools/secret.key
+let _keyDirOverride = null;
+
 /**
  * Get or generate the encryption key.
  * Uses ~/.claudetools/secret.key file (auto-generated on first run)
  * @returns {Buffer} - 32-byte encryption key
  */
 function getEncryptionKey() {
-  // Auto-generate and persist to ~/.claudetools/secret.key
-  const keyDir = join(homedir(), '.claudetools');
+  const keyDir = _keyDirOverride || join(homedir(), '.claudetools');
   const keyPath = join(keyDir, 'secret.key');
 
   if (existsSync(keyPath)) {
@@ -116,4 +118,17 @@ export function decrypt(ciphertext) {
  */
 export function _resetKeyForTesting() {
   _key = null;
+}
+
+/**
+ * Override the key directory so tests use an isolated temp path
+ * instead of the real ~/.claudetools/ directory.
+ * Pass null to restore the default behaviour.
+ * Only intended for test isolation.
+ * @param {string|null} dir
+ * @internal
+ */
+export function _setKeyDirForTesting(dir) {
+  _keyDirOverride = dir;
+  _key = null; // also clear the cached key so the new path takes effect
 }

--- a/packages/server/src/services/encryption.test.js
+++ b/packages/server/src/services/encryption.test.js
@@ -1,30 +1,33 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFileSync, unlinkSync, existsSync } from 'fs';
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { readFileSync, unlinkSync, existsSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
-import { encrypt, decrypt, _resetKeyForTesting } from './encryption.js';
+import { tmpdir } from 'os';
+import { encrypt, decrypt, _resetKeyForTesting, _setKeyDirForTesting } from './encryption.js';
 
 describe('encryption service', () => {
-  const keyPath = join(homedir(), '.claudetools', 'secret.key');
-  const keyBackupPath = join(homedir(), '.claudetools', 'secret.key.backup');
+  // Use an isolated temp directory so tests never touch ~/.claudetools/secret.key
+  const testKeyDir = join(tmpdir(), `claudetools-encryption-test-${process.pid}`);
+  const testKeyPath = join(testKeyDir, 'secret.key');
 
-  // Backup existing key file before tests, restore after
   beforeEach(() => {
-    if (existsSync(keyPath)) {
-      // Key file exists - tests will use the existing key
-      // Note: We don't actually backup/restore because encryption tests
-      // should work with any valid key
+    // Point the encryption module at our isolated temp directory
+    // (this also clears the in-memory key cache)
+    _setKeyDirForTesting(testKeyDir);
+
+    // Remove any leftover key file so each test starts clean
+    if (existsSync(testKeyPath)) {
+      unlinkSync(testKeyPath);
     }
-    // Reset key cache before each test
-    _resetKeyForTesting();
   });
 
-  afterEach(() => {
-    // Clean up any test key files, restore backup if it existed
-    if (existsSync(keyBackupPath)) {
-      // Restore original key
+  afterAll(() => {
+    // Restore default key directory so production code is unaffected
+    _setKeyDirForTesting(null);
+
+    // Clean up temp directory
+    if (existsSync(testKeyDir)) {
+      rmSync(testKeyDir, { recursive: true, force: true });
     }
-    _resetKeyForTesting();
   });
 
   describe('encrypt()', () => {
@@ -173,38 +176,30 @@ describe('encryption service', () => {
   });
 
   describe('key file management', () => {
-    it('auto-generates key file at ~/.claudetools/secret.key when missing', () => {
-      // Remove existing key if it exists
-      if (existsSync(keyPath)) {
-        unlinkSync(keyPath);
-      }
-      _resetKeyForTesting();
+    it('auto-generates key file when missing', () => {
+      // Key file should not exist (cleaned in beforeEach)
+      expect(existsSync(testKeyPath)).toBe(false);
 
       // This should trigger key generation
       encrypt('test');
 
-      expect(existsSync(keyPath)).toBe(true);
+      expect(existsSync(testKeyPath)).toBe(true);
     });
 
     it('generates a valid 64-character hex key (32 bytes)', () => {
-      // Ensure a fresh key
-      if (existsSync(keyPath)) {
-        unlinkSync(keyPath);
-      }
-      _resetKeyForTesting();
+      // Key file should not exist (cleaned in beforeEach)
+      expect(existsSync(testKeyPath)).toBe(false);
 
       encrypt('test');
 
-      const keyContent = readFileSync(keyPath, 'utf-8').trim();
+      const keyContent = readFileSync(testKeyPath, 'utf-8').trim();
       expect(keyContent).toMatch(/^[0-9a-fA-F]{64}$/);
     });
 
     it('regenerates key if existing file is corrupted (non-hex content)', () => {
-      // Note: This test verifies that the system handles corrupted keys gracefully.
-      // The actual regeneration is handled by getEncryptionKey() which logs a warning
-      // and regenerates the key when it encounters invalid hex content.
-      // We verify basic functionality works correctly with a valid key.
-
+      // Write a corrupted key file
+      mkdirSync(testKeyDir, { recursive: true });
+      writeFileSync(testKeyPath, 'not-valid-hex-content');
       _resetKeyForTesting();
 
       const plaintext = 'test';
@@ -212,6 +207,10 @@ describe('encryption service', () => {
       const decrypted = decrypt(encrypted);
 
       expect(decrypted).toBe(plaintext);
+
+      // Key file should now contain a valid key
+      const keyContent = readFileSync(testKeyPath, 'utf-8').trim();
+      expect(keyContent).toMatch(/^[0-9a-fA-F]{64}$/);
     });
   });
 


### PR DESCRIPTION
## Summary

This PR improves test isolation for the encryption service by introducing a `_setKeyDirForTesting()` function that allows tests to use an isolated temporary directory instead of the real `~/.claudetools/secret.key` file.

## Changes

- **encryption.js**: Add `_keyDirOverride` module variable and export `_setKeyDirForTesting()` function
- **encryption.test.js**: Update tests to use temp directory (`/tmp/claudetools-encryption-test-<pid>`) instead of home directory
- Replace backup/restore approach with simpler temp directory isolation
- Use `afterAll()` to restore default key directory and clean up temp files

## Benefits

- Tests never touch the user's real `~/.claudetools/secret.key` file
- Better test isolation - each test run gets a clean state
- Simpler cleanup - just delete the temp directory
- No risk of interfering with user's actual encryption key during development

## Test plan

- [x] All existing encryption tests pass
- [x] Tests no longer create files in `~/.claudetools/`
- [x] Temp directory is properly cleaned up after tests complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)