### PR TITLE
Fix: Show third-party model names instead of 'Unknown' in model indicator

### DIFF
--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -3352,5 +3352,17 @@ describe('ConversationTab - Model selector persistence on stop', () => {
       expect(modelLabel.exists()).toBe(true);
       expect(modelLabel.text()).toBe('Haiku 4.5');
     });
+
+    it('shows formatted name for third-party model', async () => {
+      mockSessionsStore.currentSession.status = 'running';
+      mockSessionsStore.currentSession.model = 'deepseek-chat';
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelLabel = wrapper.find('.running-model-label');
+      expect(modelLabel.exists()).toBe(true);
+      expect(modelLabel.text()).toBe('Deepseek Chat');
+    });
   });
 });

--- a/packages/web/src/composables/useModelInfo.js
+++ b/packages/web/src/composables/useModelInfo.js
@@ -1,4 +1,33 @@
 import { CLAUDE_MODELS, DEFAULT_MODEL } from '@claudetools/shared';
+import { useProvidersStore } from '../stores/providers.js';
+
+/**
+ * Format a raw model ID into a human-readable name
+ * Handles third-party models that aren't in CLAUDE_MODELS or providers store
+ * @param {string} modelId - The raw model ID
+ * @returns {string} - Formatted display name
+ */
+function formatModelId(modelId) {
+  if (!modelId) return 'Unknown';
+
+  // Remove path prefixes (e.g., "models/", "accounts/.../models/")
+  let formatted = modelId.replace(/^(.*\/)?models\//, '');
+  formatted = formatted.replace(/^accounts\/[^/]+\/models\//, '');
+
+  // Remove trailing date stamps (e.g., "-20241022")
+  formatted = formatted.replace(/-\d{8}$/, '');
+
+  // Replace hyphens and underscores with spaces
+  formatted = formatted.replace(/[-_]/g, ' ');
+
+  // Title case each word
+  formatted = formatted
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+
+  return formatted || 'Unknown';
+}
 
 /**
  * Composable for handling Claude model information
@@ -15,8 +44,21 @@ export function useModelInfo() {
       return 'Default';
     }
 
-    const model = CLAUDE_MODELS.find((m) => m.id === modelId);
-    return model ? model.name : 'Unknown';
+    // 1. Check hardcoded known models
+    const known = CLAUDE_MODELS.find((m) => m.id === modelId);
+    if (known) return known.name;
+
+    // 2. Check providers store for displayName
+    try {
+      const providersStore = useProvidersStore();
+      const providerModel = providersStore.allModels.find((m) => m.modelId === modelId);
+      if (providerModel?.displayName) return providerModel.displayName;
+    } catch (error) {
+      // Store might not be initialized yet, fall through to formatting
+    }
+
+    // 3. Last resort: format the raw model ID into a readable string
+    return formatModelId(modelId);
   }
 
   /**
@@ -31,7 +73,10 @@ export function useModelInfo() {
     }
 
     const model = CLAUDE_MODELS.find((m) => m.id === modelId);
-    return model ? model.description : '';
+    if (model) return model.description;
+
+    // For unknown models, return the raw model ID so users can see the exact identifier
+    return modelId;
   }
 
   /**
@@ -50,5 +95,6 @@ export function useModelInfo() {
     getModelDisplayName,
     getModelDescription,
     getModelInfo,
+    formatModelId,
   };
 }

--- a/packages/web/src/composables/useModelInfo.test.js
+++ b/packages/web/src/composables/useModelInfo.test.js
@@ -33,9 +33,9 @@ describe('useModelInfo', () => {
       expect(getModelDisplayName('')).toBe('Default');
     });
 
-    it('returns "Unknown" for unrecognized model ID', () => {
+    it('returns formatted name for unrecognized model ID', () => {
       const { getModelDisplayName } = useModelInfo();
-      expect(getModelDisplayName('some-unknown-model')).toBe('Unknown');
+      expect(getModelDisplayName('some-unknown-model')).toBe('Some Unknown Model');
     });
   });
 
@@ -61,9 +61,9 @@ describe('useModelInfo', () => {
       expect(getModelDescription(null)).toBe('Most capable (default)');
     });
 
-    it('returns empty string for unrecognized model ID', () => {
+    it('returns raw model ID for unrecognized model', () => {
       const { getModelDescription } = useModelInfo();
-      expect(getModelDescription('unknown-model')).toBe('');
+      expect(getModelDescription('unknown-model')).toBe('unknown-model');
     });
   });
 
@@ -108,14 +108,56 @@ describe('useModelInfo', () => {
       });
     });
 
-    it('returns Unknown name with empty description for unrecognized model', () => {
+    it('returns formatted name with raw model ID as description for unrecognized model', () => {
       const { getModelInfo } = useModelInfo();
       const info = getModelInfo('unknown-model-id');
 
       expect(info).toEqual({
-        name: 'Unknown',
-        description: '',
+        name: 'Unknown Model Id',
+        description: 'unknown-model-id',
       });
+    });
+  });
+
+  describe('formatModelId', () => {
+    it('formats simple model ID', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('some-unknown-model')).toBe('Some Unknown Model');
+    });
+
+    it('formats GPT model', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('gpt-4o')).toBe('Gpt 4o');
+    });
+
+    it('formats DeepSeek model', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('deepseek-chat')).toBe('Deepseek Chat');
+    });
+
+    it('formats Claude model with date stamp', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('claude-3-5-sonnet-20241022')).toBe('Claude 3 5 Sonnet');
+    });
+
+    it('formats model with path prefix', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('models/my-model')).toBe('My Model');
+    });
+
+    it('formats model with underscore', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('my_model_name')).toBe('My Model Name');
+    });
+
+    it('handles empty string', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId('')).toBe('Unknown');
+    });
+
+    it('handles null', () => {
+      const { formatModelId } = useModelInfo();
+      expect(formatModelId(null)).toBe('Unknown');
     });
   });
 


### PR DESCRIPTION
## Summary
When using a third-party model provider, the model indicator next to the stop button was displaying **"Unknown"** instead of the actual model name. This PR fixes the issue with a robust 3-tier lookup system.

## Problem
The `getModelDisplayName()` function in `useModelInfo.js` only checked hardcoded model IDs against a list of 3 known Anthropic models. Any third-party model ID (e.g., `deepseek-chat`, `gpt-4o`) fell through to the "Unknown" fallback.

## Solution
Implemented a 3-tier lookup system in `getModelDisplayName()`:
1. **Check hardcoded known models** (CLAUDE_MODELS) - for official Anthropic models
2. **Check providers store** for `displayName` - for user-configured third-party providers
3. **Fall back to `formatModelId()`** - intelligent string formatting for any unknown model

## Changes
### `packages/web/src/composables/useModelInfo.js`
- Added `formatModelId()` helper function that:
  - Strips path prefixes (`models/`, `accounts/.../models/`)
  - Removes trailing date stamps (`-YYYYMMDD`)
  - Replaces hyphens/underscores with spaces
  - Title-cases each word
- Updated `getModelDisplayName()` with 3-tier lookup
- Updated `getModelDescription()` to return raw model ID for unknown models (instead of empty string)

### `packages/web/src/composables/useModelInfo.test.js`
- Updated 3 existing tests to match new behavior
- Added comprehensive `formatModelId` test suite with 8 test cases

### `packages/web/src/components/ConversationTab.test.js`
- Added test for third-party model display ("Deepseek Chat")

## Example Behavior
- `deepseek-chat` → **"Deepseek Chat"**
- `gpt-4o` → **"Gpt 4o"**
- `claude-3-5-sonnet-20241022` → **"Claude 3 5 Sonnet"** (date removed)
- `models/my-model` → **"My Model"** (prefix stripped)

## Test Plan
✅ All 27 useModelInfo tests pass
✅ All 67 ConversationTab tests pass
✅ Full web package test suite passes

## Test Plan
- [x] Unit tests for formatModelId() function
- [x] Unit tests for getModelDisplayName() with third-party models
- [x] Integration test in ConversationTab for model display
- [x] Verified all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)