### PR TITLE
refactor: Clear provider environment variables before running tests

### DIFF
--- a/scripts/pw.sh
+++ b/scripts/pw.sh
@@ -170,6 +170,18 @@ ensure_directories() {
     mkdir -p "$PROJECT_ROOT/tests"
 }
 
+# Clear provider environment variables to prevent leakage into tests
+# This ensures test isolation and prevents accidental use of production credentials
+clear_provider_env_vars() {
+    unset ANTHROPIC_BASE_URL
+    unset ANTHROPIC_API_KEY
+    unset ANTHROPIC_AUTH_TOKEN
+    unset ANTHROPIC_DEFAULT_OPUS_MODEL
+    unset ANTHROPIC_DEFAULT_SONNET_MODEL
+    unset ANTHROPIC_DEFAULT_HAIKU_MODEL
+    unset API_TIMEOUT_MS
+}
+
 # Build the container
 cmd_build() {
     if [ "$USE_DOCKER" = true ]; then
@@ -187,6 +199,9 @@ cmd_build() {
 cmd_test() {
     ensure_dependencies
     ensure_directories
+
+    # Clear provider environment variables before running tests
+    clear_provider_env_vars
 
     # Enable VCR mode for E2E tests (replay existing cassettes, record new ones)
     export VCR_MODE=${VCR_MODE:-auto}
@@ -256,6 +271,9 @@ cmd_screenshot() {
 cmd_codegen() {
     ensure_dependencies
 
+    # Clear provider environment variables before running codegen
+    clear_provider_env_vars
+
     # Ensure server is running to provide a default URL
     local SERVER_PORT
     SERVER_PORT=$(detect_or_start_server)
@@ -300,6 +318,9 @@ cmd_shell() {
 cmd_debug() {
     ensure_dependencies
     ensure_directories
+
+    # Clear provider environment variables before running tests
+    clear_provider_env_vars
 
     # Enable VCR mode for E2E tests (replay existing cassettes, record new ones)
     export VCR_MODE=${VCR_MODE:-auto}

--- a/tests/e2e/cassettes/runSession-277455119d319a21.json
+++ b/tests/e2e/cassettes/runSession-277455119d319a21.json
@@ -1,0 +1,512 @@
+{
+  "prompt": "Reply with exactly: \"API cross-check test.\" Nothing else.",
+  "model": "claude-haiku-4-5-20251001",
+  "events": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "cwd": "/Users/ferrislucas/claudetools.io/.worktrees/2f7a52de-0769-4aeb-93c8-ecddc57c2de1",
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "tools": [
+        "Task",
+        "TaskOutput",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "KillShell",
+        "AskUserQuestion",
+        "Skill",
+        "EnterPlanMode",
+        "LSP"
+      ],
+      "mcp_servers": [],
+      "model": "claude-haiku-4-5-20251001",
+      "permissionMode": "default",
+      "slash_commands": [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "pr-comments",
+        "release-notes",
+        "review",
+        "security-review"
+      ],
+      "apiKeySource": "none",
+      "claude_code_version": "2.0.77",
+      "output_style": "default",
+      "agents": [
+        "Bash",
+        "general-purpose",
+        "statusline-setup",
+        "Explore",
+        "Plan",
+        "playwright-e2e-runner"
+      ],
+      "skills": [],
+      "plugins": [],
+      "uuid": "cf28c650-edb0-45be-a0ef-d77788421aa4"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011aNK7G2ddumVgKuc3oUdBt",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 6403,
+            "cache_read_input_tokens": 15493,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 6403
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "2882085a-fb7e-45b9-a633-18458095238f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "0caf4e49-6794-45fe-ba49-01e442ed3849"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The user is"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "b1e82ee2-024a-43fe-a812-8a245a2c17db"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " asking me to reply"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "c27d615d-58b3-4eff-8da3-bc2d3f099739"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with exactly \"API cross-check test"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "ca90c6e5-c0f4-4fee-a0c1-b56f371e0ee8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ".\" and"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "91201c3d-6caf-4573-9f43-bf532e3d69a5"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " nothing else. This is"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "12cff720-0c6b-439b-9a45-e275dffa831f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " a straight"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "ec6e0c57-b706-433c-bad6-b062004d2837"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "forward request -"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "e35b1f30-3508-4948-a4e0-23373614a9be"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " I"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "7064e3ba-220e-4786-bab5-8a050be6c7a1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " should"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "53d513e2-c00f-4d7b-9b41-11a012e165ea"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " follow"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "c18ecb8c-eeeb-43db-bbf1-012aa9b8d257"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " their"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "458a37d7-faed-45f0-a439-0bfcdfcdd85b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " instructions precisely"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "e1e87413-a494-4409-86c5-dba1f79d6075"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "."
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "c0c848cb-9e85-400d-a040-ab0bef9bc601"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ""
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "0fa29393-e9b3-49c0-a6bc-7129561c7586"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "EtACCkYICxgCKkARoWS44MLR3VzQez2qI6rHefPcAR62RcWA6mYI2aLYW1teXA9FDaZ6jb7Sz1ufoFyu+bvha4qW/8We3sM00vF0EgyAUvyA5jIt/Qh8PsIaDAaDT/7WSdQFkl7jtyIwYJKfvnhqcyTGllM4v6brT5IEHAVahp+Y8N3eMMN1UU2dHNtTde9Un582YxiNAq7YKrcBU+keMCK1HN+/L6m3Rq3b+pWLKOdPJgre905j4bql5UHIuGOKyKxoCj9MLkyikNkcBkfRSh2RQQEBRvgw57HAov/VYhQX1TODN1BB6SawffA1QLNbFbLT3mmuTaivYmnRHbwBOaOofgH/LXraXqnjgyi6HaXwsW92VAynEWYtiAD5XQt/dmuRnBu0sHKqDY8X7SEv6/0r2Pfx4vFLb6YWSUM8F7Ect+98oYLIfFqSeYfqMrFWijw7GAE="
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "a1da0126-cb80-4e1e-b535-e3f1decc3aec"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_011aNK7G2ddumVgKuc3oUdBt",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The user is asking me to reply with exactly \"API cross-check test.\" and nothing else. This is a straightforward request - I should follow their instructions precisely.",
+            "signature": "EtACCkYICxgCKkARoWS44MLR3VzQez2qI6rHefPcAR62RcWA6mYI2aLYW1teXA9FDaZ6jb7Sz1ufoFyu+bvha4qW/8We3sM00vF0EgyAUvyA5jIt/Qh8PsIaDAaDT/7WSdQFkl7jtyIwYJKfvnhqcyTGllM4v6brT5IEHAVahp+Y8N3eMMN1UU2dHNtTde9Un582YxiNAq7YKrcBU+keMCK1HN+/L6m3Rq3b+pWLKOdPJgre905j4bql5UHIuGOKyKxoCj9MLkyikNkcBkfRSh2RQQEBRvgw57HAov/VYhQX1TODN1BB6SawffA1QLNbFbLT3mmuTaivYmnRHbwBOaOofgH/LXraXqnjgyi6HaXwsW92VAynEWYtiAD5XQt/dmuRnBu0sHKqDY8X7SEv6/0r2Pfx4vFLb6YWSUM8F7Ect+98oYLIfFqSeYfqMrFWijw7GAE="
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 6403,
+          "cache_read_input_tokens": 15493,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6403
+          },
+          "output_tokens": 51,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "uuid": "ed975247-09f8-42c0-82cb-e578ac0c1d99"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "4e600120-f1cd-4a18-94c4-380e25fc415d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "text",
+          "text": ""
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "8c8aa9b3-bcd6-4cec-85e5-321a05721aca"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "API"
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "f40b0e7c-52be-4016-accd-46b5b2a087d5"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " cross-check test."
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "a5e8f5dd-ee1e-4b20-bb85-bd706991bc3c"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_011aNK7G2ddumVgKuc3oUdBt",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "API cross-check test."
+          }
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 6403,
+          "cache_read_input_tokens": 15493,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6403
+          },
+          "output_tokens": 51,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "uuid": "3de1ee1c-891b-49a3-96e7-53cc644352b1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "de3eab6c-9356-4b66-8d24-69d5bee31a53"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "end_turn",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 6403,
+          "cache_read_input_tokens": 15493,
+          "output_tokens": 51
+        }
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "944cf2ba-0148-4db7-9d68-a1605ef9b17e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "parent_tool_use_id": null,
+      "uuid": "24f3a7d6-c6b1-4ab2-b26b-0853268677dc"
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "duration_ms": 1676,
+      "duration_api_ms": 1575,
+      "num_turns": 1,
+      "result": "API cross-check test.",
+      "session_id": "c58706c7-9e7d-4197-98ac-c909d7231327",
+      "total_cost_usd": 0.00981805,
+      "usage": {
+        "input_tokens": 10,
+        "cache_creation_input_tokens": 6403,
+        "cache_read_input_tokens": 15493,
+        "output_tokens": 51,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 6403,
+          "ephemeral_5m_input_tokens": 0
+        }
+      },
+      "modelUsage": {
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 10,
+          "outputTokens": 51,
+          "cacheReadInputTokens": 15493,
+          "cacheCreationInputTokens": 6403,
+          "webSearchRequests": 0,
+          "costUSD": 0.00981805,
+          "contextWindow": 200000
+        }
+      },
+      "permission_denials": [],
+      "uuid": "a6aa0eb5-b8ac-4428-9344-349f67816844"
+    }
+  ],
+  "key": "runSession-277455119d319a21",
+  "recordedAt": "2026-03-04T03:26:52.928Z"
+}

