### PR TITLE
Add running session indicator and model display to improve session UX

### DIFF
--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -3321,4 +3321,53 @@ describe('ConversationTab - Model selector persistence on stop', () => {
       expect(modelSelector.attributes('data-model')).toBe('haiku');
     });
   });
+
+  describe('model display in running state', () => {
+    it('shows model display name next to stop button when session is running', async () => {
+      mockSessionsStore.currentSession.status = 'running';
+      mockSessionsStore.currentSession.model = 'claude-opus-4-6';
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelLabel = wrapper.find('.running-model-label');
+      expect(modelLabel.exists()).toBe(true);
+      expect(modelLabel.text()).toBe('Opus 4.6');
+    });
+
+    it('does not show model label when session has no model set', async () => {
+      mockSessionsStore.currentSession.status = 'running';
+      mockSessionsStore.currentSession.model = null;
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelLabel = wrapper.find('.running-model-label');
+      expect(modelLabel.exists()).toBe(false);
+    });
+
+    it('shows correct name for sonnet model', async () => {
+      mockSessionsStore.currentSession.status = 'running';
+      mockSessionsStore.currentSession.model = 'claude-sonnet-4-6';
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelLabel = wrapper.find('.running-model-label');
+      expect(modelLabel.exists()).toBe(true);
+      expect(modelLabel.text()).toBe('Sonnet 4.6');
+    });
+
+    it('shows correct name for haiku model', async () => {
+      mockSessionsStore.currentSession.status = 'running';
+      mockSessionsStore.currentSession.model = 'claude-haiku-4-5-20251001';
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelLabel = wrapper.find('.running-model-label');
+      expect(modelLabel.exists()).toBe(true);
+      expect(modelLabel.text()).toBe('Haiku 4.5');
+    });
+  });
 });

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -207,10 +207,13 @@
           <span class="loading-spinner"></span>
           <span class="running-title">Claude is working...</span>
         </div>
-        <button type="button" class="btn btn-danger btn-stop" @click="handleStop" :disabled="stopping">
-          <span v-if="stopping" class="loading-spinner"></span>
-          Stop
-        </button>
+        <div class="running-actions">
+          <span v-if="activeModelDisplayName" class="running-model-label">{{ activeModelDisplayName }}</span>
+          <button type="button" class="btn btn-danger btn-stop" @click="handleStop" :disabled="stopping">
+            <span v-if="stopping" class="loading-spinner"></span>
+            Stop
+          </button>
+        </div>
       </div>
 
       <!-- Work logs panel (without its own header) -->
@@ -296,6 +299,7 @@ import { useUiStore } from '../stores/ui.js';
 import { useTemplatesStore } from '../stores/templates.js';
 import { useProjectDefaultsStore } from '../stores/projectDefaults.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
+import { useModelInfo } from '../composables/useModelInfo.js';
 import { useSubmitShortcut } from '../composables/useSubmitShortcut.js';
 import { api } from '../composables/useApi.js';
 import TodoDrawer from './TodoDrawer.vue';
@@ -330,6 +334,7 @@ const templatesStore = useTemplatesStore();
 const defaultsStore = useProjectDefaultsStore();
 const quickResponsesStore = useQuickResponsesStore();
 const projectsStore = useProjectsStore();
+const { getModelDisplayName } = useModelInfo();
 const router = useRouter();
 const route = useRoute();
 
