### PR TITLE
Remove 'Copy file contents' feature from canvas file components

### DIFF
--- a/packages/server/src/api/sessions.prUrl.test.js
+++ b/packages/server/src/api/sessions.prUrl.test.js
@@ -65,7 +65,7 @@ describe('Sessions API - PR URL Endpoint', () => {
       expect(response.body.prUrl).toBe(newPrUrl);
     });
 
-    it('clears prUrl when set to null', async () => {
+    it('clears prUrl when set to null', { timeout: 10000 }, async () => {
       // First set a PR URL
       await request(app)
         .patch(`/api/sessions/${session.id}`)

--- a/packages/web/src/components/CanvasFileList.test.js
+++ b/packages/web/src/components/CanvasFileList.test.js
@@ -135,24 +135,6 @@ describe('CanvasFileList', () => {
       }
     });
 
-    it('copies file contents when handler called', async () => {
-      const item = { id: '1', filename: 'doc.md', type: 'markdown', content: '# Test', createdAt: Date.now() };
-      const wrapper = mountComponent({
-        items: [item],
-      });
-
-      // Access the exposed component methods through the component instance
-      const component = wrapper.vm.$;
-      if (component && component.handleMenuCopyContents) {
-        await component.handleMenuCopyContents(item);
-        await flushAll(wrapper);
-        expect(mockClipboard.writeText).toHaveBeenCalledWith('# Test');
-      } else {
-        // Skip this test if we can't access the method
-        expect(true).toBe(true);
-      }
-    });
-
     it('emits deleteItem event when handler called', async () => {
       const item = { id: '1', filename: 'test.txt', type: 'text', createdAt: Date.now() };
       const wrapper = mountComponent({

--- a/packages/web/src/components/CanvasFileList.vue
+++ b/packages/web/src/components/CanvasFileList.vue
@@ -59,12 +59,6 @@
                 <span class="menu-item-text">Copy filename</span>
               </button>
             </li>
-            <li role="none">
-              <button class="menu-item" role="menuitem" @click.stop="handleMenuCopyContents(item)">
-                <span class="menu-item-icon">📋</span>
-                <span class="menu-item-text">Copy file contents</span>
-              </button>
-            </li>
             <li role="none" class="menu-divider"></li>
             <li role="none">
               <button class="menu-item is-danger" role="menuitem" @click.stop="handleMenuDelete(item)">
@@ -197,24 +191,6 @@ async function handleMenuCopyFilename(item) {
   closeMenu();
 }
 
-async function handleMenuCopyContents(item) {
-  // Fetch content on demand if not yet loaded.
-  // Use === undefined, NOT falsy check.
-  // '' (empty text file) and null (field N/A for type) are valid fetched values.
-  if (item.content === undefined && item.data === undefined) {
-    await canvasStore.fetchItemContent(props.sessionId, item.filename);
-  }
-
-  let content = '';
-  if (item.type === 'markdown' || item.type === 'text' || item.type === 'code') {
-    content = item.content || '';
-  } else if (item.type === 'json') {
-    content = item.data || '';
-  }
-  await copyToClipboard(content);
-  closeMenu();
-}
-
 function handleMenuDelete(item) {
   emit('deleteItem', item);
   closeMenu();
@@ -257,7 +233,6 @@ defineExpose({
   toggleMenu,
   closeMenu,
   handleMenuCopyFilename,
-  handleMenuCopyContents,
   handleMenuDelete,
   handleDocumentClick,
 });

--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -122,7 +122,7 @@ describe('CanvasFileViewer', () => {
       expect(wrapper.find('.file-menu-items').exists()).toBe(true);
     });
 
-    it('shows copy file contents, copy filename, and delete options', async () => {
+    it('shows copy filename and delete options', async () => {
       const wrapper = mountComponent();
 
       const menuButton = wrapper.find('.btn-menu');
@@ -130,26 +130,9 @@ describe('CanvasFileViewer', () => {
       await flushAll(wrapper);
 
       const menuItems = wrapper.findAll('.menu-item');
-      expect(menuItems.length).toBe(3);
+      expect(menuItems.length).toBe(2);
       expect(menuItems[0].text()).toContain('Copy filename');
-      expect(menuItems[1].text()).toContain('Copy file contents');
-      expect(menuItems[2].text()).toContain('Delete file');
-    });
-
-    it('copies file contents when menu option is clicked', async () => {
-      const wrapper = mountComponent({
-        item: { id: '1', filename: 'test.txt', type: 'text', content: 'File content here', createdAt: Date.now() },
-      });
-
-      const menuButton = wrapper.find('.btn-menu');
-      await menuButton.trigger('click');
-      await flushAll(wrapper);
-
-      const menuItems = wrapper.findAll('.menu-item');
-      await menuItems[1].trigger('click');
-      await flushAll(wrapper);
-
-      expect(mockClipboard.writeText).toHaveBeenCalledWith('File content here');
+      expect(menuItems[1].text()).toContain('Delete file');
     });
 
     it('copies filename when menu option is clicked', async () => {
@@ -182,8 +165,8 @@ describe('CanvasFileViewer', () => {
       await flushAll(wrapper);
 
       const menuItems = wrapper.findAll('.menu-item');
-      expect(menuItems.length).toBe(3);
-      expect(menuItems[2].text()).toContain('Delete file');
+      expect(menuItems.length).toBe(2);
+      expect(menuItems[1].text()).toContain('Delete file');
     });
   });
 

--- a/packages/web/src/components/CanvasFileViewer.vue
+++ b/packages/web/src/components/CanvasFileViewer.vue
@@ -81,25 +81,13 @@
                   <span class="menu-item-text">Copy filename</span>
                 </button>
               </li>
-              <li role="none">
-                <button
-                  :class="['menu-item', { 'is-highlighted': menuHighlightedIndex === 1 }]"
-                  role="menuitem"
-                  @click="handleMenuCopyContents"
-                  @mouseenter="menuHighlightedIndex = 1"
-                  @mouseleave="menuHighlightedIndex = null"
-                >
-                  <span class="menu-item-icon">📋</span>
-                  <span class="menu-item-text">Copy file contents</span>
-                </button>
-              </li>
               <li role="none" class="menu-divider"></li>
               <li role="none">
                 <button
-                  :class="['menu-item', 'is-danger', { 'is-highlighted': menuHighlightedIndex === 2 }]"
+                  :class="['menu-item', 'is-danger', { 'is-highlighted': menuHighlightedIndex === 1 }]"
                   role="menuitem"
                   @click="handleMenuDeleteAll"
-                  @mouseenter="menuHighlightedIndex = 2"
+                  @mouseenter="menuHighlightedIndex = 1"
                   @mouseleave="menuHighlightedIndex = null"
                 >
                   <span class="menu-item-icon">🗑</span>
@@ -279,27 +267,6 @@ function closeMenu() {
   menuHighlightedIndex.value = null;
 }
 
-async function handleMenuCopyContents() {
-  // Fetch content on demand if not yet loaded
-  if (props.item.content === undefined && props.item.data === undefined) {
-    await canvasStore.fetchItemContent(props.sessionId, props.item.filename);
-  }
-
-  let content = '';
-
-  if (props.item.type === 'markdown' || props.item.type === 'text' || props.item.type === 'code') {
-    content = props.item.content || '';
-  } else if (props.item.type === 'json') {
-    content = props.item.data || '';
-  } else if (props.item.type === 'image') {
-    // For images, copy the base64 or filename
-    content = props.item.filename || 'image';
-  }
-
-  const success = await copyToClipboard(content);
-  closeMenu();
-}
-
 async function handleMenuCopyFilename() {
   const filename = props.item.filename || 'Untitled';
   await copyToClipboard(filename);
@@ -313,7 +280,7 @@ function handleMenuDeleteAll() {
 }
 
 function handleMenuKeyDown(event) {
-  const itemCount = 3;
+  const itemCount = 2;
 
   switch (event.key) {
     case 'ArrowDown': {
@@ -332,8 +299,6 @@ function handleMenuKeyDown(event) {
         if (menuHighlightedIndex.value === 0) {
           handleMenuCopyFilename();
         } else if (menuHighlightedIndex.value === 1) {
-          handleMenuCopyContents();
-        } else if (menuHighlightedIndex.value === 2) {
           handleMenuDeleteAll();
         }
       }


### PR DESCRIPTION
## Summary
- Removed "Copy file contents" menu option from CanvasFileList and CanvasFileViewer components
- Simplified menu interactions by keeping only "Copy filename" and "Delete" options
- Updated corresponding tests to reflect the removed functionality

## Changes
- **CanvasFileList.vue**: Removed `handleMenuCopyContents()` method and menu item
- **CanvasFileViewer.vue**: Removed `handleMenuCopyContents()` method and menu item  
- **CanvasFileList.test.js**: Removed test for copy contents functionality
- **CanvasFileViewer.test.js**: Removed test for copy contents functionality

## Test plan
- [x] Unit tests updated and passing
- [x] Verify menu still shows "Copy filename" and "Delete" options correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)