### PR TITLE
Fix bulk canvas operations to handle all file versions

### DIFF
--- a/packages/server/src/api/canvas.js
+++ b/packages/server/src/api/canvas.js
@@ -481,6 +481,46 @@ router.get('/:id/canvas/file/:filename', async (req, res) => {
   }
 });
 
+// DELETE /api/sessions/:id/canvas/bulk-delete-permanent - Permanently delete multiple items from trash
+// NOTE: This must be defined BEFORE /:id/canvas/:itemId to avoid Express matching it as :itemId = "bulk-delete-permanent"
+router.delete('/:id/canvas/bulk-delete-permanent', (req, res) => {
+  const session = sessions.getById(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const { itemIds } = req.body;
+  if (!Array.isArray(itemIds)) {
+    return res.status(400).json({ error: 'itemIds must be an array' });
+  }
+
+  if (itemIds.length === 0) {
+    return res.json({ deletedCount: 0 });
+  }
+
+  // Verify all items are in trash and belong to this session
+  for (const itemId of itemIds) {
+    const item = canvasItems.getById(itemId);
+    if (!item || item.sessionId !== req.params.id) {
+      return res.status(404).json({ error: `Item ${itemId} not found in session` });
+    }
+    if (!item.deletedAt) {
+      return res.status(400).json({ error: `Item ${itemId} is not in trash (cannot permanently delete active items)` });
+    }
+  }
+
+  // Expand to include all versions of each file
+  const expandedIds = canvasItems.expandToAllVersions(itemIds, { deletedOnly: true });
+  const deletedCount = canvasItems.permanentDeleteBatch(expandedIds);
+
+  // Broadcast each deleted item to session subscribers
+  expandedIds.forEach(itemId => {
+    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId: req.params.id, itemId });
+  });
+
+  res.json({ deletedCount, deletedIds: expandedIds });
+});
+
 // DELETE /api/sessions/:id/canvas/:itemId - Soft delete canvas item (move to trash)
 router.delete('/:id/canvas/:itemId', (req, res) => {
   const item = canvasItems.getById(req.params.itemId);
@@ -584,14 +624,16 @@ router.post('/:id/canvas/bulk-delete', (req, res) => {
     }
   }
 
-  const deletedCount = canvasItems.softDeleteBatch(itemIds);
+  // Expand to include all versions of each file
+  const expandedIds = canvasItems.expandToAllVersions(itemIds, { activeOnly: true });
+  const deletedCount = canvasItems.softDeleteBatch(expandedIds);
 
   // Broadcast each deleted item to session subscribers
-  itemIds.forEach(itemId => {
+  expandedIds.forEach(itemId => {
     broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId: req.params.id, itemId });
   });
 
-  res.json({ deletedCount });
+  res.json({ deletedCount, deletedIds: expandedIds });
 });
 
 // POST /api/sessions/:id/canvas/bulk-recover - Recover multiple items from trash
@@ -610,54 +652,27 @@ router.post('/:id/canvas/bulk-recover', (req, res) => {
     return res.json({ recoveredCount: 0 });
   }
 
-  const recoveredCount = canvasItems.recoverBatch(itemIds);
+  // Validate all items belong to this session
+  for (const itemId of itemIds) {
+    const item = canvasItems.getById(itemId);
+    if (!item || item.sessionId !== req.params.id) {
+      return res.status(404).json({ error: `Item ${itemId} not found in session` });
+    }
+  }
+
+  // Expand to include all versions of each file
+  const expandedIds = canvasItems.expandToAllVersions(itemIds, { deletedOnly: true });
+  const recoveredCount = canvasItems.recoverBatch(expandedIds);
 
   // Broadcast each recovered item to session subscribers
-  itemIds.forEach(itemId => {
+  expandedIds.forEach(itemId => {
     const item = canvasItems.getById(itemId);
     if (item) {
       broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_ADD, { item });
     }
   });
 
-  res.json({ recoveredCount });
-});
-
-// DELETE /api/sessions/:id/canvas/bulk-delete-permanent - Permanently delete multiple items from trash
-router.delete('/:id/canvas/bulk-delete-permanent', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) {
-    return res.status(404).json({ error: 'Session not found' });
-  }
-
-  const { itemIds } = req.body;
-  if (!Array.isArray(itemIds)) {
-    return res.status(400).json({ error: 'itemIds must be an array' });
-  }
-
-  if (itemIds.length === 0) {
-    return res.json({ deletedCount: 0 });
-  }
-
-  // Verify all items are in trash and belong to this session
-  for (const itemId of itemIds) {
-    const item = canvasItems.getById(itemId);
-    if (!item || item.sessionId !== req.params.id) {
-      return res.status(404).json({ error: `Item ${itemId} not found in session` });
-    }
-    if (!item.deletedAt) {
-      return res.status(400).json({ error: `Item ${itemId} is not in trash (cannot permanently delete active items)` });
-    }
-  }
-
-  const deletedCount = canvasItems.permanentDeleteBatch(itemIds);
-
-  // Broadcast each deleted item to session subscribers
-  itemIds.forEach(itemId => {
-    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_REMOVE, { sessionId: req.params.id, itemId });
-  });
-
-  res.json({ deletedCount });
+  res.json({ recoveredCount, recoveredIds: expandedIds });
 });
 
 export default router;

