### PR TITLE
Move session active spinner to Conversations tab

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -117,15 +117,6 @@
         </router-link>
         <span class="tab-separator"></span>
 
-        <!-- Session active indicator — sibling of tabs-desktop and tabs-mobile -->
-        <span
-          v-if="isSessionActive"
-          class="session-active-indicator"
-          :title="sessionsStore.currentSession?.status === 'starting' ? 'Session starting...' : 'Session running...'"
-        >
-          <span class="active-spinner"></span>
-        </span>
-
         <!-- Desktop tabs -->
         <div class="tabs-desktop">
           <router-link
@@ -145,6 +136,14 @@
               class="canvas-indicator"
               title="Canvas contains files"
             ></span>
+            <span
+              v-if="tab.id === 'conversation' && isSessionActive"
+              class="session-active-indicator"
+              :title="sessionsStore.currentSession?.status === 'starting'
+                ? 'Session starting...' : 'Session running...'"
+            >
+              <span class="active-spinner"></span>
+            </span>
           </router-link>
         </div>
 
@@ -152,7 +151,7 @@
         <div class="tabs-mobile">
           <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
             <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
-              {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' •' : '' }}{{ tab.id === 'canvas' && canvasItemCount > 0 ? ' •' : '' }}
+              {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' •' : '' }}{{ tab.id === 'canvas' && canvasItemCount > 0 ? ' •' : '' }}{{ tab.id === 'conversation' && isSessionActive ? ' ...' : '' }}
             </option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- Relocates the active session spinner indicator from a standalone element to inline within the Conversations tab
- Adds ellipsis indicator (...) to mobile dropdown when session is active
- Maintains consistent visual pattern with other tab indicators (Changes •, Canvas •)

## Changes
**Before:** The spinner was a standalone element positioned before all tabs in the sub-nav, creating visual separation from the actual tab content.

**After:** The spinner now appears directly next to the "Conversations" tab label, inline with other tab indicators like the dot for Changes and Canvas tabs.

### Desktop View
- Spinner moves from outside the tabs container to inside the Conversations tab link
- Uses existing `.session-active-indicator` and `.active-spinner` CSS classes

### Mobile View
- Adds "..." suffix to Conversations option in dropdown when session is active
- Follows same pattern as Changes (•) and Canvas (•) indicators

## Files Changed
- `packages/web/src/views/SessionDetailView.vue` - Template restructuring to move spinner inline

## Test Plan
- [ ] Verify spinner appears next to Conversations tab when session is running/starting
- [ ] Verify spinner tooltip displays correct status message
- [ ] Test desktop view - spinner positioned correctly inline
- [ ] Test mobile view - ellipsis (...) appears in dropdown when session active
- [ ] Verify no visual regressions with other tab indicators (Changes, Canvas)
- [ ] Confirm spinner hidden when session is not active

🤖 Generated with [Claude Code](https://claude.com/claude-code)