### PR TITLE
fix: Popup menu overflow on mobile devices (Commands tab)

### DIFF
--- a/packages/web/src/components/ActionMenu.test.js
+++ b/packages/web/src/components/ActionMenu.test.js
@@ -421,4 +421,76 @@ describe('ActionMenu.vue', () => {
       expect(items[1].isDanger).toBe(true);
     });
   });
+
+  describe('Menu Positioning', () => {
+    it('positions menu with left: 0 when it would overflow left edge', async () => {
+      const wrapper = mount(ActionMenu, {
+        props: { items: testItems },
+        attachTo: document.body
+      });
+
+      // Mock getBoundingClientRect to simulate overflow on the left
+      const mockRect = { left: -50, right: 150, top: 0, bottom: 100, width: 200, height: 100 };
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+      wrapper.vm.toggleMenu();
+      await flushPromises();
+
+      // Should flip to left-anchored
+      expect(wrapper.vm.menuStyle).toEqual({
+        right: 'auto',
+        left: '0'
+      });
+
+      wrapper.unmount();
+    });
+
+    it('keeps default right: 0 positioning when menu fits in viewport', async () => {
+      const wrapper = mount(ActionMenu, {
+        props: { items: testItems },
+        attachTo: document.body
+      });
+
+      // Mock getBoundingClientRect to show menu fits in viewport
+      const mockRect = { left: 100, right: 300, top: 0, bottom: 100, width: 200, height: 100 };
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+      wrapper.vm.toggleMenu();
+      await flushPromises();
+
+      // Should keep default positioning (empty style object)
+      expect(wrapper.vm.menuStyle).toEqual({});
+
+      wrapper.unmount();
+    });
+
+    it('resets menuStyle when menu is closed', async () => {
+      const wrapper = mount(ActionMenu, {
+        props: { items: testItems },
+        attachTo: document.body
+      });
+
+      // Mock getBoundingClientRect to simulate overflow
+      const mockRect = { left: -50, right: 150, top: 0, bottom: 100, width: 200, height: 100 };
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+      wrapper.vm.toggleMenu();
+      await flushPromises();
+
+      // Menu should have positioning override
+      expect(wrapper.vm.menuStyle).toEqual({
+        right: 'auto',
+        left: '0'
+      });
+
+      // Close the menu
+      wrapper.vm.closeMenu();
+      await flushPromises();
+
+      // menuStyle should be reset
+      expect(wrapper.vm.menuStyle).toEqual({});
+
+      wrapper.unmount();
+    });
+  });
 });

--- a/packages/web/src/components/ActionMenu.vue
+++ b/packages/web/src/components/ActionMenu.vue
@@ -21,8 +21,10 @@
     <Transition name="slide">
       <ul
         v-if="isOpen"
+        ref="menuRef"
         class="menu-items"
         role="menu"
+        :style="menuStyle"
         @keydown="handleKeyDown"
       >
         <li
@@ -48,7 +50,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, defineExpose } from 'vue';
+import { ref, onMounted, onUnmounted, defineExpose, nextTick } from 'vue';
 
 const emit = defineEmits(['action-click']);
 