--- a/tests/e2e/cassettes/runSession-40b6b836a2e97349.json
+++ b/tests/e2e/cassettes/runSession-40b6b836a2e97349.json
@@ -1,0 +1,1866 @@
+{
+  "prompt": "What is in this file?\n\n## Attached Files\n--- File: unique-test.txt (text/plain) ---\nUNIQUE_TEST_CONTENT_1772594572177\n--- End of unique-test.txt ---",
+  "model": "claude-haiku-4-5-20251001",
+  "events": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "cwd": "/private/tmp/test",
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "tools": [
+        "Task",
+        "TaskOutput",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "KillShell",
+        "AskUserQuestion",
+        "Skill",
+        "EnterPlanMode",
+        "LSP"
+      ],
+      "mcp_servers": [],
+      "model": "claude-haiku-4-5-20251001",
+      "permissionMode": "default",
+      "slash_commands": [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "pr-comments",
+        "release-notes",
+        "review",
+        "security-review"
+      ],
+      "apiKeySource": "none",
+      "claude_code_version": "2.0.77",
+      "output_style": "default",
+      "agents": [
+        "Bash",
+        "general-purpose",
+        "statusline-setup",
+        "Explore",
+        "Plan"
+      ],
+      "skills": [],
+      "plugins": [],
+      "uuid": "977a0e83-0fed-4a28-a303-85bb3701c79f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_019xF4h7AP3ynwxkC7gpbaKF",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 2284,
+            "cache_read_input_tokens": 15006,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 2284
+            },
+            "output_tokens": 6,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "2c4abb83-7f81-4a72-a37d-bc7171dddf8e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "de2af25e-5c83-4a3c-9e11-29d47e93bcc3"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The user is asking about the"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c0138c3b-cdbf-4884-be3b-c2bf47053cba"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " content"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e267d372-7e3c-4dfc-bee3-8b139540d680"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " of the"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "7c095db5-31cc-4c36-8a76-66c035547352"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " attached"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "4cac7276-ee81-4b05-ad92-4206355f1548"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " file. I"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "8f467613-4a0f-4e67-8a08-e736ce3c21c6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " can"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "112cb3d4-a52b-47d4-a565-4796248e2074"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " see from"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "9a11018e-49e7-45ba-8b15-28df3309006f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the file preview"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "8317e664-9bad-46bd-a48a-64cca0e75f28"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " that it contains"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d9d99137-799d-47c5-9843-69651d27cdf2"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ":"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e9c347d7-4161-4d8d-be01-f5fd984586cd"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\n\nUNIQUE_TEST_CONTENT_1"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "447e7171-4246-4215-8746-4a14e043fe5d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "772594572177\n\nLet"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "33c26b58-04fd-4e01-9336-af159002056f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " me also"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "a0f84748-6ad9-41be-ba70-7727c3fa9ff9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " read"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "2c37151f-f1b1-4c23-8f45-130437b6aa57"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " it"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "4560ae1a-1ad0-4e07-81f6-6a9d026d20bf"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " using"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "b1d7aa65-a87e-4791-ae21-5f8563e47eca"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the Read"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e7382372-1bb7-4ebb-878c-7d9248b8f51b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " tool"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "2430a400-b424-49b8-a0e1-8c0ae3ad5c15"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " to provide"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d1bd1267-f8ef-450d-9b2f-273d6f192329"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " a proper"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "587963d3-caa6-4678-93ac-54b2227df1ea"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " response"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "6d087bbd-2e8c-4683-a867-2a6d6db3c5c3"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ","
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d0896cc6-ed3f-400f-8eb6-ea98ecfdbaed"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " using"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "ce60c9a2-bdaa-4acf-a7b8-ead478b744dc"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the file"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "2a77145d-6acf-4ad8-8ca0-fdcaaedd0cd2"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " path"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "502b0fa0-fbd0-4b4a-aab3-50784277f6ca"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " provided"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "aeb321e4-dc55-4cae-9d9e-fc828a4ab052"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " in"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "832d2ce0-d342-47f4-993a-d5b8d154be80"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the session"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "8c6a32c3-3db8-444b-be6c-71d5bb558cf6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " information"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c9d6f968-2951-44f3-8f6a-1bd7c81fcff5"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "."
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "6ce238b5-1d85-4bc3-9594-3c2c6a332265"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "ErYDCkYICxgCKkD9uZ6CHO4ZnN7WgDMtySr7NjEiog82VeXtCy0Q+BUEHIq1TFFOtuCvgTc89Ml1UNqWD+Oesh+osn2JuVa0W3kLEgzcTfvX1995EyKSZMgaDL1IJS/KQirdxQ7tCiIwJmvzHcfW2FtkV/krWXxx7zzxf0Ty20suVjw7Bla58gi4VUYw5Dn8JTYSbqrvSIYaKp0CNbA6110YJ2bG2riDTKd3LN05pvQi2A2QeJ0uQMv6pqVfaOKZVEItT6Gqr04/n3Vm0aJ2xCnvpXBP04X0evrYMCKffUivD8PAlfcE38tZ8GnPVOOwaPR+tQbsMM+/GP96IJShtT2ZXq8OQiK1EVl2/VCPwp7iBDKOISbY3wCXpMYBzzisNa5M1+mPIvpiy//YjqZ14G5lP0ya/hU9Eg5CJuCDVzN8v/BRI8MtSLAPCV4m1T02LTvUCviZiFU9VJJHEKzy3/KornenC6MWxKvEGIcUiwyzOKKkuNyIJW65YlVx4quy0XTvifGR2nkbxe9k3laeamTFiSbUtFTz6J/nKtedgJMgrqH8ty1wewxDuXaHcxk+VGM51NyOdfw9GAE="
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "03dde4f5-b0e4-4ecd-a58e-179da14caf90"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_019xF4h7AP3ynwxkC7gpbaKF",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The user is asking about the content of the attached file. I can see from the file preview that it contains:\n\nUNIQUE_TEST_CONTENT_1772594572177\n\nLet me also read it using the Read tool to provide a proper response, using the file path provided in the session information.",
+            "signature": "ErYDCkYICxgCKkD9uZ6CHO4ZnN7WgDMtySr7NjEiog82VeXtCy0Q+BUEHIq1TFFOtuCvgTc89Ml1UNqWD+Oesh+osn2JuVa0W3kLEgzcTfvX1995EyKSZMgaDL1IJS/KQirdxQ7tCiIwJmvzHcfW2FtkV/krWXxx7zzxf0Ty20suVjw7Bla58gi4VUYw5Dn8JTYSbqrvSIYaKp0CNbA6110YJ2bG2riDTKd3LN05pvQi2A2QeJ0uQMv6pqVfaOKZVEItT6Gqr04/n3Vm0aJ2xCnvpXBP04X0evrYMCKffUivD8PAlfcE38tZ8GnPVOOwaPR+tQbsMM+/GP96IJShtT2ZXq8OQiK1EVl2/VCPwp7iBDKOISbY3wCXpMYBzzisNa5M1+mPIvpiy//YjqZ14G5lP0ya/hU9Eg5CJuCDVzN8v/BRI8MtSLAPCV4m1T02LTvUCviZiFU9VJJHEKzy3/KornenC6MWxKvEGIcUiwyzOKKkuNyIJW65YlVx4quy0XTvifGR2nkbxe9k3laeamTFiSbUtFTz6J/nKtedgJMgrqH8ty1wewxDuXaHcxk+VGM51NyOdfw9GAE="
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 2284,
+          "cache_read_input_tokens": 15006,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2284
+          },
+          "output_tokens": 6,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "uuid": "0142ace5-ec23-4cf7-ac81-efe5cba7a114"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "81c3f480-2833-4755-a2f5-378026214b7b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "tool_use",
+          "id": "toolu_01ELWs3MU23QfbXSkXnPKbry",
+          "name": "Read",
+          "input": {},
+          "caller": {
+            "type": "direct"
+          }
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "1269fede-e729-4e3e-aedc-8b885482ad75"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": ""
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "9d57ac23-e711-4e59-8718-0991443db154"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "{\"file_pa"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c48ad5e5-1bbd-4e74-8e30-fa564984500e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "th\": \"/t"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "18ace840-11ad-487a-9751-476caa30c2c4"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "mp/test/."
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "bfeec738-8b38-4f07-a731-c2b4ce4d6a8d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "attachments/"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "0445b5f2-a88f-4ef7-88ae-03bb07eeadc1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "61bad1"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "4eb051a3-fab8-4e8c-ac7d-e1d985305bac"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "c7-b27b"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e3af03ef-d4a5-4647-8127-7a09a57c135d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "-4d40-9"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "0d1b3ee9-a1c2-4ddc-a486-7ad442c54d61"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "ed8-"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "ffa97182-6a6e-46b4-bcf4-62255d7b0637"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "b0b58e6c43"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "ded69622-734d-42ba-b348-b4fa3355b82f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "dc/10ce58"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "66a5f872-4f21-4458-a2b9-e099ac1fec31"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "b3-cfd9-48b"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c1337d0b-1a8c-4bab-8139-7a30db25062f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "e-"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "39aa7d0f-ee2d-403c-92ac-b865efab195f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "b054-cbf201e"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "81b4d83d-9394-4bbd-a2fb-80cabc03d839"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "a88b4_uniq"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "f9884584-3701-46f0-b5d7-2edba05e1343"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "ue-test.t"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "29ffa05a-e6c8-4523-b018-fc5eaf887bfe"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "input_json_delta",
+          "partial_json": "xt\"}"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "cc6367b8-61f9-46b5-a873-a9f7043d965f"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_019xF4h7AP3ynwxkC7gpbaKF",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_use",
+            "id": "toolu_01ELWs3MU23QfbXSkXnPKbry",
+            "name": "Read",
+            "input": {
+              "file_path": "/tmp/test/.attachments/61bad1c7-b27b-4d40-9ed8-b0b58e6c43dc/10ce58b3-cfd9-48be-b054-cbf201ea88b4_unique-test.txt"
+            },
+            "caller": {
+              "type": "direct"
+            }
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 2284,
+          "cache_read_input_tokens": 15006,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2284
+          },
+          "output_tokens": 188,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "uuid": "2fe5a1a7-87e4-4ef6-b322-49bec84aa245"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "6ba52e33-049e-4159-adc8-2d98b59274b6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "tool_use",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 2284,
+          "cache_read_input_tokens": 15006,
+          "output_tokens": 188
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "1ce3102d-7766-405c-a8bf-1fc3d21c9718"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "3b065c50-f2b8-4efd-ba9f-76be23d3f619"
+    },
+    {
+      "type": "user",
+      "message": {
+        "role": "user",
+        "content": [
+          {
+            "tool_use_id": "toolu_01ELWs3MU23QfbXSkXnPKbry",
+            "type": "tool_result",
+            "content": "     1→UNIQUE_TEST_CONTENT_1772594572177\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n"
+          }
+        ]
+      },
+      "parent_tool_use_id": null,
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "uuid": "7159943f-b90f-43ba-b6bc-30bb2a381939",
+      "tool_use_result": {
+        "type": "text",
+        "file": {
+          "filePath": "/tmp/test/.attachments/61bad1c7-b27b-4d40-9ed8-b0b58e6c43dc/10ce58b3-cfd9-48be-b054-cbf201ea88b4_unique-test.txt",
+          "content": "UNIQUE_TEST_CONTENT_1772594572177",
+          "numLines": 1,
+          "startLine": 1,
+          "totalLines": 1
+        }
+      }
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_01Ru1iSoqwo61UYTnekTuvhJ",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 13,
+            "cache_creation_input_tokens": 299,
+            "cache_read_input_tokens": 17290,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 299
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "bc0ce0b7-33ff-4c08-9e76-9cc7a6be6987"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "8b903cbb-296f-4096-ac7d-18f159a406a8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The file contains"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "ec24939c-c9e5-4b19-9787-6303711c66d6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " a"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c56bb353-5f05-4b67-a8ad-f924aa9c7554"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " simple text string"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "88a1d805-e12a-4227-9087-b02c8c064495"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ":"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c5678377-0008-4054-bf26-afb063da3c28"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " `"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "b061a092-5d09-4377-aa6d-518e2bc70f41"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "UNIQUE_TEST_CONTENT_"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "5708e2fd-e794-4868-8915-4cef367edbea"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "1772594572177`\n\nThis"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "06a535e0-b674-4e0a-94b1-9224f70e3ecd"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " appears"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d385f404-f5c5-4e58-b331-acce97574c3e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " to be some"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "3bd7054e-5463-472b-b34d-e929c72d1da7"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " kind of unique identifier or test"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e2bf77a7-3d26-49f9-bdbe-4405478ccb54"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " content. The"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d2f608d0-242e-4579-a64d-2f0b80121e6b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " number"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "73bd671c-92eb-40cc-819f-60bfb32721a0"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " at"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "915f4e8c-96c2-43ca-ad5a-21ca2355b5d0"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the end"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "7245f43e-9d06-4259-ba8a-e28da82c36dd"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " (1772594572177) looks"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c19a37c9-70e2-490a-8914-5f0f77b75e35"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " like it"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "cbf451d1-9d6a-4aef-a966-041b6f262f44"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " could be a timestamp"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "6e77563d-dd83-4695-a07f-b53201add069"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " or a"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "77363e2f-a590-483c-a4cf-feda1f7c8cbe"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " unique"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c1e48b25-cc96-4880-b448-8229e6b189f6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " numeric"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "950774f4-8e2f-4d7f-83a7-09bc56f87b4d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " identifier."
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "1c8fc026-7423-452e-9bac-3c12d2b54f4a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ""
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "8c599d29-8598-4ad6-ad13-86d5e9c676fa"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "EqEDCkYICxgCKkD/KL2r7s/WFjX2GOMMV0fiWwib1DzVI86e8uErgDMohfPfsSFcDFPPTBm3oePbmic597Oor3aPd3pdZexXJWlqEgxG4mB2bTLynDfGQbMaDIgRQ8MsjHxji1H98CIwncyEgRTjKMfBGX+oTTHgKBs69eDFyjnvfPTUyXy+3Jr8iMCP/Sl1E7N76N4N1DIwKogCHPf9CY7q1+1HDLLqSuy02KX5jkHkh7sSW6jSjAENpYcKk1xFrY1q1JC3TsOSBNBzQr/+SeiYlwG/0DA+qeDrfp1EJhEcsugmywnshflTEPdhnp/cOzS/LeTTos8R03RctvSUjrotgesWbk1iE29X7XKvseJQcJb0Lyup8gCDaKlH/WDfbrAdmjP66d0P1E4/jkBLUnyso2ucgVNTZXYSRGPaHs7qpdF4UFy+O2caOTja3t+ZYm1yNZJVKlR1L90JP2yaLp4OJ2AdU/dauPwLNK3tiHXitYgQtF6hUokvpx0+4Pwq5ImH4agOQ9/94t7zn8b2zYohPAQ0Nvh/9TrgeF9gVt33MjxBGAE="
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "fcd20acb-74f1-4d36-ad46-9c0815b66d8e"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01Ru1iSoqwo61UYTnekTuvhJ",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The file contains a simple text string: `UNIQUE_TEST_CONTENT_1772594572177`\n\nThis appears to be some kind of unique identifier or test content. The number at the end (1772594572177) looks like it could be a timestamp or a unique numeric identifier.",
+            "signature": "EqEDCkYICxgCKkD/KL2r7s/WFjX2GOMMV0fiWwib1DzVI86e8uErgDMohfPfsSFcDFPPTBm3oePbmic597Oor3aPd3pdZexXJWlqEgxG4mB2bTLynDfGQbMaDIgRQ8MsjHxji1H98CIwncyEgRTjKMfBGX+oTTHgKBs69eDFyjnvfPTUyXy+3Jr8iMCP/Sl1E7N76N4N1DIwKogCHPf9CY7q1+1HDLLqSuy02KX5jkHkh7sSW6jSjAENpYcKk1xFrY1q1JC3TsOSBNBzQr/+SeiYlwG/0DA+qeDrfp1EJhEcsugmywnshflTEPdhnp/cOzS/LeTTos8R03RctvSUjrotgesWbk1iE29X7XKvseJQcJb0Lyup8gCDaKlH/WDfbrAdmjP66d0P1E4/jkBLUnyso2ucgVNTZXYSRGPaHs7qpdF4UFy+O2caOTja3t+ZYm1yNZJVKlR1L90JP2yaLp4OJ2AdU/dauPwLNK3tiHXitYgQtF6hUokvpx0+4Pwq5ImH4agOQ9/94t7zn8b2zYohPAQ0Nvh/9TrgeF9gVt33MjxBGAE="
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 13,
+          "cache_creation_input_tokens": 299,
+          "cache_read_input_tokens": 17290,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 299
+          },
+          "output_tokens": 3,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "uuid": "0a54f8dd-c35a-4b8b-891b-4e16c100ac9f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "0cd4d7af-cc9b-4347-b2b1-009bcb7c9134"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "text",
+          "text": ""
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "780157af-16c8-4409-833d-a50b65955a8e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "The"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "77de2100-55f3-456d-8bd4-0adbaabdce92"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " file **"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d5d5c39d-3f39-4e7b-8c06-1fb0eae107fd"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "unique"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "37ee0102-eba2-450e-8ec7-c74e0e1f222b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "-test.txt** contains a single"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "c76ece59-6842-4a90-955c-0369a326e381"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " line:"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "bb64d1c4-2ea9-4b8b-94d1-edea52b7f360"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "\n\n```"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "1f1a6aba-6275-4358-875d-ffd31eb23d75"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "\nUNIQUE_TEST_CONTENT"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "2991caeb-c837-4d39-9296-5c95b7adbd88"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "_1772594572177\n```"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "3762c6f7-da88-413a-8935-da584a963513"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "\n\nThis appears to be a test"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "cb95f621-fc63-4726-bd41-af7aa1579c3d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " file"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e6a55c8c-143b-4957-9224-7f4f5bf4e6ab"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " containing a unique identifier string"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "915b2115-4f89-4bcb-8ed1-c1dfd2db0e22"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": ". The number"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "30214628-ff68-4a1b-ac0b-031b43c8e60f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " at"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "1775a8ab-929c-4eff-a018-488974362af4"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " the end (1772594572177"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "68294720-e239-4213-8046-2238ad358be9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": ") looks"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "328eed67-56cd-41b1-91c9-7fb80a3e26e3"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " like it could be a timestamp or unique"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "95df8fa3-1ed4-4eb3-afa1-d12e080b58c7"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " numeric"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "2f5c35ef-86bf-4dc0-8009-8c7b65e0ae96"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " identifier. It"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "36899827-b101-4bb8-962c-13206f16ae32"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "'s likely"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "e752ee1c-d890-4798-9dbd-31e8df7a6b86"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " used"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "73a4ea6d-cd04-42ac-8506-940a7578ca22"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " for testing purposes to"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "17b16c8a-22d4-4d24-af5e-a720e27af36b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " verify"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "3c3cf57f-4b6a-4f3d-a49e-7e0c2d7fb206"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " file"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "b24818ac-eda8-41e5-8620-e9aa70dbc0dd"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " handling"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "02763d27-ef19-4227-a334-548230fa6a3a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " or content"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "7241c32f-0927-492c-bf7f-cc419b3b4c16"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " validation"
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "b701e46b-a2a6-4481-8830-0c5b910aa5fc"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "."
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "a018a586-7efa-491f-8a80-9a523a4f1992"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01Ru1iSoqwo61UYTnekTuvhJ",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "The file **unique-test.txt** contains a single line:\n\n```\nUNIQUE_TEST_CONTENT_1772594572177\n```\n\nThis appears to be a test file containing a unique identifier string. The number at the end (1772594572177) looks like it could be a timestamp or unique numeric identifier. It's likely used for testing purposes to verify file handling or content validation."
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 13,
+          "cache_creation_input_tokens": 299,
+          "cache_read_input_tokens": 17290,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 299
+          },
+          "output_tokens": 158,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "uuid": "d698b79e-fca1-48e2-999d-063d8b79d49c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "d5b55139-85bf-4f2b-93bd-8174f52d330a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "end_turn",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 13,
+          "cache_creation_input_tokens": 299,
+          "cache_read_input_tokens": 17290,
+          "output_tokens": 158
+        }
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "38c06560-3d27-412a-8286-d6f604147299"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "parent_tool_use_id": null,
+      "uuid": "6e401d6b-d26c-4e51-ae6a-9ff4a973381a"
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "duration_ms": 5478,
+      "duration_api_ms": 15925,
+      "num_turns": 2,
+      "result": "The file **unique-test.txt** contains a single line:\n\n```\nUNIQUE_TEST_CONTENT_1772594572177\n```\n\nThis appears to be a test file containing a unique identifier string. The number at the end (1772594572177) looks like it could be a timestamp or unique numeric identifier. It's likely used for testing purposes to verify file handling or content validation.",
+      "session_id": "1454524d-b4ab-41df-a92c-a37b99762c53",
+      "total_cost_usd": 0.04163445,
+      "usage": {
+        "input_tokens": 23,
+        "cache_creation_input_tokens": 2583,
+        "cache_read_input_tokens": 32296,
+        "output_tokens": 346,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 2583,
+          "ephemeral_5m_input_tokens": 0
+        }
+      },
+      "modelUsage": {
+        "claude-opus-4-5-20251101": {
+          "inputTokens": 3943,
+          "outputTokens": 240,
+          "cacheReadInputTokens": 11068,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.031249000000000002,
+          "contextWindow": 200000
+        },
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 32,
+          "outputTokens": 560,
+          "cacheReadInputTokens": 43247,
+          "cacheCreationInputTokens": 2583,
+          "webSearchRequests": 0,
+          "costUSD": 0.010385450000000001,
+          "contextWindow": 200000
+        }
+      },
+      "permission_denials": [],
+      "uuid": "ae808301-606d-4388-b6f3-6242db031dd1"
+    }
+  ],
+  "key": "runSession-40b6b836a2e97349",
+  "recordedAt": "2026-03-04T03:23:01.726Z"
+}

