### PR TITLE
Fix cross-session conversation and streaming state issues

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -298,7 +298,6 @@ import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useTemplatesStore } from '../stores/templates.js';
 import { useProjectDefaultsStore } from '../stores/projectDefaults.js';
-import { useSessionSubscription } from '../composables/useWebSocket.js';
 import { useModelInfo } from '../composables/useModelInfo.js';
 import { useSubmitShortcut } from '../composables/useSubmitShortcut.js';
 import { api } from '../composables/useApi.js';
@@ -368,13 +367,11 @@ const branchEditorRef = ref(null);
 const selectedModel = ref(null); // Currently selected model for next message
 let draftSaveTimer = null;
 
-const partialText = ref('');
+// partialText comes from the sessions store (set by SessionDetailView's WebSocket handlers)
+const partialText = computed(() => sessionsStore.partialText);
 const isNearBottom = ref(true);
 const hasNewMessages = ref(false);
 let debounceTimer = null;
-let partialThrottleTimer = null;
-let pendingPartialText = null;
-const PARTIAL_THROTTLE_MS = 150; // Throttle streaming updates to reduce CPU load on iPad
 
 const SCROLL_THRESHOLD = 100; // pixels from bottom to consider "at bottom"
 
@@ -506,25 +503,8 @@ const workingDirectory = computed(() => {
   return result;
 });
 
-// Subscribe to partial messages for streaming, work logs, and conversation events
-const {
-  onPartial,
-  onMessage,
-  onWorkLog,
-  onWorkLogsAssociated,
-  onThinkingPartial,
-  onConversationCreated,
-  onConversationUpdated,
-  onConversationDeleted,
-} = useSessionSubscription(props.sessionId);
-let unsubPartial = null;
-let unsubMessage = null;
-let unsubWorkLog = null;
-let unsubWorkLogsAssociated = null;
-let unsubThinkingPartial = null;
-let unsubConvCreated = null;
-let unsubConvUpdated = null;
-let unsubConvDeleted = null;
+// WebSocket handlers are now consolidated in SessionDetailView.
+// ConversationTab reads from the Pinia store reactively.
 
 function handleScroll() {
   const container = messagesContainer.value;
@@ -590,78 +570,10 @@ onMounted(async () => {
     }
   }
 
-  // Throttle partial text updates to reduce CPU load on iPad
-  // Without throttling, rapid updates cause excessive re-renders and markdown parsing
-  unsubPartial = onPartial((text) => {
-    pendingPartialText = text;
-
-    // If no throttle timer is running, update immediately and start timer
-    if (!partialThrottleTimer) {
-      partialText.value = text;
-      scrollToBottom();
-
-      partialThrottleTimer = setTimeout(() => {
-        // Apply any pending update that arrived during throttle period
-        if (pendingPartialText !== null && pendingPartialText !== partialText.value) {
-          partialText.value = pendingPartialText;
-          scrollToBottom();
-        }
-        partialThrottleTimer = null;
-        pendingPartialText = null;
-      }, PARTIAL_THROTTLE_MS);
-    }
-  });
-
-  // Clear partial text when full message arrives
-  unsubMessage = onMessage(() => {
-    partialText.value = '';
-  });
-
-  // Subscribe to work log updates
-  // Note: Work logs are displayed in LiveWorkLogPanel which has its own scroll management
-  unsubWorkLog = onWorkLog((log) => {
-    sessionsStore.addWorkLog(log);
-  });
-
-  // Subscribe to work log association events (re-associate _unassociated logs)
-  unsubWorkLogsAssociated = onWorkLogsAssociated((messageId) => {
-    sessionsStore.associateWorkLogs(messageId);
-  });
-
-  // Subscribe to partial thinking updates for streaming display
-  // Note: Partial thinking is displayed in LiveWorkLogPanel which has its own scroll management
-  unsubThinkingPartial = onThinkingPartial((thinking) => {
-    if (thinking === null) {
-      sessionsStore.clearPartialThinking(props.sessionId);
-    } else {
-      sessionsStore.setPartialThinking(thinking, props.sessionId);
-    }
-  });
-
-  // Subscribe to conversation events for real-time updates
-  unsubConvCreated = onConversationCreated((conversation) => {
-    console.log(`[CONV] CONVERSATION_CREATED event: conversation ${conversation.id}, isActive: ${conversation.isActive}`);
-    sessionsStore.addConversation(conversation);
-    // The watcher on activeConversationId will trigger the fetch automatically
-  });
-
-  unsubConvUpdated = onConversationUpdated((conversation) => {
-    console.log(`[CONV] CONVERSATION_UPDATED event: conversation ${conversation.id}, isActive: ${conversation.isActive}`);
-    sessionsStore.updateConversation(conversation);
-  });
-
-  unsubConvDeleted = onConversationDeleted((conversationId, newActiveConv) => {
-    console.log(`[CONV] CONVERSATION_DELETED event: deleted ${conversationId}, newActive: ${newActiveConv?.id || 'none'}`);
-    sessionsStore.removeConversation(conversationId, newActiveConv);
-    // If we have a new active conversation, fetch its messages
-    if (newActiveConv) {
-      console.log(`[CONV] CONVERSATION_DELETED: fetching messages for new active conversation ${newActiveConv.id}`);
-      sessionsStore.fetchMessages(props.sessionId, false);
-    }
-  });
-
-  // NOTE: onUsageUpdate subscription moved to SessionDetailView.onMounted to ensure
-  // conversations are loaded before usage updates arrive (avoids race conditions)
+  // NOTE: All WebSocket handler subscriptions (onPartial, onMessage, onWorkLog,
+  // onWorkLogsAssociated, onThinkingPartial, onConversationCreated, onConversationUpdated,
+  // onConversationDeleted, onUsageUpdate) are now consolidated in SessionDetailView.
+  // ConversationTab reads from the Pinia store reactively.
 
   // Fetch initial work logs
   await sessionsStore.fetchWorkLogs(props.sessionId);
@@ -678,19 +590,10 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  if (unsubPartial) unsubPartial();
-  if (unsubMessage) unsubMessage();
-  if (unsubWorkLog) unsubWorkLog();
-  if (unsubWorkLogsAssociated) unsubWorkLogsAssociated();
-  if (unsubThinkingPartial) unsubThinkingPartial();
-  if (unsubConvCreated) unsubConvCreated();
-  if (unsubConvUpdated) unsubConvUpdated();
-  if (unsubConvDeleted) unsubConvDeleted();
-  // NOTE: unsubUsage removed - subscription moved to SessionDetailView
+  // NOTE: All WebSocket unsubs removed - handlers are now in SessionDetailView
   if (debounceTimer) clearTimeout(debounceTimer);
   if (draftSaveTimer) clearTimeout(draftSaveTimer);
   if (inputSyncTimer) clearTimeout(inputSyncTimer);
-  if (partialThrottleTimer) clearTimeout(partialThrottleTimer);
   if (messagesContainer.value) {
     messagesContainer.value.removeEventListener('scroll', handleScroll);
   }
@@ -776,6 +679,11 @@ watch(
   }
 );
 
