### PR TITLE
Show model name on small screens when Claude is responding

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -1799,9 +1799,5 @@ async function handleBranchCreate({ messageId, prompt }) {
   .running-title {
     display: none;
   }
-
-  .running-model-label {
-    display: none;
-  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Make the model name visible on all screen sizes when Claude is responding
- Previously hidden on screens < 360px width, now always displayed to inform users which model is processing

## Test Plan
- [x] All unit tests pass (1,000+)
- [ ] Test on small mobile devices (< 360px width)
- [ ] Verify model name is visible and readable
- [ ] Check layout doesn't overflow on various screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)