### PR TITLE
Fix third-party model provider data lost on server restart

### DIFF
--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -25,11 +25,6 @@ export class DatabaseManager {
     this.#db.pragma('journal_mode = WAL');
     this.#db.pragma('foreign_keys = ON');
 
-    // Clean up legacy model_providers table from development (before running schema)
-    // Also drop provider_models if it has a FK reference to model_providers
-    this.#db.exec('DROP TABLE IF EXISTS model_providers');
-    this.#db.exec('DROP TABLE IF EXISTS provider_models');
-
     // Run schema
     const schema = readFileSync(join(__dirname, '..', 'schema.sql'), 'utf-8');
     this.#db.exec(schema);
@@ -428,6 +423,17 @@ export class DatabaseManager {
         updated_at INTEGER NOT NULL
       )
     `);
+
+    // Clean up legacy model_providers table from early development.
+    // If it exists, provider_models may have a stale FK pointing to it,
+    // so drop provider_models too — it will be recreated below with the correct FK.
+    const hasLegacyTable = this.#db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='model_providers'")
+      .get();
+    if (hasLegacyTable) {
+      this.#db.exec('DROP TABLE IF EXISTS provider_models');
+      this.#db.exec('DROP TABLE IF EXISTS model_providers');
+    }
 
     // Create providers and provider_models tables for custom provider support.
     // New installs get the clean schema here; existing installs go through #migrateProvidersTable().


### PR DESCRIPTION
## Summary
- **Fixed a bug where third-party model provider models were deleted on every server restart.** The `DatabaseManager.init()` method unconditionally dropped the `provider_models` table on startup, destroying all custom provider model choices. Only the built-in Anthropic provider survived because it was re-seeded from hardcoded values each time.
- **Moved legacy table cleanup into the migration path** so `provider_models` is only dropped when the obsolete `model_providers` table actually exists (indicating a stale FK reference from early development that needs fixing). Normal restarts now preserve all provider data.

## Test plan
- [x] `DatabaseManager.test.js` — 51 tests pass, including legacy migration scenarios
- [x] `providers-migration.test.js` — 3 integration tests pass (old DB migration, minimal schema, fresh install)
- [x] `providers.test.js`, `sessionProvider.test.js`, `sessionManager-customProviders.test.js` — 53 provider-related tests pass
- [ ] Manual: Add a third-party model provider with model choices, restart the server, verify models persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)