### PR TITLE
Add Skills support (discovery, UI, precedence fix, tests)

### DIFF
--- a/packages/server/src/api/commands.js
+++ b/packages/server/src/api/commands.js
@@ -94,23 +94,55 @@ router.post('/:name/execute', async (req, res) => {
   // Determine working directory (may be a worktree)
   const workingDirectory = session.gitWorktree || project.workingDirectory;
 
-  try {
-    // Build the command string (handles argument substitution)
-    const commandString = await slashCommandService.buildCommandString(
-      workingDirectory,
-      name,
-      args
-    );
-
-    // Send the command as a message to the session
-    // This works for both built-in and custom commands
-    // The session must be in a state that accepts messages (waiting, stopped, error)
+  // The session must be in a state that accepts messages (waiting, stopped, error)
     const validStatuses = ['waiting', 'stopped', 'error'];
     if (!validStatuses.includes(session.status)) {
       return res.status(400).json({
         error: `Session is not ready for commands. Current status: ${session.status}`,
       });
     }
+
+  try {
+    // Check if this is a skill — skills need special handling:
+    // skill body → system prompt, user args → user message
+    const skillInvocation = await slashCommandService.buildSkillInvocation(
+      workingDirectory,
+      name,
+      args
+    );
+
+    if (skillInvocation) {
+      // Skill: inject body as system prompt context, args as user message
+      const skillSystemPrompt = slashCommandService.buildSkillSystemPrompt(
+        project.systemPrompt || null,
+        skillInvocation
+      );
+      const userMessage = slashCommandService.buildSkillUserMessage(skillInvocation);
+
+      continueSession(
+        sessionId,
+        userMessage,
+        workingDirectory,
+        skillSystemPrompt,
+        [] // No file attachments for slash commands
+      ).catch(err => {
+        console.error('Error executing skill:', err);
+      });
+
+      res.json({
+        success: true,
+        command: name,
+        message: userMessage,
+      });
+      return;
+    }
+
+    // Non-skill command: build command string and send as user message
+    const commandString = await slashCommandService.buildCommandString(
+      workingDirectory,
+      name,
+      args
+    );
 
     // Use continueSession to send the command
     // This handles the full message flow including broadcasting to WebSocket

--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -5,6 +5,7 @@ import { CreateProjectRequest, UpdateProjectRequest, ProjectSessionDefaultsReque
 import { ProjectDefaultsRepository } from '../db/ProjectDefaultsRepository.js';
 import { CreateSessionTemplateRequest } from '@claudetools/shared/contracts/templates';
 import { CreateCommandButtonRequest, UpdateCommandButtonRequest } from '@claudetools/shared/contracts/commandButtons';
+import * as slashCommandService from '../services/slashCommandService.js';
 import { setupGitForSession } from '../services/gitSessionSetup.js';
 import { isGitRepo } from '../services/gitService.js';
 import { executeHookAsync } from '../services/hookService.js';
@@ -373,9 +374,16 @@ router.post('/:id/sessions', uploadMiddleware('files', 10), handleUploadError, a
     // Only start session manager if startImmediately is true AND not scheduled
     const isScheduled = scheduledAt && scheduledAt > Date.now();
     if (startImmediately && !isScheduled) {
+      // Resolve skill/command invocations so skill body goes into system prompt
+      const resolved = await slashCommandService.resolvePromptSkillOrCommand(
+        workingDirectory, prompt, project.systemPrompt
+      );
+      const finalPrompt = resolved ? resolved.userMessage : prompt;
+      const finalSystemPrompt = resolved ? resolved.systemPrompt : project.systemPrompt;
+
       // Start session manager (non-blocking) - pass attachments for context
       const { runSession } = await import('../services/sessionManager.js');
-      runSession(session.id, prompt, workingDirectory, project.systemPrompt, sessionAttachments, model).catch((error) => {
+      runSession(session.id, finalPrompt, workingDirectory, finalSystemPrompt, sessionAttachments, model).catch((error) => {
         console.error('Session error:', error);
         sessions.update(session.id, { status: 'error', error: error.message });
       });

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -13,6 +13,7 @@ import { upload as _upload, handleUploadError } from '../middleware/upload.js';
 import { commandRunner } from '../services/commandRunner.js';
 import { databaseManager } from '../db/DatabaseManager.js';
 import { duplicateSession } from '../services/sessionDuplicator.js';
+import * as slashCommandService from '../services/slashCommandService.js';
 
 const router = Router();
 
@@ -413,7 +414,19 @@ router.post('/:id/message', _upload.array('files', 10), handleUploadError, async
     // [MODEL AUDIT] Log model being passed to continueSession
     console.log(`[MODEL AUDIT - API] Calling continueSession with model: "${model}"`);
 
-    // Start continuation (non-blocking) - pass attachments for context and model
+    // Check if the message is a slash command/skill invocation (starts with "/")
+    const resolved = await slashCommandService.resolvePromptSkillOrCommand(
+      workingDirectory, content, project.systemPrompt || null
+    );
+
+    if (resolved) {
+      continueSession(session.id, resolved.userMessage, workingDirectory, resolved.systemPrompt, messageAttachments, model).catch((error) => {
+        console.error(`Continue session error (${resolved.type}):`, error);
+      });
+      return res.json({ success: true });
+    }
+
+    // Standard plain text message
     continueSession(session.id, content, workingDirectory, project.systemPrompt, messageAttachments, model).catch((error) => {
       console.error('Continue session error:', error);
     });
@@ -604,9 +617,16 @@ router.post('/:id/start', async (req, res) => {
     // Update session status to starting and clear pendingModel (mirrors pendingPrompt cleanup above)
     sessions.update(session.id, { status: 'starting', pendingModel: null });
 
+    // Resolve skill/command invocations so skill body goes into system prompt
+    const resolved = await slashCommandService.resolvePromptSkillOrCommand(
+      workingDirectory, finalPrompt, project.systemPrompt
+    );
+    const effectivePrompt = resolved ? resolved.userMessage : finalPrompt;
+    const effectiveSystemPrompt = resolved ? resolved.systemPrompt : project.systemPrompt;
+
     // Start session manager (non-blocking)
     const { runSession } = await import('../services/sessionManager.js');
-    runSession(session.id, finalPrompt, workingDirectory, project.systemPrompt, sessionAttachments, model).catch((error) => {
+    runSession(session.id, effectivePrompt, workingDirectory, effectiveSystemPrompt, sessionAttachments, model).catch((error) => {
       console.error('Session error:', error);
       sessions.update(session.id, { status: 'error', error: error.message });
     });

--- a/packages/server/src/services/schedulerService.js
+++ b/packages/server/src/services/schedulerService.js
@@ -1,6 +1,7 @@
 import { sessions, messages, conversations, projects, attachments } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import * as slashCommandService from './slashCommandService.js';
 
 /**
  * Service for managing scheduled session execution
@@ -108,6 +109,13 @@ class SchedulerService {
     // Get attachments for context
     const sessionAttachments = attachments.getBySessionId(session.id);
 
+    // Resolve skill/command invocations so skill body goes into system prompt
+    const resolved = await slashCommandService.resolvePromptSkillOrCommand(
+      workingDirectory, prompt, project.systemPrompt
+    );
+    const effectivePrompt = resolved ? resolved.userMessage : prompt;
+    const effectiveSystemPrompt = resolved ? resolved.systemPrompt : project.systemPrompt;
+
     // Determine if this is an initial run or a continuation
     if (hasAssistantResponses) {
       // Session has conversation history - this is a scheduled continuation
@@ -122,9 +130,9 @@ class SchedulerService {
 
       await this.sessionManager.continueSession(
         session.id,
-        prompt,
+        effectivePrompt,
         workingDirectory,
-        project.systemPrompt,
+        effectiveSystemPrompt,
         sessionAttachments,
         session.pendingModel
       );
@@ -157,9 +165,9 @@ class SchedulerService {
 
       await this.sessionManager.runSession(
         session.id,
-        prompt,
+        effectivePrompt,
         workingDirectory,
-        project.systemPrompt,
+        effectiveSystemPrompt,
         sessionAttachments,
         session.pendingModel
       );

--- a/packages/server/src/services/slashCommandService.js
+++ b/packages/server/src/services/slashCommandService.js
@@ -17,6 +17,7 @@ const BUILTIN_COMMANDS = [];
 // 3. Plugins: ~/.claude/plugins/cache/.../{plugin}/.../commands/*.md
 // 4. Built-in: hardcoded list below
 const COMMANDS_DIR = '.claude/commands';
+const SKILLS_DIR = '.claude/skills';
 
 /**
  * Parse YAML frontmatter from a markdown command file
@@ -113,6 +114,65 @@ function normalizeArgument(arg) {
 }
 
 /**
+ * Parse a SKILL.md file with its extended frontmatter
+ * @param {string} content - File content
+ * @param {string} directoryName - The skill directory name (used as fallback name)
+ * @returns {Object} Parsed skill object with name, description, argumentHint, userInvocable, disableModelInvocation, body
+ */
+export function parseSkillFile(content, directoryName) {
+  // Check for frontmatter
+  if (!content.startsWith('---')) {
+    return {
+      name: directoryName,
+      description: '',
+      argumentHint: null,
+      userInvocable: true,
+      disableModelInvocation: false,
+      body: content.trim(),
+    };
+  }
+
+  // Find end of frontmatter
+  const endIndex = content.indexOf('---', 3);
+  if (endIndex === -1) {
+    return {
+      name: directoryName,
+      description: '',
+      argumentHint: null,
+      userInvocable: true,
+      disableModelInvocation: false,
+      body: content.trim(),
+    };
+  }
+
+  const frontmatterStr = content.slice(3, endIndex).trim();
+  const body = content.slice(endIndex + 3).trim();
+
+  try {
+    const frontmatter = YAML.parse(frontmatterStr);
+
+    return {
+      name: frontmatter.name || directoryName,
+      description: frontmatter.description || '',
+      argumentHint: frontmatter['argument-hint'] || null,
+      userInvocable: frontmatter['user-invocable'] !== false,
+      disableModelInvocation: frontmatter['disable-model-invocation'] === true,
+      body,
+    };
+  } catch (err) {
+    console.warn('Failed to parse skill frontmatter:', err.message);
+    return {
+      name: directoryName,
+      description: '',
+      argumentHint: null,
+      userInvocable: true,
+      disableModelInvocation: false,
+      body: content.trim(),
+    };
+  }
+}
+
+/**
  * Discover commands from a directory
  * @param {string} directory - Directory to scan
  * @param {string} source - Source type ('project', 'user', or 'plugin')
@@ -156,6 +216,52 @@ async function discoverCommandsFromDir(directory, source, namespace = null) {
   }
 
   return commands;
+}
+
+// Discover skills from a directory
+// Scans basePath/.claude/skills/*/SKILL.md
+async function discoverSkillsFromDir(basePath, source, namespace = null) {
+  const skillsDir = join(basePath, SKILLS_DIR);
+  const skills = [];
+
+  try {
+    await access(skillsDir, constants.R_OK);
+    const entries = await readdir(skillsDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const skillMdPath = join(skillsDir, entry.name, 'SKILL.md');
+
+      try {
+        const content = await readFile(skillMdPath, 'utf-8');
+        const parsed = parseSkillFile(content, entry.name);
+
+        // Filter out skills that aren't user-invocable
+        if (!parsed.userInvocable) continue;
+
+        // For plugin skills, prefix with namespace (e.g., "plugin-name:skill-name")
+        const name = namespace ? `${namespace}:${parsed.name}` : parsed.name;
+
+        skills.push({
+          name,
+          description: parsed.description,
+          arguments: [], // Skills use argument-hint, not structured args
+          argumentHint: parsed.argumentHint,
+          source,
+          filePath: skillMdPath,
+          isSkill: true,
+          disableModelInvocation: parsed.disableModelInvocation,
+        });
+      } catch {
+        // SKILL.md doesn't exist or isn't readable in this directory
+      }
+    }
+  } catch {
+    // Skills directory doesn't exist - that's fine
+  }
+
+  return skills;
 }
 
 /**
@@ -235,6 +341,77 @@ async function discoverPluginCommands(workingDirectory) {
 }
 
 /**
+ * Discover skills from installed plugins
+ * Reads ~/.claude/plugins/installed_plugins.json and scans each plugin's skills/ directory
+ *
+ * @param {string} workingDirectory - Project directory to filter plugins for
+ * @returns {Promise<Array>} Array of plugin skill objects
+ */
+async function discoverPluginSkills(workingDirectory) {
+  const skills = [];
+  const installedPluginsPath = join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+
+  try {
+    const content = await readFile(installedPluginsPath, 'utf-8');
+    const installedPlugins = JSON.parse(content);
+
+    if (!installedPlugins.plugins) {
+      return skills;
+    }
+
+    for (const [pluginId, installations] of Object.entries(installedPlugins.plugins)) {
+      const relevantInstall = installations.find(
+        install => install.scope === 'global' || isMatchingProject(workingDirectory, install.projectPath)
+      );
+
+      if (!relevantInstall) continue;
+
+      const namespace = pluginId.split('@')[0];
+
+      // Scan skills directory inside plugin
+      const pluginSkillsDir = join(relevantInstall.installPath, 'skills');
+
+      try {
+        await access(pluginSkillsDir, constants.R_OK);
+        const entries = await readdir(pluginSkillsDir, { withFileTypes: true });
+
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+
+          const skillMdPath = join(pluginSkillsDir, entry.name, 'SKILL.md');
+
+          try {
+            const content = await readFile(skillMdPath, 'utf-8');
+            const parsed = parseSkillFile(content, entry.name);
+
+            if (!parsed.userInvocable) continue;
+
+            skills.push({
+              name: `${namespace}:${parsed.name}`,
+              description: parsed.description,
+              arguments: [],
+              argumentHint: parsed.argumentHint,
+              source: 'plugin-skill',
+              filePath: skillMdPath,
+              isSkill: true,
+              disableModelInvocation: parsed.disableModelInvocation,
+            });
+          } catch {
+            // SKILL.md doesn't exist in this directory
+          }
+        }
+      } catch {
+        // Plugin has no skills directory
+      }
+    }
+  } catch {
+    // No installed plugins or file doesn't exist
+  }
+
+  return skills;
+}
+
+/**
  * Get all available slash commands for a working directory
  * Commands are discovered from:
  * 1. Project .claude/commands/ (highest priority)
@@ -259,6 +436,11 @@ export async function getCommands(workingDirectory) {
 
   const pluginCommands = await discoverPluginCommands(workingDirectory);
 
+  // Discover skills from all sources
+  const projectSkills = await discoverSkillsFromDir(workingDirectory, 'project-skill');
+  const userSkills = await discoverSkillsFromDir(homedir(), 'user-skill');
+  const pluginSkills = await discoverPluginSkills(workingDirectory);
+
   // Create built-in command objects
   const builtinCommands = BUILTIN_COMMANDS.map(cmd => ({
     ...cmd,
@@ -266,35 +448,24 @@ export async function getCommands(workingDirectory) {
     arguments: [],
   }));
 
-  // Deduplicate: project > user > plugin > builtin
+  // Deduplicate: commands take precedence over skills with same name
+  // Priority: project > user > plugin > builtin
   const seen = new Set();
   const commands = [];
 
-  for (const cmd of projectCommands) {
+  // Add all commands first (they take precedence)
+  for (const cmd of [...projectCommands, ...userCommands, ...pluginCommands, ...builtinCommands]) {
     if (!seen.has(cmd.name)) {
       seen.add(cmd.name);
       commands.push(cmd);
     }
   }
 
-  for (const cmd of userCommands) {
-    if (!seen.has(cmd.name)) {
-      seen.add(cmd.name);
-      commands.push(cmd);
-    }
-  }
-
-  for (const cmd of pluginCommands) {
-    if (!seen.has(cmd.name)) {
-      seen.add(cmd.name);
-      commands.push(cmd);
-    }
-  }
-
-  for (const cmd of builtinCommands) {
-    if (!seen.has(cmd.name)) {
-      seen.add(cmd.name);
-      commands.push(cmd);
+  // Then add skills (only if name not already taken by a command)
+  for (const skill of [...projectSkills, ...userSkills, ...pluginSkills]) {
+    if (!seen.has(skill.name)) {
+      seen.add(skill.name);
+      commands.push(skill);
     }
   }
 
@@ -363,7 +534,32 @@ export async function buildCommandString(workingDirectory, name, args = {}) {
     return `/${name}`;
   }
 
-  // Build argument string
+  // For skills, use different argument substitution
+  if (command.isSkill) {
+    const body = await getCommandBody(workingDirectory, name);
+    if (!body) return `/${name}`;
+
+    // Skills use $ARGUMENTS for all args, $0, $1, etc. for positional
+    const rawArgs = args._raw || '';
+    let processedBody = body;
+
+    // Replace $ARGUMENTS with raw args string
+    processedBody = processedBody
+      .replace(/\$\{ARGUMENTS\}/g, rawArgs)
+      .replace(/\$ARGUMENTS\b/g, rawArgs);
+
+    // Replace positional args $0, $1, $2, etc.
+    const argParts = rawArgs.split(/\s+/).filter(Boolean);
+    for (let i = 0; i < argParts.length; i++) {
+      processedBody = processedBody
+        .replace(new RegExp(`\\$\\{${i}\\}`, 'g'), argParts[i])
+        .replace(new RegExp(`\\$${i}\\b`, 'g'), argParts[i]);
+    }
+
+    return processedBody;
+  }
+
+  // Build argument string for commands
   const argParts = [];
   for (const argDef of command.arguments) {
     const value = args[argDef.name];
@@ -418,4 +614,5 @@ export default {
   getCommandBody,
   buildCommandString,
   parseCommandFile,
+  parseSkillFile,
 };

--- a/packages/server/src/services/slashCommandService.js
+++ b/packages/server/src/services/slashCommandService.js
@@ -426,7 +426,7 @@ async function discoverMarketplaceSkills() {
     const content = await readFile(knownMarketplacesPath, 'utf-8');
     const marketplaces = JSON.parse(content);
 
-    for (const [marketplaceId, marketplace] of Object.entries(marketplaces)) {
+    for (const [_marketplaceId, marketplace] of Object.entries(marketplaces)) {
       const basePath = marketplace.installLocation;
       if (!basePath) continue;
 
@@ -495,7 +495,7 @@ async function discoverMarketplaceCommands() {
     const content = await readFile(knownMarketplacesPath, 'utf-8');
     const marketplaces = JSON.parse(content);
 
-    for (const [marketplaceId, marketplace] of Object.entries(marketplaces)) {
+    for (const [_marketplaceId, marketplace] of Object.entries(marketplaces)) {
       const basePath = marketplace.installLocation;
       if (!basePath) continue;
 
@@ -729,11 +729,135 @@ export async function buildCommandString(workingDirectory, name, args = {}) {
   return commandString;
 }
 
+/**
+ * Build a structured skill invocation, separating skill content (for system prompt)
+ * from user arguments (for user message).
+ *
+ * Returns null if the command is not a skill or not found.
+ *
+ * @param {string} workingDirectory - The project working directory
+ * @param {string} name - Skill name (e.g., "frontend-design" or "frontend-design:frontend-design")
+ * @param {Object} args - Arguments object, with _raw for the raw argument string
+ * @returns {Promise<{skillContent: string, userMessage: string|null, skillName: string}|null>}
+ */
+export async function buildSkillInvocation(workingDirectory, name, args = {}) {
+  const command = await getCommand(workingDirectory, name);
+  if (!command || !command.isSkill) return null;
+
+  const body = await getCommandBody(workingDirectory, name);
+  if (!body) return null;
+
+  const rawArgs = args._raw || '';
+
+  // Process $ARGUMENTS and positional args in the body
+  let processedBody = body;
+  processedBody = processedBody
+    .replace(/\$\{ARGUMENTS\}/g, rawArgs)
+    .replace(/\$ARGUMENTS\b/g, rawArgs);
+
+  const argParts = rawArgs.split(/\s+/).filter(Boolean);
+  for (let i = 0; i < argParts.length; i++) {
+    processedBody = processedBody
+      .replace(new RegExp(`\\$\\{${i}\\}`, 'g'), argParts[i])
+      .replace(new RegExp(`\\$${i}\\b`, 'g'), argParts[i]);
+  }
+
+  return {
+    skillContent: processedBody,
+    userMessage: rawArgs.trim() || null,
+    skillName: name,
+  };
+}
+
+/**
+ * Build a system prompt that includes skill content as context.
+ * Merges the project system prompt with the skill body wrapped in a <skill> tag.
+ *
+ * @param {string|null} projectSystemPrompt - The project's custom system prompt
+ * @param {{skillContent: string, skillName: string}} skillInvocation - From buildSkillInvocation()
+ * @returns {string} Combined system prompt
+ */
+export function buildSkillSystemPrompt(projectSystemPrompt, skillInvocation) {
+  const parts = [];
+  if (projectSystemPrompt) {
+    parts.push(projectSystemPrompt);
+  }
+  parts.push(`<skill name="${skillInvocation.skillName}">\n${skillInvocation.skillContent}\n</skill>`);
+  return parts.join('\n\n');
+}
+
+/**
+ * Build the user message for a skill invocation.
+ * Returns the user's args if provided, otherwise a default prompt
+ * telling Claude the skill was invoked.
+ *
+ * @param {{userMessage: string|null, skillName: string}} skillInvocation - From buildSkillInvocation()
+ * @returns {string} User message to send
+ */
+export function buildSkillUserMessage(skillInvocation) {
+  return skillInvocation.userMessage
+    || `The user invoked the /${skillInvocation.skillName} skill. Follow the skill instructions above and ask the user what they would like you to build.`;
+}
+
+/**
+ * Detect and resolve a skill or command invocation from a prompt string.
+ * Returns null if the prompt is not a recognized skill/command (pass it through as plain text).
+ *
+ * @param {string} workingDirectory - Project working directory for command discovery
+ * @param {string} prompt - The user's prompt text
+ * @param {string|null} projectSystemPrompt - The project's system prompt
+ * @returns {Promise<{type: 'skill'|'command', userMessage: string, systemPrompt: string|null}|null>}
+ */
+export async function resolvePromptSkillOrCommand(workingDirectory, prompt, projectSystemPrompt) {
+  if (!prompt || typeof prompt !== 'string' || !prompt.startsWith('/')) return null;
+
+  const match = prompt.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
+  if (!match) return null;
+
+  const [, commandName, rawArgs] = match;
+
+  // Try skill first — skills take precedence over commands
+  try {
+    const skillInvocation = await buildSkillInvocation(
+      workingDirectory, commandName, { _raw: rawArgs || '' }
+    );
+    if (skillInvocation) {
+      return {
+        type: 'skill',
+        userMessage: buildSkillUserMessage(skillInvocation),
+        systemPrompt: buildSkillSystemPrompt(projectSystemPrompt, skillInvocation),
+      };
+    }
+  } catch (err) {
+    // Skill lookup failed — fall through
+  }
+
+  // Try regular (non-skill) command
+  try {
+    const commandString = await buildCommandString(workingDirectory, commandName, { _raw: rawArgs || '' });
+    if (commandString) {
+      return {
+        type: 'command',
+        userMessage: commandString,
+        systemPrompt: projectSystemPrompt || null,
+      };
+    }
+  } catch (err) {
+    // Command not found — fall through
+  }
+
+  return null;
+}
+
 export default {
   getCommands,
   getCommand,
   getCommandBody,
   buildCommandString,
+  buildSkillInvocation,
+  buildSkillSystemPrompt,
+  buildSkillUserMessage,
+  resolvePromptSkillOrCommand,
   parseCommandFile,
   parseSkillFile,
 };

--- a/packages/server/src/services/slashCommandService.js
+++ b/packages/server/src/services/slashCommandService.js
@@ -412,6 +412,117 @@ async function discoverPluginSkills(workingDirectory) {
 }
 
 /**
+ * Discover skills from marketplace plugins
+ * Reads ~/.claude/plugins/known_marketplaces.json and scans each marketplace's
+ * plugins/ and external_plugins/ directories for skills
+ *
+ * @returns {Promise<Array>} Array of marketplace skill objects
+ */
+async function discoverMarketplaceSkills() {
+  const skills = [];
+  const knownMarketplacesPath = join(homedir(), '.claude', 'plugins', 'known_marketplaces.json');
+
+  try {
+    const content = await readFile(knownMarketplacesPath, 'utf-8');
+    const marketplaces = JSON.parse(content);
+
+    for (const [marketplaceId, marketplace] of Object.entries(marketplaces)) {
+      const basePath = marketplace.installLocation;
+      if (!basePath) continue;
+
+      // Scan both plugins/ and external_plugins/ directories
+      for (const subdir of ['plugins', 'external_plugins']) {
+        const pluginsDir = join(basePath, subdir);
+
+        try {
+          await access(pluginsDir, constants.R_OK);
+          const pluginDirs = await readdir(pluginsDir, { withFileTypes: true });
+
+          for (const pluginEntry of pluginDirs) {
+            if (!pluginEntry.isDirectory()) continue;
+
+            const pluginPath = join(pluginsDir, pluginEntry.name);
+            const namespace = pluginEntry.name;
+            const skillsDir = join(pluginPath, 'skills');
+
+            try {
+              await access(skillsDir, constants.R_OK);
+              const skillEntries = await readdir(skillsDir, { withFileTypes: true });
+
+              for (const entry of skillEntries) {
+                if (!entry.isDirectory()) continue;
+
+                const skillMdPath = join(skillsDir, entry.name, 'SKILL.md');
+                try {
+                  const skillContent = await readFile(skillMdPath, 'utf-8');
+                  const parsed = parseSkillFile(skillContent, entry.name);
+                  if (!parsed.userInvocable) continue;
+
+                  skills.push({
+                    name: `${namespace}:${parsed.name}`,
+                    description: parsed.description,
+                    arguments: [],
+                    argumentHint: parsed.argumentHint,
+                    source: 'plugin-skill',
+                    filePath: skillMdPath,
+                    isSkill: true,
+                    disableModelInvocation: parsed.disableModelInvocation,
+                  });
+                } catch { /* no SKILL.md */ }
+              }
+            } catch { /* no skills dir */ }
+          }
+        } catch { /* subdir doesn't exist */ }
+      }
+    }
+  } catch { /* no known_marketplaces.json */ }
+
+  return skills;
+}
+
+/**
+ * Discover commands from marketplace plugins
+ * Reads ~/.claude/plugins/known_marketplaces.json and scans each marketplace's
+ * plugins/ and external_plugins/ directories for commands
+ *
+ * @returns {Promise<Array>} Array of marketplace command objects
+ */
+async function discoverMarketplaceCommands() {
+  const commands = [];
+  const knownMarketplacesPath = join(homedir(), '.claude', 'plugins', 'known_marketplaces.json');
+
+  try {
+    const content = await readFile(knownMarketplacesPath, 'utf-8');
+    const marketplaces = JSON.parse(content);
+
+    for (const [marketplaceId, marketplace] of Object.entries(marketplaces)) {
+      const basePath = marketplace.installLocation;
+      if (!basePath) continue;
+
+      for (const subdir of ['plugins', 'external_plugins']) {
+        const pluginsDir = join(basePath, subdir);
+
+        try {
+          await access(pluginsDir, constants.R_OK);
+          const pluginDirs = await readdir(pluginsDir, { withFileTypes: true });
+
+          for (const pluginEntry of pluginDirs) {
+            if (!pluginEntry.isDirectory()) continue;
+
+            const namespace = pluginEntry.name;
+            const pluginCommandsDir = join(pluginsDir, pluginEntry.name, 'commands');
+            const pluginCommands = await discoverCommandsFromDir(pluginCommandsDir, 'plugin', namespace);
+            commands.push(...pluginCommands);
+          }
+        } catch { /* subdir doesn't exist */ }
+      }
+    }
+  } catch { /* no known_marketplaces.json */ }
+
+  return commands;
+}
+
+/**
  * Get all available slash commands for a working directory
  * Commands are discovered from:
  * 1. Project .claude/commands/ (highest priority)
@@ -436,10 +547,14 @@ export async function getCommands(workingDirectory) {
 
   const pluginCommands = await discoverPluginCommands(workingDirectory);
 
+  // Discover marketplace plugins (global, not scoped to installed_plugins.json)
+  const marketplaceCommands = await discoverMarketplaceCommands();
+
   // Discover skills from all sources
   const projectSkills = await discoverSkillsFromDir(workingDirectory, 'project-skill');
   const userSkills = await discoverSkillsFromDir(homedir(), 'user-skill');
   const pluginSkills = await discoverPluginSkills(workingDirectory);
+  const marketplaceSkills = await discoverMarketplaceSkills();
 
   // Create built-in command objects
   const builtinCommands = BUILTIN_COMMANDS.map(cmd => ({
@@ -449,12 +564,13 @@ export async function getCommands(workingDirectory) {
   }));
 
   // Skills take precedence over commands with the same name (per Anthropic docs)
-  // Priority: project > user > plugin; then commands fill remaining slots
+  // Priority: project > user > installed-plugin > marketplace; then commands fill remaining slots
   const seen = new Set();
   const commands = [];
 
   // Add all skills first (they take precedence)
-  for (const skill of [...projectSkills, ...userSkills, ...pluginSkills]) {
+  // installed_plugins.json entries come before marketplace to win dedup
+  for (const skill of [...projectSkills, ...userSkills, ...pluginSkills, ...marketplaceSkills]) {
     if (!seen.has(skill.name)) {
       seen.add(skill.name);
       commands.push(skill);
@@ -462,7 +578,8 @@ export async function getCommands(workingDirectory) {
   }
 
   // Then add commands (only if name not already taken by a skill)
-  for (const cmd of [...projectCommands, ...userCommands, ...pluginCommands, ...builtinCommands]) {
+  // installed_plugins.json entries come before marketplace to win dedup
+  for (const cmd of [...projectCommands, ...userCommands, ...pluginCommands, ...marketplaceCommands, ...builtinCommands]) {
     if (!seen.has(cmd.name)) {
       seen.add(cmd.name);
       commands.push(cmd);

--- a/packages/server/src/services/slashCommandService.js
+++ b/packages/server/src/services/slashCommandService.js
@@ -448,24 +448,24 @@ export async function getCommands(workingDirectory) {
     arguments: [],
   }));
 
-  // Deduplicate: commands take precedence over skills with same name
-  // Priority: project > user > plugin > builtin
+  // Skills take precedence over commands with the same name (per Anthropic docs)
+  // Priority: project > user > plugin; then commands fill remaining slots
   const seen = new Set();
   const commands = [];
 
-  // Add all commands first (they take precedence)
-  for (const cmd of [...projectCommands, ...userCommands, ...pluginCommands, ...builtinCommands]) {
-    if (!seen.has(cmd.name)) {
-      seen.add(cmd.name);
-      commands.push(cmd);
-    }
-  }
-
-  // Then add skills (only if name not already taken by a command)
+  // Add all skills first (they take precedence)
   for (const skill of [...projectSkills, ...userSkills, ...pluginSkills]) {
     if (!seen.has(skill.name)) {
       seen.add(skill.name);
       commands.push(skill);
+    }
+  }
+
+  // Then add commands (only if name not already taken by a skill)
+  for (const cmd of [...projectCommands, ...userCommands, ...pluginCommands, ...builtinCommands]) {
+    if (!seen.has(cmd.name)) {
+      seen.add(cmd.name);
+      commands.push(cmd);
     }
   }
 
@@ -504,6 +504,10 @@ export async function getCommandBody(workingDirectory, name) {
   // Read and parse the file to get the body
   try {
     const content = await readFile(command.filePath, 'utf-8');
+    if (command.isSkill) {
+      const parsed = parseSkillFile(content, command.name);
+      return parsed.body;
+    }
     const parsed = parseCommandFile(content);
     return parsed.body;
   } catch (err) {

--- a/packages/server/src/services/slashCommandService.test.js
+++ b/packages/server/src/services/slashCommandService.test.js
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   parseCommandFile,
+  parseSkillFile,
   getCommands,
   getCommand,
   getCommandBody,
@@ -349,6 +350,311 @@ Say: $ARGUMENTS`
       await expect(buildCommandString(testDir, 'nonexistent', {})).rejects.toThrow(
         'Command not found: nonexistent'
       );
+    });
+  });
+
+  describe('parseSkillFile', () => {
+    it('parses a skill file with full frontmatter', () => {
+      const content = `---
+name: my-skill
+description: A test skill
+argument-hint: "[filename]"
+user-invocable: true
+disable-model-invocation: false
+---
+Process the file: $ARGUMENTS`;
+
+      const result = parseSkillFile(content, 'fallback-name');
+
+      expect(result.name).toBe('my-skill');
+      expect(result.description).toBe('A test skill');
+      expect(result.argumentHint).toBe('[filename]');
+      expect(result.userInvocable).toBe(true);
+      expect(result.disableModelInvocation).toBe(false);
+      expect(result.body).toBe('Process the file: $ARGUMENTS');
+    });
+
+    it('uses directory name as fallback when name not specified', () => {
+      const content = `---
+description: A skill without name
+---
+Body content`;
+
+      const result = parseSkillFile(content, 'directory-name');
+
+      expect(result.name).toBe('directory-name');
+    });
+
+    it('handles skill without frontmatter', () => {
+      const content = 'Just a body, no frontmatter';
+
+      const result = parseSkillFile(content, 'my-skill');
+
+      expect(result.name).toBe('my-skill');
+      expect(result.description).toBe('');
+      expect(result.body).toBe('Just a body, no frontmatter');
+    });
+
+    it('handles malformed frontmatter gracefully', () => {
+      const content = `---
+name: incomplete`;
+
+      const result = parseSkillFile(content, 'fallback');
+
+      expect(result.name).toBe('fallback');
+      expect(result.body).toBe(content.trim());
+    });
+
+    it('defaults user-invocable to true', () => {
+      const content = `---
+name: test
+---
+body`;
+
+      const result = parseSkillFile(content, 'test');
+
+      expect(result.userInvocable).toBe(true);
+    });
+
+    it('respects user-invocable: false', () => {
+      const content = `---
+name: hidden
+user-invocable: false
+---
+body`;
+
+      const result = parseSkillFile(content, 'hidden');
+
+      expect(result.userInvocable).toBe(false);
+    });
+
+    it('defaults disable-model-invocation to false', () => {
+      const content = `---
+name: test
+---
+body`;
+
+      const result = parseSkillFile(content, 'test');
+
+      expect(result.disableModelInvocation).toBe(false);
+    });
+
+    it('respects disable-model-invocation: true', () => {
+      const content = `---
+name: user-only
+disable-model-invocation: true
+---
+body`;
+
+      const result = parseSkillFile(content, 'user-only');
+
+      expect(result.disableModelInvocation).toBe(true);
+    });
+  });
+
+  describe('skill discovery', () => {
+    let skillsDir;
+
+    beforeEach(async () => {
+      // Clear and recreate skills directory
+      skillsDir = join(testDir, '.claude', 'skills');
+      await rm(skillsDir, { recursive: true, force: true });
+    });
+
+    it('discovers skills from .claude/skills/', async () => {
+      await mkdir(join(skillsDir, 'my-skill'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'my-skill', 'SKILL.md'),
+        `---
+name: my-skill
+description: A test skill
+argument-hint: "[filename]"
+---
+Process the file: $ARGUMENTS`
+      );
+
+      const commands = await getCommands(testDir);
+      const skill = commands.find((c) => c.name === 'my-skill');
+
+      expect(skill).toBeDefined();
+      expect(skill.isSkill).toBe(true);
+      expect(skill.source).toBe('project-skill');
+      expect(skill.argumentHint).toBe('[filename]');
+      expect(skill.arguments).toEqual([]);
+    });
+
+    it('filters out skills with user-invocable: false', async () => {
+      await mkdir(join(skillsDir, 'hidden-skill'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'hidden-skill', 'SKILL.md'),
+        `---
+name: hidden-skill
+user-invocable: false
+---
+This skill is model-only`
+      );
+
+      const commands = await getCommands(testDir);
+
+      expect(commands.find((c) => c.name === 'hidden-skill')).toBeUndefined();
+    });
+
+    it('returns empty array when .claude/skills/ does not exist', async () => {
+      // Don't create skills directory
+      const commands = await getCommands(testDir);
+      const skills = commands.filter((c) => c.isSkill);
+
+      expect(skills).toEqual([]);
+    });
+
+    it('ignores directories without SKILL.md', async () => {
+      await mkdir(join(skillsDir, 'incomplete-skill'), { recursive: true });
+      await writeFile(join(skillsDir, 'incomplete-skill', 'README.md'), 'Not a skill');
+
+      const commands = await getCommands(testDir);
+
+      expect(commands.find((c) => c.name === 'incomplete-skill')).toBeUndefined();
+    });
+
+    it('ignores files in skills directory (only directories)', async () => {
+      await mkdir(skillsDir, { recursive: true });
+      await writeFile(join(skillsDir, 'not-a-skill.md'), 'This is a file, not a directory');
+
+      const commands = await getCommands(testDir);
+      const skills = commands.filter((c) => c.isSkill);
+
+      expect(skills).toEqual([]);
+    });
+
+    it('command takes precedence over skill with same name', async () => {
+      // Create a command
+      await mkdir(projectCommandsDir, { recursive: true });
+      await writeFile(
+        join(projectCommandsDir, 'deploy.md'),
+        `---
+description: Deploy command
+---
+Deploy now`
+      );
+
+      // Create a skill with the same name
+      await mkdir(join(skillsDir, 'deploy'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'deploy', 'SKILL.md'),
+        `---
+name: deploy
+description: Deploy skill
+---
+Deploy skill body`
+      );
+
+      const commands = await getCommands(testDir);
+      const deployItems = commands.filter((c) => c.name === 'deploy');
+
+      expect(deployItems).toHaveLength(1);
+      expect(deployItems[0].source).toBe('project'); // Command, not skill
+      expect(deployItems[0].isSkill).toBeUndefined();
+    });
+
+    it('uses directory name when skill name not specified', async () => {
+      await mkdir(join(skillsDir, 'auto-named'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'auto-named', 'SKILL.md'),
+        `---
+description: No name specified
+---
+Body`
+      );
+
+      const commands = await getCommands(testDir);
+      const skill = commands.find((c) => c.name === 'auto-named');
+
+      expect(skill).toBeDefined();
+      expect(skill.name).toBe('auto-named');
+    });
+  });
+
+  describe('buildCommandString with skills', () => {
+    let skillsDir;
+
+    beforeEach(async () => {
+      skillsDir = join(testDir, '.claude', 'skills');
+      await rm(skillsDir, { recursive: true, force: true });
+    });
+
+    it('substitutes $ARGUMENTS in skill body', async () => {
+      await mkdir(join(skillsDir, 'process'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'process', 'SKILL.md'),
+        `---
+name: process
+---
+Process these: $ARGUMENTS`
+      );
+
+      const result = await buildCommandString(testDir, 'process', { _raw: 'file1.txt file2.txt' });
+
+      expect(result).toBe('Process these: file1.txt file2.txt');
+    });
+
+    it('substitutes positional args $0, $1, $2', async () => {
+      await mkdir(join(skillsDir, 'copy'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'copy', 'SKILL.md'),
+        `---
+name: copy
+---
+Copy $0 to $1`
+      );
+
+      const result = await buildCommandString(testDir, 'copy', { _raw: 'source.txt dest.txt' });
+
+      expect(result).toBe('Copy source.txt to dest.txt');
+    });
+
+    it('handles ${ARGUMENTS} brace syntax', async () => {
+      await mkdir(join(skillsDir, 'echo'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'echo', 'SKILL.md'),
+        `---
+name: echo
+---
+Echo: \${ARGUMENTS}`
+      );
+
+      const result = await buildCommandString(testDir, 'echo', { _raw: 'hello world' });
+
+      expect(result).toBe('Echo: hello world');
+    });
+
+    it('handles empty arguments', async () => {
+      await mkdir(join(skillsDir, 'simple'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'simple', 'SKILL.md'),
+        `---
+name: simple
+---
+Args: $ARGUMENTS (end)`
+      );
+
+      const result = await buildCommandString(testDir, 'simple', { _raw: '' });
+
+      expect(result).toBe('Args:  (end)');
+    });
+
+    it('handles multiple positional arguments', async () => {
+      await mkdir(join(skillsDir, 'multi'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'multi', 'SKILL.md'),
+        `---
+name: multi
+---
+First: $0, Second: $1, Third: $2, All: $ARGUMENTS`
+      );
+
+      const result = await buildCommandString(testDir, 'multi', { _raw: 'one two three' });
+
+      expect(result).toBe('First: one, Second: two, Third: three, All: one two three');
     });
   });
 });

--- a/packages/server/src/services/slashCommandService.test.js
+++ b/packages/server/src/services/slashCommandService.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { mkdir, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -14,17 +14,30 @@ import {
 describe('slashCommandService', () => {
   let testDir;
   let projectCommandsDir;
+  let originalHome;
+  let fakeHome;
 
   beforeAll(async () => {
     // Create a temporary directory for test files
     testDir = join(tmpdir(), `slash-command-test-${Date.now()}`);
     projectCommandsDir = join(testDir, '.claude', 'commands');
     await mkdir(projectCommandsDir, { recursive: true });
+
+    // Isolate from real ~/.claude/plugins to prevent real marketplace plugins
+    // from leaking into tests
+    originalHome = process.env.HOME;
+    fakeHome = join(tmpdir(), `slash-cmd-home-${Date.now()}`);
+    await mkdir(fakeHome, { recursive: true });
+    process.env.HOME = fakeHome;
   });
 
   afterAll(async () => {
-    // Clean up test directory
+    // Restore HOME
+    process.env.HOME = originalHome;
+
+    // Clean up test directories
     await rm(testDir, { recursive: true, force: true });
+    await rm(fakeHome, { recursive: true, force: true });
   });
 
   describe('parseCommandFile', () => {
@@ -703,6 +716,284 @@ First: $0, Second: $1, Third: $2, All: $ARGUMENTS`
       const result = await buildCommandString(testDir, 'multi', { _raw: 'one two three' });
 
       expect(result).toBe('First: one, Second: two, Third: three, All: one two three');
+    });
+  });
+
+  describe('marketplace plugin discovery', () => {
+    let marketplaceDir;
+    let originalHome;
+
+    beforeEach(async () => {
+      // Save original HOME and set to temp directory so known_marketplaces.json is discovered
+      originalHome = process.env.HOME;
+      marketplaceDir = join(tmpdir(), `marketplace-test-${Date.now()}`);
+      process.env.HOME = marketplaceDir;
+
+      // Clean project commands/skills to avoid interference
+      await rm(join(testDir, '.claude', 'commands'), { recursive: true, force: true });
+      await mkdir(join(testDir, '.claude', 'commands'), { recursive: true });
+      await rm(join(testDir, '.claude', 'skills'), { recursive: true, force: true });
+    });
+
+    afterEach(async () => {
+      process.env.HOME = originalHome;
+      await rm(marketplaceDir, { recursive: true, force: true });
+    });
+
+    async function setupMarketplace(structure = {}) {
+      const installLocation = join(marketplaceDir, '.claude', 'plugins', 'marketplaces', 'official');
+      const knownMarketplacesPath = join(marketplaceDir, '.claude', 'plugins', 'known_marketplaces.json');
+
+      await mkdir(join(marketplaceDir, '.claude', 'plugins'), { recursive: true });
+      await writeFile(knownMarketplacesPath, JSON.stringify({
+        'official': { installLocation, ...structure.marketplaceProps },
+      }));
+
+      return installLocation;
+    }
+
+    // Marketplace skill tests
+
+    it('discovers skills from marketplace plugins', async () => {
+      const installLocation = await setupMarketplace();
+      const skillDir = join(installLocation, 'plugins', 'test-plugin', 'skills', 'test-skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), `---
+name: test-skill
+description: A marketplace skill
+argument-hint: "[file]"
+---
+Process $ARGUMENTS`);
+
+      const commands = await getCommands(testDir);
+      const skill = commands.find(c => c.name === 'test-plugin:test-skill');
+
+      expect(skill).toBeDefined();
+      expect(skill.source).toBe('plugin-skill');
+      expect(skill.isSkill).toBe(true);
+      expect(skill.description).toBe('A marketplace skill');
+      expect(skill.argumentHint).toBe('[file]');
+    });
+
+    it('discovers skills from external_plugins', async () => {
+      const installLocation = await setupMarketplace();
+      const skillDir = join(installLocation, 'external_plugins', 'ext-plugin', 'skills', 'ext-skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), `---
+name: ext-skill
+description: An external plugin skill
+---
+Body`);
+
+      const commands = await getCommands(testDir);
+      const skill = commands.find(c => c.name === 'ext-plugin:ext-skill');
+
+      expect(skill).toBeDefined();
+      expect(skill.source).toBe('plugin-skill');
+      expect(skill.isSkill).toBe(true);
+      expect(skill.description).toBe('An external plugin skill');
+    });
+
+    it('filters out non-user-invocable marketplace skills', async () => {
+      const installLocation = await setupMarketplace();
+      const skillDir = join(installLocation, 'plugins', 'test-plugin', 'skills', 'hidden');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), `---
+name: hidden
+description: Model-only skill
+user-invocable: false
+---
+Hidden body`);
+
+      const commands = await getCommands(testDir);
+      const skill = commands.find(c => c.name === 'test-plugin:hidden');
+
+      expect(skill).toBeUndefined();
+    });
+
+    it('handles missing known_marketplaces.json gracefully', async () => {
+      // Don't create known_marketplaces.json — just set HOME to empty temp dir
+      await mkdir(join(marketplaceDir, '.claude', 'plugins'), { recursive: true });
+
+      const commands = await getCommands(testDir);
+      // Should not throw, just return no marketplace items
+      expect(Array.isArray(commands)).toBe(true);
+    });
+
+    it('handles marketplace with no plugins directory', async () => {
+      // Create known_marketplaces.json pointing to directory with no plugins/ or external_plugins/
+      await setupMarketplace();
+
+      const commands = await getCommands(testDir);
+      // Should not throw
+      expect(Array.isArray(commands)).toBe(true);
+    });
+
+    it('marketplace skills are included in getCommands()', async () => {
+      const installLocation = await setupMarketplace();
+      const skillDir = join(installLocation, 'plugins', 'frontend-design', 'skills', 'frontend-design');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), `---
+name: frontend-design
+description: Create frontend interfaces
+---
+Design $ARGUMENTS`);
+
+      const commands = await getCommands(testDir);
+      const skill = commands.find(c => c.name === 'frontend-design:frontend-design');
+
+      expect(skill).toBeDefined();
+      expect(skill.isSkill).toBe(true);
+    });
+
+    // Marketplace command tests
+
+    it('discovers commands from marketplace plugins', async () => {
+      const installLocation = await setupMarketplace();
+      const commandsDir = join(installLocation, 'plugins', 'test-plugin', 'commands');
+      await mkdir(commandsDir, { recursive: true });
+      await writeFile(join(commandsDir, 'test.md'), `---
+description: A test command
+---
+Test command body`);
+
+      const commands = await getCommands(testDir);
+      const cmd = commands.find(c => c.name === 'test-plugin:test');
+
+      expect(cmd).toBeDefined();
+      expect(cmd.source).toBe('plugin');
+      expect(cmd.description).toBe('A test command');
+    });
+
+    it('discovers commands from external_plugins', async () => {
+      const installLocation = await setupMarketplace();
+      const commandsDir = join(installLocation, 'external_plugins', 'ext-plugin', 'commands');
+      await mkdir(commandsDir, { recursive: true });
+      await writeFile(join(commandsDir, 'run.md'), `---
+description: An external command
+---
+Run something`);
+
+      const commands = await getCommands(testDir);
+      const cmd = commands.find(c => c.name === 'ext-plugin:run');
+
+      expect(cmd).toBeDefined();
+      expect(cmd.source).toBe('plugin');
+      expect(cmd.description).toBe('An external command');
+    });
+
+    it('marketplace commands are included in getCommands()', async () => {
+      const installLocation = await setupMarketplace();
+      const commandsDir = join(installLocation, 'plugins', 'code-review', 'commands');
+      await mkdir(commandsDir, { recursive: true });
+      await writeFile(join(commandsDir, 'review.md'), `---
+description: Review code
+---
+Review the code`);
+
+      const commands = await getCommands(testDir);
+      const cmd = commands.find(c => c.name === 'code-review:review');
+
+      expect(cmd).toBeDefined();
+    });
+
+    // Deduplication tests
+
+    it('installed_plugins.json skill entries take precedence over marketplace duplicates', async () => {
+      const installLocation = await setupMarketplace();
+
+      // Create the same skill in both installed plugins (cache path) and marketplace
+      // Set up installed_plugins.json
+      const cachePluginPath = join(marketplaceDir, '.claude', 'plugins', 'cache', 'duped-plugin');
+      const cacheSkillDir = join(cachePluginPath, 'skills', 'my-skill');
+      await mkdir(cacheSkillDir, { recursive: true });
+      await writeFile(join(cacheSkillDir, 'SKILL.md'), `---
+name: my-skill
+description: Installed version
+---
+Installed body`);
+
+      const installedPluginsPath = join(marketplaceDir, '.claude', 'plugins', 'installed_plugins.json');
+      await writeFile(installedPluginsPath, JSON.stringify({
+        plugins: {
+          'duped-plugin@official': [{
+            scope: 'global',
+            installPath: cachePluginPath,
+          }],
+        },
+      }));
+
+      // Create same skill in marketplace
+      const marketplaceSkillDir = join(installLocation, 'plugins', 'duped-plugin', 'skills', 'my-skill');
+      await mkdir(marketplaceSkillDir, { recursive: true });
+      await writeFile(join(marketplaceSkillDir, 'SKILL.md'), `---
+name: my-skill
+description: Marketplace version
+---
+Marketplace body`);
+
+      const commands = await getCommands(testDir);
+      const matches = commands.filter(c => c.name === 'duped-plugin:my-skill');
+
+      expect(matches).toHaveLength(1);
+      // The installed_plugins.json version should win (its filePath is in the cache dir)
+      expect(matches[0].filePath).toContain('cache');
+      expect(matches[0].description).toBe('Installed version');
+    });
+
+    it('installed_plugins.json command entries take precedence over marketplace duplicates', async () => {
+      const installLocation = await setupMarketplace();
+
+      // Set up installed_plugins.json with commit-commands
+      const cachePluginPath = join(marketplaceDir, '.claude', 'plugins', 'cache', 'commit-commands');
+      const cacheCommandsDir = join(cachePluginPath, 'commands');
+      await mkdir(cacheCommandsDir, { recursive: true });
+      await writeFile(join(cacheCommandsDir, 'commit.md'), `---
+description: Installed commit command
+---
+Installed commit body`);
+
+      const installedPluginsPath = join(marketplaceDir, '.claude', 'plugins', 'installed_plugins.json');
+      await writeFile(installedPluginsPath, JSON.stringify({
+        plugins: {
+          'commit-commands@claude-plugins-official': [{
+            scope: 'global',
+            installPath: cachePluginPath,
+          }],
+        },
+      }));
+
+      // Create same command in marketplace
+      const marketplaceCommandsDir = join(installLocation, 'plugins', 'commit-commands', 'commands');
+      await mkdir(marketplaceCommandsDir, { recursive: true });
+      await writeFile(join(marketplaceCommandsDir, 'commit.md'), `---
+description: Marketplace commit command
+---
+Marketplace commit body`);
+
+      const commands = await getCommands(testDir);
+      const matches = commands.filter(c => c.name === 'commit-commands:commit');
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].filePath).toContain('cache');
+      expect(matches[0].description).toBe('Installed commit command');
+    });
+
+    // Integration test
+
+    it('buildCommandString works with marketplace-discovered skills', async () => {
+      const installLocation = await setupMarketplace();
+      const skillDir = join(installLocation, 'plugins', 'test-plugin', 'skills', 'process');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), `---
+name: process
+description: Process files
+---
+Process these files: $ARGUMENTS`);
+
+      const result = await buildCommandString(testDir, 'test-plugin:process', { _raw: 'file1.txt file2.txt' });
+
+      expect(result).toBe('Process these files: file1.txt file2.txt');
     });
   });
 });

--- a/packages/server/src/services/slashCommandService.test.js
+++ b/packages/server/src/services/slashCommandService.test.js
@@ -9,6 +9,10 @@ import {
   getCommand,
   getCommandBody,
   buildCommandString,
+  buildSkillInvocation,
+  buildSkillSystemPrompt,
+  buildSkillUserMessage,
+  resolvePromptSkillOrCommand,
 } from './slashCommandService.js';
 
 describe('slashCommandService', () => {
@@ -994,6 +998,248 @@ Process these files: $ARGUMENTS`);
       const result = await buildCommandString(testDir, 'test-plugin:process', { _raw: 'file1.txt file2.txt' });
 
       expect(result).toBe('Process these files: file1.txt file2.txt');
+    });
+  });
+
+  describe('buildSkillInvocation', () => {
+    let skillsDir;
+
+    beforeEach(async () => {
+      skillsDir = join(testDir, '.claude', 'skills');
+      await rm(skillsDir, { recursive: true, force: true });
+    });
+
+    it('returns null for non-skill commands', async () => {
+      await mkdir(join(testDir, '.claude', 'commands'), { recursive: true });
+      await writeFile(
+        join(testDir, '.claude', 'commands', 'deploy.md'),
+        `---
+description: Deploy command
+---
+Deploy now`
+      );
+
+      const result = await buildSkillInvocation(testDir, 'deploy', {});
+      expect(result).toBeNull();
+    });
+
+    it('returns null for unknown commands', async () => {
+      const result = await buildSkillInvocation(testDir, 'nonexistent', {});
+      expect(result).toBeNull();
+    });
+
+    it('returns structured skill invocation with no args', async () => {
+      await mkdir(join(skillsDir, 'design'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'design', 'SKILL.md'),
+        `---
+name: design
+description: Design skill
+---
+Create distinctive interfaces for $ARGUMENTS`
+      );
+
+      const result = await buildSkillInvocation(testDir, 'design', {});
+
+      expect(result).not.toBeNull();
+      expect(result.skillName).toBe('design');
+      expect(result.skillContent).toBe('Create distinctive interfaces for ');
+      expect(result.userMessage).toBeNull();
+    });
+
+    it('returns structured skill invocation with args', async () => {
+      await mkdir(join(skillsDir, 'design'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'design', 'SKILL.md'),
+        `---
+name: design
+description: Design skill
+---
+Create distinctive interfaces for $ARGUMENTS`
+      );
+
+      const result = await buildSkillInvocation(testDir, 'design', { _raw: 'a landing page' });
+
+      expect(result).not.toBeNull();
+      expect(result.skillName).toBe('design');
+      expect(result.skillContent).toBe('Create distinctive interfaces for a landing page');
+      expect(result.userMessage).toBe('a landing page');
+    });
+
+    it('substitutes positional args in skill content', async () => {
+      await mkdir(join(skillsDir, 'copy'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'copy', 'SKILL.md'),
+        `---
+name: copy
+---
+Copy $0 to $1`
+      );
+
+      const result = await buildSkillInvocation(testDir, 'copy', { _raw: 'source.txt dest.txt' });
+
+      expect(result.skillContent).toBe('Copy source.txt to dest.txt');
+      expect(result.userMessage).toBe('source.txt dest.txt');
+    });
+  });
+
+  describe('buildSkillSystemPrompt', () => {
+    it('combines project system prompt with skill content', () => {
+      const result = buildSkillSystemPrompt('You are a helpful assistant.', {
+        skillName: 'design',
+        skillContent: 'Create distinctive interfaces.',
+      });
+
+      expect(result).toContain('You are a helpful assistant.');
+      expect(result).toContain('<skill name="design">');
+      expect(result).toContain('Create distinctive interfaces.');
+      expect(result).toContain('</skill>');
+    });
+
+    it('handles null project system prompt', () => {
+      const result = buildSkillSystemPrompt(null, {
+        skillName: 'design',
+        skillContent: 'Create distinctive interfaces.',
+      });
+
+      expect(result).not.toContain('null');
+      expect(result).toContain('<skill name="design">');
+      expect(result).toContain('Create distinctive interfaces.');
+    });
+
+    it('handles empty project system prompt', () => {
+      const result = buildSkillSystemPrompt('', {
+        skillName: 'design',
+        skillContent: 'Create distinctive interfaces.',
+      });
+
+      expect(result).toContain('<skill name="design">');
+      // Should not have leading empty content
+      expect(result.startsWith('<skill')).toBe(true);
+    });
+  });
+
+  describe('buildSkillUserMessage', () => {
+    it('returns user args when provided', () => {
+      const result = buildSkillUserMessage({
+        skillName: 'design',
+        userMessage: 'create a 1999 landing page',
+      });
+
+      expect(result).toBe('create a 1999 landing page');
+    });
+
+    it('returns default prompt when no args provided', () => {
+      const result = buildSkillUserMessage({
+        skillName: 'design',
+        userMessage: null,
+      });
+
+      expect(result).toContain('/design');
+      expect(result).toContain('skill');
+    });
+  });
+
+  describe('resolvePromptSkillOrCommand', () => {
+    beforeEach(async () => {
+      await rm(join(testDir, '.claude', 'commands'), { recursive: true, force: true });
+      await mkdir(join(testDir, '.claude', 'commands'), { recursive: true });
+      await rm(join(testDir, '.claude', 'skills'), { recursive: true, force: true });
+    });
+
+    it('returns skill resolution when prompt starts with a valid skill name', async () => {
+      const skillsDir = join(testDir, '.claude', 'skills');
+      await mkdir(join(skillsDir, 'design'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'design', 'SKILL.md'),
+        '---\nname: design\ndescription: Design skill\n---\nCreate interfaces for $ARGUMENTS'
+      );
+
+      const result = await resolvePromptSkillOrCommand(
+        testDir, '/design create a landing page', 'You are helpful.'
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.type).toBe('skill');
+      expect(result.userMessage).toBe('create a landing page');
+      expect(result.systemPrompt).toContain('You are helpful.');
+      expect(result.systemPrompt).toContain('<skill name="design">');
+      expect(result.systemPrompt).toContain('Create interfaces for create a landing page');
+    });
+
+    it('returns default user message when skill invoked with no args', async () => {
+      const skillsDir = join(testDir, '.claude', 'skills');
+      await mkdir(join(skillsDir, 'design'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'design', 'SKILL.md'),
+        '---\nname: design\n---\nCreate interfaces for $ARGUMENTS'
+      );
+
+      const result = await resolvePromptSkillOrCommand(testDir, '/design', null);
+
+      expect(result).not.toBeNull();
+      expect(result.type).toBe('skill');
+      expect(result.userMessage).toContain('/design');
+      expect(result.userMessage).toContain('skill');
+    });
+
+    it('returns command resolution for a non-skill command', async () => {
+      await writeFile(
+        join(projectCommandsDir, 'deploy.md'),
+        '---\ndescription: Deploy\n---\nDeploy to production now!'
+      );
+
+      const result = await resolvePromptSkillOrCommand(
+        testDir, '/deploy', 'Project prompt.'
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.type).toBe('command');
+      expect(result.userMessage).toBe('Deploy to production now!');
+      expect(result.systemPrompt).toBe('Project prompt.');
+    });
+
+    it('returns null for plain text prompts', async () => {
+      const result = await resolvePromptSkillOrCommand(testDir, 'hello world', 'sys');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for unrecognized slash commands', async () => {
+      const result = await resolvePromptSkillOrCommand(testDir, '/nonexistent foo bar', null);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for null or empty prompts', async () => {
+      expect(await resolvePromptSkillOrCommand(testDir, null, null)).toBeNull();
+      expect(await resolvePromptSkillOrCommand(testDir, '', null)).toBeNull();
+    });
+
+    it('handles null project system prompt for skills', async () => {
+      const skillsDir = join(testDir, '.claude', 'skills');
+      await mkdir(join(skillsDir, 'test'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'test', 'SKILL.md'),
+        '---\nname: test\n---\nDo something'
+      );
+
+      const result = await resolvePromptSkillOrCommand(testDir, '/test args', null);
+
+      expect(result).not.toBeNull();
+      expect(result.systemPrompt).toContain('<skill name="test">');
+      expect(result.systemPrompt).not.toContain('null');
+    });
+
+    it('handles null project system prompt for commands', async () => {
+      await writeFile(
+        join(projectCommandsDir, 'cmd.md'),
+        '---\ndescription: A command\n---\nRun this'
+      );
+
+      const result = await resolvePromptSkillOrCommand(testDir, '/cmd', null);
+
+      expect(result).not.toBeNull();
+      expect(result.type).toBe('command');
+      expect(result.systemPrompt).toBeNull();
     });
   });
 });

--- a/packages/server/src/services/slashCommandService.test.js
+++ b/packages/server/src/services/slashCommandService.test.js
@@ -271,12 +271,60 @@ Hello, world!`
 
       expect(body).toBeNull();
     });
+
+    it('returns the body content of a skill using parseSkillFile', async () => {
+      const skillsDir = join(testDir, '.claude', 'skills');
+      await mkdir(join(skillsDir, 'review'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'review', 'SKILL.md'),
+        `---
+name: review
+description: Review code
+argument-hint: "[file]"
+user-invocable: true
+---
+Review the code in $ARGUMENTS`
+      );
+
+      const body = await getCommandBody(testDir, 'review');
+
+      expect(body).toBe('Review the code in $ARGUMENTS');
+    });
+
+    it('returns skill body (not command body) when both share same name', async () => {
+      // Create a command
+      await writeFile(
+        join(projectCommandsDir, 'deploy.md'),
+        `---
+description: Deploy command
+---
+Command body here`
+      );
+
+      // Create a skill with the same name
+      const skillsDir = join(testDir, '.claude', 'skills');
+      await mkdir(join(skillsDir, 'deploy'), { recursive: true });
+      await writeFile(
+        join(skillsDir, 'deploy', 'SKILL.md'),
+        `---
+name: deploy
+description: Deploy skill
+---
+Skill body here`
+      );
+
+      const body = await getCommandBody(testDir, 'deploy');
+
+      expect(body).toBe('Skill body here'); // Skill wins per Anthropic docs
+    });
   });
 
   describe('buildCommandString', () => {
     beforeEach(async () => {
       await rm(projectCommandsDir, { recursive: true, force: true });
       await mkdir(projectCommandsDir, { recursive: true });
+      // Also clean skills dir to avoid leaking from other tests
+      await rm(join(testDir, '.claude', 'skills'), { recursive: true, force: true });
     });
 
     it('substitutes arguments in the command body', async () => {
@@ -526,7 +574,7 @@ This skill is model-only`
       expect(skills).toEqual([]);
     });
 
-    it('command takes precedence over skill with same name', async () => {
+    it('skill takes precedence over command with same name', async () => {
       // Create a command
       await mkdir(projectCommandsDir, { recursive: true });
       await writeFile(
@@ -552,8 +600,8 @@ Deploy skill body`
       const deployItems = commands.filter((c) => c.name === 'deploy');
 
       expect(deployItems).toHaveLength(1);
-      expect(deployItems[0].source).toBe('project'); // Command, not skill
-      expect(deployItems[0].isSkill).toBeUndefined();
+      expect(deployItems[0].source).toBe('project-skill'); // Skill wins per Anthropic docs
+      expect(deployItems[0].isSkill).toBe(true);
     });
 
     it('uses directory name when skill name not specified', async () => {

--- a/packages/web/src/components/SlashCommandWizard.test.js
+++ b/packages/web/src/components/SlashCommandWizard.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import SlashCommandWizard from './SlashCommandWizard.vue';
+import CommandGrid from './slash-commands/CommandGrid.vue';
+import ArgumentsForm from './slash-commands/ArgumentsForm.vue';
+import { useSlashCommandsStore } from '../stores/slashCommands.js';
+import { useUiStore } from '../stores/ui.js';
+
+// Mock the API
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getSlashCommands: vi.fn(),
+    getSlashCommand: vi.fn(),
+    executeSlashCommand: vi.fn(),
+    getSession: vi.fn(),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+
+describe('SlashCommandWizard.vue', () => {
+  let commandsStore;
+  let uiStore;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    commandsStore = useSlashCommandsStore();
+    uiStore = useUiStore();
+    vi.clearAllMocks();
+
+    // Mock fetchCommands to return some test commands
+    api.getSlashCommands.mockResolvedValue([
+      {
+        name: 'test-cmd',
+        source: 'project',
+        description: 'A test command',
+        arguments: [{ name: 'arg1', label: 'Argument 1', type: 'text', required: true }],
+      },
+      {
+        name: 'no-args-cmd',
+        source: 'project',
+        description: 'Command with no args',
+        arguments: [],
+      },
+    ]);
+  });
+
+  describe('skill handling - integration tests', () => {
+    it('renders CommandGrid when open', async () => {
+      // Set commands in store
+      commandsStore.commands = [
+        {
+          name: 'my-skill',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'A test skill',
+        },
+      ];
+
+      const wrapper = mount(SlashCommandWizard, {
+        props: {
+          isOpen: true,
+          sessionId: 'test-session',
+          workingDirectory: '/test',
+          mode: 'execute',
+        },
+        global: {
+          stubs: {
+            Teleport: true,
+          },
+        },
+      });
+
+      const grid = wrapper.findComponent(CommandGrid);
+      expect(grid.exists()).toBe(true);
+    });
+
+    it('shows ArgumentsForm after selecting skill with argumentHint', async () => {
+      const skill = {
+        name: 'args-skill',
+        source: 'project-skill',
+        isSkill: true,
+        description: 'A skill with args',
+        argumentHint: '[filename]',
+      };
+
+      commandsStore.commands = [skill];
+
+      const wrapper = mount(SlashCommandWizard, {
+        props: {
+          isOpen: true,
+          sessionId: 'test-session',
+          workingDirectory: '/test',
+          mode: 'execute',
+        },
+        global: {
+          stubs: {
+            Teleport: true,
+          },
+        },
+      });
+
+      const grid = wrapper.findComponent(CommandGrid);
+      grid.vm.$emit('select', skill);
+
+      await wrapper.vm.$nextTick();
+
+      const argsForm = wrapper.findComponent(ArgumentsForm);
+      expect(argsForm.exists()).toBe(true);
+    });
+
+    it('passes skill to ArgumentsForm when skill is selected', async () => {
+      const skill = {
+        name: 'process',
+        source: 'project-skill',
+        isSkill: true,
+        description: 'Process files',
+        argumentHint: '[file]',
+      };
+
+      commandsStore.commands = [skill];
+
+      const wrapper = mount(SlashCommandWizard, {
+        props: {
+          isOpen: true,
+          workingDirectory: '/test',
+          mode: 'insert',
+        },
+        global: {
+          stubs: {
+            Teleport: true,
+          },
+        },
+      });
+
+      // Select skill
+      const grid = wrapper.findComponent(CommandGrid);
+      await grid.vm.$emit('select', skill);
+      await wrapper.vm.$nextTick();
+
+      // Check that ArgumentsForm receives the skill
+      const argsForm = wrapper.findComponent(ArgumentsForm);
+      expect(argsForm.exists()).toBe(true);
+      expect(argsForm.props('command')).toEqual(skill);
+      expect(argsForm.props('command').isSkill).toBe(true);
+    });
+
+    it('executes skill command when ArgumentsForm submits in execute mode', async () => {
+      const skill = {
+        name: 'analyze',
+        source: 'project-skill',
+        isSkill: true,
+        argumentHint: '[target]',
+      };
+
+      api.executeSlashCommand.mockResolvedValue({ success: true });
+      commandsStore.commands = [skill];
+
+      const wrapper = mount(SlashCommandWizard, {
+        props: {
+          isOpen: true,
+          sessionId: 'test-session',
+          workingDirectory: '/test',
+          mode: 'execute',
+        },
+        global: {
+          stubs: {
+            Teleport: true,
+          },
+        },
+      });
+
+      // Select skill
+      const grid = wrapper.findComponent(CommandGrid);
+      grid.vm.$emit('select', skill);
+
+      await wrapper.vm.$nextTick();
+
+      // Submit args form
+      const argsForm = wrapper.findComponent(ArgumentsForm);
+      argsForm.vm.$emit('submit', { _raw: 'codebase' });
+
+      await wrapper.vm.$nextTick();
+
+      expect(api.executeSlashCommand).toHaveBeenCalledWith('test-session', 'analyze', {
+        _raw: 'codebase',
+      });
+    });
+  });
+});

--- a/packages/web/src/components/SlashCommandWizard.vue
+++ b/packages/web/src/components/SlashCommandWizard.vue
@@ -130,7 +130,19 @@ function close() {
 function selectCommand(cmd) {
   selectedCommand.value = cmd;
 
-  // If command has no arguments, execute/insert immediately
+  // For skills: check if it has argumentHint to determine if we need args form
+  if (cmd.isSkill) {
+    if (cmd.argumentHint) {
+      // Show args form for skills with argument hint
+      step.value = 2;
+    } else {
+      // Execute immediately for skills without args
+      handleExecute({ _raw: '' });
+    }
+    return;
+  }
+
+  // For commands: check if it has arguments
   if (!cmd.arguments || cmd.arguments.length === 0) {
     handleExecute({});
   } else {
@@ -192,7 +204,16 @@ async function handleExecute(args) {
 function buildInsertString(command, args) {
   let result = `/${command.name}`;
 
-  // Add arguments
+  // For skills, use raw args
+  if (command.isSkill) {
+    const rawArgs = args._raw || '';
+    if (rawArgs) {
+      result += ` ${rawArgs}`;
+    }
+    return result;
+  }
+
+  // For commands, use structured arguments
   const argValues = [];
   for (const argDef of command.arguments || []) {
     const value = args[argDef.name];

--- a/packages/web/src/components/slash-commands/ArgumentsForm.test.js
+++ b/packages/web/src/components/slash-commands/ArgumentsForm.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ArgumentsForm from './ArgumentsForm.vue';
+
+describe('ArgumentsForm.vue', () => {
+  describe('skill rendering', () => {
+    it('renders skill args input for skills', () => {
+      const skill = {
+        name: 'my-skill',
+        isSkill: true,
+        description: 'A test skill',
+        argumentHint: '[filename]',
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const input = wrapper.find('[data-testid="skill-args-input"]');
+      expect(input.exists()).toBe(true);
+      expect(input.attributes('placeholder')).toBe('[filename]');
+    });
+
+    it('displays argumentHint as a hint label for skills', () => {
+      const skill = {
+        name: 'process',
+        isSkill: true,
+        argumentHint: '[target]',
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const hint = wrapper.find('.hint');
+      expect(hint.exists()).toBe(true);
+      expect(hint.text()).toBe('[target]');
+    });
+
+    it('does not render argumentHint label if not provided', () => {
+      const skill = {
+        name: 'simple',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const hint = wrapper.find('.hint');
+      expect(hint.exists()).toBe(false);
+    });
+
+    it('uses default placeholder when argumentHint is not provided', () => {
+      const skill = {
+        name: 'simple',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const input = wrapper.find('[data-testid="skill-args-input"]');
+      expect(input.attributes('placeholder')).toBe('Enter arguments...');
+    });
+
+    it('does not render structured argument fields for skills', () => {
+      const skill = {
+        name: 'my-skill',
+        isSkill: true,
+        argumentHint: '[file]',
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const argFields = wrapper.findAll('.form-field');
+      // Should only have one field (the skill args input)
+      expect(argFields.length).toBe(1);
+    });
+  });
+
+  describe('command rendering', () => {
+    it('renders structured argument fields for commands', () => {
+      const command = {
+        name: 'deploy',
+        description: 'Deploy the app',
+        arguments: [
+          { name: 'env', label: 'Environment', type: 'text', required: true },
+          { name: 'verbose', label: 'Verbose', type: 'text', required: false },
+        ],
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command,
+        },
+      });
+
+      const envField = wrapper.find('[data-testid="arg-env"]');
+      const verboseField = wrapper.find('[data-testid="arg-verbose"]');
+
+      expect(envField.exists()).toBe(true);
+      expect(verboseField.exists()).toBe(true);
+    });
+
+    it('does not render skill args input for commands', () => {
+      const command = {
+        name: 'deploy',
+        arguments: [{ name: 'env', label: 'Environment', type: 'text', required: true }],
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command,
+        },
+      });
+
+      const skillInput = wrapper.find('[data-testid="skill-args-input"]');
+      expect(skillInput.exists()).toBe(false);
+    });
+  });
+
+  describe('skill validation', () => {
+    it('allows empty skill args', () => {
+      const skill = {
+        name: 'my-skill',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const submitBtn = wrapper.find('[data-testid="execute-command-btn"]');
+      expect(submitBtn.attributes('disabled')).toBeUndefined();
+    });
+  });
+
+  describe('command validation', () => {
+    it('does not submit when command has invalid required fields', async () => {
+      const command = {
+        name: 'deploy',
+        arguments: [{ name: 'env', label: 'Environment', type: 'text', required: true }],
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command,
+        },
+      });
+
+      const form = wrapper.find('form');
+      await form.trigger('submit');
+
+      const submitEvent = wrapper.emitted('submit');
+      expect(submitEvent).toBeFalsy();
+    });
+  });
+
+  describe('button behavior', () => {
+    it('renders back button', () => {
+      const skill = {
+        name: 'test',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const backBtn = wrapper.find('.btn-secondary');
+      expect(backBtn.exists()).toBe(true);
+      expect(backBtn.text()).toBe('Back');
+    });
+  });
+
+  describe('executing state', () => {
+    it('disables submit button when executing', () => {
+      const skill = {
+        name: 'test',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+          executing: true,
+        },
+      });
+
+      const submitBtn = wrapper.find('[data-testid="execute-command-btn"]');
+      expect(submitBtn.attributes('disabled')).toBeDefined();
+    });
+
+    it('shows loading spinner when executing', () => {
+      const skill = {
+        name: 'test',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+          executing: true,
+        },
+      });
+
+      const spinner = wrapper.find('.loading-spinner');
+      expect(spinner.exists()).toBe(true);
+    });
+
+    it('does not submit when executing', async () => {
+      const skill = {
+        name: 'test',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+          executing: true,
+        },
+      });
+
+      const form = wrapper.find('form');
+      await form.trigger('submit');
+
+      const submitEvent = wrapper.emitted('submit');
+      expect(submitEvent).toBeFalsy();
+    });
+  });
+
+  describe('execute label', () => {
+    it('displays custom execute label', () => {
+      const skill = {
+        name: 'test',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+          executeLabel: 'Insert Command',
+        },
+      });
+
+      const submitBtn = wrapper.find('[data-testid="execute-command-btn"]');
+      expect(submitBtn.text()).toContain('Insert Command');
+    });
+
+    it('displays default execute label', () => {
+      const skill = {
+        name: 'test',
+        isSkill: true,
+      };
+
+      const wrapper = mount(ArgumentsForm, {
+        props: {
+          command: skill,
+        },
+      });
+
+      const submitBtn = wrapper.find('[data-testid="execute-command-btn"]');
+      expect(submitBtn.text()).toContain('Execute Command');
+    });
+  });
+});

--- a/packages/web/src/components/slash-commands/ArgumentsForm.vue
+++ b/packages/web/src/components/slash-commands/ArgumentsForm.vue
@@ -6,59 +6,81 @@
     </div>
 
     <form @submit.prevent="handleSubmit" class="form-fields">
-      <div
-        v-for="arg in command.arguments"
-        :key="arg.name"
-        class="form-field"
-      >
-        <label :for="`arg-${arg.name}`" class="field-label">
-          {{ arg.label }}
-          <span v-if="arg.required" class="required-indicator">*</span>
-        </label>
+      <!-- Skill arguments (simple text input) -->
+      <template v-if="command.isSkill">
+        <div class="form-field">
+          <label for="skill-args" class="field-label">
+            Arguments
+            <span v-if="command.argumentHint" class="hint">{{ command.argumentHint }}</span>
+          </label>
+          <input
+            id="skill-args"
+            type="text"
+            v-model="skillRawArgs"
+            :placeholder="command.argumentHint || 'Enter arguments...'"
+            class="field-input"
+            data-testid="skill-args-input"
+            @keydown.enter.prevent="handleSubmit"
+          />
+        </div>
+      </template>
 
-        <!-- Select type -->
-        <select
-          v-if="arg.type === 'select'"
-          :id="`arg-${arg.name}`"
-          v-model="formData[arg.name]"
-          :required="arg.required"
-          class="field-select"
-          :data-testid="`arg-${arg.name}`"
+      <!-- Structured command arguments -->
+      <template v-else>
+        <div
+          v-for="arg in command.arguments"
+          :key="arg.name"
+          class="form-field"
         >
-          <option value="" disabled>Select an option...</option>
-          <option
-            v-for="opt in arg.options || []"
-            :key="opt.value"
-            :value="opt.value"
+          <label :for="`arg-${arg.name}`" class="field-label">
+            {{ arg.label }}
+            <span v-if="arg.required" class="required-indicator">*</span>
+          </label>
+
+          <!-- Select type -->
+          <select
+            v-if="arg.type === 'select'"
+            :id="`arg-${arg.name}`"
+            v-model="formData[arg.name]"
+            :required="arg.required"
+            class="field-select"
+            :data-testid="`arg-${arg.name}`"
           >
-            {{ opt.label }}
-          </option>
-        </select>
+            <option value="" disabled>Select an option...</option>
+            <option
+              v-for="opt in arg.options || []"
+              :key="opt.value"
+              :value="opt.value"
+            >
+              {{ opt.label }}
+            </option>
+          </select>
 
-        <!-- Multiline type -->
-        <textarea
-          v-else-if="arg.type === 'multiline'"
-          :id="`arg-${arg.name}`"
-          v-model="formData[arg.name]"
-          :required="arg.required"
-          :placeholder="arg.placeholder || ''"
-          class="field-textarea"
-          rows="4"
-          :data-testid="`arg-${arg.name}`"
-        ></textarea>
+          <!-- Multiline type -->
+          <textarea
+            v-else-if="arg.type === 'multiline'"
+            :id="`arg-${arg.name}`"
+            v-model="formData[arg.name]"
+            :required="arg.required"
+            :placeholder="arg.placeholder || ''"
+            class="field-textarea"
+            rows="4"
+            :data-testid="`arg-${arg.name}`"
+          ></textarea>
 
-        <!-- Text type (default) -->
-        <input
-          v-else
-          type="text"
-          :id="`arg-${arg.name}`"
-          v-model="formData[arg.name]"
-          :required="arg.required"
-          :placeholder="arg.placeholder || ''"
-          class="field-input"
-          :data-testid="`arg-${arg.name}`"
-        />
-      </div>
+          <!-- Text type (default) -->
+          <input
+            v-else
+            type="text"
+            :id="`arg-${arg.name}`"
+            v-model="formData[arg.name]"
+            :required="arg.required"
+            :placeholder="arg.placeholder || ''"
+            class="field-input"
+            :data-testid="`arg-${arg.name}`"
+          />
+        </div>
+      </template>
 
       <div class="form-actions">
         <button type="button" class="btn btn-secondary" @click="emit('back')">
@@ -92,6 +114,9 @@ const emit = defineEmits(['back', 'submit']);
 // Initialize form data with defaults
 const formData = ref({});
 
+// For skills: raw arguments string
+const skillRawArgs = ref('');
+
 // Initialize form data when command changes
 function initFormData() {
   const data = {};
@@ -111,6 +136,12 @@ watch(() => props.command, () => {
 
 // Validation
 const isValid = computed(() => {
+  // Skills are always valid (args are optional)
+  if (props.command.isSkill) {
+    return true;
+  }
+
+  // For commands, validate required fields
   for (const arg of props.command.arguments || []) {
     if (arg.required) {
       const value = formData.value[arg.name];
@@ -124,6 +155,14 @@ const isValid = computed(() => {
 
 function handleSubmit() {
   if (!isValid.value || props.executing) return;
+
+  // For skills, submit raw args
+  if (props.command.isSkill) {
+    emit('submit', { _raw: skillRawArgs.value });
+    return;
+  }
+
+  // For commands, submit structured args
   emit('submit', formData.value);
 }
 </script>
@@ -176,6 +215,14 @@ function handleSubmit() {
 .required-indicator {
   color: var(--color-danger, #ef4444);
   margin-left: 0.125rem;
+}
+
+.hint {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--color-text-soft);
+  font-family: ui-monospace, monospace;
 }
 
 .field-input,

--- a/packages/web/src/components/slash-commands/CommandGrid.test.js
+++ b/packages/web/src/components/slash-commands/CommandGrid.test.js
@@ -1,0 +1,552 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CommandGrid from './CommandGrid.vue';
+
+describe('CommandGrid.vue', () => {
+  describe('skill sections rendering', () => {
+    it('renders Project Skills section when project skills exist', () => {
+      const commands = [
+        {
+          name: 'project-skill-1',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'A project skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const section = wrapper.find('.section-title');
+      expect(section.text()).toBe('Project Skills');
+    });
+
+    it('renders User Skills section when user skills exist', () => {
+      const commands = [
+        {
+          name: 'user-skill-1',
+          source: 'user-skill',
+          isSkill: true,
+          description: 'A user skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const section = wrapper.find('.section-title');
+      expect(section.text()).toBe('User Skills');
+    });
+
+    it('renders Plugin Skills section when plugin skills exist', () => {
+      const commands = [
+        {
+          name: 'plugin:skill-1',
+          source: 'plugin-skill',
+          isSkill: true,
+          description: 'A plugin skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const section = wrapper.find('.section-title');
+      expect(section.text()).toBe('Plugin Skills');
+    });
+
+    it('does not render skill sections when no skills exist', () => {
+      const commands = [
+        {
+          name: 'deploy',
+          source: 'project',
+          description: 'Deploy command',
+          arguments: [],
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const sections = wrapper.findAll('.section-title');
+      const skillSections = sections.filter(
+        (s) =>
+          s.text() === 'Project Skills' ||
+          s.text() === 'User Skills' ||
+          s.text() === 'Plugin Skills'
+      );
+
+      expect(skillSections).toHaveLength(0);
+    });
+  });
+
+  describe('skill cards rendering', () => {
+    it('renders skill cards with correct data-testid', () => {
+      const commands = [
+        {
+          name: 'my-skill',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Test skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const skillCard = wrapper.find('[data-testid="skill-my-skill"]');
+      expect(skillCard.exists()).toBe(true);
+    });
+
+    it('displays skill name with forward slash prefix', () => {
+      const commands = [
+        {
+          name: 'process',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Process files',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const skillName = wrapper.find('.command-name');
+      expect(skillName.text()).toBe('/process');
+    });
+
+    it('displays skill description', () => {
+      const commands = [
+        {
+          name: 'analyze',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Analyze the codebase',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const description = wrapper.find('.command-description');
+      expect(description.text()).toBe('Analyze the codebase');
+    });
+
+    it('displays "No description" when skill has no description', () => {
+      const commands = [
+        {
+          name: 'my-skill',
+          source: 'project-skill',
+          isSkill: true,
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const description = wrapper.find('.command-description');
+      expect(description.text()).toBe('No description');
+    });
+
+    it('displays argumentHint badge when skill has argumentHint', () => {
+      const commands = [
+        {
+          name: 'copy',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Copy files',
+          argumentHint: '[source] [dest]',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const badge = wrapper.find('.command-args-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.text()).toBe('[source] [dest]');
+    });
+
+    it('does not display badge when skill has no argumentHint', () => {
+      const commands = [
+        {
+          name: 'simple',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Simple skill',
+          argumentHint: null,
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const badge = wrapper.find('.command-args-badge');
+      expect(badge.exists()).toBe(false);
+    });
+  });
+
+  describe('command cards vs skill cards', () => {
+    it('displays argument count badge for commands', () => {
+      const commands = [
+        {
+          name: 'deploy',
+          source: 'project',
+          description: 'Deploy app',
+          arguments: [
+            { name: 'env', label: 'Environment', type: 'text', required: true },
+            { name: 'verbose', label: 'Verbose', type: 'text', required: false },
+          ],
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const badge = wrapper.find('.command-args-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.text()).toBe('2 args');
+    });
+
+    it('displays argumentHint for skills instead of arg count', () => {
+      const commands = [
+        {
+          name: 'skill',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'A skill',
+          argumentHint: '[file]',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const badge = wrapper.find('.command-args-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.text()).toBe('[file]');
+    });
+  });
+
+  describe('skill filtering by search', () => {
+    it('filters project skills by name', async () => {
+      const commands = [
+        {
+          name: 'analyze',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Analyze code',
+        },
+        {
+          name: 'process',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Process files',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const searchInput = wrapper.find('[data-testid="command-search"]');
+      await searchInput.setValue('analyze');
+
+      const skillCards = wrapper.findAll('[data-testid^="skill-"]');
+      expect(skillCards).toHaveLength(1);
+      expect(skillCards[0].attributes('data-testid')).toBe('skill-analyze');
+    });
+
+    it('filters skills by description', async () => {
+      const commands = [
+        {
+          name: 'skill1',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Process the codebase',
+        },
+        {
+          name: 'skill2',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Analyze files',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const searchInput = wrapper.find('[data-testid="command-search"]');
+      await searchInput.setValue('codebase');
+
+      const skillCards = wrapper.findAll('[data-testid^="skill-"]');
+      expect(skillCards).toHaveLength(1);
+      expect(skillCards[0].attributes('data-testid')).toBe('skill-skill1');
+    });
+
+    it('shows all skills when search is cleared', async () => {
+      const commands = [
+        {
+          name: 'skill1',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Skill 1',
+        },
+        {
+          name: 'skill2',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Skill 2',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const searchInput = wrapper.find('[data-testid="command-search"]');
+      await searchInput.setValue('skill1');
+
+      let skillCards = wrapper.findAll('[data-testid^="skill-"]');
+      expect(skillCards).toHaveLength(1);
+
+      await searchInput.setValue('');
+
+      skillCards = wrapper.findAll('[data-testid^="skill-"]');
+      expect(skillCards).toHaveLength(2);
+    });
+  });
+
+  describe('skill selection', () => {
+    it('renders skill card as clickable button', () => {
+      const skill = {
+        name: 'my-skill',
+        source: 'project-skill',
+        isSkill: true,
+        description: 'Test skill',
+      };
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands: [skill],
+        },
+      });
+
+      const skillCard = wrapper.find('[data-testid="skill-my-skill"]');
+      expect(skillCard.exists()).toBe(true);
+      expect(skillCard.element.tagName).toBe('BUTTON');
+      expect(skillCard.attributes('type')).toBe('button');
+    });
+  });
+
+  describe('multiple skill sources', () => {
+    it('renders all three skill sections when all types exist', () => {
+      const commands = [
+        {
+          name: 'project-skill',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Project skill',
+        },
+        {
+          name: 'user-skill',
+          source: 'user-skill',
+          isSkill: true,
+          description: 'User skill',
+        },
+        {
+          name: 'plugin-skill',
+          source: 'plugin-skill',
+          isSkill: true,
+          description: 'Plugin skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const sections = wrapper.findAll('.section-title');
+      const sectionTexts = sections.map((s) => s.text());
+
+      expect(sectionTexts).toContain('Project Skills');
+      expect(sectionTexts).toContain('User Skills');
+      expect(sectionTexts).toContain('Plugin Skills');
+    });
+
+    it('separates skills into correct sections', () => {
+      const commands = [
+        {
+          name: 'ps1',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Project skill 1',
+        },
+        {
+          name: 'ps2',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Project skill 2',
+        },
+        {
+          name: 'us1',
+          source: 'user-skill',
+          isSkill: true,
+          description: 'User skill 1',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      // Find all sections
+      const sections = wrapper.findAll('.command-section');
+      const projectSection = sections.find((s) => s.find('.section-title').text() === 'Project Skills');
+      const userSection = sections.find((s) => s.find('.section-title').text() === 'User Skills');
+
+      const projectSkills = projectSection.findAll('[data-testid^="skill-"]');
+      const userSkills = userSection.findAll('[data-testid^="skill-"]');
+
+      expect(projectSkills).toHaveLength(2);
+      expect(userSkills).toHaveLength(1);
+    });
+  });
+
+  describe('mixed commands and skills', () => {
+    it('displays both command and skill sections', () => {
+      const commands = [
+        {
+          name: 'deploy',
+          source: 'project',
+          description: 'Deploy command',
+          arguments: [],
+        },
+        {
+          name: 'analyze',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Analyze skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const sections = wrapper.findAll('.section-title');
+      const sectionTexts = sections.map((s) => s.text());
+
+      expect(sectionTexts).toContain('Project Commands');
+      expect(sectionTexts).toContain('Project Skills');
+    });
+
+    it('filters both commands and skills with search', async () => {
+      const commands = [
+        {
+          name: 'deploy',
+          source: 'project',
+          description: 'Deploy the app',
+          arguments: [],
+        },
+        {
+          name: 'analyze',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'Analyze the codebase',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const searchInput = wrapper.find('[data-testid="command-search"]');
+      await searchInput.setValue('analyze');
+      await wrapper.vm.$nextTick();
+
+      const commandCards = wrapper.findAll('[data-testid="command-deploy"]');
+      const skillCards = wrapper.findAll('[data-testid="skill-analyze"]');
+
+      expect(commandCards).toHaveLength(0);
+      expect(skillCards).toHaveLength(1);
+    });
+  });
+
+  describe('empty states', () => {
+    it('shows empty state when no skills match search', async () => {
+      const commands = [
+        {
+          name: 'my-skill',
+          source: 'project-skill',
+          isSkill: true,
+          description: 'A skill',
+        },
+      ];
+
+      const wrapper = mount(CommandGrid, {
+        props: {
+          commands,
+        },
+      });
+
+      const searchInput = wrapper.find('[data-testid="command-search"]');
+      await searchInput.setValue('nonexistent');
+
+      const emptyState = wrapper.find('.empty-state');
+      expect(emptyState.exists()).toBe(true);
+      expect(emptyState.text()).toContain('No commands match "nonexistent"');
+    });
+  });
+});

--- a/packages/web/src/components/slash-commands/CommandGrid.vue
+++ b/packages/web/src/components/slash-commands/CommandGrid.vue
@@ -113,6 +113,69 @@
           </button>
         </div>
       </div>
+
+      <!-- Project Skills -->
+      <div v-if="filteredProjectSkills.length > 0" class="command-section">
+        <h3 class="section-title">Project Skills</h3>
+        <div class="command-cards">
+          <button
+            v-for="skill in filteredProjectSkills"
+            :key="skill.name"
+            type="button"
+            class="command-card"
+            @click="selectCommand(skill)"
+            :data-testid="`skill-${skill.name}`"
+          >
+            <span class="command-name">/{{ skill.name }}</span>
+            <span class="command-description">{{ skill.description || 'No description' }}</span>
+            <span v-if="skill.argumentHint" class="command-args-badge">
+              {{ skill.argumentHint }}
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <!-- User Skills -->
+      <div v-if="filteredUserSkills.length > 0" class="command-section">
+        <h3 class="section-title">User Skills</h3>
+        <div class="command-cards">
+          <button
+            v-for="skill in filteredUserSkills"
+            :key="skill.name"
+            type="button"
+            class="command-card"
+            @click="selectCommand(skill)"
+            :data-testid="`skill-${skill.name}`"
+          >
+            <span class="command-name">/{{ skill.name }}</span>
+            <span class="command-description">{{ skill.description || 'No description' }}</span>
+            <span v-if="skill.argumentHint" class="command-args-badge">
+              {{ skill.argumentHint }}
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Plugin Skills -->
+      <div v-if="filteredPluginSkills.length > 0" class="command-section">
+        <h3 class="section-title">Plugin Skills</h3>
+        <div class="command-cards">
+          <button
+            v-for="skill in filteredPluginSkills"
+            :key="skill.name"
+            type="button"
+            class="command-card"
+            @click="selectCommand(skill)"
+            :data-testid="`skill-${skill.name}`"
+          >
+            <span class="command-name">/{{ skill.name }}</span>
+            <span class="command-description">{{ skill.description || 'No description' }}</span>
+            <span v-if="skill.argumentHint" class="command-args-badge">
+              {{ skill.argumentHint }}
+            </span>
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -145,6 +208,15 @@ const userCommands = computed(() =>
 const pluginCommands = computed(() =>
   props.commands.filter((c) => c.source === 'plugin')
 );
+const projectSkills = computed(() =>
+  props.commands.filter((c) => c.source === 'project-skill')
+);
+const userSkills = computed(() =>
+  props.commands.filter((c) => c.source === 'user-skill')
+);
+const pluginSkills = computed(() =>
+  props.commands.filter((c) => c.source === 'plugin-skill')
+);
 
 // Filtered by search
 function filterBySearch(commands) {
@@ -163,11 +235,17 @@ const filteredBuiltinCommands = computed(() => filterBySearch(builtinCommands.va
 const filteredProjectCommands = computed(() => filterBySearch(projectCommands.value));
 const filteredUserCommands = computed(() => filterBySearch(userCommands.value));
 const filteredPluginCommands = computed(() => filterBySearch(pluginCommands.value));
+const filteredProjectSkills = computed(() => filterBySearch(projectSkills.value));
+const filteredUserSkills = computed(() => filterBySearch(userSkills.value));
+const filteredPluginSkills = computed(() => filterBySearch(pluginSkills.value));
 const filteredCommands = computed(() => [
   ...filteredBuiltinCommands.value,
   ...filteredProjectCommands.value,
   ...filteredUserCommands.value,
   ...filteredPluginCommands.value,
+  ...filteredProjectSkills.value,
+  ...filteredUserSkills.value,
+  ...filteredPluginSkills.value,
 ]);
 
 function selectCommand(cmd) {

--- a/packages/web/src/stores/slashCommands.js
+++ b/packages/web/src/stores/slashCommands.js
@@ -27,9 +27,51 @@ export const useSlashCommandsStore = defineStore('slashCommands', {
     userCommands: (state) => state.commands.filter((c) => c.source === 'user'),
 
     /**
+     * Get plugin commands only
+     */
+    pluginCommands: (state) => state.commands.filter((c) => c.source === 'plugin'),
+
+    /**
      * Get custom commands only (project + user)
      */
     customCommands: (state) => state.commands.filter((c) => c.source !== 'builtin'),
+
+    /**
+     * Get project skills only
+     */
+    projectSkills: (state) => state.commands.filter((c) => c.source === 'project-skill'),
+
+    /**
+     * Get user skills only
+     */
+    userSkills: (state) => state.commands.filter((c) => c.source === 'user-skill'),
+
+    /**
+     * Get plugin skills only
+     */
+    pluginSkills: (state) => state.commands.filter((c) => c.source === 'plugin-skill'),
+
+    /**
+     * Get all skills regardless of source
+     */
+    allSkills: (state) => state.commands.filter((c) => c.isSkill === true),
+
+    /**
+     * Check if any skills exist
+     */
+    hasSkills: (state) => state.commands.some((c) => c.isSkill === true),
+
+    /**
+     * Get all project items (commands + skills)
+     */
+    allProjectItems: (state) =>
+      state.commands.filter((c) => c.source === 'project' || c.source === 'project-skill'),
+
+    /**
+     * Get all user items (commands + skills)
+     */
+    allUserItems: (state) =>
+      state.commands.filter((c) => c.source === 'user' || c.source === 'user-skill'),
 
     /**
      * Check if any commands are available

--- a/packages/web/src/stores/slashCommands.test.js
+++ b/packages/web/src/stores/slashCommands.test.js
@@ -126,6 +126,133 @@ describe('useSlashCommandsStore', () => {
         expect(store.hasCustomCommands).toBe(false);
       });
     });
+
+    describe('pluginCommands', () => {
+      it('returns only plugin commands', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'deploy', source: 'project' },
+          { name: 'test', source: 'user' },
+          { name: 'plugin-cmd', source: 'plugin' },
+        ];
+
+        expect(store.pluginCommands).toHaveLength(1);
+        expect(store.pluginCommands[0].name).toBe('plugin-cmd');
+      });
+    });
+
+    describe('projectSkills', () => {
+      it('returns only project skills', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+          { name: 'skill2', source: 'user-skill', isSkill: true },
+        ];
+
+        expect(store.projectSkills).toHaveLength(1);
+        expect(store.projectSkills[0].name).toBe('skill1');
+      });
+    });
+
+    describe('userSkills', () => {
+      it('returns only user skills', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+          { name: 'skill2', source: 'user-skill', isSkill: true },
+        ];
+
+        expect(store.userSkills).toHaveLength(1);
+        expect(store.userSkills[0].name).toBe('skill2');
+      });
+    });
+
+    describe('pluginSkills', () => {
+      it('returns only plugin skills', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+          { name: 'skill2', source: 'plugin-skill', isSkill: true },
+        ];
+
+        expect(store.pluginSkills).toHaveLength(1);
+        expect(store.pluginSkills[0].name).toBe('skill2');
+      });
+    });
+
+    describe('allSkills', () => {
+      it('returns all skills regardless of source', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'deploy', source: 'project' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+          { name: 'skill2', source: 'user-skill', isSkill: true },
+          { name: 'skill3', source: 'plugin-skill', isSkill: true },
+        ];
+
+        expect(store.allSkills).toHaveLength(3);
+        expect(store.allSkills.map((s) => s.name)).toEqual(['skill1', 'skill2', 'skill3']);
+      });
+    });
+
+    describe('hasSkills', () => {
+      it('returns true if any skills exist', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+        ];
+
+        expect(store.hasSkills).toBe(true);
+      });
+
+      it('returns false if no skills exist', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'deploy', source: 'project' },
+        ];
+
+        expect(store.hasSkills).toBe(false);
+      });
+    });
+
+    describe('allProjectItems', () => {
+      it('returns both project commands and project skills', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'deploy', source: 'project' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+          { name: 'test', source: 'user' },
+          { name: 'skill2', source: 'user-skill', isSkill: true },
+        ];
+
+        expect(store.allProjectItems).toHaveLength(2);
+        expect(store.allProjectItems.map((i) => i.name)).toEqual(['deploy', 'skill1']);
+      });
+    });
+
+    describe('allUserItems', () => {
+      it('returns both user commands and user skills', () => {
+        const store = useSlashCommandsStore();
+        store.commands = [
+          { name: 'help', source: 'builtin' },
+          { name: 'deploy', source: 'project' },
+          { name: 'skill1', source: 'project-skill', isSkill: true },
+          { name: 'test', source: 'user' },
+          { name: 'skill2', source: 'user-skill', isSkill: true },
+        ];
+
+        expect(store.allUserItems).toHaveLength(2);
+        expect(store.allUserItems.map((i) => i.name)).toEqual(['test', 'skill2']);
+      });
+    });
   });
 
   describe('actions', () => {


### PR DESCRIPTION
## Summary

- **Cherry-picked skill feature** from the mixed `ad62` branch (`88a1369`) — adds Claude Code Skills discovery alongside existing slash commands
- **Fixed two bugs** identified during review:
  - Skills now take precedence over commands with the same name (per [Anthropic docs](https://code.claude.com/docs/en/skills))
  - `getCommandBody()` now uses `parseSkillFile()` for skills instead of `parseCommandFile()`
- **Fixed skill invocation** — skills now properly inject their body into the system prompt (matches CLI behavior)
- **No refactoring included** — this is a clean extraction of just the skill feature work

## What's new

**Server:**
- `parseSkillFile()` — parses `SKILL.md` frontmatter (name, description, argument-hint, user-invocable, disable-model-invocation)
- `discoverSkillsFromDir()` — scans `.claude/skills/*/SKILL.md` directories
- `discoverPluginSkills()` — discovers skills from installed plugins
- Updated `getCommands()` with correct skill-over-command precedence
- Updated `buildCommandString()` with `$ARGUMENTS` and positional arg substitution for skills
- **NEW:** `buildSkillInvocation()` — returns structured skill data separating content from user args
- **NEW:** `buildSkillSystemPrompt()` — combines project system prompt with skill content
- **NEW:** `buildSkillUserMessage()` — generates appropriate user message for skill invocation
- **NEW:** `resolvePromptSkillOrCommand()` — detects and processes slash commands in text input
- **NEW:** Skills now inject body as system prompt context (not user message) — matches CLI behavior

**Frontend:**
- `CommandGrid.vue` — new sections for Project Skills, User Skills, Plugin Skills with `argumentHint` badges
- `ArgumentsForm.vue` — raw text input for skill arguments (vs structured fields for commands)
- `SlashCommandWizard.vue` — skill execution flow
- `slashCommands.js` store — new getters: `projectSkills`, `userSkills`, `pluginSkills`, `allSkills`, `hasSkills`

**Tests (all new):**
- 44 server tests (parsing, discovery, precedence, argument substitution, getCommandBody for skills)
- 18+ new server tests for skill invocation functions (buildSkillInvocation, buildSkillSystemPrompt, buildSkillUserMessage, resolvePromptSkillOrCommand)
- `CommandGrid.test.js` — grid display, filtering, skill card rendering
- `ArgumentsForm.test.js` — form rendering/validation for skills
- `SlashCommandWizard.test.js` — wizard skill integration
- `slashCommands.test.js` — store getter and execution tests

## Skill Invocation Fix Details

Previously, skills were broken in two ways:
1. **Wizard UI path:** Skill body was sent as the user message instead of system prompt context
2. **Text input path:** Slash commands typed manually were sent raw to CLI without processing

Now both paths work correctly:
- Skill content is injected into the system prompt (wrapped in `<skill name="...">` tags)
- User arguments become the actual user message
- If no arguments provided, Claude sees skill instructions and asks what to build
- This matches the CLI behavior where skills guide Claude's behavior

The fix adds:
- Detection of slash commands in text input (`/sessions/:id/message` endpoint)
- Proper routing through skill execution logic (body → system prompt, args → user message)
- Same fix applied to session creation, scheduled sessions, and command execution
- Comprehensive test coverage for all new functions

## Test plan

- [x] All 2,670+ server tests pass (including 18+ new skill invocation tests)
- [x] All web unit tests pass
- [ ] Manual: create `.claude/skills/test-skill/SKILL.md` and verify it appears in the Commands tab
- [ ] Manual: execute a skill with arguments via wizard and verify substitution works
- [ ] Manual: execute a skill via text input (e.g., `/frontend-design create a landing page`) and verify it works
- [ ] Manual: create a command and skill with the same name, verify the skill wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)