--- a/tests/e2e/cassettes/runSession-856c4f2335f0dace.json
+++ b/tests/e2e/cassettes/runSession-856c4f2335f0dace.json
@@ -1,0 +1,456 @@
+{
+  "prompt": "Reply with exactly: \"Refresh comparison test.\" Nothing else.",
+  "model": "claude-haiku-4-5-20251001",
+  "events": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "cwd": "/Users/ferrislucas/claudetools.io/.worktrees/2f7a52de-0769-4aeb-93c8-ecddc57c2de1",
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "tools": [
+        "Task",
+        "TaskOutput",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "KillShell",
+        "AskUserQuestion",
+        "Skill",
+        "EnterPlanMode",
+        "LSP"
+      ],
+      "mcp_servers": [],
+      "model": "claude-haiku-4-5-20251001",
+      "permissionMode": "default",
+      "slash_commands": [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "pr-comments",
+        "release-notes",
+        "review",
+        "security-review"
+      ],
+      "apiKeySource": "none",
+      "claude_code_version": "2.0.77",
+      "output_style": "default",
+      "agents": [
+        "Bash",
+        "general-purpose",
+        "statusline-setup",
+        "Explore",
+        "Plan",
+        "playwright-e2e-runner"
+      ],
+      "skills": [],
+      "plugins": [],
+      "uuid": "2f1f5050-b6df-41e1-8878-4979d571f10a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_01PF9NvcVDiwxsMDj32N7Sss",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 6407,
+            "cache_read_input_tokens": 15493,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 6407
+            },
+            "output_tokens": 7,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "5b270cb1-eba5-4a44-b4ad-12d5dcddedec"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "86a568ff-5e5a-4f1c-b954-9984db5a94b8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The user is asking me to reply"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "b78636ba-9be5-471f-a395-9aab145c2142"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with exactly: \"Refresh comparison test"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "b86d1ea7-1823-4b81-9fc2-cd96c770eb66"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ".\" and"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "43aa2c50-4bd8-4cd8-aac4-f75912206260"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " nothing else.\n\nThis is"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "4899e157-dd2e-4549-8073-e1e3d56d6b92"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " a clear and"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "5efd64e8-25d4-4889-a3a6-8c826249fa02"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " specific instruction."
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "c192ec5b-b548-4d97-94e4-a505d7db9b04"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " I should"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "de8c6857-fc7e-4dc6-bd00-27d624b3c697"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " follow"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "c46c307b-558c-4e46-8c3b-30b3d638aaea"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " it"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "c130ef8c-0493-495c-a140-ce55b5fb0263"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " exactly as written"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "56ad5912-c916-4ced-a724-7dce580d4c8e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "."
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "e1151da9-9376-418f-ab79-39fc80c3aedb"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "EtQCCkYICxgCKkDY/FPPVID8i1eonD6SUrxZc2rqa7/ddKs/Up5/tPgiyVKhvkYK8E3ldW9xYCjlEwRg9XuAXv+YMY7Od3pXLOogEgxnUqkKCrOln+WevmUaDFhmRpyUaqX14LAfiCIwTvwp78WMQoc82WbrKV3rG/rsj/0nbs5tQa9us9uWJmA2m6SCxSLDKT43gMTiKB0BKrsB2xJW7gZr01BwJ2pfXho2aqwXh9jXl1BuLzMj6KcDppxTsJlW6AddOCM43LyDW2QR4tpKUMhXLo9thg8LMD87c24aecY4U3+0BPJXE5Q2shtfo4OmqcOR2zU+JwIMu7jrZbf9wxFZMjZUDRIba2ynW2Lhy7B5FHt55bJDTz6CMfnwBRENDrgOgQw/AeFmvTVuWkL3EFwbQbrodAzx8YOc/UEb1hx+czpvmMEM/6xWFnJqPLs5SpkxLt4hLhgB"
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "0f3e9f83-e45c-4505-827e-f5cc26edf62f"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01PF9NvcVDiwxsMDj32N7Sss",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The user is asking me to reply with exactly: \"Refresh comparison test.\" and nothing else.\n\nThis is a clear and specific instruction. I should follow it exactly as written.",
+            "signature": "EtQCCkYICxgCKkDY/FPPVID8i1eonD6SUrxZc2rqa7/ddKs/Up5/tPgiyVKhvkYK8E3ldW9xYCjlEwRg9XuAXv+YMY7Od3pXLOogEgxnUqkKCrOln+WevmUaDFhmRpyUaqX14LAfiCIwTvwp78WMQoc82WbrKV3rG/rsj/0nbs5tQa9us9uWJmA2m6SCxSLDKT43gMTiKB0BKrsB2xJW7gZr01BwJ2pfXho2aqwXh9jXl1BuLzMj6KcDppxTsJlW6AddOCM43LyDW2QR4tpKUMhXLo9thg8LMD87c24aecY4U3+0BPJXE5Q2shtfo4OmqcOR2zU+JwIMu7jrZbf9wxFZMjZUDRIba2ynW2Lhy7B5FHt55bJDTz6CMfnwBRENDrgOgQw/AeFmvTVuWkL3EFwbQbrodAzx8YOc/UEb1hx+czpvmMEM/6xWFnJqPLs5SpkxLt4hLhgB"
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 6407,
+          "cache_read_input_tokens": 15493,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6407
+          },
+          "output_tokens": 7,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "uuid": "cace7480-dcfd-493f-a9f7-cdb0127c4f19"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "ce6aff48-0f67-4a5f-bc7a-95be6b89b3d8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "text",
+          "text": ""
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "b545a994-7cd6-4f83-a752-f67edf8ade1b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "Refresh comparison test."
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "8f2498b7-7222-415f-bba3-291a570df985"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01PF9NvcVDiwxsMDj32N7Sss",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "Refresh comparison test."
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 6407,
+          "cache_read_input_tokens": 15493,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 6407
+          },
+          "output_tokens": 53,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "uuid": "d6cc9162-f2ef-4da3-bedb-6f957e912a4c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "d53d7d18-bdba-4647-ad0b-4814ab2526df"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "end_turn",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 6407,
+          "cache_read_input_tokens": 15493,
+          "output_tokens": 53
+        }
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "760ce30a-7000-4b68-83cc-04c072639c9e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "parent_tool_use_id": null,
+      "uuid": "cdbc21d4-bdf9-450b-b393-8cc86af6f322"
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "duration_ms": 1567,
+      "duration_api_ms": 1535,
+      "num_turns": 1,
+      "result": "Refresh comparison test.",
+      "session_id": "922460a6-cd09-4bbe-96f9-c0fa6c9607f1",
+      "total_cost_usd": 0.00983305,
+      "usage": {
+        "input_tokens": 10,
+        "cache_creation_input_tokens": 6407,
+        "cache_read_input_tokens": 15493,
+        "output_tokens": 53,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 6407,
+          "ephemeral_5m_input_tokens": 0
+        }
+      },
+      "modelUsage": {
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 10,
+          "outputTokens": 53,
+          "cacheReadInputTokens": 15493,
+          "cacheCreationInputTokens": 6407,
+          "webSearchRequests": 0,
+          "costUSD": 0.00983305,
+          "contextWindow": 200000
+        }
+      },
+      "permission_denials": [],
+      "uuid": "85d1932f-ae2a-4f19-8301-840a8260b0cb"
+    }
+  ],
+  "key": "runSession-856c4f2335f0dace",
+  "recordedAt": "2026-03-04T03:26:49.051Z"
+}

