### PR TITLE
Fix: Child session count no longer inflated by 1

### DIFF
--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -266,7 +266,7 @@ export const useSessionsStore = defineStore('sessions', {
         scheduledCount,
         waitingCount,
         completedCount,
-        totalCount: allSessions.length,
+        totalCount: allSessions.length - 1,
         hasScheduledDescendant: allSessions.slice(1).some((s) => s.status === 'scheduled'),
         rootIsScheduled: root.status === 'scheduled',
       };

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -4706,5 +4706,70 @@ describe('Sessions Store', () => {
         expect(store.conversations[1].id).toBe('conv-A2'); // not removed
       });
     });
+
+    describe('getWorkflowAggregatedStatus', () => {
+      it('totalCount is 0 for a session with no children', () => {
+        const store = useSessionsStore();
+        store.sessions = [{ id: 'root', status: 'running', parentSessionId: null }];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.totalCount).toBe(0);
+      });
+
+      it('totalCount is 1 for a session with one child', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'running', parentSessionId: null },
+          { id: 'child-1', status: 'running', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.totalCount).toBe(1);
+      });
+
+      it('totalCount is 3 for a session with three children', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'running', parentSessionId: null },
+          { id: 'child-1', status: 'running', parentSessionId: 'root' },
+          { id: 'child-2', status: 'running', parentSessionId: 'root' },
+          { id: 'child-3', status: 'running', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.totalCount).toBe(3);
+      });
+
+      it('totalCount counts nested descendants (grandchildren)', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'running', parentSessionId: null },
+          { id: 'child-1', status: 'running', parentSessionId: 'root' },
+          { id: 'grandchild-1', status: 'running', parentSessionId: 'child-1' },
+        ];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        // root has 2 descendants (child-1 and grandchild-1), but not counting root itself
+        expect(result.totalCount).toBe(2);
+      });
+
+      it('status counts still include the root session', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'running', parentSessionId: null },
+          { id: 'child-1', status: 'scheduled', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.runningCount).toBe(1); // the root
+        expect(result.scheduledCount).toBe(1); // the child
+        expect(result.totalCount).toBe(1); // only the child (descendants only)
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes an issue where the UI displayed "Show X sessions" with the count inflated by 1. A session with 1 child would incorrectly show "Show 2 sessions".

## Problem
In `packages/web/src/stores/sessions.js`, the `getWorkflowAggregatedStatus` getter built an `allSessions` array that **includes the root/parent session itself**. This meant `totalCount` = 1 (parent) + N (children) = N+1, when the UI intends to show just the child count.

## Root Cause
Line 269 in sessions.js:
```js
totalCount: allSessions.length,  // Includes root + children
```

## Solution
Changed line 269 to:
```js
totalCount: allSessions.length - 1,  // Excludes root, only counts descendants
```

This makes `totalCount` represent only the descendant/child sessions, which is what the UI displays. The root session is already shown as the main card — the expand toggle is specifically for revealing child sessions.

## Changes
- **Modified**: `packages/web/src/stores/sessions.js` - Fixed `totalCount` calculation
- **Modified**: `packages/web/src/stores/sessions.test.js` - Added 5 comprehensive test cases

## Test Coverage
Added 5 test cases in a new `describe('getWorkflowAggregatedStatus')` block:
1. ✅ `totalCount` is 0 for a session with no children
2. ✅ `totalCount` is 1 for a session with one child (exact bug scenario)
3. ✅ `totalCount` is 3 for a session with three children
4. ✅ `totalCount` counts nested descendants (grandchildren)
5. ✅ Status counts still include the root session (verifies we only changed `totalCount`)

All 287 tests pass ✅

## Affected UI
After this fix, `SessionCard.vue` will correctly display:
- Expand toggle text: "Show 1 session" for 1 child (instead of "Show 2 sessions")
- Session count badge: Correct count for 2+ children

## Note
The `runningCount`, `scheduledCount`, `waitingCount`, and `completedCount` values still include the root session since those badges describe the overall workflow status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)