--- a/packages/server/src/api/canvas.test.js
+++ b/packages/server/src/api/canvas.test.js
@@ -2104,4 +2104,114 @@ describe('Canvas API', () => {
       expect(res.body.content).toBe('Only version');
     });
   });
+
+  describe('Bulk endpoints with version expansion', () => {
+    let app;
+    let sessionId;
+
+    beforeEach(() => {
+      app = express();
+      app.use(express.json());
+      app.use('/api/sessions', canvasRouter);
+
+      const project = projects.create('Test Project', '/tmp/test');
+      const now = Date.now();
+      const id = databaseManager.generateId();
+      databaseManager.get().prepare(
+        'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      ).run(id, project.id, 'Test Session', 'running', 'standard', now, now);
+      sessionId = id;
+    });
+
+    it('POST /bulk-delete expands IDs to include all versions', async () => {
+      const v1 = canvasItems.create(sessionId, { type: 'text', content: 'V1', filename: 'file.png' });
+      const v2 = canvasItems.create(sessionId, { type: 'text', content: 'V2', filename: 'file.png' });
+      const v3 = canvasItems.create(sessionId, { type: 'text', content: 'V3', filename: 'file.png' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${sessionId}/canvas/bulk-delete`)
+        .send({ itemIds: [v3.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.deletedCount).toBe(3);
+      expect(res.body.deletedIds).toHaveLength(3);
+      expect(res.body.deletedIds).toContain(v1.id);
+      expect(res.body.deletedIds).toContain(v2.id);
+      expect(res.body.deletedIds).toContain(v3.id);
+
+      // Verify all 3 appear in trash
+      const trashRes = await request(app).get(`/api/sessions/${sessionId}/canvas-trash`);
+      expect(trashRes.body).toHaveLength(3);
+    });
+
+    it('POST /bulk-recover expands IDs to include all versions', async () => {
+      const v1 = canvasItems.create(sessionId, { type: 'text', content: 'V1', filename: 'file.png' });
+      const v2 = canvasItems.create(sessionId, { type: 'text', content: 'V2', filename: 'file.png' });
+      const v3 = canvasItems.create(sessionId, { type: 'text', content: 'V3', filename: 'file.png' });
+
+      // Soft delete all
+      canvasItems.softDeleteBatch([v1.id, v2.id, v3.id]);
+
+      const res = await request(app)
+        .post(`/api/sessions/${sessionId}/canvas/bulk-recover`)
+        .send({ itemIds: [v1.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.recoveredCount).toBe(3);
+      expect(res.body.recoveredIds).toHaveLength(3);
+      expect(res.body.recoveredIds).toContain(v1.id);
+      expect(res.body.recoveredIds).toContain(v2.id);
+      expect(res.body.recoveredIds).toContain(v3.id);
+
+      // Verify all are active again
+      const listRes = await request(app).get(`/api/sessions/${sessionId}/canvas/all`);
+      expect(listRes.body).toHaveLength(3);
+    });
+
+    it('DELETE /bulk-delete-permanent expands IDs to include all versions', async () => {
+      const v1 = canvasItems.create(sessionId, { type: 'text', content: 'V1', filename: 'file.png' });
+      const v2 = canvasItems.create(sessionId, { type: 'text', content: 'V2', filename: 'file.png' });
+      const v3 = canvasItems.create(sessionId, { type: 'text', content: 'V3', filename: 'file.png' });
+
+      // Soft delete all first
+      canvasItems.softDeleteBatch([v1.id, v2.id, v3.id]);
+
+      const res = await request(app)
+        .delete(`/api/sessions/${sessionId}/canvas/bulk-delete-permanent`)
+        .send({ itemIds: [v2.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.deletedCount).toBe(3);
+      expect(res.body.deletedIds).toHaveLength(3);
+      expect(res.body.deletedIds).toContain(v1.id);
+      expect(res.body.deletedIds).toContain(v2.id);
+      expect(res.body.deletedIds).toContain(v3.id);
+
+      // Verify trash is empty
+      const trashRes = await request(app).get(`/api/sessions/${sessionId}/canvas-trash`);
+      expect(trashRes.body).toHaveLength(0);
+    });
+
+    it('POST /bulk-recover validates session ownership', async () => {
+      // Create another session
+      const project2 = projects.create('Other Project', '/tmp/other');
+      const otherSessionId = databaseManager.generateId();
+      const now = Date.now();
+      databaseManager.get().prepare(
+        'INSERT INTO sessions (id, project_id, name, status, mode, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      ).run(otherSessionId, project2.id, 'Other Session', 'running', 'standard', now, now);
+
+      // Create item in session A
+      const item = canvasItems.create(sessionId, { type: 'text', content: 'Session A item', filename: 'test.txt' });
+      canvasItems.softDelete(item.id);
+
+      // Try to recover from session B
+      const res = await request(app)
+        .post(`/api/sessions/${otherSessionId}/canvas/bulk-recover`)
+        .send({ itemIds: [item.id] });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain('not found in session');
+    });
+  });
 });

--- a/packages/server/src/db/CanvasItemRepository.js
+++ b/packages/server/src/db/CanvasItemRepository.js
@@ -176,6 +176,44 @@ export class CanvasItemRepository extends BaseRepository {
   }
 
   /**
+   * Expand item IDs to include all versions sharing the same filename.
+   * For each given ID, finds the item's filename + session, then collects
+   * all items with that filename in that session.
+   * @param {string[]} itemIds - Array of item IDs
+   * @param {object} options
+   * @param {boolean} [options.deletedOnly] - Only include deleted items (for trash operations)
+   * @param {boolean} [options.activeOnly] - Only include active (non-deleted) items
+   * @returns {string[]} Expanded array of item IDs (deduplicated)
+   */
+  expandToAllVersions(itemIds, { deletedOnly = false, activeOnly = false } = {}) {
+    if (!itemIds || itemIds.length === 0) return [];
+
+    const allIds = new Set();
+
+    for (const itemId of itemIds) {
+      const item = this.getById(itemId);
+      if (!item || !item.filename) {
+        allIds.add(itemId);
+        continue;
+      }
+
+      let filter = 'session_id = ? AND filename = ?';
+      if (deletedOnly) filter += ' AND deleted_at IS NOT NULL';
+      if (activeOnly) filter += ' AND deleted_at IS NULL';
+
+      const siblings = this.db
+        .prepare(`SELECT id FROM canvas_items WHERE ${filter}`)
+        .all(item.sessionId, item.filename);
+
+      for (const sibling of siblings) {
+        allIds.add(sibling.id);
+      }
+    }
+
+    return [...allIds];
+  }
+
+  /**
    * Duplicates all canvas items from one session to another.
    * Only copies non-deleted items.
    * @param {string} sourceSessionId - Source session ID

--- a/packages/server/src/db/CanvasItemRepository.test.js
+++ b/packages/server/src/db/CanvasItemRepository.test.js
@@ -637,6 +637,98 @@ describe('CanvasItemRepository', () => {
       });
     });
 
+    describe('expandToAllVersions', () => {
+      it('returns all sibling version IDs for a given item ID', () => {
+        const v1 = repo.create(sessionId, { type: 'image', data: 'data1', filename: 'report.png' });
+        const v2 = repo.create(sessionId, { type: 'image', data: 'data2', filename: 'report.png' });
+        const v3 = repo.create(sessionId, { type: 'image', data: 'data3', filename: 'report.png' });
+
+        const result = repo.expandToAllVersions([v3.id]);
+
+        expect(result).toHaveLength(3);
+        expect(result).toContain(v1.id);
+        expect(result).toContain(v2.id);
+        expect(result).toContain(v3.id);
+      });
+
+      it('handles multiple files and deduplicates', () => {
+        const a1 = repo.create(sessionId, { type: 'image', data: 'data1', filename: 'a.png' });
+        const a2 = repo.create(sessionId, { type: 'image', data: 'data2', filename: 'a.png' });
+        const b1 = repo.create(sessionId, { type: 'image', data: 'data3', filename: 'b.png' });
+        const b2 = repo.create(sessionId, { type: 'image', data: 'data4', filename: 'b.png' });
+
+        const result = repo.expandToAllVersions([a2.id, b2.id]);
+
+        expect(result).toHaveLength(4);
+        expect(result).toContain(a1.id);
+        expect(result).toContain(a2.id);
+        expect(result).toContain(b1.id);
+        expect(result).toContain(b2.id);
+      });
+
+      it('with activeOnly: true, excludes deleted items', () => {
+        const v1 = repo.create(sessionId, { type: 'text', content: 'v1', filename: 'file.txt' });
+        const v2 = repo.create(sessionId, { type: 'text', content: 'v2', filename: 'file.txt' });
+        const v3 = repo.create(sessionId, { type: 'text', content: 'v3', filename: 'file.txt' });
+
+        repo.softDelete(v2.id);
+
+        const result = repo.expandToAllVersions([v1.id], { activeOnly: true });
+
+        expect(result).toHaveLength(2);
+        expect(result).toContain(v1.id);
+        expect(result).toContain(v3.id);
+        expect(result).not.toContain(v2.id);
+      });
+
+      it('with deletedOnly: true, excludes active items', () => {
+        const v1 = repo.create(sessionId, { type: 'text', content: 'v1', filename: 'file.txt' });
+        const v2 = repo.create(sessionId, { type: 'text', content: 'v2', filename: 'file.txt' });
+        const v3 = repo.create(sessionId, { type: 'text', content: 'v3', filename: 'file.txt' });
+
+        repo.softDelete(v1.id);
+        repo.softDelete(v2.id);
+
+        const result = repo.expandToAllVersions([v1.id], { deletedOnly: true });
+
+        expect(result).toHaveLength(2);
+        expect(result).toContain(v1.id);
+        expect(result).toContain(v2.id);
+        expect(result).not.toContain(v3.id);
+      });
+
+      it('handles items with no filename (falls back to just the given ID)', () => {
+        const item = repo.create(sessionId, { type: 'text', content: 'no filename' });
+
+        const result = repo.expandToAllVersions([item.id]);
+
+        expect(result).toEqual([item.id]);
+      });
+
+      it('deduplicates when multiple input IDs map to the same file', () => {
+        const v1 = repo.create(sessionId, { type: 'text', content: 'v1', filename: 'file.png' });
+        const v2 = repo.create(sessionId, { type: 'text', content: 'v2', filename: 'file.png' });
+        const v3 = repo.create(sessionId, { type: 'text', content: 'v3', filename: 'file.png' });
+
+        const result = repo.expandToAllVersions([v1.id, v2.id]);
+
+        expect(result).toHaveLength(3);
+        expect(result).toContain(v1.id);
+        expect(result).toContain(v2.id);
+        expect(result).toContain(v3.id);
+      });
+
+      it('returns empty array for empty input', () => {
+        const result = repo.expandToAllVersions([]);
+        expect(result).toEqual([]);
+      });
+
+      it('handles non-existent IDs gracefully', () => {
+        const result = repo.expandToAllVersions(['non-existent-id']);
+        expect(result).toEqual(['non-existent-id']);
+      });
+    });
+
     describe('duplicateForSession', () => {
       let targetSessionId;
       let targetProject;

--- a/packages/web/src/stores/canvas.js
+++ b/packages/web/src/stores/canvas.js
@@ -15,11 +15,13 @@ export const useCanvasStore = defineStore('canvas', {
     selectedItemCount: (state) => state.selectedItemIds.size,
 
     isAllItemsSelected: (state) => {
-      return state.items.length > 0 && state.selectedItemIds.size === state.items.length;
+      const uniqueFiles = new Set(state.items.map(i => i.filename || i.id));
+      return uniqueFiles.size > 0 && state.selectedItemIds.size === uniqueFiles.size;
     },
 
     isPartialSelection: (state) => {
-      return state.selectedItemIds.size > 0 && state.selectedItemIds.size < state.items.length;
+      const uniqueFiles = new Set(state.items.map(i => i.filename || i.id));
+      return state.selectedItemIds.size > 0 && state.selectedItemIds.size < uniqueFiles.size;
     },
 
     selectedItems: (state) => {
@@ -202,8 +204,13 @@ export const useCanvasStore = defineStore('canvas', {
     },
 
     selectAllItems() {
+      const seen = new Set();
       for (const item of this.items) {
-        this.selectedItemIds.add(item.id);
+        const key = item.filename || item.id;
+        if (!seen.has(key)) {
+          seen.add(key);
+          this.selectedItemIds.add(item.id);
+        }
       }
     },
 
@@ -217,10 +224,17 @@ export const useCanvasStore = defineStore('canvas', {
       this.error = null;
       try {
         const result = await api.bulkDeleteCanvasItems(sessionId, itemIds);
+        const allDeletedIds = new Set(result.deletedIds);
 
-        // Remove from active items
-        const deletedIds = new Set(itemIds);
-        this.items = this.items.filter((i) => !deletedIds.has(i.id));
+        // Move to trash
+        const now = Date.now();
+        const deletedItems = this.items
+          .filter((i) => allDeletedIds.has(i.id))
+          .map((i) => ({ ...i, deletedAt: now }));
+        this.trashedItems.unshift(...deletedItems);
+
+        // Remove from active
+        this.items = this.items.filter((i) => !allDeletedIds.has(i.id));
 
         // Clear selection
         this.selectedItemIds.clear();
@@ -240,13 +254,13 @@ export const useCanvasStore = defineStore('canvas', {
       this.error = null;
       try {
         const result = await api.bulkRecoverCanvasItems(sessionId, itemIds);
+        const allRecoveredIds = new Set(result.recoveredIds);
 
         // Get the items from trash before removing
-        const recoveredIds = new Set(itemIds);
-        const recoveredItems = this.trashedItems.filter((i) => recoveredIds.has(i.id));
+        const recoveredItems = this.trashedItems.filter((i) => allRecoveredIds.has(i.id));
 
         // Remove from trash
-        this.trashedItems = this.trashedItems.filter((i) => !recoveredIds.has(i.id));
+        this.trashedItems = this.trashedItems.filter((i) => !allRecoveredIds.has(i.id));
 
         // Add back to active items
         this.items.unshift(...recoveredItems);
@@ -269,10 +283,10 @@ export const useCanvasStore = defineStore('canvas', {
       this.error = null;
       try {
         const result = await api.bulkPermanentlyDeleteCanvasItems(sessionId, itemIds);
+        const allDeletedIds = new Set(result.deletedIds);
 
         // Remove from trash
-        const deletedIds = new Set(itemIds);
-        this.trashedItems = this.trashedItems.filter((i) => !deletedIds.has(i.id));
+        this.trashedItems = this.trashedItems.filter((i) => !allDeletedIds.has(i.id));
 
         // Clear selection
         this.selectedItemIds.clear();

--- a/packages/web/src/stores/canvas.test.js
+++ b/packages/web/src/stores/canvas.test.js
@@ -13,6 +13,9 @@ vi.mock('../composables/useApi.js', () => ({
     recoverCanvasItem: vi.fn(),
     recoverCanvasFile: vi.fn(),
     permanentlyDeleteCanvasItem: vi.fn(),
+    bulkDeleteCanvasItems: vi.fn(),
+    bulkRecoverCanvasItems: vi.fn(),
+    bulkPermanentlyDeleteCanvasItems: vi.fn(),
   },
 }));
 
@@ -514,6 +517,159 @@ describe('Canvas Store', () => {
       api.getCanvasFileContent.mockRejectedValue(error);
 
       await expect(store.fetchItemContent('session-1', 'missing.txt')).rejects.toThrow();
+    });
+  });
+
+  describe('bulkDeleteItems action', () => {
+    it('uses server-returned deletedIds to remove all versions from items', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'a.png', createdAt: 1000 },
+        { id: '2', filename: 'a.png', createdAt: 2000 },
+        { id: '3', filename: 'a.png', createdAt: 3000 },
+        { id: '4', filename: 'b.png', createdAt: 4000 },
+        { id: '5', filename: 'b.png', createdAt: 5000 },
+      ];
+
+      api.bulkDeleteCanvasItems.mockResolvedValue({
+        deletedCount: 3,
+        deletedIds: ['1', '2', '3'],
+      });
+
+      await store.bulkDeleteItems('session-1', ['3']);
+
+      expect(store.items).toHaveLength(2);
+      expect(store.items[0].id).toBe('4');
+      expect(store.items[1].id).toBe('5');
+    });
+
+    it('moves all deleted items to trashedItems', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'a.png', createdAt: 1000 },
+        { id: '2', filename: 'a.png', createdAt: 2000 },
+        { id: '3', filename: 'a.png', createdAt: 3000 },
+        { id: '4', filename: 'b.png', createdAt: 4000 },
+      ];
+
+      api.bulkDeleteCanvasItems.mockResolvedValue({
+        deletedCount: 3,
+        deletedIds: ['1', '2', '3'],
+      });
+
+      await store.bulkDeleteItems('session-1', ['3']);
+
+      expect(store.trashedItems).toHaveLength(3);
+      expect(store.trashedItems.every(i => i.deletedAt !== undefined && i.deletedAt !== null)).toBe(true);
+      expect(store.trashedItems.map(i => i.id).sort()).toEqual(['1', '2', '3']);
+    });
+
+    it('clears selectedItemIds after operation', async () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'a.png', createdAt: 1000 },
+      ];
+      store.selectedItemIds.add('1');
+
+      api.bulkDeleteCanvasItems.mockResolvedValue({
+        deletedCount: 1,
+        deletedIds: ['1'],
+      });
+
+      await store.bulkDeleteItems('session-1', ['1']);
+
+      expect(store.selectedItemIds.size).toBe(0);
+    });
+  });
+
+  describe('bulkRecoverItems action', () => {
+    it('uses server-returned recoveredIds to move all versions from trash to items', async () => {
+      const store = useCanvasStore();
+      store.trashedItems = [
+        { id: '1', filename: 'a.png', deletedAt: 1000 },
+        { id: '2', filename: 'a.png', deletedAt: 1001 },
+        { id: '3', filename: 'a.png', deletedAt: 1002 },
+      ];
+
+      api.bulkRecoverCanvasItems.mockResolvedValue({
+        recoveredCount: 3,
+        recoveredIds: ['1', '2', '3'],
+      });
+
+      await store.bulkRecoverItems('session-1', ['1']);
+
+      expect(store.trashedItems).toHaveLength(0);
+      expect(store.items).toHaveLength(3);
+    });
+  });
+
+  describe('bulkPermanentlyDeleteItems action', () => {
+    it('uses server-returned deletedIds to remove all versions from trashedItems', async () => {
+      const store = useCanvasStore();
+      store.trashedItems = [
+        { id: '1', filename: 'a.png', deletedAt: 1000 },
+        { id: '2', filename: 'a.png', deletedAt: 1001 },
+        { id: '3', filename: 'a.png', deletedAt: 1002 },
+      ];
+
+      api.bulkPermanentlyDeleteCanvasItems.mockResolvedValue({
+        deletedCount: 3,
+        deletedIds: ['1', '2', '3'],
+      });
+
+      await store.bulkPermanentlyDeleteItems('session-1', ['1']);
+
+      expect(store.trashedItems).toHaveLength(0);
+    });
+  });
+
+  describe('selectAllItems action', () => {
+    it('selects one ID per unique filename', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'a.png', createdAt: 1000 },
+        { id: '2', filename: 'a.png', createdAt: 2000 },
+        { id: '3', filename: 'a.png', createdAt: 3000 },
+        { id: '4', filename: 'b.png', createdAt: 4000 },
+        { id: '5', filename: 'b.png', createdAt: 5000 },
+      ];
+
+      store.selectAllItems();
+
+      expect(store.selectedItemIds.size).toBe(2);
+    });
+  });
+
+  describe('isAllItemsSelected getter', () => {
+    it('compares against unique file count', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'a.png', createdAt: 1000 },
+        { id: '2', filename: 'a.png', createdAt: 2000 },
+        { id: '3', filename: 'b.png', createdAt: 3000 },
+        { id: '4', filename: 'b.png', createdAt: 4000 },
+      ];
+
+      // Select one per filename (2 unique filenames)
+      store.selectedItemIds.add('1');
+      store.selectedItemIds.add('3');
+
+      expect(store.isAllItemsSelected).toBe(true);
+    });
+  });
+
+  describe('isPartialSelection getter', () => {
+    it('is true when some but not all groups selected', () => {
+      const store = useCanvasStore();
+      store.items = [
+        { id: '1', filename: 'a.png', createdAt: 1000 },
+        { id: '2', filename: 'b.png', createdAt: 2000 },
+        { id: '3', filename: 'c.png', createdAt: 3000 },
+      ];
+
+      store.selectedItemIds.add('1');
+
+      expect(store.isPartialSelection).toBe(true);
     });
   });
 });

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -136,6 +136,202 @@ test.describe('Canvas Trash & Soft Delete', () => {
     expect(trashedItems.length).toBe(0);
   });
 
+  test('bulk delete moves all versions of selected files to trash', async ({ page }) => {
+    // Create two files, each with multiple versions
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Alpha V1',
+      filename: 'alpha.txt',
+    });
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Alpha V2',
+      filename: 'alpha.txt',
+    });
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Alpha V3',
+      filename: 'alpha.txt',
+    });
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Beta V1',
+      filename: 'beta.txt',
+    });
+    await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Beta V2',
+      filename: 'beta.txt',
+    });
+
+    // Verify 5 items via API
+    const itemsBefore = await getAllCanvasItems(session.id);
+    expect(itemsBefore.length).toBe(5);
+
+    // Handle confirmation dialog for bulk delete
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Navigate to canvas — wait for the file list container to render
+    await navigateAndWait(page, `/sessions/${session.id}/canvas`, {
+      waitFor: '.canvas-file-list',
+      timeout: 15000,
+    });
+
+    // The list shows grouped items (2 rows: alpha.txt and beta.txt)
+    await expect(page.locator('.file-row')).toHaveCount(2);
+
+    // Click the checkbox on the row containing "alpha.txt" to select it
+    const alphaRow = page.locator('.file-row', { hasText: 'alpha.txt' });
+    await alphaRow.locator('.item-checkbox').click();
+
+    // Bulk toolbar should appear with "Delete Selected"
+    await expect(page.locator('.bulk-action-toolbar')).toBeVisible();
+
+    // Click "Delete Selected"
+    await page.locator('.btn-danger').filter({ hasText: 'Delete Selected' }).click();
+
+    // Wait for the operation to complete
+    await page.waitForTimeout(500);
+
+    // Verify via API: all 3 versions of alpha.txt are in trash
+    const trashedItems = await getCanvasTrash(session.id);
+    const trashedAlpha = trashedItems.filter((i: any) => i.filename === 'alpha.txt');
+    expect(trashedAlpha.length).toBe(3);
+
+    // beta.txt should still be active with both versions (use /all to get all versions)
+    const activeItems = await getAllCanvasItems(session.id);
+    const activeBeta = activeItems.filter((i: any) => i.filename === 'beta.txt');
+    expect(activeBeta.length).toBe(2);
+  });
+
+  test('bulk recover in trash restores all versions of selected files', async ({ page }) => {
+    // Create a file with 3 versions and soft-delete all of them
+    const v1 = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Report V1',
+      filename: 'report.txt',
+    });
+    const v2 = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Report V2',
+      filename: 'report.txt',
+    });
+    const v3 = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Report V3',
+      filename: 'report.txt',
+    });
+
+    // Also create another file in trash to ensure it's untouched
+    const other = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Other file',
+      filename: 'other.txt',
+    });
+
+    // Soft-delete all items via API
+    await deleteCanvasItem(session.id, v1.id);
+    await deleteCanvasItem(session.id, v2.id);
+    await deleteCanvasItem(session.id, v3.id);
+    await deleteCanvasItem(session.id, other.id);
+
+    // Handle confirmation dialog for bulk recover
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Navigate to canvas and open trash
+    await navigateAndWait(page, `/sessions/${session.id}/canvas`, {
+      waitFor: '.trash-toggle',
+      timeout: 15000,
+    });
+    await page.locator('.trash-toggle').click();
+
+    // Trash should show 2 grouped rows (report.txt and other.txt)
+    await expect(page.locator('.trash-row')).toHaveCount(2);
+
+    // Click checkbox on the report.txt trash row to select it
+    const reportRow = page.locator('.trash-row', { hasText: 'report.txt' });
+    await reportRow.locator('.item-checkbox').click();
+
+    // Bulk toolbar should appear with "Recover Selected"
+    await expect(page.locator('.bulk-action-toolbar')).toBeVisible();
+
+    // Click "Recover Selected"
+    await page.locator('.bulk-action-toolbar .btn-success').filter({ hasText: 'Recover Selected' }).click();
+
+    // Wait for operation
+    await page.waitForTimeout(1000);
+
+    // Verify via API: all 3 versions of report.txt are recovered (use /all to get all versions)
+    const activeItems = await getAllCanvasItems(session.id);
+    const activeReports = activeItems.filter((i: any) => i.filename === 'report.txt');
+    expect(activeReports.length).toBe(3);
+
+    // other.txt should still be in trash
+    const trashedItems = await getCanvasTrash(session.id);
+    const trashedOther = trashedItems.filter((i: any) => i.filename === 'other.txt');
+    expect(trashedOther.length).toBe(1);
+  });
+
+  test('bulk permanent delete in trash removes all versions of selected files', async ({ page }) => {
+    // Create a file with 3 versions and soft-delete all
+    const v1 = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Delete V1',
+      filename: 'deleteme.txt',
+    });
+    const v2 = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Delete V2',
+      filename: 'deleteme.txt',
+    });
+    const v3 = await seedCanvasItem(session.id, {
+      type: 'text',
+      content: 'Delete V3',
+      filename: 'deleteme.txt',
+    });
+
+    // Soft-delete all versions
+    await deleteCanvasItem(session.id, v1.id);
+    await deleteCanvasItem(session.id, v2.id);
+    await deleteCanvasItem(session.id, v3.id);
+
+    // Handle confirmation dialog for bulk permanent delete
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Navigate to canvas and open trash
+    await navigateAndWait(page, `/sessions/${session.id}/canvas`, {
+      waitFor: '.trash-toggle',
+      timeout: 15000,
+    });
+    await page.locator('.trash-toggle').click();
+
+    // Trash should show 1 grouped row (deleteme.txt with 3 versions)
+    await expect(page.locator('.trash-row')).toHaveCount(1);
+    await expect(page.locator('.trash-row').first()).toContainText('3 versions');
+
+    // Click checkbox to select the trash row
+    const deleteRow = page.locator('.trash-row', { hasText: 'deleteme.txt' });
+    await deleteRow.locator('.item-checkbox').click();
+
+    // Bulk toolbar should appear
+    await expect(page.locator('.bulk-action-toolbar')).toBeVisible();
+
+    // Click "Delete Forever" in the bulk toolbar (not the per-row button)
+    await page.locator('.bulk-action-toolbar .btn-danger').filter({ hasText: 'Delete Forever' }).click();
+
+    // Wait for operation
+    await page.waitForTimeout(1000);
+
+    // Trash should be empty
+    await expect(page.getByText('Trash is empty')).toBeVisible({ timeout: 5000 });
+
+    // Verify via API: all items are completely gone
+    const activeItems = await getAllCanvasItems(session.id);
+    const trashedItems = await getCanvasTrash(session.id);
+    expect(activeItems.length).toBe(0);
+    expect(trashedItems.length).toBe(0);
+  });
+
   test('deleting from list view removes all versions', async ({ page }) => {
     // Create two versions of the same file
     await seedCanvasItem(session.id, {
@@ -158,7 +354,7 @@ test.describe('Canvas Trash & Soft Delete', () => {
 
     // waitFor ensures async fetchItems completes so canvas file list renders
     await navigateAndWait(page, `/sessions/${session.id}/canvas`, {
-      waitFor: '.btn-menu',
+      waitFor: '.canvas-file-list',
       timeout: 15000,
     });
 


### PR DESCRIPTION
## Summary

- **Fix bulk delete/recover/permanent-delete** to affect all versions of each file, not just the selected representative item
- **Add `CanvasItemRepository.expandToAllVersions()`** that takes item IDs and finds all sibling versions (same filename + session), with `activeOnly`/`deletedOnly` filters
- **Fix Express route shadowing bug** where `DELETE /:id/canvas/bulk-delete-permanent` was matched by `DELETE /:id/canvas/:itemId` because it was defined later
- **Fix frontend selection model** (`selectAllItems`, `isAllItemsSelected`, `isPartialSelection`) to count unique file groups instead of raw item count
- **Add session ownership validation** to `bulk-recover` endpoint (was missing)

## Test plan

- [x] 8 unit tests for `expandToAllVersions` (siblings, dedup, activeOnly, deletedOnly, no-filename fallback, empty input, non-existent IDs)
- [x] 4 integration tests for canvas API bulk endpoints (expansion for all 3 endpoints + session ownership validation)
- [x] 7 unit tests for canvas store (bulk ops with expanded IDs, selectAll, isAllSelected, isPartialSelection)
- [x] All 2556 web tests pass, all 151 canvas API tests pass
- [ ] Manual: select a file with multiple versions → bulk delete → verify all versions move to trash
- [ ] Manual: in trash, select a file group → bulk recover → verify all versions restored
- [ ] Manual: in trash, select a file group → bulk permanent delete → verify all versions removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)