--- a/tests/e2e/cassettes/runSession-d07d434042aa6b94.json
+++ b/tests/e2e/cassettes/runSession-d07d434042aa6b94.json
@@ -1,0 +1,960 @@
+{
+  "prompt": "Reply with exactly: \"Hello, persistence test complete.\" Nothing else.",
+  "model": "claude-haiku-4-5-20251001",
+  "events": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "cwd": "/Users/ferrislucas/claudetools.io/.worktrees/2f7a52de-0769-4aeb-93c8-ecddc57c2de1",
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "tools": [
+        "Task",
+        "TaskOutput",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "KillShell",
+        "AskUserQuestion",
+        "Skill",
+        "EnterPlanMode",
+        "LSP"
+      ],
+      "mcp_servers": [],
+      "model": "claude-haiku-4-5-20251001",
+      "permissionMode": "default",
+      "slash_commands": [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "pr-comments",
+        "release-notes",
+        "review",
+        "security-review"
+      ],
+      "apiKeySource": "none",
+      "claude_code_version": "2.0.77",
+      "output_style": "default",
+      "agents": [
+        "Bash",
+        "general-purpose",
+        "statusline-setup",
+        "Explore",
+        "Plan",
+        "playwright-e2e-runner"
+      ],
+      "skills": [],
+      "plugins": [],
+      "uuid": "d9fdb808-c62f-4d0b-835b-17d01ffb4359"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_01Nk1PDRbcAePRi5uVbifW3u",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 21910,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 21910
+            },
+            "output_tokens": 7,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "ae7984bf-ad9c-4c63-8618-8dcb895ced95"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "d0a34cd0-7593-4b44-980d-48b560a84d5b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The user is asking me to reply"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "84a34ff4-126d-4d8a-83d4-75ce72f7756c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with exactly \"Hello, persistence test complete"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "28824501-c42e-4782-ab03-7332c314363f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ".\" and"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "7db1ca8f-e5d3-4226-ab9c-95a5152795b3"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " nothing else."
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "a3f996c2-08de-4f19-a889-239ca39fd09d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\n\nThis appears to be a test to"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "19bd9174-7f0d-477e-b5cd-a5cb076ed385"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " see if I will"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "1bd0f895-21fb-493c-8a6e-34b936421fcc"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " follow"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "a2d3f9ee-df04-4adb-baea-786f961972c0"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " specific"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "23fb8334-e227-4425-917a-781258dd6ed6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " instructions even"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "3d6fb5c1-2111-4f28-b358-f3137db76664"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " when there"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "0cb5406d-3285-4f7b-aa2d-ab2924472747"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "'s a"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "4984a30a-41c4-42df-b0ba-43f4bcd5fcf7"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " lot"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "fff32d9f-e24e-4e38-b6e9-14e3464a4d3e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " of context provided"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "675b887b-bc6c-45a5-aafc-fc349ea579cf"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " before"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "b4b51b96-2e1d-48c8-a08b-88719d0b33a8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " it"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "29aeb42e-f9d7-40fa-b58c-5fa61f4666fa"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ". The system"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "0ce216f4-fcc1-4003-800e-c3ed09389da1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " reminder"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "01286e7d-4711-41f1-a5dd-deff4045fb68"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "7da0817b-74f0-4c83-8691-55776033a885"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "c314e0f8-93c5-4bb7-b4d2-f733a282bfb2"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " CLAUDE"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "b9852e7e-52a5-4761-89cc-5007cbd18f88"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "."
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "a8008f69-07a2-492a-a64b-c435cdfc61b6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "md instructions"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "978473cb-f4aa-43dc-974b-caed8761b497"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " is"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "71a38ba8-bbb6-4690-a800-52cebf66284e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " context"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "5f80eacf-770a-4b26-9385-ea4a53eef30b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " that I should be"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "bf8253f0-3ad0-444f-a4d5-6ed3b6e2e888"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " aware of for"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "c5da8349-06bb-4e0a-a9df-0d7051c278df"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " working"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "10faa562-7f67-4f48-9a50-512a35eb77c4"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with this"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "a4a38124-e0e8-418d-8ef0-c3816e0ccd5f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " codebase,"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "bfe4db6d-4680-4cc9-99ad-0b2f8322a5fc"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " but the"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "4b5851b9-3c74-4754-ab30-5f78c925d55e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " actual user"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "57d70f8f-12e0-4b92-a50a-413f82ff5b3e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " request"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "f4483559-91fb-4cb7-9d4f-07d5c0914df6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " is simple"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "9e058234-0e67-4eb2-96c0-b7090d408fb9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " and"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "50ebf99b-165b-4e5d-ac10-8b71ee9d7c91"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " clear"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "0f1456a4-e075-4e60-a3d0-f3dd895d0c57"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ":"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "2089bbc4-50be-4f42-9b7d-07f9ec876a24"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " just"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "c7ecf8b3-6ed1-4a7c-bcc0-3db155cb76f8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " reply"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "39b2b920-1a1c-42db-8390-40c6966fdcc0"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with that"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "b3269a6e-297e-4343-8dee-623325033286"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " exact"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "f95c86b1-cb40-416b-b76b-b229270add49"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " phrase"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "693568d5-bb4a-4f8c-8604-f9ae5ceb6467"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ".\n\nI"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "06c8da30-1a5a-4ace-b631-bcd33c3188ed"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " should follow"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "94c5eaa4-e67c-4617-bc54-1fed11d40860"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the user"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "cf47eceb-8f7d-4336-b5c9-83da157a368f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "'s explicit"
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "0191cfc5-5db1-4c83-b147-c567a115218c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " instruction."
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "f42dc1f4-2abc-4658-8900-df78236c3f62"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ""
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "a0b67508-0490-472e-b8a0-51a2628f77c7"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "EocFCkYICxgCKkCiqpqK0GA+tfBEGeYPGABnA/ItN18JIMeeaDr8RAnnLZsClL9vdltV4Ykpw0RXQZrV5QL1Ybe7AlSdZV3fPU2HEgyDOLpM0oilkF4OVd0aDNjmgEjP8RHsvcERmSIw62IkKM/BaAMLfwIl3C/o1Q+6BzKJTtDD4vPibAQ5LUwuS6DWqqhFuyjrx4Fvwj1RKu4D8lrddkP/5/lrC/QKQgOxfnDT110cRp/uPdLKrvJvm/kOg1Ge6VPUEVu3ntGy9EKkPWP0FlcmLc8OREgry7VuxUPIIL1B7zkn62Y+/+T4DbuTnat6PX48YdnU4dJI2MWl5s7nCWYLFv0bBOzHPDM0rNsiPODPioFfJO6xrVBavVd3qlYpz0LM25hmS39lqOJexkdyTbadQM/9C9czv0wYCjDdMxj+rVfLYFxHjDDma06jBcXERxZcEQvENSDkx+NJHbTkxwUgJXjWJdY83q5CjAUFPKsAGYTb4nqE7cH9EJRvkytnI1TRUtecm59qx0iOInpWzebGXepWC2HiFpw19bPUGJyJ9fScT6qjEIoE0teAJ9k/wLJQZ540NgkG6P0DpfX8dwOCeNNXwNEFtbdUd0RDsLQBrLlQBcfra4g0kLBlPg/DqIpFHzCxVZxUvphJkR1eQC4MxsuHyVpftnfa7eQ8M6PPAfX6FgvTGx4911vf6HTjbnOLz43RLIR+wdF6QP+uB6uIo/HqhGNZcQehKxRQQy9palqXOl7U3a8J1ZMpc9FXrQiKnSEpvDKLxAHWEU18UtkvYiOnPlHAIBoXhFlLCx0yWyO43yKe/99gBVBDRkPyLTrg1bJzsfNohAW/jwLOp3ZgW1GZa8Gn/88YAQ=="
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "126db2f6-0032-41b2-929d-98a1be42db45"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01Nk1PDRbcAePRi5uVbifW3u",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The user is asking me to reply with exactly \"Hello, persistence test complete.\" and nothing else.\n\nThis appears to be a test to see if I will follow specific instructions even when there's a lot of context provided before it. The system reminder with the CLAUDE.md instructions is context that I should be aware of for working with this codebase, but the actual user request is simple and clear: just reply with that exact phrase.\n\nI should follow the user's explicit instruction.",
+            "signature": "EocFCkYICxgCKkCiqpqK0GA+tfBEGeYPGABnA/ItN18JIMeeaDr8RAnnLZsClL9vdltV4Ykpw0RXQZrV5QL1Ybe7AlSdZV3fPU2HEgyDOLpM0oilkF4OVd0aDNjmgEjP8RHsvcERmSIw62IkKM/BaAMLfwIl3C/o1Q+6BzKJTtDD4vPibAQ5LUwuS6DWqqhFuyjrx4Fvwj1RKu4D8lrddkP/5/lrC/QKQgOxfnDT110cRp/uPdLKrvJvm/kOg1Ge6VPUEVu3ntGy9EKkPWP0FlcmLc8OREgry7VuxUPIIL1B7zkn62Y+/+T4DbuTnat6PX48YdnU4dJI2MWl5s7nCWYLFv0bBOzHPDM0rNsiPODPioFfJO6xrVBavVd3qlYpz0LM25hmS39lqOJexkdyTbadQM/9C9czv0wYCjDdMxj+rVfLYFxHjDDma06jBcXERxZcEQvENSDkx+NJHbTkxwUgJXjWJdY83q5CjAUFPKsAGYTb4nqE7cH9EJRvkytnI1TRUtecm59qx0iOInpWzebGXepWC2HiFpw19bPUGJyJ9fScT6qjEIoE0teAJ9k/wLJQZ540NgkG6P0DpfX8dwOCeNNXwNEFtbdUd0RDsLQBrLlQBcfra4g0kLBlPg/DqIpFHzCxVZxUvphJkR1eQC4MxsuHyVpftnfa7eQ8M6PPAfX6FgvTGx4911vf6HTjbnOLz43RLIR+wdF6QP+uB6uIo/HqhGNZcQehKxRQQy9palqXOl7U3a8J1ZMpc9FXrQiKnSEpvDKLxAHWEU18UtkvYiOnPlHAIBoXhFlLCx0yWyO43yKe/99gBVBDRkPyLTrg1bJzsfNohAW/jwLOp3ZgW1GZa8Gn/88YAQ=="
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 21910,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 21910
+          },
+          "output_tokens": 7,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "uuid": "ad5df12f-5a57-4cb3-bc88-4b2118648be9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "7a0453b1-e8d5-4703-a6c8-df1a49f871b9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "text",
+          "text": ""
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "5be56ac6-3c38-4f66-b58a-d37a2030f419"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "Hello, persistence test complete."
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "1eb73f9d-7af0-451b-b1a6-99ed59e8d89f"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01Nk1PDRbcAePRi5uVbifW3u",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "Hello, persistence test complete."
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 21910,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 21910
+          },
+          "output_tokens": 117,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "uuid": "9151dd06-92fe-458f-8a8d-def38b3dda9b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "f53199dd-9a59-403c-b32d-0fd28340e841"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "end_turn",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 21910,
+          "cache_read_input_tokens": 0,
+          "output_tokens": 117
+        }
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "1add1081-f79e-4d21-8c17-1a6f202d2078"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "parent_tool_use_id": null,
+      "uuid": "128a8d0b-4128-4624-8a15-89acd27fe1d7"
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "duration_ms": 2021,
+      "duration_api_ms": 1993,
+      "num_turns": 1,
+      "result": "Hello, persistence test complete.",
+      "session_id": "46bddc09-537f-4706-9813-b1799b1a6022",
+      "total_cost_usd": 0.0279825,
+      "usage": {
+        "input_tokens": 10,
+        "cache_creation_input_tokens": 21910,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 117,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 21910,
+          "ephemeral_5m_input_tokens": 0
+        }
+      },
+      "modelUsage": {
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 10,
+          "outputTokens": 117,
+          "cacheReadInputTokens": 0,
+          "cacheCreationInputTokens": 21910,
+          "webSearchRequests": 0,
+          "costUSD": 0.0279825,
+          "contextWindow": 200000
+        }
+      },
+      "permission_denials": [],
+      "uuid": "48702f0d-c6ff-4d2c-830b-1dc19050a77f"
+    }
+  ],
+  "key": "runSession-d07d434042aa6b94",
+  "recordedAt": "2026-03-04T03:26:41.670Z"
+}