@@ -397,6 +402,12 @@ const isDraft = computed(() => {
 const isScheduledDraft = computed(() => {
   if (!sessionsStore.currentSession) return false;
   return sessionsStore.isScheduledDraft(sessionsStore.currentSession);
+});
+
+const activeModelDisplayName = computed(() => {
+  const model = sessionsStore.currentSession?.model;
+  if (!model) return null;
+  return getModelDisplayName(model);
 });
 
 const unassociatedWorkLogs = computed(() => {
@@ -1726,6 +1737,19 @@ async function handleBranchCreate({ messageId, prompt }) {
   flex-shrink: 0;
 }
 
+.running-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.running-model-label {
+  font-size: 0.75rem;
+  color: var(--color-text-soft, #888);
+  white-space: nowrap;
+}
+
 /* Responsive messages container height */
 @media (min-width: 1200px) {
   .messages {
@@ -1773,6 +1797,10 @@ async function handleBranchCreate({ messageId, prompt }) {
 /* Hide "Claude is working..." text on extremely small screens */
 @media (max-width: 360px) {
   .running-title {
+    display: none;
+  }
+
+  .running-model-label {
     display: none;
   }
 }

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -2216,4 +2216,223 @@ describe('SessionDetailView', () => {
       expect(childPanel.props('summaries')).toBeDefined();
     });
   });
+
+  describe('session active indicator', () => {
+    it('shows spinner when session status is running', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'running',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.exists()).toBe(true);
+    });
+
+    it('shows spinner when session status is starting', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'starting',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.exists()).toBe(true);
+    });
+
+    it('does not show spinner when session status is completed', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'completed',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.exists()).toBe(false);
+    });
+
+    it('does not show spinner when session status is waiting', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.exists()).toBe(false);
+    });
+
+    it('does not show spinner when session status is error', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'error',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.exists()).toBe(false);
+    });
+
+    it('spinner has correct title for running status', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'running',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const indicator = wrapper.find('.session-active-indicator');
+      expect(indicator.attributes('title')).toBe('Session running...');
+    });
+
+    it('spinner has correct title for starting status', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'starting',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const indicator = wrapper.find('.session-active-indicator');
+      expect(indicator.attributes('title')).toBe('Session starting...');
+    });
+  });
 });

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -117,6 +117,15 @@
         </router-link>
         <span class="tab-separator"></span>
 
+        <!-- Session active indicator — sibling of tabs-desktop and tabs-mobile -->
+        <span
+          v-if="isSessionActive"
+          class="session-active-indicator"
+          :title="sessionsStore.currentSession?.status === 'starting' ? 'Session starting...' : 'Session running...'"
+        >
+          <span class="active-spinner"></span>
+        </span>
+
         <!-- Desktop tabs -->
         <div class="tabs-desktop">
           <router-link
@@ -249,6 +258,11 @@ const buttonStatusesToDisplay = computed(() => {
 const canArchive = computed(() => {
   const status = sessionsStore.currentSession?.status;
   return status && status !== 'running';
+});
+
+const isSessionActive = computed(() => {
+  const status = sessionsStore.currentSession?.status;
+  return status === 'running' || status === 'starting';
 });
 
 const tabs = computed(() => [
@@ -875,6 +889,22 @@ async function clearPrUrl() {
   border-radius: 50%;
   margin-left: 4px;
   vertical-align: middle;
+}
+
+.session-active-indicator {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.5rem;
+}
+
+.active-spinner {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid rgba(0, 188, 212, 0.2);
+  border-top-color: #00bcd4;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
 }
 
 /* PR URL editing styles */


### PR DESCRIPTION
## Summary
- Add low-profile spinner in SessionDetailView sub-nav that appears when session is running or starting
- Display model name (e.g., "Opus 4.6") next to Stop button in ConversationTab running state

## Changes

### Part 1: Session Running Indicator in Sub-Nav
**File: `packages/web/src/views/SessionDetailView.vue`**

- Added spinner element that appears in the tab bar when session is running or starting
- Spinner positioned as sibling of desktop/mobile tab containers for responsive support
- Shows different tooltips: "Session running..." vs "Session starting..."
- Added `isSessionActive` computed property
- Added CSS for `.session-active-indicator` and `.active-spinner` with spinning animation

**Visual Result:**
- Desktop: `← Sessions  |  [spinner]  Summary  Conversation  Changes  Canvas  Commands`
- Mobile: `← Sessions  |  [spinner]  [dropdown ▼]`

### Part 2: Model Name in Running State
**File: `packages/web/src/components/ConversationTab.vue`**

- Modified `.running-header` to include model label next to Stop button
- Model label displays clean model name (e.g., "Opus 4.6", "Sonnet 4.6")
- Wrapped model label and Stop button in new `.running-actions` container
- Added `activeModelDisplayName` computed property using `useModelInfo` composable
- Model display hidden on screens ≤360px to match existing responsive patterns

**Visual Result:**
```
┌──────────────────────────────────────────────────┐
│  ⊙ Claude is working...         Opus 4.6  [Stop] │
└──────────────────────────────────────────────────┘
```

## Test Coverage
Added 11 new unit tests:
- **SessionDetailView.test.js** (7 tests): Spinner visibility for different session statuses, tooltip text verification
- **ConversationTab.test.js** (4 tests): Model display name formatting, visibility behavior

All tests passing ✅

## Test Plan
- [x] Unit tests pass (2414 tests passed)
- [ ] Manual testing of spinner in session detail view
- [ ] Verify spinner appears on both desktop and mobile layouts
- [ ] Verify model display shows correct model names
- [ ] Verify model display hides on small screens (≤360px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)