+// Watch partialText from store and scroll to bottom when streaming updates arrive
+watch(partialText, () => {
+  scrollToBottom();
+});
+
 // Re-fetch messages and work logs when session status changes from running to waiting/completed
 // This ensures the UI shows the correct messages after Claude's turn ends.
 // Note: fetchMessages() uses a smart merge strategy that preserves any messages
@@ -788,7 +696,7 @@ watch(
     if (oldStatus === 'running' && (newStatus === 'waiting' || newStatus === 'completed')) {
       console.log(`[CONV] Status changed from ${oldStatus} to ${newStatus}, refetching messages and work logs`);
       // Clear any lingering streaming state (Step 2 - safety net)
-      partialText.value = '';
+      sessionsStore.clearPartialText();
       // Fetch messages first, then work logs - this ensures messages are visible
       await sessionsStore.fetchMessages(props.sessionId, false);
       await sessionsStore.fetchWorkLogs(props.sessionId);
@@ -825,15 +733,8 @@ watch(
   () => sessionsStore.activeConversationId,
   async (newConvId, oldConvId) => {
     if (newConvId && newConvId !== oldConvId) {
-      // Clear streaming message state from previous conversation (Step 1)
-      partialText.value = '';
-
-      // Clear throttle timer to prevent stale partial updates (Step 3)
-      if (partialThrottleTimer) {
-        clearTimeout(partialThrottleTimer);
-        partialThrottleTimer = null;
-      }
-      pendingPartialText = null;
+      // Clear streaming message state from previous conversation
+      sessionsStore.clearPartialText();
 
       // Reset scroll state when switching conversations
       hasNewMessages.value = false;

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -15,6 +15,9 @@ export const useSessionsStore = defineStore('sessions', {
     activeConversationId: null, // Currently selected conversation ID
     workLogs: {}, // Keyed by messageId: { [messageId]: WorkLog[] }
     partialThinkingBySession: {}, // Keyed by sessionId: { [sessionId]: string | null }
+    partialText: '', // Streaming partial text for current assistant response
+    _partialThrottleTimer: null, // Timer for throttling partial text updates (not reactive)
+    _pendingPartialText: null, // Pending partial text during throttle window (not reactive)
     expandedSessions: new Set(), // Track which parent sessions are expanded
     statusFilter: null, // 'running' | 'idle' | null (null = show all)
     starredFilter: null, // 'starred' | 'unstarred' | null (null = show all)
@@ -969,6 +972,10 @@ export const useSessionsStore = defineStore('sessions', {
     },
 
     addMessage(message) {
+      // Guard: only accept messages for the currently-viewed session
+      if (this.currentSession && message.sessionId && message.sessionId !== this.currentSession.id) {
+        return;
+      }
       // Prevent duplicate additions (can happen if WebSocket delivers message multiple times
       // or if fetchMessages returns the message while we're also receiving it via WebSocket)
       const exists = this.messages.some(m => m.id === message.id);
@@ -1013,6 +1020,10 @@ export const useSessionsStore = defineStore('sessions', {
     },
 
     addWorkLog(log) {
+      // Guard: only accept work logs for the currently-viewed session
+      if (this.currentSession && log.sessionId && log.sessionId !== this.currentSession.id) {
+        return;
+      }
       const messageId = log.messageId || '_unassociated';
       const currentLogs = this.workLogs[messageId] || [];
       // Prevent duplicate work logs - check if log with same id already exists
@@ -1077,6 +1088,43 @@ export const useSessionsStore = defineStore('sessions', {
     // Clear all partial thinking (for cleanup)
     clearAllPartialThinking() {
       this.partialThinkingBySession = {};
+    },
+
+    // ==================== PARTIAL TEXT ACTIONS ====================
+
+    /**
+     * Set partial text with throttling to reduce CPU load on iPad
+     * @param {string} text - The streaming partial text
+     */
+    setPartialText(text) {
+      const PARTIAL_THROTTLE_MS = 150;
+      this._pendingPartialText = text;
+
+      // If no throttle timer is running, update immediately and start timer
+      if (!this._partialThrottleTimer) {
+        this.partialText = text;
+
+        this._partialThrottleTimer = setTimeout(() => {
+          // Apply any pending update that arrived during throttle period
+          if (this._pendingPartialText !== null && this._pendingPartialText !== this.partialText) {
+            this.partialText = this._pendingPartialText;
+          }
+          this._partialThrottleTimer = null;
+          this._pendingPartialText = null;
+        }, PARTIAL_THROTTLE_MS);
+      }
+    },
+
+    /**
+     * Clear partial text and reset throttle state
+     */
+    clearPartialText() {
+      this.partialText = '';
+      this._pendingPartialText = null;
+      if (this._partialThrottleTimer) {
+        clearTimeout(this._partialThrottleTimer);
+        this._partialThrottleTimer = null;
+      }
     },
 
     // ==================== USAGE ACTIONS ====================
@@ -1643,6 +1691,10 @@ export const useSessionsStore = defineStore('sessions', {
      */
     updateConversation(conversation) {
       if (!conversation?.id) return;
+      // Guard: only accept conversations for the currently-viewed session
+      if (this.currentSession && conversation.sessionId && conversation.sessionId !== this.currentSession.id) {
+        return;
+      }
 
       const index = this.conversations.findIndex((c) => c.id === conversation.id);
       if (index !== -1) {
@@ -1667,6 +1719,10 @@ export const useSessionsStore = defineStore('sessions', {
      */
     addConversation(conversation) {
       if (!conversation?.id) return;
+      // Guard: only accept conversations for the currently-viewed session
+      if (this.currentSession && conversation.sessionId && conversation.sessionId !== this.currentSession.id) {
+        return;
+      }
 
       // Check if already exists
       const exists = this.conversations.some((c) => c.id === conversation.id);
@@ -1691,7 +1747,11 @@ export const useSessionsStore = defineStore('sessions', {
      * @param {string} conversationId - Conversation ID
      * @param {Object|null} newActiveConversation - New active conversation if any
      */
-    removeConversation(conversationId, newActiveConversation = null) {
+    removeConversation(conversationId, newActiveConversation = null, sessionId = null) {
+      // Guard: only accept conversation removals for the currently-viewed session
+      if (this.currentSession && sessionId && sessionId !== this.currentSession.id) {
+        return;
+      }
       this.conversations = this.conversations.filter((c) => c.id !== conversationId);
 
       if (newActiveConversation) {

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -4329,4 +4329,364 @@ describe('Sessions Store', () => {
       });
     });
   });
+
+  // ==================== PARTIAL TEXT TESTS ====================
+
+  describe('partialText streaming state', () => {
+    describe('initial state', () => {
+      it('partialText starts as empty string', () => {
+        const store = useSessionsStore();
+        expect(store.partialText).toBe('');
+      });
+    });
+
+    describe('setPartialText', () => {
+      it('updates partialText immediately on first call', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        store.setPartialText('Hello world');
+
+        expect(store.partialText).toBe('Hello world');
+        vi.useRealTimers();
+      });
+
+      it('does not update partialText on a second rapid call (throttled)', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        store.setPartialText('First chunk');
+        expect(store.partialText).toBe('First chunk');
+
+        // Second call within throttle window - should not update yet
+        store.setPartialText('Second chunk');
+        expect(store.partialText).toBe('First chunk');
+
+        vi.useRealTimers();
+      });
+
+      it('applies the latest pending update after the throttle window expires', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        store.setPartialText('First chunk');
+        store.setPartialText('Second chunk');
+        store.setPartialText('Third chunk');
+
+        // Still showing first update immediately
+        expect(store.partialText).toBe('First chunk');
+
+        // Advance past the 150ms throttle window
+        vi.advanceTimersByTime(150);
+
+        // Now should show the latest pending value
+        expect(store.partialText).toBe('Third chunk');
+
+        vi.useRealTimers();
+      });
+
+      it('allows a new immediate update after the throttle window expires', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        store.setPartialText('First chunk');
+        vi.advanceTimersByTime(150);
+
+        // After throttle expires, the next call should update immediately again
+        store.setPartialText('New chunk');
+        expect(store.partialText).toBe('New chunk');
+
+        vi.useRealTimers();
+      });
+
+      it('does not flush if pending text matches current text after throttle', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        store.setPartialText('Same text');
+        // Call again with same text (no-op case)
+        store.setPartialText('Same text');
+
+        vi.advanceTimersByTime(150);
+
+        // Should still have the same text
+        expect(store.partialText).toBe('Same text');
+
+        vi.useRealTimers();
+      });
+    });
+
+    describe('clearPartialText', () => {
+      it('resets partialText to empty string', () => {
+        const store = useSessionsStore();
+        store.partialText = 'some streaming text';
+
+        store.clearPartialText();
+
+        expect(store.partialText).toBe('');
+      });
+
+      it('clears the throttle timer so next setPartialText updates immediately', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        // Start throttling
+        store.setPartialText('First chunk');
+        store.setPartialText('Second chunk'); // Queued
+
+        // Clear resets the timer
+        store.clearPartialText();
+        expect(store.partialText).toBe('');
+
+        // Next call should update immediately (no active timer)
+        store.setPartialText('Fresh chunk');
+        expect(store.partialText).toBe('Fresh chunk');
+
+        vi.useRealTimers();
+      });
+
+      it('does not apply queued partial text after clear even when timer would fire', () => {
+        vi.useFakeTimers();
+        const store = useSessionsStore();
+
+        store.setPartialText('First');
+        store.setPartialText('Second'); // Queued via _pendingPartialText
+
+        store.clearPartialText();
+        expect(store.partialText).toBe('');
+
+        // Advance timer - should NOT re-apply the queued "Second"
+        vi.advanceTimersByTime(200);
+
+        expect(store.partialText).toBe('');
+
+        vi.useRealTimers();
+      });
+    });
+  });
+
+  // ==================== SESSION-SCOPED GUARD TESTS ====================
+
+  describe('session-scoped guards (cross-session contamination prevention)', () => {
+    describe('addMessage guard', () => {
+      it('accepts messages for the current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addMessage({ id: 'msg-1', sessionId: 'session-1', content: 'hello' });
+
+        expect(store.messages).toHaveLength(1);
+        expect(store.messages[0].id).toBe('msg-1');
+      });
+
+      it('ignores messages for a different session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addMessage({ id: 'msg-1', sessionId: 'session-2', content: 'wrong session' });
+
+        expect(store.messages).toHaveLength(0);
+      });
+
+      it('accepts messages when currentSession is null (no guard applied)', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+
+        store.addMessage({ id: 'msg-1', sessionId: 'session-1', content: 'hello' });
+
+        expect(store.messages).toHaveLength(1);
+      });
+
+      it('accepts messages with no sessionId (backwards compat)', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addMessage({ id: 'msg-1', content: 'no sessionId' });
+
+        expect(store.messages).toHaveLength(1);
+      });
+    });
+
+    describe('addWorkLog guard', () => {
+      it('accepts work logs for the current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addWorkLog({ id: 'log-1', sessionId: 'session-1', messageId: 'msg-1' });
+
+        expect(store.workLogs['msg-1']).toHaveLength(1);
+      });
+
+      it('ignores work logs for a different session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addWorkLog({ id: 'log-1', sessionId: 'session-2', messageId: 'msg-1' });
+
+        expect(store.workLogs['msg-1']).toBeUndefined();
+      });
+
+      it('accepts work logs when currentSession is null', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+
+        store.addWorkLog({ id: 'log-1', sessionId: 'session-99', messageId: 'msg-1' });
+
+        expect(store.workLogs['msg-1']).toHaveLength(1);
+      });
+
+      it('accepts work logs with no sessionId', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addWorkLog({ id: 'log-1', messageId: 'msg-1' });
+
+        expect(store.workLogs['msg-1']).toHaveLength(1);
+      });
+    });
+
+    describe('addConversation guard', () => {
+      it('accepts conversations for the current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addConversation({ id: 'conv-1', sessionId: 'session-1' });
+
+        expect(store.conversations).toHaveLength(1);
+        expect(store.conversations[0].id).toBe('conv-1');
+      });
+
+      it('ignores conversations for a different session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addConversation({ id: 'conv-1', sessionId: 'session-2' });
+
+        expect(store.conversations).toHaveLength(0);
+      });
+
+      it('accepts conversations when currentSession is null', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+
+        store.addConversation({ id: 'conv-1', sessionId: 'session-any' });
+
+        expect(store.conversations).toHaveLength(1);
+      });
+
+      it('accepts conversations with no sessionId', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+
+        store.addConversation({ id: 'conv-1' });
+
+        expect(store.conversations).toHaveLength(1);
+      });
+    });
+
+    describe('updateConversation guard', () => {
+      it('accepts conversation updates for the current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [{ id: 'conv-1', sessionId: 'session-1', name: 'Original' }];
+
+        store.updateConversation({ id: 'conv-1', sessionId: 'session-1', name: 'Updated' });
+
+        expect(store.conversations[0].name).toBe('Updated');
+      });
+
+      it('ignores conversation updates for a different session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [{ id: 'conv-1', sessionId: 'session-1', name: 'Original' }];
+
+        store.updateConversation({ id: 'conv-1', sessionId: 'session-2', name: 'Should not apply' });
+
+        expect(store.conversations[0].name).toBe('Original');
+      });
+
+      it('accepts conversation updates when currentSession is null', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+        store.conversations = [{ id: 'conv-1', name: 'Original' }];
+
+        store.updateConversation({ id: 'conv-1', sessionId: 'session-any', name: 'Updated' });
+
+        expect(store.conversations[0].name).toBe('Updated');
+      });
+
+      it('accepts conversation updates with no sessionId', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [{ id: 'conv-1', name: 'Original' }];
+
+        store.updateConversation({ id: 'conv-1', name: 'Updated' });
+
+        expect(store.conversations[0].name).toBe('Updated');
+      });
+    });
+
+    describe('removeConversation guard', () => {
+      it('accepts conversation removals for the current session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [{ id: 'conv-1' }, { id: 'conv-2' }];
+
+        store.removeConversation('conv-1', null, 'session-1');
+
+        expect(store.conversations).toHaveLength(1);
+        expect(store.conversations[0].id).toBe('conv-2');
+      });
+
+      it('ignores conversation removals for a different session', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [{ id: 'conv-1' }, { id: 'conv-2' }];
+
+        store.removeConversation('conv-1', null, 'session-2');
+
+        // Conversation should NOT have been removed
+        expect(store.conversations).toHaveLength(2);
+      });
+
+      it('accepts conversation removals when currentSession is null', () => {
+        const store = useSessionsStore();
+        store.currentSession = null;
+        store.conversations = [{ id: 'conv-1' }, { id: 'conv-2' }];
+
+        store.removeConversation('conv-1', null, 'session-any');
+
+        expect(store.conversations).toHaveLength(1);
+      });
+
+      it('accepts conversation removals with no sessionId (backwards compat)', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-1' };
+        store.conversations = [{ id: 'conv-1' }, { id: 'conv-2' }];
+
+        store.removeConversation('conv-1');
+
+        expect(store.conversations).toHaveLength(1);
+      });
+
+      it('cross-session contamination: events from session B do not affect session A view', () => {
+        const store = useSessionsStore();
+        store.currentSession = { id: 'session-A' };
+        store.conversations = [
+          { id: 'conv-A1', sessionId: 'session-A' },
+          { id: 'conv-A2', sessionId: 'session-A' },
+        ];
+
+        // Simulate WebSocket events from session B (background session)
+        store.addConversation({ id: 'conv-B1', sessionId: 'session-B' });
+        store.updateConversation({ id: 'conv-A1', sessionId: 'session-B', name: 'Tampered' });
+        store.removeConversation('conv-A2', null, 'session-B');
+
+        // All events from session-B should have been ignored
+        expect(store.conversations).toHaveLength(2);
+        expect(store.conversations[0].name).toBeUndefined(); // not tampered
+        expect(store.conversations[1].id).toBe('conv-A2'); // not removed
+      });
+    });
+  });
 });

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -36,7 +36,7 @@ vi.mock('../components/OverflowMenu.vue', () => ({
 }));
 vi.mock('../composables/useApi.js', () => ({
   api: {
-    getSessionSummary: vi.fn(),
+    getSessionSummary: vi.fn().mockResolvedValue(null),
     updateSession: vi.fn(),
     getSession: vi.fn(),
     getConversations: vi.fn(),

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -43,6 +43,39 @@ vi.mock('../composables/useApi.js', () => ({
   },
 }));
 
+// Mock useWebSocket so ensureSubscribed resolves immediately (no real WebSocket needed)
+// and useSessionSubscription returns no-op handler stubs.
+vi.mock('../composables/useWebSocket.js', () => {
+  const h = () => vi.fn(() => () => {});
+  return {
+    ensureSubscribed: vi.fn(() => Promise.resolve()),
+    useSessionSubscription: vi.fn(() => ({
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      onStatus: h(),
+      onMessage: h(),
+      onPartial: h(),
+      onError: h(),
+      onCanvasAdd: h(),
+      onCanvasRemove: h(),
+      onTodosUpdate: h(),
+      onSessionUpdate: h(),
+      onSummaryUpdate: h(),
+      onConversationCreated: h(),
+      onConversationUpdated: h(),
+      onConversationDeleted: h(),
+      onUsageUpdate: h(),
+      onChangesUpdate: h(),
+      onWorkLog: h(),
+      onWorkLogsAssociated: h(),
+      onThinkingPartial: h(),
+      onCommandOutput: h(),
+      onCommandComplete: h(),
+      onCommandError: h(),
+    })),
+  };
+});
+
 // Import the mocked api for use in tests
 import { api } from '../composables/useApi.js';
 
@@ -274,7 +307,7 @@ describe('SessionDetailView', () => {
       expect(wrapper.exists()).toBe(true);
     });
 
-    it('fetches canvas items during initialization (eager-loaded for tab indicator)', async () => {
+    it('fetches canvas items eagerly during initialization so tab count is correct immediately', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -304,10 +337,9 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Canvas items SHOULD be fetched during initialization to populate the tab indicator count
-      // Note: Due to test environment limitations with async lifecycle and WebSocket initialization,
-      // we verify the method is available and would be called in a real environment
-      expect(canvasStore.fetchItems).toBeDefined();
+      // Canvas items SHOULD be fetched during initialization so the Canvas tab badge
+      // shows the correct count even when the user starts on a different tab.
+      expect(canvasStore.fetchItems).toHaveBeenCalledWith('session-1');
     });
 
     it('fetches work logs on mount', async () => {
@@ -2137,6 +2169,118 @@ describe('SessionDetailView', () => {
 
       // clearTodos should have been called during cleanup
       expect(clearTodosSpy).toHaveBeenCalled();
+    });
+
+    it('clears messages, conversations, and workLogs on unmount to prevent stale state', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Session 1',
+        status: 'running',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            SummaryTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Simulate data that was loaded for the session
+      sessionsStore.messages = [{ id: 'msg-1', content: 'hello' }];
+      sessionsStore.conversations = [{ id: 'conv-1', name: 'main' }];
+      sessionsStore.workLogs = { 'msg-1': [{ id: 'log-1' }] };
+
+      wrapper.unmount();
+
+      // All session-specific state should be cleared on cleanup
+      expect(sessionsStore.messages).toEqual([]);
+      expect(sessionsStore.conversations).toEqual([]);
+      expect(sessionsStore.workLogs).toEqual({});
+    });
+
+    it('calls clearPartialText on unmount to stop any in-progress streaming display', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Session 1',
+        status: 'running',
+        projectId: 'proj-1',
+      };
+
+      const clearPartialTextSpy = vi.spyOn(sessionsStore, 'clearPartialText');
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            SummaryTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      clearPartialTextSpy.mockClear();
+
+      wrapper.unmount();
+
+      // clearPartialText should be called during cleanup to prevent stale streaming text
+      expect(clearPartialTextSpy).toHaveBeenCalled();
+    });
+
+    it('clears canvas items on unmount to prevent stale items when switching sessions', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Session 1',
+        status: 'running',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            SummaryTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Simulate some canvas items loaded for this session
+      canvasStore.items = [{ id: 'canvas-1', type: 'text', sessionId: 'session-1' }];
+
+      wrapper.unmount();
+
+      // Canvas items should be cleared on cleanup so the next session starts fresh
+      expect(canvasStore.items).toEqual([]);
     });
   });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -352,6 +352,11 @@ function cleanup() {
   cleanups.forEach((c) => c());
   cleanups = [];
   sessionsStore.clearRunningUsage();
+  // Clear all session-specific store state to prevent stale data during transitions
+  sessionsStore.messages = [];
+  sessionsStore.conversations = [];
+  sessionsStore.workLogs = {};
+  sessionsStore.clearPartialText();
   todosStore.clearTodos();
   // Reset local state
   summary.value = null;
@@ -365,7 +370,7 @@ function cleanup() {
 async function initializeSession(sessionId) {
   // STEP 1: Create new subscription for this session
   currentSubscription = useSessionSubscription(sessionId);
-  const { subscribe, unsubscribe, onStatus, onMessage, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onConversationUpdated, onUsageUpdate, onChangesUpdate, onCommandOutput, onCommandComplete, onCommandError } = currentSubscription;
+  const { subscribe, unsubscribe, onStatus, onMessage, onPartial, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onConversationCreated, onConversationUpdated, onConversationDeleted, onUsageUpdate, onChangesUpdate, onWorkLog, onWorkLogsAssociated, onThinkingPartial, onCommandOutput, onCommandComplete, onCommandError } = currentSubscription;
 
   // STEP 2: Subscribe via the subscription object AND await connection
   // CRITICAL: We must call subscribe() to set thisInstanceSubscribed = true,
@@ -411,6 +416,42 @@ async function initializeSession(sessionId) {
   cleanups.push(
     onMessage((message) => {
       sessionsStore.addMessage(message);
+      // Clear partial text when full message arrives (previously in ConversationTab)
+      sessionsStore.clearPartialText();
+    })
+  );
+
+  cleanups.push(
+    onPartial((text) => {
+      sessionsStore.setPartialText(text);
+    })
+  );
+
+  cleanups.push(
+    onWorkLog((log) => {
+      sessionsStore.addWorkLog(log);
+    })
+  );
+
+  cleanups.push(
+    onWorkLogsAssociated((messageId) => {
+      sessionsStore.associateWorkLogs(messageId);
+    })
+  );
+
+  cleanups.push(
+    onThinkingPartial((thinking) => {
+      if (thinking === null) {
+        sessionsStore.clearPartialThinking(sessionId);
+      } else {
+        sessionsStore.setPartialThinking(thinking, sessionId);
+      }
+    })
+  );
+
+  cleanups.push(
+    onConversationCreated((conversation) => {
+      sessionsStore.addConversation(conversation);
     })
   );
 
@@ -455,6 +496,16 @@ async function initializeSession(sessionId) {
   cleanups.push(
     onConversationUpdated((conversation) => {
       sessionsStore.updateConversation(conversation);
+    })
+  );
+
+  cleanups.push(
+    onConversationDeleted((conversationId, newActiveConv) => {
+      sessionsStore.removeConversation(conversationId, newActiveConv, sessionId);
+      // If we have a new active conversation, fetch its messages
+      if (newActiveConv) {
+        sessionsStore.fetchMessages(sessionId, false);
+      }
     })
   );
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -358,6 +358,7 @@ function cleanup() {
   sessionsStore.workLogs = {};
   sessionsStore.clearPartialText();
   todosStore.clearTodos();
+  canvasStore.items = [];
   // Reset local state
   summary.value = null;
   hasChanges.value = false;
@@ -570,8 +571,11 @@ async function initializeSession(sessionId) {
   // STEP 5: Fetch remaining data
   await sessionsStore.fetchMessages(sessionId);
   await sessionsStore.fetchWorkLogs(sessionId);
-  // Canvas data is lazy-loaded: CanvasTab.onMounted handles fetching when the tab is activated.
-  // canvasItemCount starts at 0 and is updated by onCanvasAdd/onCanvasRemove WebSocket handlers.
+  // Fetch canvas items upfront so the tab indicator shows the correct count immediately,
+  // even when the user is on a different tab. CanvasTab still calls fetchItems on mount
+  // to ensure fresh data (the fetch is idempotent).
+  await canvasStore.fetchItems(sessionId);
+  canvasItemCount.value = canvasStore.groupedItems.length;
   todosStore.fetchTodos(sessionId, sessionsStore.activeConversationId);
 
   // Fetch summary for PR indicators (don't await, not critical)

--- a/scripts/seed-messages-batch.mjs
+++ b/scripts/seed-messages-batch.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * seed-messages-batch.mjs
+ * Direct DB seeding script for E2E tests — inserts multiple message rows in a single transaction.
+ *
+ * Reads a JSON payload from stdin:
+ * {
+ *   dbPath: string,
+ *   messages: Array<{
+ *     sessionId: string,
+ *     role: string,
+ *     content: string,
+ *     model?: string,
+ *     toolUse?: object[],
+ *     conversationId?: string
+ *   }>
+ * }
+ *
+ * Outputs an array of created message rows as JSON on stdout.
+ */
+
+import Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+
+let raw = '';
+process.stdin.setEncoding('utf-8');
+for await (const chunk of process.stdin) {
+  raw += chunk;
+}
+
+const { dbPath, messages } = JSON.parse(raw);
+
+const db = new Database(dbPath, { readonly: false });
+db.pragma('journal_mode = WAL');
+
+// Cache resolved conversation IDs by sessionId
+const convCache = new Map();
+
+function resolveConversationId(sessionId, conversationId) {
+  if (conversationId) return conversationId;
+  if (convCache.has(sessionId)) return convCache.get(sessionId);
+  const conv = db
+    .prepare('SELECT id FROM conversations WHERE session_id = ? AND is_active = 1 ORDER BY created_at DESC LIMIT 1')
+    .get(sessionId);
+  const resolved = conv ? conv.id : null;
+  convCache.set(sessionId, resolved);
+  return resolved;
+}
+
+const insertStmt = db.prepare(
+  `INSERT INTO conversation_messages (id, session_id, conversation_id, role, content, tool_use, model, timestamp)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+);
+
+const selectStmt = db.prepare('SELECT * FROM conversation_messages WHERE id = ?');
+
+const results = [];
+
+const insertAll = db.transaction(() => {
+  let now = Date.now();
+  for (const msg of messages) {
+    const id = randomUUID();
+    const resolvedConvId = resolveConversationId(msg.sessionId, msg.conversationId || null);
+    const toolUseStr = msg.toolUse ? JSON.stringify(msg.toolUse) : null;
+
+    insertStmt.run(id, msg.sessionId, resolvedConvId, msg.role, msg.content, toolUseStr, msg.model ?? null, now);
+
+    const row = selectStmt.get(id);
+    results.push({
+      id: row.id,
+      sessionId: row.session_id,
+      conversationId: row.conversation_id,
+      role: row.role,
+      content: row.content,
+      toolUse: row.tool_use ? JSON.parse(row.tool_use) : null,
+      timestamp: row.timestamp,
+      model: row.model,
+    });
+
+    // Increment timestamp so messages have distinct ordering
+    now++;
+  }
+});
+
+insertAll();
+db.close();
+
+process.stdout.write(JSON.stringify(results));

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -528,13 +528,24 @@ export async function seedWorkLog(
 }
 
 export async function updateSessionStatus(sessionId: string, status: string) {
-  const response = await fetch(`${API_URL}/api/sessions/${sessionId}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ status }),
-  });
-  if (!response.ok) throw new Error('Failed to update session status');
-  return response.json();
+  const maxRetries = 3;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const response = await fetch(`${API_URL}/api/sessions/${sessionId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!response.ok) throw new Error('Failed to update session status');
+      return response.json();
+    } catch (err: any) {
+      if (attempt < maxRetries - 1 && (err?.cause?.code === 'ECONNRESET' || err?.message?.includes('fetch failed'))) {
+        await new Promise(r => setTimeout(r, 200 * (attempt + 1)));
+        continue;
+      }
+      throw err;
+    }
+  }
 }
 
 export async function updateSessionMode(sessionId: string, mode: string) {
@@ -1430,22 +1441,38 @@ export function seedAssistantMessageWithTools(
 }
 
 /**
- * Seed multiple alternating user/assistant messages to create a scrollable conversation
+ * Seed multiple alternating user/assistant messages to create a scrollable conversation.
+ * Uses a batch script to insert all messages in a single process/transaction
+ * instead of spawning a separate process per message.
  */
 export function seedConversationHistory(sessionId: string, messageCount: number) {
-  const msgs: any[] = [];
+  const messages: any[] = [];
   for (let i = 0; i < messageCount; i++) {
     const isUser = i % 2 === 0;
-    const msg = isUser
-      ? seedUserMessage(sessionId, `User message ${i + 1}: Tell me about topic ${i + 1}.`)
-      : seedAssistantMessage(
-          sessionId,
-          `Assistant response ${i + 1}: Here is a detailed response about topic ${i}. `.repeat(5),
-          'claude-sonnet-4-20250514'
-        );
-    msgs.push(msg);
+    if (isUser) {
+      messages.push({
+        sessionId,
+        role: 'user',
+        content: `User message ${i + 1}: Tell me about topic ${i + 1}.`,
+      });
+    } else {
+      messages.push({
+        sessionId,
+        role: 'assistant',
+        content: `Assistant response ${i + 1}: Here is a detailed response about topic ${i}. `.repeat(5),
+        model: 'claude-sonnet-4-20250514',
+      });
+    }
   }
-  return msgs;
+
+  const seedScript = join(process.cwd(), 'scripts', 'seed-messages-batch.mjs');
+  const input = JSON.stringify({ dbPath: getDBPath(), messages });
+  const result = execSync(`node "${seedScript}"`, {
+    input,
+    encoding: 'utf-8',
+    timeout: 30000,
+  });
+  return JSON.parse(result);
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
This PR fixes an issue where conversation state and streaming message updates were leaking between sessions when users switched between multiple Claude Code conversations.

## Problem
The WebSocket handlers for streaming messages (partial text), work logs, and conversation events were subscribed to in ConversationTab but not properly scoped to individual sessions. When a user switched between sessions, the old handlers would continue to fire and update the Pinia store with events from the new session, causing:
- Previous conversation to show new messages
- Streaming text appearing in wrong conversation
- Cross-session state pollution

## Solution
Consolidate all WebSocket handler subscriptions from ConversationTab into SessionDetailView, where they are properly scoped to individual sessions via the session-aware subscription object. This ensures:
- Handlers are created fresh for each session
- Old handlers are properly cleaned up when switching sessions
- Store mutations are guarded with session ID checks

### Key Changes
- Move `onPartial`, `onMessage`, `onWorkLog`, `onWorkLogsAssociated`, `onThinkingPartial`, and conversation event handlers to SessionDetailView
- Make `partialText` in ConversationTab a computed property reading from Pinia store
- Move partial text throttling logic to sessions store as `setPartialText()` and `clearPartialText()` methods
- Add session ID guards to store actions to prevent cross-session updates
- Clear all session-specific state (messages, conversations, work logs, partial text) during cleanup

## Test plan
- [ ] Switch between multiple sessions rapidly
- [ ] Verify messages don't appear in wrong conversation
- [ ] Verify streaming text appears only in active conversation
- [ ] Verify work logs are associated with correct messages
- [ ] Run E2E tests: `./scripts/pw.sh test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)