--- a/tests/e2e/cassettes/runSession-d128e0c753f313ac.json
+++ b/tests/e2e/cassettes/runSession-d128e0c753f313ac.json
@@ -1,0 +1,1001 @@
+{
+  "prompt": "What is in this file?\n\n## Attached Files\n--- File: unique-test.txt (text/plain) ---\nUNIQUE_TEST_CONTENT_1772593242123\n--- End of unique-test.txt ---",
+  "model": "claude-haiku-4-5-20251001",
+  "events": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "cwd": "/private/tmp/test",
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "tools": [
+        "Task",
+        "TaskOutput",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "KillShell",
+        "AskUserQuestion",
+        "Skill",
+        "EnterPlanMode",
+        "LSP"
+      ],
+      "mcp_servers": [],
+      "model": "claude-haiku-4-5-20251001",
+      "permissionMode": "default",
+      "slash_commands": [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "pr-comments",
+        "release-notes",
+        "review",
+        "security-review"
+      ],
+      "apiKeySource": "none",
+      "claude_code_version": "2.0.77",
+      "output_style": "default",
+      "agents": [
+        "Bash",
+        "general-purpose",
+        "statusline-setup",
+        "Explore",
+        "Plan"
+      ],
+      "skills": [],
+      "plugins": [],
+      "uuid": "52f29096-ac72-461e-8ef7-898c7b0f5053"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_01MzHB8drrDfA12wBdMqBJWs",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 2264,
+            "cache_read_input_tokens": 15006,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 2264
+            },
+            "output_tokens": 6,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "d9680c67-2e9c-4402-bbac-a9b394920282"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "d8aa60be-040a-4672-88ac-26dfc01756e9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The user is asking about the"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "42c82ac7-f324-4a6b-89cb-3a88772b7a3a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " content"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "11f36bc9-9f39-4f32-8070-b33847614383"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " of the"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "5ffcc291-0494-4760-8bb2-79154ac1cdee"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " attached"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "b1955220-edb7-4b2a-8ae4-903f13763f60"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " file. I can"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "b66c9d70-27ca-4aaf-99e9-c88c5a9cac98"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " see the"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "57bd36cb-f4be-4a44-b139-d4d16f76dab6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " file content"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "81bcb852-ecc2-4bbb-9d58-37122ac4fb47"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " is"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "5418bb42-e9b4-426e-848c-b32a552ee28b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " already"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "64ef3b08-099c-46ff-b2fe-156946f00bd8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " displayed"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "e275252e-04ed-49cc-8dbc-377ba77a57ab"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " in the message"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "1961c15e-ff14-4fbd-8dda-451d6755f569"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ":"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "ce94f248-f3f9-4420-a210-a79af0573d26"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\n\nThe"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "ea922367-aa22-4049-822f-cc13d8263259"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " file"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "644f7b7a-6a0b-4c7d-a8d6-5e5c4dcc27bd"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " `"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "4a60a70f-4393-4514-98a2-36a8f0d5e21c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "unique-test.txt` contains:"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "99276676-d761-4930-98fc-5685995c6ab1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\n```"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "2f77ad46-1a46-49d0-a5f3-d39c97fa122f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\nUNIQUE_TEST_CONTENT"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "1d945298-85ff-4b7c-93a1-e48c4f2524b9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "_1772593242123\n```"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "1a60eebd-1abb-42c4-be93-51312251d985"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\n\nThe"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "93abb437-e24b-47e7-b471-14669f12044e"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " user is asking what's in the"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "0c27664f-665b-4a37-9b66-80ee9de8a253"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " file, and"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "a553e07e-4ff9-4810-9965-b645f48a8d97"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "429852c0-aa70-4cb8-9015-f69193f3a92c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " content is already shown"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "87a6f674-43c6-4641-8a78-aefb6dc80278"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " in"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "bd1a81e7-b488-445b-a28a-1e61212e9973"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the prompt"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "66f29b9e-a962-4a66-8a09-5dca88a6c3a0"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ". I can"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "a04fc777-ffce-4c3f-963e-a399f283911f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " simply"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "d4dec5c0-3e9b-4dd5-a951-3b2661b79314"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " tell"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "2b4ee388-db19-4a08-9e71-a87ca3ca0cc4"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " them what's in it"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "968c1633-df7e-4aaa-a1c1-67605ed69d64"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " based"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "e46b5595-5dbc-430e-96e9-b83b7dac85fc"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " on the content provided"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "88a7b4c6-064f-4a2f-9785-3d2c3bafe964"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "."
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "c59ae959-f385-4ca8-90a5-e2142d464ca8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "EogECkYICxgCKkAPIlvbA92uhPVgoQ7SIJA9mpro++0b4R45gn+jj+vHOF5WfPEIXzfZEa1021uFws3bFlNGqBtEM6UdbdSCGTkXEgwRFE30+FxEXwNVRIYaDOupafq7lX9q3W4TjCIwqUHxp8bZ6rtXA5fi+jbkWYtGovWhELHQc5ol5o33IaXMvGgjvSfL697jYg9VX1UFKu8Cvua6Jknzl+SpudIQI+s4hm4cLB7njjJp5DsiwmeijKftrcOFaF9jhc4qG+fzfQUU4SPMuUGQLGDp98Xe79HziDmjtcaHpgw4OCWXt+8UfjzyiISnFmQ0WAbQN9t/2QR/kWWFmyJpWHdcAvgXMHO2nAymsNdUMJmtNGHrVwtH7zdPfpboHzo2c10PfbmzpZhs2X2o6cGjw5wokjZv08rSFVpNNwERew1YGp9DtXSN3g+r2iuouJVEEueeaafouYqWWPe0ednsLUg3dc1o03UQVk0ORpDn9pgY24EWtxfEe45WlqG3COmjKFap8r0EpLiIk4c7tBltCp8hF/JcF603AzyBNX5U/DICXlslR+eVUNig795ILLL1uedVmn6x5wbUVBrZHUHmKV6IAXZKjkTkd1sfVLcR+NROjRS+xbJc8MwuuKOQeoBGRiOblgQ2BG31oY1pvOj7OOuYOEjjiezF5fTe3ioCKnCmz8aQ5d6oGBgB"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "d51925f4-8ba7-42c8-9e6b-b19d06472066"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01MzHB8drrDfA12wBdMqBJWs",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The user is asking about the content of the attached file. I can see the file content is already displayed in the message:\n\nThe file `unique-test.txt` contains:\n```\nUNIQUE_TEST_CONTENT_1772593242123\n```\n\nThe user is asking what's in the file, and the content is already shown in the prompt. I can simply tell them what's in it based on the content provided.",
+            "signature": "EogECkYICxgCKkAPIlvbA92uhPVgoQ7SIJA9mpro++0b4R45gn+jj+vHOF5WfPEIXzfZEa1021uFws3bFlNGqBtEM6UdbdSCGTkXEgwRFE30+FxEXwNVRIYaDOupafq7lX9q3W4TjCIwqUHxp8bZ6rtXA5fi+jbkWYtGovWhELHQc5ol5o33IaXMvGgjvSfL697jYg9VX1UFKu8Cvua6Jknzl+SpudIQI+s4hm4cLB7njjJp5DsiwmeijKftrcOFaF9jhc4qG+fzfQUU4SPMuUGQLGDp98Xe79HziDmjtcaHpgw4OCWXt+8UfjzyiISnFmQ0WAbQN9t/2QR/kWWFmyJpWHdcAvgXMHO2nAymsNdUMJmtNGHrVwtH7zdPfpboHzo2c10PfbmzpZhs2X2o6cGjw5wokjZv08rSFVpNNwERew1YGp9DtXSN3g+r2iuouJVEEueeaafouYqWWPe0ednsLUg3dc1o03UQVk0ORpDn9pgY24EWtxfEe45WlqG3COmjKFap8r0EpLiIk4c7tBltCp8hF/JcF603AzyBNX5U/DICXlslR+eVUNig795ILLL1uedVmn6x5wbUVBrZHUHmKV6IAXZKjkTkd1sfVLcR+NROjRS+xbJc8MwuuKOQeoBGRiOblgQ2BG31oY1pvOj7OOuYOEjjiezF5fTe3ioCKnCmz8aQ5d6oGBgB"
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 2264,
+          "cache_read_input_tokens": 15006,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2264
+          },
+          "output_tokens": 6,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "uuid": "5493fb47-f789-471a-bca7-f82c4a78b08a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "4b449a55-3ff1-4274-b73f-51e6d0af87d0"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "text",
+          "text": ""
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "27f4602d-8b0c-4233-b607-f4c2c3e064de"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "The"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "e933cc0c-77fd-4067-a68d-c01362111708"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " file `unique-test.txt`"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "02c6c794-6e28-4cc9-884a-cb91a817ef9b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " contains a"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "e26017c9-ddd1-43de-a60c-66b1ec30d1c4"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " single line of text:\n\n```"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "574b5f2c-92c4-4e0e-8659-b23509b1e3bf"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "\nUNIQUE_TEST_CONTENT_"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "6b32c20b-a806-48f6-90e6-66436936fd79"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "1772593242123\n```"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "770c12f1-9780-42f9-90f0-feb7fab28835"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "\n\nIt"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "ea614a03-c973-4a5b-b06d-c59eb4971887"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " appears to be a test file with a"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "4cc19d03-a3e4-4bf0-8dfe-5d8e3e23b09a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " unique identifier"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "364ad698-8ea7-4f83-8284-1e142ba5e0c1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " or"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "6641574e-a153-4089-a727-9496bf8feedf"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " test"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "a6ed4354-0d3c-4f30-b0ed-1a74c462c0b7"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " content string"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "c9f9abfe-9ce6-4a40-a194-d1a04089afd1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " that includes"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "8c184b13-8421-44c6-b3b4-c0796d04f7ce"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " a"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "9107c515-de16-4b02-b855-9fa05144496a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " timestamp"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "63b8af1a-89da-4572-87fc-58a90883a69f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "-"
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "3375a7d8-e8e6-459c-8403-a67319afc6c1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "like number ("
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "d036c15b-0aff-42a0-b4bd-a31a1dc0d8f6"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "1772593242123)."
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "737c16de-a6a2-4134-b4a5-65f0e608e8c6"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01MzHB8drrDfA12wBdMqBJWs",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "The file `unique-test.txt` contains a single line of text:\n\n```\nUNIQUE_TEST_CONTENT_1772593242123\n```\n\nIt appears to be a test file with a unique identifier or test content string that includes a timestamp-like number (1772593242123)."
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 2264,
+          "cache_read_input_tokens": 15006,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 2264
+          },
+          "output_tokens": 6,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "uuid": "897e085c-b182-4fed-99a7-678f3b9088ce"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "855c4a1b-62b0-417c-a4dd-c6d83e9e3b45"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "end_turn",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 2264,
+          "cache_read_input_tokens": 15006,
+          "output_tokens": 166
+        }
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "24e11a28-8a8c-4bab-ae5a-634b636ac0f8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "parent_tool_use_id": null,
+      "uuid": "14a1ba02-4f8e-4ae7-b2d2-3ad46fbca949"
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "duration_ms": 1865,
+      "duration_api_ms": 1819,
+      "num_turns": 1,
+      "result": "The file `unique-test.txt` contains a single line of text:\n\n```\nUNIQUE_TEST_CONTENT_1772593242123\n```\n\nIt appears to be a test file with a unique identifier or test content string that includes a timestamp-like number (1772593242123).",
+      "session_id": "2d1f8782-a4ff-4717-918f-ee4d69937903",
+      "total_cost_usd": 0.0051706,
+      "usage": {
+        "input_tokens": 10,
+        "cache_creation_input_tokens": 2264,
+        "cache_read_input_tokens": 15006,
+        "output_tokens": 166,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 2264,
+          "ephemeral_5m_input_tokens": 0
+        }
+      },
+      "modelUsage": {
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 10,
+          "outputTokens": 166,
+          "cacheReadInputTokens": 15006,
+          "cacheCreationInputTokens": 2264,
+          "webSearchRequests": 0,
+          "costUSD": 0.0051706,
+          "contextWindow": 200000
+        }
+      },
+      "permission_denials": [],
+      "uuid": "3386549c-77e6-4c7d-bf23-11d893d53760"
+    }
+  ],
+  "key": "runSession-d128e0c753f313ac",
+  "recordedAt": "2026-03-04T03:00:47.443Z"
+}