@@ -76,12 +78,41 @@ const props = defineProps({
 
 const isOpen = ref(false);
 const containerRef = ref(null);
+const menuRef = ref(null);
 const highlightedIndex = ref(null);
+const menuStyle = ref({});
+
+async function updateMenuPosition() {
+  await nextTick();
+  const menuEl = menuRef.value;
+  if (!menuEl) return;
+
+  // Get the menu's bounding rectangle
+  const rect = menuEl.getBoundingClientRect();
+
+  // Default: anchor right edge to container right edge
+  const style = {};
+
+  // If menu overflows left edge of viewport, flip to left-anchored
+  if (rect.left < 0) {
+    style.right = 'auto';
+    style.left = '0';
+  }
+
+  // If menu overflows right edge of viewport, ensure right-anchored
+  if (rect.right > window.innerWidth) {
+    style.left = 'auto';
+    style.right = '0';
+  }
+
+  menuStyle.value = style;
+}
 
 function toggleMenu() {
   isOpen.value = !isOpen.value;
   if (isOpen.value) {
     highlightedIndex.value = 0;
+    updateMenuPosition();
   } else {
     highlightedIndex.value = null;
   }
@@ -90,6 +121,7 @@ function toggleMenu() {
 function closeMenu() {
   isOpen.value = false;
   highlightedIndex.value = null;
+  menuStyle.value = {};
 }
 
 function handleOutsideClick() {
@@ -150,6 +182,7 @@ onUnmounted(() => {
 defineExpose({
   isOpen,
   highlightedIndex,
+  menuStyle,
   toggleMenu,
   closeMenu,
   handleItemClick,

--- a/packages/web/src/components/OverflowMenu.test.js
+++ b/packages/web/src/components/OverflowMenu.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
 import OverflowMenu from './OverflowMenu.vue';
 
 describe('OverflowMenu.vue', () => {
@@ -196,6 +196,75 @@ describe('OverflowMenu.vue', () => {
 
       await menu.trigger('keydown', { key: 'ArrowDown' });
       expect(wrapper.vm.highlightedIndex).not.toBeNull();
+    });
+  });
+
+  describe('Menu Positioning', () => {
+    it('positions menu with left: 0 when it would overflow left edge', async () => {
+      const wrapper = mount(OverflowMenu, {
+        attachTo: document.body
+      });
+
+      // Mock getBoundingClientRect to simulate overflow on the left
+      const mockRect = { left: -50, right: 150, top: 0, bottom: 100, width: 200, height: 100 };
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+      wrapper.vm.toggleMenu();
+      await flushPromises();
+
+      // Should flip to left-anchored
+      expect(wrapper.vm.menuStyle).toEqual({
+        right: 'auto',
+        left: '0'
+      });
+
+      wrapper.unmount();
+    });
+
+    it('keeps default right: 0 positioning when menu fits in viewport', async () => {
+      const wrapper = mount(OverflowMenu, {
+        attachTo: document.body
+      });
+
+      // Mock getBoundingClientRect to show menu fits in viewport
+      const mockRect = { left: 100, right: 300, top: 0, bottom: 100, width: 200, height: 100 };
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+      wrapper.vm.toggleMenu();
+      await flushPromises();
+
+      // Should keep default positioning (empty style object)
+      expect(wrapper.vm.menuStyle).toEqual({});
+
+      wrapper.unmount();
+    });
+
+    it('resets menuStyle when menu is closed', async () => {
+      const wrapper = mount(OverflowMenu, {
+        attachTo: document.body
+      });
+
+      // Mock getBoundingClientRect to simulate overflow
+      const mockRect = { left: -50, right: 150, top: 0, bottom: 100, width: 200, height: 100 };
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+      wrapper.vm.toggleMenu();
+      await flushPromises();
+
+      // Menu should have positioning override
+      expect(wrapper.vm.menuStyle).toEqual({
+        right: 'auto',
+        left: '0'
+      });
+
+      // Close the menu
+      wrapper.vm.closeMenu();
+      await flushPromises();
+
+      // menuStyle should be reset
+      expect(wrapper.vm.menuStyle).toEqual({});
+
+      wrapper.unmount();
     });
   });
 });

--- a/packages/web/src/components/OverflowMenu.vue
+++ b/packages/web/src/components/OverflowMenu.vue
@@ -21,8 +21,10 @@
     <Transition name="slide">
       <ul
         v-if="isOpen"
+        ref="menuRef"
         class="menu-items"
         role="menu"
+        :style="menuStyle"
         @keydown="handleKeyDown"
       >
         <li
@@ -63,7 +65,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted, nextTick, defineExpose } from 'vue';
 
 const emit = defineEmits(['duplicate', 'archive', 'copySessionId', 'delete']);
 
@@ -104,7 +106,9 @@ const props = defineProps({
 
 const isOpen = ref(false);
 const containerRef = ref(null);
+const menuRef = ref(null);
 const highlightedIndex = ref(null);
+const menuStyle = ref({});
 
 const archiveText = computed(() => {
   if (props.archiveText !== null) {
@@ -125,16 +129,44 @@ const items = computed(() => {
   return baseItems;
 });
 
+async function updateMenuPosition() {
+  await nextTick();
+  const menuEl = menuRef.value;
+  if (!menuEl) return;
+
+  // Get the menu's bounding rectangle
+  const rect = menuEl.getBoundingClientRect();
+
+  // Default: anchor right edge to container right edge
+  const style = {};
+
+  // If menu overflows left edge of viewport, flip to left-anchored
+  if (rect.left < 0) {
+    style.right = 'auto';
+    style.left = '0';
+  }
+
+  // If menu overflows right edge of viewport, ensure right-anchored
+  if (rect.right > window.innerWidth) {
+    style.left = 'auto';
+    style.right = '0';
+  }
+
+  menuStyle.value = style;
+}
+
 function toggleMenu() {
   isOpen.value = !isOpen.value;
   if (isOpen.value) {
     highlightedIndex.value = 0;
+    updateMenuPosition();
   }
 }
 
 function closeMenu() {
   isOpen.value = false;
   highlightedIndex.value = null;
+  menuStyle.value = {};
 }
 
 function handleOutsideClick() {
@@ -207,6 +239,19 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('click', handleDocumentClick);
+});
+
+// Expose methods and state for testing
+defineExpose({
+  isOpen,
+  highlightedIndex,
+  menuStyle,
+  toggleMenu,
+  closeMenu,
+  handleItemClick,
+  handleOutsideClick,
+  handleDelete,
+  handleKeyDown
 });
 </script>
 


### PR DESCRIPTION
## Summary
Fixes the issue where popup menus overflow off-screen on mobile devices, particularly on the **Commands tab** where the kebab menu button is positioned toward the center of the screen rather than at the right edge.

## Problem
On narrow mobile screens, the three-dot (kebab) popup menu on the Commands tab would overflow off the left edge of the viewport. The menu used `position: absolute; right: 0`, which anchored the menu's right edge to the trigger button's right edge. When the button is positioned toward the left/center of the screen (as it is on the Commands tab), this pushes the menu past the left edge of the viewport.

## Solution
Implemented **viewport-aware menu positioning** that:
1. Measures the menu's bounding rectangle after it opens
2. Automatically flips the horizontal anchor if it would overflow
3. Switches from `right: 0` to `left: 0` when the menu would overflow the left edge
4. Keeps/enforces `right: 0` when the menu would overflow the right edge
5. Resets the positioning when the menu closes

## Changes
### Components Modified
- **ActionMenu.vue** - Added viewport-aware positioning logic
- **OverflowMenu.vue** - Applied the same positioning pattern
- **ActionMenu.test.js** - Added 3 positioning tests
- **OverflowMenu.test.js** - Added 3 positioning tests

### Technical Details
- Added `updateMenuPosition()` async function that measures menu with `getBoundingClientRect()`
- Calls `updateMenuPosition()` in `toggleMenu()` after menu opens
- Resets `menuStyle` ref in `closeMenu()` 
- Exposed `menuStyle` via `defineExpose()` for testing

## Testing
- ✅ All 31 ActionMenu tests passing
- ✅ All 22 OverflowMenu tests passing
- ✅ Full web package test suite passing (1000+ tests)
- ✅ New tests cover: left overflow detection, default positioning, and style reset

## Scope
**Primary fix:** `ActionMenu.vue` - the reusable component used on the Commands tab
**Also fixed:** `OverflowMenu.vue` - same positioning pattern, same risk

**Skipped:** `CanvasFileList.vue` and `CanvasFileViewer.vue` - their three-dot buttons are always positioned at the right edge, so `right: 0` works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)