### PR TITLE
Move Auto-Reschedule Enabled UI to bottom of Conversation tab

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -267,6 +267,9 @@
       mode="execute"
       @executed="handleSlashCommandExecuted"
     />
+
+    <!-- Scheduling Info Panel -->
+    <SchedulingInfo v-if="sessionsStore.currentSession" :session="sessionsStore.currentSession" />
   </div>
 </template>
 
@@ -300,6 +303,7 @@ import ResizableTextarea from './ResizableTextarea.vue';
 import SlashCommandButton from './SlashCommandButton.vue';
 import SlashCommandWizard from './SlashCommandWizard.vue';
 import OrchestrationPanel from './OrchestrationPanel.vue';
+import SchedulingInfo from './SchedulingInfo.vue';
 import { useQuickResponsesStore } from '../stores/quickResponses.js';
 import { useProjectsStore } from '../stores/projects.js';
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -190,9 +190,6 @@
         </div>
       </div>
 
-      <!-- Scheduling Info Panel -->
-      <SchedulingInfo v-if="sessionsStore.currentSession" :session="sessionsStore.currentSession" />
-
       <div class="tab-content">
         <!-- CRITICAL: :key ensures components remount when navigating between sessions,
              preventing stale WebSocket handlers from capturing the wrong sessionId -->
@@ -225,7 +222,6 @@ import CommandsTab from '../components/CommandsTab.vue';
 import PrIndicators from '../components/PrIndicators.vue';
 import DuplicateSessionButton from '../components/DuplicateSessionButton.vue';
 import OverflowMenu from '../components/OverflowMenu.vue';
-import SchedulingInfo from '../components/SchedulingInfo.vue';
 import CommandButtonStatusBar from '../components/CommandButtonStatusBar.vue';
 import SessionHierarchyBreadcrumb from '../components/SessionHierarchyBreadcrumb.vue';
 import { useTemplatesStore } from '../stores/templates.js';


### PR DESCRIPTION
## Summary
Moves the "Auto-Reschedule Enabled" panel from the top of SessionDetailView (above all tabs) to the bottom of ConversationTab, making it more contextually appropriate for the conversation flow.

## Changes
- **ConversationTab.vue**: Added `SchedulingInfo` component at the bottom of the template
- **SessionDetailView.vue**: Removed `SchedulingInfo` component import and rendering
- Both `AutoRescheduleModal` instances are preserved (serving different triggers from OrchestrationPanel and SchedulingInfo)

## Impact
The "Scheduled Session" panel also moves to the conversation tab bottom, which is acceptable since scheduling info is conversation-context-specific. The SchedulingInfo component now renders only when viewing the Conversation tab, making the UI cleaner when viewing other tabs (Canvas, Notes, Changes).

## Testing
✅ All unit tests pass (2,641 tests)
✅ All E2E tests pass:
- scheduling-reschedule.spec.ts (26 tests)
- orchestration-panel.spec.ts (21 tests)
- SchedulingInfo.test.js (23 tests)
- ConversationTab.test.js (55 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)