--- a/tests/e2e/cassettes/runSession-f607a7ab0f6ee1fa.json
+++ b/tests/e2e/cassettes/runSession-f607a7ab0f6ee1fa.json
@@ -1,0 +1,526 @@
+{
+  "prompt": "Reply with exactly: \"UI creation persistence test.\" Nothing else.",
+  "model": "claude-haiku-4-5-20251001",
+  "events": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "cwd": "/Users/ferrislucas/claudetools.io/.worktrees/2f7a52de-0769-4aeb-93c8-ecddc57c2de1/.worktrees/95d79893-0150-40dc-ba32-e5b3f9d9a334",
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "tools": [
+        "Task",
+        "TaskOutput",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "KillShell",
+        "AskUserQuestion",
+        "Skill",
+        "EnterPlanMode",
+        "LSP"
+      ],
+      "mcp_servers": [],
+      "model": "claude-haiku-4-5-20251001",
+      "permissionMode": "bypassPermissions",
+      "slash_commands": [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "pr-comments",
+        "release-notes",
+        "review",
+        "security-review"
+      ],
+      "apiKeySource": "none",
+      "claude_code_version": "2.0.77",
+      "output_style": "default",
+      "agents": [
+        "Bash",
+        "general-purpose",
+        "statusline-setup",
+        "Explore",
+        "Plan",
+        "playwright-e2e-runner"
+      ],
+      "skills": [],
+      "plugins": [],
+      "uuid": "6781661e-7c48-4ae1-a8bb-4d47f9230d9b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_01XtU2XbCecsLReG2Cot2GyN",
+          "type": "message",
+          "role": "assistant",
+          "content": [],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 8739,
+            "cache_read_input_tokens": 15493,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 8739
+            },
+            "output_tokens": 7,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          }
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "acf92f98-b0e2-488e-a49b-534ccc3e3ebe"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {
+          "type": "thinking",
+          "thinking": "",
+          "signature": ""
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "a8d9e78c-7af5-4b1b-a4a7-dfeef23fe337"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "The user is asking me to reply"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "d113587e-8873-417b-b174-687e12d698cb"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " with exactly:"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "6349cd42-2140-44c8-8bd9-7692e971e666"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " \"UI creation persistence test.\" and"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "a365c65c-0197-405a-ad05-fd2beaebf90c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " nothing else."
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "791e28be-4bb2-4c38-8428-349405765a52"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "\n\nThis is"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "b05f592d-ad84-4087-93b9-57426a7067ae"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " a very straight"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "b6dece82-06b7-4a22-838a-b0ecce19e21d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "forward request"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "bb7d9d21-09e7-4f26-8a32-c6fc1d70278d"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ". I"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "9109ad78-f256-40b6-9844-d54257abf692"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " should"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "b19cb6f9-926a-4bf7-b9cd-bf7bec5d874f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " follow"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "6e806778-c765-4e9f-b552-6190e0b02d05"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " the instruction"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "b6e10840-ba41-4954-8ceb-6feabc4d2b2c"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " exactly as"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "dfa5c965-f87f-461b-8f42-36e2e95460de"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": " stated"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "da9babaf-f733-40e9-a5df-0a00cf9e62aa"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": "."
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "f3c7766b-f597-4196-8078-4a6f9eda7898"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "thinking_delta",
+          "thinking": ""
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "4880f132-b72a-485a-b05a-fd72d34c017b"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+          "type": "signature_delta",
+          "signature": "EuECCkYICxgCKkDuLyiZyCwBtlzBr/9qx0sfRTe016x/QDCZtAYfiZJ06b38vz3H6Qac9AEKNEb0r+o4bxU/XRjREWguXo8Qq1nIEgwPYhI9FHMqQJdy+WUaDJu78S18Ylgj7T4qFyIw97bP0NuBehvejGSGbqO3sV2SFcv+xv4eJUQKsDvlxqIdn1flPfUaJha66B17EcoTKsgBVJPpYk9nJptUqTIRBnQh+CkLZJmtgKPOgvmtFLaU7uYSqOb9JTeyZFInUvB9VNfA2UhYmCHo8nHl/7hmjdsLryxePNEWhhTI8oQqZWfhMH4+hAMLHlPaiv+RcbWQ5MnGBA07PkRaQvL+DMokXIsEv0wZ/iNEcx96okI5EcYYIcqz7CCmahtfzwIkJYnXf6GyIzhKHHliSyFeiG+sdtXTzZ0tUxtKiYsAP4PoU0yHqa8mhjL7A9QTY2DzWghONpD4pisOiNgfMmgYAQ=="
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "4b394ddd-de50-4545-befa-b63858ac6034"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01XtU2XbCecsLReG2Cot2GyN",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "The user is asking me to reply with exactly: \"UI creation persistence test.\" and nothing else.\n\nThis is a very straightforward request. I should follow the instruction exactly as stated.",
+            "signature": "EuECCkYICxgCKkDuLyiZyCwBtlzBr/9qx0sfRTe016x/QDCZtAYfiZJ06b38vz3H6Qac9AEKNEb0r+o4bxU/XRjREWguXo8Qq1nIEgwPYhI9FHMqQJdy+WUaDJu78S18Ylgj7T4qFyIw97bP0NuBehvejGSGbqO3sV2SFcv+xv4eJUQKsDvlxqIdn1flPfUaJha66B17EcoTKsgBVJPpYk9nJptUqTIRBnQh+CkLZJmtgKPOgvmtFLaU7uYSqOb9JTeyZFInUvB9VNfA2UhYmCHo8nHl/7hmjdsLryxePNEWhhTI8oQqZWfhMH4+hAMLHlPaiv+RcbWQ5MnGBA07PkRaQvL+DMokXIsEv0wZ/iNEcx96okI5EcYYIcqz7CCmahtfzwIkJYnXf6GyIzhKHHliSyFeiG+sdtXTzZ0tUxtKiYsAP4PoU0yHqa8mhjL7A9QTY2DzWghONpD4pisOiNgfMmgYAQ=="
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 8739,
+          "cache_read_input_tokens": 15493,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 8739
+          },
+          "output_tokens": 7,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "uuid": "229c3d2d-f1ff-4261-a4b8-7fadc4fcc50f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 0
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "073b7c9b-cd4d-4ed0-8069-cb5574cec20a"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+          "type": "text",
+          "text": ""
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "b6f2c2b4-6731-4adb-8050-6f41083476a8"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": "UI"
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "a56d8343-1f40-4fed-9c9a-e3cbd3046538"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {
+          "type": "text_delta",
+          "text": " creation persistence test."
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "cee53b56-dfd8-47dc-99ef-2d55872b45a2"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01XtU2XbCecsLReG2Cot2GyN",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "UI creation persistence test."
+          }
+        ],
+        "stop_reason": null,
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 8739,
+          "cache_read_input_tokens": 15493,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 8739
+          },
+          "output_tokens": 54,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        },
+        "context_management": null
+      },
+      "parent_tool_use_id": null,
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "uuid": "b909f5a0-da2d-4745-a64d-41401dcdc3c9"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "content_block_stop",
+        "index": 1
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "dbd4637d-2515-4dbc-8fa3-879ed03b00fa"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "delta": {
+          "stop_reason": "end_turn",
+          "stop_sequence": null
+        },
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 8739,
+          "cache_read_input_tokens": 15493,
+          "output_tokens": 54
+        }
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "f5a565e4-4e6b-4ac5-be0b-16b2c311e18f"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      },
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "parent_tool_use_id": null,
+      "uuid": "b905a6c9-e4a2-40e7-a8b4-3d56d1639cde"
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "duration_ms": 1131,
+      "duration_api_ms": 1775,
+      "num_turns": 1,
+      "result": "UI creation persistence test.",
+      "session_id": "d98c9663-1edd-45b4-a9a3-833a2c4230b6",
+      "total_cost_usd": 0.01334205,
+      "usage": {
+        "input_tokens": 10,
+        "cache_creation_input_tokens": 8739,
+        "cache_read_input_tokens": 15493,
+        "output_tokens": 54,
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 8739,
+          "ephemeral_5m_input_tokens": 0
+        }
+      },
+      "modelUsage": {
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 459,
+          "outputTokens": 82,
+          "cacheReadInputTokens": 15493,
+          "cacheCreationInputTokens": 8739,
+          "webSearchRequests": 0,
+          "costUSD": 0.01334205,
+          "contextWindow": 200000
+        }
+      },
+      "permission_denials": [],
+      "uuid": "e821694f-c7c8-4d7a-9654-60d546ed3dec"
+    }
+  ],
+  "key": "runSession-f607a7ab0f6ee1fa",
+  "recordedAt": "2026-03-04T03:26:44.411Z"
+}


### PR DESCRIPTION
## Summary

This PR implements environment variable isolation for E2E tests to prevent credential leakage and ensure proper test isolation.

- Adds `clear_provider_env_vars()` function to unset provider-related environment variables
- Applies clearing to test, debug, and codegen commands
- Includes new VCR cassettes recorded during test runs

## Changes

- **scripts/pw.sh**
  - New `clear_provider_env_vars()` function that unsets:
    - `ANTHROPIC_BASE_URL`
    - `ANTHROPIC_API_KEY`
    - `ANTHROPIC_AUTH_TOKEN`
    - `ANTHROPIC_DEFAULT_OPUS_MODEL`
    - `ANTHROPIC_DEFAULT_SONNET_MODEL`
    - `ANTHROPIC_DEFAULT_HAIKU_MODEL`
    - `API_TIMEOUT_MS`
  - Calls this function before running tests (`cmd_test`), debug tests (`cmd_debug`), and code generation (`cmd_codegen`)

## Test Plan

- Run E2E tests to ensure cassettes are properly recorded and tests pass
- Verify that environment variables are properly isolated during test runs
- Confirm no unintended side effects from unsetting these variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)