### PR TITLE
Refactor sessions API routes into smaller, focused modules (Phase 3)

### DIFF
--- a/packages/server/src/api/sessions-commands.js
+++ b/packages/server/src/api/sessions-commands.js
@@ -1,0 +1,194 @@
+import { Router } from 'express';
+import { commandButtons, commandRuns } from '../database.js';
+import { broadcastToSession, broadcastToProject } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import { requireSession, requireSessionAndProject } from '../middleware/sessionLookup.js';
+import { commandRunner } from '../services/commandRunner.js';
+import { databaseManager } from '../db/DatabaseManager.js';
+
+const router = Router();
+
+// POST /api/sessions/:id/command-buttons/:buttonId/run - Execute button command
+router.post('/:id/command-buttons/:buttonId/run', requireSessionAndProject, (req, res) => {
+  const sessionId = req.params.id;
+  const buttonId = req.params.buttonId;
+
+  console.log(`[RUN] Starting command for buttonId: ${buttonId}, sessionId: ${sessionId}`);
+
+  const button = commandButtons.getById(buttonId);
+  if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+
+  // Generate run ID
+  const runId = databaseManager.generateId();
+
+  console.log(`[RUN] Generated runId: ${runId} for command: ${button.command}`);
+
+  // Return immediately with runId
+  res.json({ runId, buttonId, status: 'running', output: '' });
+
+  // Capture middleware values for use in async callbacks
+  const projectId = req.session_.projectId;
+  const workingDirectory = req.workingDirectory;
+
+  // Broadcast initial "running" status immediately so session list can show the running indicator
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
+    sessionId,
+    runId,
+    buttonId,
+    output: '',
+  });
+  broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
+    projectId,
+    sessionId,
+    runId,
+    buttonId,
+    output: '',
+  });
+
+  // Execute command asynchronously
+  (async () => {
+    try {
+      console.log(`[RUN] Starting async execution for runId: ${runId}`);
+      await commandRunner.run(
+        runId,
+        button.command,
+        workingDirectory,
+        (text) => {
+          // Broadcast output via WebSocket to session subscribers
+          console.log(`[RUN] Output received for runId: ${runId}`);
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
+            sessionId,
+            runId,
+            buttonId,
+            output: text,
+          });
+          // Also broadcast to project subscribers for session list updates
+          broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
+            projectId,
+            sessionId,
+            runId,
+            buttonId,
+            output: text,
+          });
+        },
+        (exitCode, output) => {
+          // Broadcast completion via WebSocket to session subscribers
+          const status = exitCode === 0 ? 'success' : 'error';
+          console.log(`[RUN] Command completed for runId: ${runId}, exitCode: ${exitCode}, status: ${status}`);
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, {
+            sessionId,
+            runId,
+            buttonId,
+            status,
+            exitCode,
+            output,
+          });
+          // Also broadcast to project subscribers for session list updates
+          console.log(`[RUN] Broadcasting COMMAND_RUN_COMPLETE to project ${projectId}`);
+          broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, {
+            projectId,
+            sessionId,
+            runId,
+            buttonId,
+            status,
+            exitCode,
+            output,
+          });
+        },
+        (message) => {
+          // Broadcast error via WebSocket to session subscribers
+          console.log(`[RUN] Error for runId: ${runId}: ${message}`);
+          broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+            sessionId,
+            runId,
+            buttonId,
+            error: message,
+          });
+          // Also broadcast to project subscribers for session list updates
+          broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+            projectId,
+            sessionId,
+            runId,
+            buttonId,
+            error: message,
+          });
+        },
+        { sessionId, buttonId }
+      );
+    } catch (error) {
+      console.error(`Error running command button ${buttonId}:`, error);
+      broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+        sessionId,
+        runId,
+        buttonId,
+        error: error.message,
+      });
+      // Also broadcast to project subscribers for session list updates
+      broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
+        projectId,
+        sessionId,
+        runId,
+        buttonId,
+        error: error.message,
+      });
+    }
+  })();
+});
+
+// GET /api/sessions/:id/command-buttons/runs - Get active runs for session
+router.get('/:id/command-buttons/runs', requireSession, (req, res) => {
+  const sessionId = req.params.id;
+
+  const activeRuns = commandRunner.getRunsBySession(sessionId);
+  res.json(activeRuns);
+});
+
+// GET /api/sessions/:id/command-buttons/runs/:runId - Get single run by ID
+router.get('/:id/command-buttons/runs/:runId', requireSession, (req, res) => {
+  const { id: sessionId, runId } = req.params;
+
+  // Check if run is currently running (in memory)
+  if (commandRunner.isRunning(runId)) {
+    const activeRuns = commandRunner.getRunsBySession(sessionId);
+    const run = activeRuns.find((r) => r.runId === runId);
+    if (run) {
+      return res.json(run);
+    }
+  }
+
+  // Otherwise check database
+  const run = commandRuns.getById(runId);
+  if (!run || run.sessionId !== sessionId) {
+    return res.status(404).json({ error: 'Run not found' });
+  }
+
+  res.json({
+    runId: run.id,
+    buttonId: run.buttonId,
+    status: run.status,
+    output: run.output,
+    exitCode: run.exitCode,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+  });
+});
+
+// POST /api/sessions/:id/command-buttons/runs/:runId/kill - Kill running command
+router.post('/:id/command-buttons/runs/:runId/kill', requireSession, (req, res) => {
+  const sessionId = req.params.id;
+  const runId = req.params.runId;
+
+  console.log(`[KILL] Kill request for runId: ${runId}, sessionId: ${sessionId}`);
+
+  const killed = commandRunner.kill(runId);
+  console.log(`[KILL] Kill result: ${killed} for runId: ${runId}`);
+  if (!killed) {
+    return res.status(404).json({ error: 'Run not found or already completed' });
+  }
+
+  res.json({ success: true, runId });
+});
+
+export default router;

--- a/packages/server/src/api/sessions-commands.test.js
+++ b/packages/server/src/api/sessions-commands.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, commandButtons } from '../database.js';
+
+// Mock websocket before importing the router
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock sessionManager
+vi.mock('../services/sessionManager.js', () => ({
+  runSession: vi.fn().mockResolvedValue(undefined),
+  continueSession: vi.fn().mockResolvedValue(undefined),
+  continueSessionWithExistingMessage: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn(),
+  restartSession: vi.fn(),
+  cleanupActiveSession: vi.fn(),
+}));
+
+// Mock summaryService
+vi.mock('../services/summaryService.js', () => ({
+  getSummary: vi.fn().mockResolvedValue(null),
+  regenerateSummary: vi.fn().mockResolvedValue(null),
+  generateConversationSummary: vi.fn().mockResolvedValue('mock summary'),
+  isConversationSummaryEnabled: vi.fn().mockReturnValue(true),
+  cleanupSession: vi.fn(),
+}));
+
+// Mock commandRunner
+vi.mock('../services/commandRunner.js', () => ({
+  commandRunner: {
+    run: vi.fn().mockResolvedValue(undefined),
+    getRunsBySession: vi.fn().mockReturnValue([]),
+    isRunning: vi.fn().mockReturnValue(false),
+    kill: vi.fn().mockReturnValue(false),
+  },
+}));
+
+// Import after mocks are set up
+import sessionsRouter from './sessions.js';
+import { commandRunner } from '../services/commandRunner.js';
+
+describe('Sessions API - Command Routes (sessions-commands.js)', () => {
+  let app;
+  let project;
+  let session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    project = projects.create('Test Project', '/tmp/test');
+    session = sessions.create(project.id, 'Test Session', 'Initial prompt', 'standard');
+    sessions.update(session.id, { status: 'waiting' });
+  });
+
+  describe('POST /api/sessions/:id/command-buttons/:buttonId/run', () => {
+    it('returns 404 when button does not exist', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/command-buttons/non-existent/run`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Command button not found');
+    });
+
+    it('starts a command run and returns runId', async () => {
+      const button = commandButtons.create({ projectId: project.id, label: 'Test Button', command: 'echo hello' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/command-buttons/${button.id}/run`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.runId).toBeDefined();
+      expect(res.body.buttonId).toBe(button.id);
+      expect(res.body.status).toBe('running');
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app)
+        .post('/api/sessions/non-existent/command-buttons/btn-1/run');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/sessions/:id/command-buttons/runs', () => {
+    it('returns active runs for the session', async () => {
+      commandRunner.getRunsBySession.mockReturnValue([
+        { runId: 'r1', buttonId: 'b1', status: 'running' },
+      ]);
+
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/command-buttons/runs`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].runId).toBe('r1');
+    });
+
+    it('returns empty array when no runs exist', async () => {
+      commandRunner.getRunsBySession.mockReturnValue([]);
+
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/command-buttons/runs`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app)
+        .get('/api/sessions/non-existent/command-buttons/runs');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/sessions/:id/command-buttons/runs/:runId', () => {
+    it('returns running command from memory', async () => {
+      commandRunner.isRunning.mockReturnValue(true);
+      commandRunner.getRunsBySession.mockReturnValue([
+        { runId: 'r1', buttonId: 'b1', status: 'running', output: 'hello' },
+      ]);
+
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/command-buttons/runs/r1`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.runId).toBe('r1');
+      expect(res.body.status).toBe('running');
+    });
+
+    it('returns 404 when run not found in memory or database', async () => {
+      commandRunner.isRunning.mockReturnValue(false);
+
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/command-buttons/runs/non-existent`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Run not found');
+    });
+  });
+
+  describe('POST /api/sessions/:id/command-buttons/runs/:runId/kill', () => {
+    it('kills a running command', async () => {
+      commandRunner.kill.mockReturnValue(true);
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/command-buttons/runs/r1/kill`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.runId).toBe('r1');
+    });
+
+    it('returns 404 when run not found or already completed', async () => {
+      commandRunner.kill.mockReturnValue(false);
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/command-buttons/runs/non-existent/kill`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Run not found or already completed');
+    });
+  });
+});

--- a/packages/server/src/api/sessions-conversations.js
+++ b/packages/server/src/api/sessions-conversations.js
@@ -1,0 +1,214 @@
+import { Router } from 'express';
+import { messages, conversations, projects } from '../database.js';
+import { continueSessionWithExistingMessage } from '../services/sessionManager.js';
+import { broadcastToSession } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import * as summaryService from '../services/summaryService.js';
+import { requireSession } from '../middleware/sessionLookup.js';
+
+const router = Router();
+
+// GET /api/sessions/:id/conversations - List all conversations for a session
+router.get('/:id/conversations', requireSession, (req, res) => {
+  // Use getBySessionIdWithBranchInfo to include branching metadata
+  const sessionConversations = conversations.getBySessionIdWithBranchInfo(req.params.id);
+  res.json(sessionConversations);
+});
+
+// POST /api/sessions/:id/conversations - Create new conversation
+router.post('/:id/conversations', requireSession, async (req, res) => {
+  // Block creating new conversation while session is running
+  if (req.session_.status === 'running') {
+    return res.status(400).json({ error: 'Cannot create new conversation while session is running' });
+  }
+
+  const { name } = req.body;
+
+  // Auto-generate summary for the current active conversation before creating new one
+  const previousActive = conversations.getActiveBySessionId(req.params.id);
+  if (previousActive && !previousActive.summary && summaryService.isConversationSummaryEnabled(req.params.id)) {
+    // Generate summary in background (don't block the request)
+    summaryService.generateConversationSummary(req.params.id, previousActive.id).catch((err) => {
+      console.error('Failed to generate conversation summary:', err);
+    });
+  }
+
+  const conversation = conversations.create(req.params.id, name || null, true);
+
+  // Broadcast conversation created event
+  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_CREATED, {
+    sessionId: req.params.id,
+    conversation,
+  });
+
+  res.status(201).json(conversation);
+});
+
+// GET /api/sessions/:id/conversations/:convId - Get specific conversation
+router.get('/:id/conversations/:convId', (req, res) => {
+  const conversation = conversations.getById(req.params.convId);
+  if (!conversation || conversation.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Conversation not found' });
+  }
+
+  // Include message count
+  const messageCount = messages.getCountByConversationId(req.params.convId);
+  res.json({ ...conversation, messageCount });
+});
+
+// PATCH /api/sessions/:id/conversations/:convId - Update conversation
+router.patch('/:id/conversations/:convId', requireSession, async (req, res) => {
+  const conversation = conversations.getById(req.params.convId);
+  if (!conversation || conversation.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Conversation not found' });
+  }
+
+  const { name, isActive } = req.body;
+
+  // Block switching conversation while session is running
+  if (isActive && req.session_.status === 'running') {
+    return res.status(400).json({ error: 'Cannot switch conversation while session is running' });
+  }
+
+  // If switching to this conversation, generate summary for the previous active one
+  if (isActive && !conversation.isActive) {
+    const previousActive = conversations.getActiveBySessionId(req.params.id);
+    if (previousActive && previousActive.id !== req.params.convId && !previousActive.summary &&
+        summaryService.isConversationSummaryEnabled(req.params.id)) {
+      // Generate summary in background
+      summaryService.generateConversationSummary(req.params.id, previousActive.id).catch((err) => {
+        console.error('Failed to generate conversation summary:', err);
+      });
+    }
+  }
+
+  const updateData = {};
+  if (name !== undefined) updateData.name = name;
+  if (isActive !== undefined) updateData.isActive = isActive;
+
+  const updated = conversations.update(req.params.convId, updateData);
+
+  // Broadcast conversation updated event
+  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_UPDATED, {
+    sessionId: req.params.id,
+    conversation: updated,
+  });
+
+  res.json(updated);
+});
+
+// DELETE /api/sessions/:id/conversations/:convId - Delete conversation
+router.delete('/:id/conversations/:convId', requireSession, (req, res) => {
+  // Block deleting conversation while session is running
+  if (req.session_.status === 'running') {
+    return res.status(400).json({ error: 'Cannot delete conversation while session is running' });
+  }
+
+  const conversation = conversations.getById(req.params.convId);
+  if (!conversation || conversation.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Conversation not found' });
+  }
+
+  // Delete and handle active conversation logic
+  const newActive = conversations.deleteAndHandleActive(req.params.convId);
+
+  // Broadcast conversation deleted event
+  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_DELETED, {
+    sessionId: req.params.id,
+    conversationId: req.params.convId,
+    newActiveConversation: newActive,
+  });
+
+  res.status(204).send();
+});
+
+// POST /api/sessions/:id/conversations/:convId/summary - Generate summary for conversation
+router.post('/:id/conversations/:convId/summary', requireSession, async (req, res) => {
+  const conversation = conversations.getById(req.params.convId);
+  if (!conversation || conversation.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Conversation not found' });
+  }
+
+  try {
+    const summary = await summaryService.generateConversationSummary(req.params.id, req.params.convId);
+    res.json({ summary });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// POST /api/sessions/:id/conversations/:convId/branch - Create a branch from a conversation
+router.post('/:id/conversations/:convId/branch', requireSession, async (req, res) => {
+  // Block branching while session is running
+  if (req.session_.status === 'running') {
+    return res.status(400).json({ error: 'Cannot branch conversation while session is running' });
+  }
+
+  const conversation = conversations.getById(req.params.convId);
+  if (!conversation || conversation.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Conversation not found' });
+  }
+
+  const { messageId, prompt } = req.body;
+
+  if (!messageId) {
+    return res.status(400).json({ error: 'messageId is required' });
+  }
+
+  if (!prompt || !prompt.trim()) {
+    return res.status(400).json({ error: 'prompt is required' });
+  }
+
+  try {
+    // Create the branch
+    // Note: name is auto-generated from the prompt in ConversationRepository.branch()
+    const branchConversation = conversations.branch(
+      req.params.convId,
+      messageId,
+      null, // name is auto-generated from prompt
+      prompt
+    );
+
+    // Generate summary for the previous active conversation before branching
+    const previousActive = conversations.getActiveBySessionId(req.params.id);
+    if (previousActive && !previousActive.summary && summaryService.isConversationSummaryEnabled(req.params.id)) {
+      // Generate summary in background (don't block the request)
+      summaryService.generateConversationSummary(req.params.id, previousActive.id).catch((err) => {
+        console.error('Failed to generate conversation summary:', err);
+      });
+    }
+
+    // Broadcast the new conversation to session subscribers
+    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_CREATED, {
+      sessionId: req.params.id,
+      conversation: branchConversation,
+    });
+
+    // Auto-submit to Claude: Start the session with the new prompt
+    // The branch already has the user message, so we use continueSessionWithExistingMessage
+    // which triggers Claude's response WITHOUT creating a duplicate user message
+    try {
+      const project = projects.getById(req.session_.projectId);
+      const workingDirectory = req.session_.gitWorktree || project?.workingDirectory;
+      if (workingDirectory) {
+        await continueSessionWithExistingMessage(
+          req.params.id,
+          branchConversation.id,
+          workingDirectory,
+          project?.systemPrompt
+        );
+      }
+    } catch (err) {
+      console.error('Failed to auto-start branched conversation:', err);
+      // Don't fail the whole request if auto-start fails
+      // User can manually trigger from the UI
+    }
+
+    res.status(201).json(branchConversation);
+  } catch (error) {
+    console.error('Branch conversation error:', error);
+    res.status(400).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/packages/server/src/api/sessions-conversations.test.js
+++ b/packages/server/src/api/sessions-conversations.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, messages, conversations } from '../database.js';
+
+// Mock websocket before importing the router
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock sessionManager
+vi.mock('../services/sessionManager.js', () => ({
+  runSession: vi.fn().mockResolvedValue(undefined),
+  continueSession: vi.fn().mockResolvedValue(undefined),
+  continueSessionWithExistingMessage: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn(),
+  restartSession: vi.fn(),
+  cleanupActiveSession: vi.fn(),
+}));
+
+// Mock summaryService
+vi.mock('../services/summaryService.js', () => ({
+  getSummary: vi.fn().mockResolvedValue(null),
+  regenerateSummary: vi.fn().mockResolvedValue(null),
+  generateConversationSummary: vi.fn().mockResolvedValue('mock summary'),
+  isConversationSummaryEnabled: vi.fn().mockReturnValue(true),
+  cleanupSession: vi.fn(),
+}));
+
+// Import after mocks are set up
+import sessionsRouter from './sessions.js';
+
+describe('Sessions API - Conversation Routes (sessions-conversations.js)', () => {
+  let app;
+  let project;
+  let session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    project = projects.create('Test Project', '/tmp/test');
+    session = sessions.create(project.id, 'Test Session', 'Initial prompt', 'standard');
+    sessions.update(session.id, { status: 'waiting' });
+  });
+
+  describe('GET /api/sessions/:id/conversations', () => {
+    it('returns conversations for the session', async () => {
+      const res = await request(app).get(`/api/sessions/${session.id}/conversations`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      // Session auto-creates an initial conversation
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app).get('/api/sessions/non-existent/conversations');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/sessions/:id/conversations', () => {
+    it('creates a new conversation', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations`)
+        .send({ name: 'New Conversation' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBe('New Conversation');
+      expect(res.body.sessionId).toBe(session.id);
+      expect(res.body.isActive).toBe(true);
+    });
+
+    it('creates conversation with null name when not provided', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations`)
+        .send({});
+
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBeNull();
+    });
+
+    it('returns 400 when session is running', async () => {
+      sessions.update(session.id, { status: 'running' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations`)
+        .send({ name: 'Test' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Cannot create new conversation while session is running');
+    });
+  });
+
+  describe('GET /api/sessions/:id/conversations/:convId', () => {
+    it('returns conversation with message count', async () => {
+      const conv = conversations.create(session.id, 'Test Conv', true);
+      messages.create(session.id, 'user', 'Hello', null, conv.id);
+
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/conversations/${conv.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(conv.id);
+      expect(res.body.messageCount).toBe(1);
+    });
+
+    it('returns 404 for non-existent conversation', async () => {
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/conversations/non-existent`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 when conversation belongs to a different session', async () => {
+      const otherSession = sessions.create(project.id, 'Other', 'Prompt', 'standard');
+      const conv = conversations.create(otherSession.id, 'Other Conv', true);
+
+      const res = await request(app)
+        .get(`/api/sessions/${session.id}/conversations/${conv.id}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('PATCH /api/sessions/:id/conversations/:convId', () => {
+    it('updates conversation name', async () => {
+      const conv = conversations.create(session.id, 'Original', true);
+
+      const res = await request(app)
+        .patch(`/api/sessions/${session.id}/conversations/${conv.id}`)
+        .send({ name: 'Updated Name' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('Updated Name');
+    });
+
+    it('blocks switching when session is running', async () => {
+      const conv = conversations.create(session.id, 'Test', false);
+      sessions.update(session.id, { status: 'running' });
+
+      const res = await request(app)
+        .patch(`/api/sessions/${session.id}/conversations/${conv.id}`)
+        .send({ isActive: true });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Cannot switch conversation while session is running');
+    });
+
+    it('returns 404 for non-existent conversation', async () => {
+      const res = await request(app)
+        .patch(`/api/sessions/${session.id}/conversations/non-existent`)
+        .send({ name: 'Test' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/sessions/:id/conversations/:convId', () => {
+    it('deletes a conversation', async () => {
+      // Create two conversations so we can delete one
+      conversations.create(session.id, 'Keep', true);
+      const conv2 = conversations.create(session.id, 'Delete', false);
+
+      const res = await request(app)
+        .delete(`/api/sessions/${session.id}/conversations/${conv2.id}`);
+
+      expect(res.status).toBe(204);
+    });
+
+    it('returns 400 when session is running', async () => {
+      const conv = conversations.create(session.id, 'Test', true);
+      sessions.update(session.id, { status: 'running' });
+
+      const res = await request(app)
+        .delete(`/api/sessions/${session.id}/conversations/${conv.id}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Cannot delete conversation while session is running');
+    });
+
+    it('returns 404 for non-existent conversation', async () => {
+      const res = await request(app)
+        .delete(`/api/sessions/${session.id}/conversations/non-existent`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/sessions/:id/conversations/:convId/summary', () => {
+    it('returns 404 for non-existent conversation', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations/non-existent/summary`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/sessions/:id/conversations/:convId/branch', () => {
+    it('returns 400 when messageId is missing', async () => {
+      const conv = conversations.create(session.id, 'Test', true);
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations/${conv.id}/branch`)
+        .send({ prompt: 'branch prompt' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('messageId is required');
+    });
+
+    it('returns 400 when prompt is missing', async () => {
+      const conv = conversations.create(session.id, 'Test', true);
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations/${conv.id}/branch`)
+        .send({ messageId: 'msg-1' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('prompt is required');
+    });
+
+    it('returns 400 when session is running', async () => {
+      const conv = conversations.create(session.id, 'Test', true);
+      sessions.update(session.id, { status: 'running' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations/${conv.id}/branch`)
+        .send({ messageId: 'msg-1', prompt: 'branch' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Cannot branch conversation while session is running');
+    });
+
+    it('returns 404 for non-existent conversation', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/conversations/non-existent/branch`)
+        .send({ messageId: 'msg-1', prompt: 'branch' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/server/src/api/sessions-notes.js
+++ b/packages/server/src/api/sessions-notes.js
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import { sessionNotes } from '../database.js';
+import { requireSession } from '../middleware/sessionLookup.js';
+
+const router = Router();
+
+// GET /api/sessions/:id/notes - Get session notes
+router.get('/:id/notes', requireSession, (req, res) => {
+  const notes = sessionNotes.getBySessionId(req.params.id);
+  res.json(notes);
+});
+
+// POST /api/sessions/:id/notes - Create session note
+router.post('/:id/notes', requireSession, (req, res) => {
+  const { content } = req.body;
+  if (!content) {
+    return res.status(400).json({ error: 'Content is required' });
+  }
+
+  const note = sessionNotes.create(req.params.id, content);
+  res.status(201).json(note);
+});
+
+// PUT /api/sessions/:id/notes/:noteId - Update session note
+router.put('/:id/notes/:noteId', (req, res) => {
+  const note = sessionNotes.getById(req.params.noteId);
+  if (!note || note.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Note not found' });
+  }
+
+  const { content } = req.body;
+  if (!content) {
+    return res.status(400).json({ error: 'Content is required' });
+  }
+
+  const updated = sessionNotes.update(req.params.noteId, content);
+  res.json(updated);
+});
+
+// DELETE /api/sessions/:id/notes/:noteId - Delete session note
+router.delete('/:id/notes/:noteId', (req, res) => {
+  const note = sessionNotes.getById(req.params.noteId);
+  if (!note || note.sessionId !== req.params.id) {
+    return res.status(404).json({ error: 'Note not found' });
+  }
+
+  sessionNotes.delete(req.params.noteId);
+  res.status(204).send();
+});
+
+export default router;

--- a/packages/server/src/api/sessions-notes.test.js
+++ b/packages/server/src/api/sessions-notes.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, sessionNotes } from '../database.js';
+
+// Mock websocket before importing the router
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock sessionManager
+vi.mock('../services/sessionManager.js', () => ({
+  runSession: vi.fn().mockResolvedValue(undefined),
+  continueSession: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn(),
+  restartSession: vi.fn(),
+}));
+
+// Mock summaryService
+vi.mock('../services/summaryService.js', () => ({
+  getSummary: vi.fn().mockResolvedValue(null),
+  generateConversationSummary: vi.fn().mockResolvedValue('mock summary'),
+  isConversationSummaryEnabled: vi.fn().mockReturnValue(true),
+}));
+
+// Import after mocks are set up
+import sessionsRouter from './sessions.js';
+
+describe('Sessions API - Notes Routes (sessions-notes.js)', () => {
+  let app;
+  let project;
+  let session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    project = projects.create('Test Project', '/tmp/test');
+    session = sessions.create(project.id, 'Test Session', 'Initial prompt', 'standard');
+    sessions.update(session.id, { status: 'waiting' });
+  });
+
+  describe('GET /api/sessions/:id/notes', () => {
+    it('returns empty array when no notes exist', async () => {
+      const res = await request(app).get(`/api/sessions/${session.id}/notes`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('returns all notes for the session', async () => {
+      sessionNotes.create(session.id, 'First note');
+      sessionNotes.create(session.id, 'Second note');
+
+      const res = await request(app).get(`/api/sessions/${session.id}/notes`);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+      const contents = res.body.map(n => n.content);
+      expect(contents).toContain('First note');
+      expect(contents).toContain('Second note');
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app).get('/api/sessions/non-existent/notes');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/sessions/:id/notes', () => {
+    it('creates a new note', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/notes`)
+        .send({ content: 'My new note' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.content).toBe('My new note');
+      expect(res.body.sessionId).toBe(session.id);
+      expect(res.body.id).toBeDefined();
+    });
+
+    it('returns 400 when content is missing', async () => {
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/notes`)
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Content is required');
+    });
+
+    it('returns 404 for non-existent session', async () => {
+      const res = await request(app)
+        .post('/api/sessions/non-existent/notes')
+        .send({ content: 'note' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('PUT /api/sessions/:id/notes/:noteId', () => {
+    it('updates an existing note', async () => {
+      const note = sessionNotes.create(session.id, 'Original content');
+
+      const res = await request(app)
+        .put(`/api/sessions/${session.id}/notes/${note.id}`)
+        .send({ content: 'Updated content' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe('Updated content');
+    });
+
+    it('returns 404 when note does not exist', async () => {
+      const res = await request(app)
+        .put(`/api/sessions/${session.id}/notes/non-existent`)
+        .send({ content: 'Updated' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Note not found');
+    });
+
+    it('returns 404 when note belongs to a different session', async () => {
+      const otherSession = sessions.create(project.id, 'Other', 'Prompt', 'standard');
+      const note = sessionNotes.create(otherSession.id, 'Other note');
+
+      const res = await request(app)
+        .put(`/api/sessions/${session.id}/notes/${note.id}`)
+        .send({ content: 'Updated' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Note not found');
+    });
+
+    it('returns 400 when content is missing', async () => {
+      const note = sessionNotes.create(session.id, 'Original');
+
+      const res = await request(app)
+        .put(`/api/sessions/${session.id}/notes/${note.id}`)
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Content is required');
+    });
+  });
+
+  describe('DELETE /api/sessions/:id/notes/:noteId', () => {
+    it('deletes an existing note', async () => {
+      const note = sessionNotes.create(session.id, 'To be deleted');
+
+      const res = await request(app)
+        .delete(`/api/sessions/${session.id}/notes/${note.id}`);
+
+      expect(res.status).toBe(204);
+
+      // Verify note is gone
+      const remaining = sessionNotes.getBySessionId(session.id);
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('returns 404 when note does not exist', async () => {
+      const res = await request(app)
+        .delete(`/api/sessions/${session.id}/notes/non-existent`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Note not found');
+    });
+
+    it('returns 404 when note belongs to a different session', async () => {
+      const otherSession = sessions.create(project.id, 'Other', 'Prompt', 'standard');
+      const note = sessionNotes.create(otherSession.id, 'Other note');
+
+      const res = await request(app)
+        .delete(`/api/sessions/${session.id}/notes/${note.id}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { readFileSync, existsSync } from 'fs';
 import { extname, resolve, normalize } from 'path';
-import { sessions, messages, sessionNotes, projects, todos, workLogs, sessionTemplates, conversations, attachments, commandButtons, commandRuns, modelProviders, sessionSummaries } from '../database.js';
-import { continueSession, stopSession, restartSession, cleanupActiveSession, continueSessionWithExistingMessage } from '../services/sessionManager.js';
+import { sessions, messages, projects, todos, workLogs, sessionTemplates, conversations, attachments, commandRuns, modelProviders, sessionSummaries } from '../database.js';
+import { continueSession, stopSession, restartSession, cleanupActiveSession } from '../services/sessionManager.js';
 import { getChanges, getChangesBranch } from '../services/diffService.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
@@ -12,11 +12,22 @@ import { executeHookAsync } from '../services/hookService.js';
 import { upload as _upload, handleUploadError } from '../middleware/upload.js';
 import { requireSession, requireSessionAndProject } from '../middleware/sessionLookup.js';
 import { commandRunner } from '../services/commandRunner.js';
-import { databaseManager } from '../db/DatabaseManager.js';
 import { duplicateSession } from '../services/sessionDuplicator.js';
 import * as slashCommandService from '../services/slashCommandService.js';
+import { validateDraftSession, startDraft, DraftSessionError } from '../services/draftSessionService.js';
+import { configureSchedule, ScheduleError } from '../services/scheduleService.js';
+
+// Import sub-routers
+import notesRouter from './sessions-notes.js';
+import conversationsRouter from './sessions-conversations.js';
+import commandsRouter from './sessions-commands.js';
 
 const router = Router();
+
+// Mount sub-routers
+router.use('/', notesRouter);
+router.use('/', conversationsRouter);
+router.use('/', commandsRouter);
 
 // TTL cache for files-count endpoint (60 second TTL)
 const filesCountCache = new Map();
@@ -392,16 +403,9 @@ router.post('/:id/restart', requireSession, (req, res) => {
 
 // PUT /api/sessions/:id/initial-prompt - Update the initial prompt for a draft session
 router.put('/:id/initial-prompt', requireSession, (req, res) => {
-  // Validate session is in waiting status (draft state)
-  if (req.session_.status !== 'waiting') {
-    return res.status(400).json({ error: 'Session must be in waiting status to edit the prompt' });
-  }
-
-  // Check if session has any assistant messages (should not have any for a draft)
-  const allMessages = messages.getBySessionId(req.session_.id);
-  const hasAssistantMessages = allMessages.some(msg => msg.role === 'assistant');
-  if (hasAssistantMessages) {
-    return res.status(400).json({ error: 'Session is not a draft - it already has responses' });
+  const validation = validateDraftSession(req.session_);
+  if (!validation.valid) {
+    return res.status(400).json({ error: validation.error });
   }
 
   // Get the request body
@@ -413,6 +417,7 @@ router.put('/:id/initial-prompt', requireSession, (req, res) => {
   }
 
   try {
+    const allMessages = messages.getBySessionId(req.session_.id);
     // Find the first user message and update it
     const userMessages = allMessages.filter(msg => msg.role === 'user');
     if (userMessages.length === 0) {
@@ -437,370 +442,24 @@ router.put('/:id/initial-prompt', requireSession, (req, res) => {
 
 // POST /api/sessions/:id/start - Start a draft session (waiting status with no assistant messages)
 router.post('/:id/start', requireSession, async (req, res) => {
-  // Validate session is in waiting status (draft state)
-  if (req.session_.status !== 'waiting') {
-    return res.status(400).json({ error: 'Session must be in waiting status to start' });
-  }
-
-  // Check if session has any assistant messages (should not have any for a draft)
-  const allMessages = messages.getBySessionId(req.session_.id);
-  const hasAssistantMessages = allMessages.some(msg => msg.role === 'assistant');
-  if (hasAssistantMessages) {
-    return res.status(400).json({ error: 'Session is not a draft - it already has responses' });
+  const validation = validateDraftSession(req.session_);
+  if (!validation.valid) {
+    return res.status(400).json({ error: validation.error });
   }
 
   try {
-    // Get the project and initial prompt
-    const project = projects.getById(req.session_.projectId);
-    if (!project) {
-      return res.status(404).json({ error: 'Project not found' });
-    }
-
-    // Use gitWorktree if set, otherwise use project's working directory
-    const workingDirectory = req.session_.gitWorktree || project.workingDirectory;
-
-    // Model to use for this session (optional - SDK will use default if not provided)
-    // Fallback chain: explicit request body > pendingModel (set at draft creation) > session.model > null (SDK default)
-    const model = req.body.model || req.session_.pendingModel || req.session_.model || null;
-
-    // Get or create the initial user message (prompt)
-    let userMessages = allMessages.filter(msg => msg.role === 'user');
-    let initialMessage;
-
-    if (userMessages.length === 0) {
-      // For draft/scheduled sessions, there may not be an initial message yet
-      // Create it from pendingPrompt or request body
-      const promptToUse = req.body.prompt || req.session_.pendingPrompt;
-      if (!promptToUse || typeof promptToUse !== 'string' || promptToUse.trim() === '') {
-        return res.status(400).json({ error: 'No initial prompt found' });
-      }
-
-      // Get the active conversation
-      const activeConv = conversations.getActiveBySessionId(req.session_.id);
-      if (!activeConv) {
-        return res.status(500).json({ error: 'No active conversation found' });
-      }
-
-      // Create the initial message
-      initialMessage = messages.create(req.session_.id, 'user', promptToUse, null, activeConv.id);
-
-      // Clear pendingPrompt since we've created the message
-      sessions.update(req.session_.id, { pendingPrompt: null });
-
-      // Broadcast the new message
-      broadcastToSession(req.session_.id, WS_MESSAGE_TYPES.MESSAGE_CREATED, {
-        sessionId: req.session_.id,
-        message: initialMessage,
-      });
-    } else {
-      initialMessage = userMessages[0];
-
-      // If a new prompt is provided in the request body, update the message
-      if (req.body.prompt !== undefined) {
-        // Validate provided prompt
-        if (!req.body.prompt || typeof req.body.prompt !== 'string' || req.body.prompt.trim() === '') {
-          return res.status(400).json({ error: 'Prompt must be a non-empty string' });
-        }
-        // Update the message with the new prompt
-        const updatedMessage = messages.updateContent(initialMessage.id, req.body.prompt);
-        initialMessage = updatedMessage;
-
-        // Broadcast the update to session subscribers
-        broadcastToSession(req.session_.id, WS_MESSAGE_TYPES.MESSAGE_UPDATED, {
-          sessionId: req.session_.id,
-          message: updatedMessage,
-        });
-      }
-    }
-
-    const finalPrompt = initialMessage.content;
-
-    // Get session attachments for context
-    const sessionAttachments = attachments.getBySessionId(req.session_.id);
-
-    // Update session status to starting and clear pendingModel (mirrors pendingPrompt cleanup above)
-    sessions.update(req.session_.id, { status: 'starting', pendingModel: null });
-
-    // Resolve skill/command invocations so skill body goes into system prompt
-    const resolved = await slashCommandService.resolvePromptSkillOrCommand(
-      workingDirectory, finalPrompt, project.systemPrompt
-    );
-    const effectivePrompt = resolved ? resolved.userMessage : finalPrompt;
-    const effectiveSystemPrompt = resolved ? resolved.systemPrompt : project.systemPrompt;
-
-    // Start session manager (non-blocking)
-    const { runSession } = await import('../services/sessionManager.js');
-    runSession(req.session_.id, effectivePrompt, workingDirectory, effectiveSystemPrompt, sessionAttachments, model).catch((error) => {
-      console.error('Session error:', error);
-      sessions.update(req.session_.id, { status: 'error', error: error.message });
+    const updatedSession = await startDraft(req.session_, {
+      prompt: req.body.prompt,
+      model: req.body.model,
     });
 
-    // Broadcast status update
-    broadcastToSession(req.session_.id, WS_MESSAGE_TYPES.SESSION_STATUS, {
-      sessionId: req.session_.id,
-      status: 'starting',
-    });
-
-    // Broadcast to project subscribers
-    broadcastToProject(req.session_.projectId, WS_MESSAGE_TYPES.SESSION_UPDATED, {
-      projectId: req.session_.projectId,
-      sessionId: req.session_.id,
-      session: sessions.getById(req.session_.id),
-    });
-
-    res.json({ success: true, session: sessions.getById(req.session_.id) });
+    res.json({ success: true, session: updatedSession });
   } catch (error) {
+    if (error instanceof DraftSessionError) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
     console.error('Start session error:', error);
     res.status(500).json({ error: error.message });
-  }
-});
-
-// GET /api/sessions/:id/notes - Get session notes
-router.get('/:id/notes', requireSession, (req, res) => {
-  const notes = sessionNotes.getBySessionId(req.params.id);
-  res.json(notes);
-});
-
-// POST /api/sessions/:id/notes - Create session note
-router.post('/:id/notes', requireSession, (req, res) => {
-  const { content } = req.body;
-  if (!content) {
-    return res.status(400).json({ error: 'Content is required' });
-  }
-
-  const note = sessionNotes.create(req.params.id, content);
-  res.status(201).json(note);
-});
-
-// PUT /api/sessions/:id/notes/:noteId - Update session note
-router.put('/:id/notes/:noteId', (req, res) => {
-  const note = sessionNotes.getById(req.params.noteId);
-  if (!note || note.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Note not found' });
-  }
-
-  const { content } = req.body;
-  if (!content) {
-    return res.status(400).json({ error: 'Content is required' });
-  }
-
-  const updated = sessionNotes.update(req.params.noteId, content);
-  res.json(updated);
-});
-
-// DELETE /api/sessions/:id/notes/:noteId - Delete session note
-router.delete('/:id/notes/:noteId', (req, res) => {
-  const note = sessionNotes.getById(req.params.noteId);
-  if (!note || note.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Note not found' });
-  }
-
-  sessionNotes.delete(req.params.noteId);
-  res.status(204).send();
-});
-
-// ==================== CONVERSATION ENDPOINTS ====================
-
-// GET /api/sessions/:id/conversations - List all conversations for a session
-router.get('/:id/conversations', requireSession, (req, res) => {
-  // Use getBySessionIdWithBranchInfo to include branching metadata
-  const sessionConversations = conversations.getBySessionIdWithBranchInfo(req.params.id);
-  res.json(sessionConversations);
-});
-
-// POST /api/sessions/:id/conversations - Create new conversation
-router.post('/:id/conversations', requireSession, async (req, res) => {
-  // Block creating new conversation while session is running
-  if (req.session_.status === 'running') {
-    return res.status(400).json({ error: 'Cannot create new conversation while session is running' });
-  }
-
-  const { name } = req.body;
-
-  // Auto-generate summary for the current active conversation before creating new one
-  const previousActive = conversations.getActiveBySessionId(req.params.id);
-  if (previousActive && !previousActive.summary && summaryService.isConversationSummaryEnabled(req.params.id)) {
-    // Generate summary in background (don't block the request)
-    summaryService.generateConversationSummary(req.params.id, previousActive.id).catch((err) => {
-      console.error('Failed to generate conversation summary:', err);
-    });
-  }
-
-  const conversation = conversations.create(req.params.id, name || null, true);
-
-  // Broadcast conversation created event
-  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_CREATED, {
-    sessionId: req.params.id,
-    conversation,
-  });
-
-  res.status(201).json(conversation);
-});
-
-// GET /api/sessions/:id/conversations/:convId - Get specific conversation
-router.get('/:id/conversations/:convId', (req, res) => {
-  const conversation = conversations.getById(req.params.convId);
-  if (!conversation || conversation.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Conversation not found' });
-  }
-
-  // Include message count
-  const messageCount = messages.getCountByConversationId(req.params.convId);
-  res.json({ ...conversation, messageCount });
-});
-
-// PATCH /api/sessions/:id/conversations/:convId - Update conversation
-router.patch('/:id/conversations/:convId', requireSession, async (req, res) => {
-  const conversation = conversations.getById(req.params.convId);
-  if (!conversation || conversation.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Conversation not found' });
-  }
-
-  const { name, isActive } = req.body;
-
-  // Block switching conversation while session is running
-  if (isActive && req.session_.status === 'running') {
-    return res.status(400).json({ error: 'Cannot switch conversation while session is running' });
-  }
-
-  // If switching to this conversation, generate summary for the previous active one
-  if (isActive && !conversation.isActive) {
-    const previousActive = conversations.getActiveBySessionId(req.params.id);
-    if (previousActive && previousActive.id !== req.params.convId && !previousActive.summary &&
-        summaryService.isConversationSummaryEnabled(req.params.id)) {
-      // Generate summary in background
-      summaryService.generateConversationSummary(req.params.id, previousActive.id).catch((err) => {
-        console.error('Failed to generate conversation summary:', err);
-      });
-    }
-  }
-
-  const updateData = {};
-  if (name !== undefined) updateData.name = name;
-  if (isActive !== undefined) updateData.isActive = isActive;
-
-  const updated = conversations.update(req.params.convId, updateData);
-
-  // Broadcast conversation updated event
-  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_UPDATED, {
-    sessionId: req.params.id,
-    conversation: updated,
-  });
-
-  res.json(updated);
-});
-
-// DELETE /api/sessions/:id/conversations/:convId - Delete conversation
-router.delete('/:id/conversations/:convId', requireSession, (req, res) => {
-  // Block deleting conversation while session is running
-  if (req.session_.status === 'running') {
-    return res.status(400).json({ error: 'Cannot delete conversation while session is running' });
-  }
-
-  const conversation = conversations.getById(req.params.convId);
-  if (!conversation || conversation.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Conversation not found' });
-  }
-
-  // Delete and handle active conversation logic
-  const newActive = conversations.deleteAndHandleActive(req.params.convId);
-
-  // Broadcast conversation deleted event
-  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_DELETED, {
-    sessionId: req.params.id,
-    conversationId: req.params.convId,
-    newActiveConversation: newActive,
-  });
-
-  res.status(204).send();
-});
-
-// POST /api/sessions/:id/conversations/:convId/summary - Generate summary for conversation
-router.post('/:id/conversations/:convId/summary', requireSession, async (req, res) => {
-  const conversation = conversations.getById(req.params.convId);
-  if (!conversation || conversation.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Conversation not found' });
-  }
-
-  try {
-    const summary = await summaryService.generateConversationSummary(req.params.id, req.params.convId);
-    res.json({ summary });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
-
-// POST /api/sessions/:id/conversations/:convId/branch - Create a branch from a conversation
-router.post('/:id/conversations/:convId/branch', requireSession, async (req, res) => {
-  // Block branching while session is running
-  if (req.session_.status === 'running') {
-    return res.status(400).json({ error: 'Cannot branch conversation while session is running' });
-  }
-
-  const conversation = conversations.getById(req.params.convId);
-  if (!conversation || conversation.sessionId !== req.params.id) {
-    return res.status(404).json({ error: 'Conversation not found' });
-  }
-
-  const { messageId, prompt } = req.body;
-
-  if (!messageId) {
-    return res.status(400).json({ error: 'messageId is required' });
-  }
-
-  if (!prompt || !prompt.trim()) {
-    return res.status(400).json({ error: 'prompt is required' });
-  }
-
-  try {
-    // Create the branch
-    // Note: name is auto-generated from the prompt in ConversationRepository.branch()
-    const branchConversation = conversations.branch(
-      req.params.convId,
-      messageId,
-      null, // name is auto-generated from prompt
-      prompt
-    );
-
-    // Generate summary for the previous active conversation before branching
-    const previousActive = conversations.getActiveBySessionId(req.params.id);
-    if (previousActive && !previousActive.summary && summaryService.isConversationSummaryEnabled(req.params.id)) {
-      // Generate summary in background (don't block the request)
-      summaryService.generateConversationSummary(req.params.id, previousActive.id).catch((err) => {
-        console.error('Failed to generate conversation summary:', err);
-      });
-    }
-
-    // Broadcast the new conversation to session subscribers
-    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CONVERSATION_CREATED, {
-      sessionId: req.params.id,
-      conversation: branchConversation,
-    });
-
-    // Auto-submit to Claude: Start the session with the new prompt
-    // The branch already has the user message, so we use continueSessionWithExistingMessage
-    // which triggers Claude's response WITHOUT creating a duplicate user message
-    try {
-      const project = projects.getById(req.session_.projectId);
-      const workingDirectory = req.session_.gitWorktree || project?.workingDirectory;
-      if (workingDirectory) {
-        await continueSessionWithExistingMessage(
-          req.params.id,
-          branchConversation.id,
-          workingDirectory,
-          project?.systemPrompt
-        );
-      }
-    } catch (err) {
-      console.error('Failed to auto-start branched conversation:', err);
-      // Don't fail the whole request if auto-start fails
-      // User can manually trigger from the UI
-    }
-
-    res.status(201).json(branchConversation);
-  } catch (error) {
-    console.error('Branch conversation error:', error);
-    res.status(400).json({ error: error.message });
   }
 });
 
@@ -1097,89 +756,13 @@ router.post('/:id/star', requireSession, (req, res) => {
 
 // POST /api/sessions/:id/schedule - Schedule a follow-up message for an existing session
 router.post('/:id/schedule', requireSessionAndProject, async (req, res) => {
-  // Only allow scheduling for waiting, stopped, or error sessions
-  if (!['waiting', 'stopped', 'error'].includes(req.session_.status)) {
-    return res.status(400).json({ error: 'Session must be in waiting, stopped, or error state to schedule' });
-  }
-
-  const {
-    scheduledAt,
-    pendingModel,
-    autoRescheduleEnabled,
-    rescheduleDelayMinutes,
-    rescheduleOnTokenLimit,
-    rescheduleOnServiceError,
-    maxRescheduleCount,
-    maxTotalTokens,
-    rescheduleAtTokenCount,
-  } = req.body;
-
-  // DEBUG: Log incoming scheduledAt value
-  console.log('[DEBUG] Schedule API - scheduledAt from request:', scheduledAt, 'type:', typeof scheduledAt);
-  console.log('[DEBUG] Schedule API - Date.now():', Date.now());
-
-  // Validate scheduledAt is provided and in the future
-  if (!scheduledAt || scheduledAt <= Date.now()) {
-    return res.status(400).json({ error: 'scheduledAt must be a future timestamp' });
-  }
-
-  // Validate that pendingPrompt exists and is not empty
-  if (!req.session_.pendingPrompt || req.session_.pendingPrompt.trim() === '') {
-    return res.status(400).json({ error: 'pendingPrompt must be set before scheduling' });
-  }
-
   try {
-    // No need to create a message here - the scheduler will use pendingPrompt
-
-    // Build update data
-    const updateData = {
-      status: 'scheduled',
-      scheduledAt,
-    };
-
-    // Apply scheduling options if provided
-    if (autoRescheduleEnabled !== undefined) {
-      updateData.autoRescheduleEnabled = Boolean(autoRescheduleEnabled);
-    }
-    if (rescheduleDelayMinutes !== undefined) {
-      updateData.rescheduleDelayMinutes = parseInt(rescheduleDelayMinutes, 10);
-    }
-    if (rescheduleOnTokenLimit !== undefined) {
-      updateData.rescheduleOnTokenLimit = Boolean(rescheduleOnTokenLimit);
-    }
-    if (rescheduleOnServiceError !== undefined) {
-      updateData.rescheduleOnServiceError = Boolean(rescheduleOnServiceError);
-    }
-    if (maxRescheduleCount !== undefined) {
-      updateData.maxRescheduleCount = maxRescheduleCount ? parseInt(maxRescheduleCount, 10) : null;
-    }
-    if (maxTotalTokens !== undefined) {
-      updateData.maxTotalTokens = maxTotalTokens ? parseInt(maxTotalTokens, 10) : null;
-    }
-    if (rescheduleAtTokenCount !== undefined) {
-      updateData.rescheduleAtTokenCount = rescheduleAtTokenCount ? parseInt(rescheduleAtTokenCount, 10) : null;
-    }
-    if (pendingModel !== undefined) {
-      updateData.pendingModel = pendingModel;
-    }
-
-    const updated = sessions.update(req.params.id, updateData);
-
-    // Broadcast status update
-    broadcastToSession(req.params.id, WS_MESSAGE_TYPES.SESSION_STATUS, {
-      sessionId: req.params.id,
-      status: 'scheduled',
-    });
-
-    // Broadcast session update to project subscribers
-    broadcastToProject(req.session_.projectId, WS_MESSAGE_TYPES.SESSION_UPDATED, {
-      projectId: req.session_.projectId,
-      sessionId: req.params.id,
-      session: updated,
-    });
-
+    const updated = configureSchedule(req.session_, req.body);
     res.json(updated);
   } catch (error) {
+    if (error instanceof ScheduleError) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
     console.error('Schedule session error:', error);
     res.status(500).json({ error: error.message });
   }
@@ -1253,189 +836,6 @@ router.delete('/:id', requireSessionAndProject, async (req, res) => {
   }
 
   res.status(204).send();
-});
-
-// POST /api/sessions/:id/command-buttons/:buttonId/run - Execute button command
-router.post('/:id/command-buttons/:buttonId/run', requireSessionAndProject, (req, res) => {
-  const sessionId = req.params.id;
-  const buttonId = req.params.buttonId;
-
-  console.log(`[RUN] Starting command for buttonId: ${buttonId}, sessionId: ${sessionId}`);
-
-  const button = commandButtons.getById(buttonId);
-  if (!button) {
-    return res.status(404).json({ error: 'Command button not found' });
-  }
-
-  // Generate run ID
-  const runId = databaseManager.generateId();
-
-  console.log(`[RUN] Generated runId: ${runId} for command: ${button.command}`);
-
-  // Return immediately with runId
-  res.json({ runId, buttonId, status: 'running', output: '' });
-
-  // Capture middleware values for use in async callbacks
-  const projectId = req.session_.projectId;
-  const workingDirectory = req.workingDirectory;
-
-  // Broadcast initial "running" status immediately so session list can show the running indicator
-  broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
-    sessionId,
-    runId,
-    buttonId,
-    output: '',
-  });
-  broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
-    projectId,
-    sessionId,
-    runId,
-    buttonId,
-    output: '',
-  });
-
-  // Execute command asynchronously
-  (async () => {
-    try {
-      console.log(`[RUN] Starting async execution for runId: ${runId}`);
-      await commandRunner.run(
-        runId,
-        button.command,
-        workingDirectory,
-        (text) => {
-          // Broadcast output via WebSocket to session subscribers
-          console.log(`[RUN] Output received for runId: ${runId}`);
-          broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
-            sessionId,
-            runId,
-            buttonId,
-            output: text,
-          });
-          // Also broadcast to project subscribers for session list updates
-          broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, {
-            projectId,
-            sessionId,
-            runId,
-            buttonId,
-            output: text,
-          });
-        },
-        (exitCode, output) => {
-          // Broadcast completion via WebSocket to session subscribers
-          const status = exitCode === 0 ? 'success' : 'error';
-          console.log(`[RUN] Command completed for runId: ${runId}, exitCode: ${exitCode}, status: ${status}`);
-          broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, {
-            sessionId,
-            runId,
-            buttonId,
-            status,
-            exitCode,
-            output,
-          });
-          // Also broadcast to project subscribers for session list updates
-          console.log(`[RUN] Broadcasting COMMAND_RUN_COMPLETE to project ${projectId}`);
-          broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, {
-            projectId,
-            sessionId,
-            runId,
-            buttonId,
-            status,
-            exitCode,
-            output,
-          });
-        },
-        (message) => {
-          // Broadcast error via WebSocket to session subscribers
-          console.log(`[RUN] Error for runId: ${runId}: ${message}`);
-          broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
-            sessionId,
-            runId,
-            buttonId,
-            error: message,
-          });
-          // Also broadcast to project subscribers for session list updates
-          broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
-            projectId,
-            sessionId,
-            runId,
-            buttonId,
-            error: message,
-          });
-        },
-        { sessionId, buttonId }
-      );
-    } catch (error) {
-      console.error(`Error running command button ${buttonId}:`, error);
-      broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
-        sessionId,
-        runId,
-        buttonId,
-        error: error.message,
-      });
-      // Also broadcast to project subscribers for session list updates
-      broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, {
-        projectId,
-        sessionId,
-        runId,
-        buttonId,
-        error: error.message,
-      });
-    }
-  })();
-});
-
-// GET /api/sessions/:id/command-buttons/runs - Get active runs for session
-router.get('/:id/command-buttons/runs', requireSession, (req, res) => {
-  const sessionId = req.params.id;
-
-  const activeRuns = commandRunner.getRunsBySession(sessionId);
-  res.json(activeRuns);
-});
-
-// GET /api/sessions/:id/command-buttons/runs/:runId - Get single run by ID
-router.get('/:id/command-buttons/runs/:runId', requireSession, (req, res) => {
-  const { id: sessionId, runId } = req.params;
-
-  // Check if run is currently running (in memory)
-  if (commandRunner.isRunning(runId)) {
-    const activeRuns = commandRunner.getRunsBySession(sessionId);
-    const run = activeRuns.find((r) => r.runId === runId);
-    if (run) {
-      return res.json(run);
-    }
-  }
-
-  // Otherwise check database
-  const run = commandRuns.getById(runId);
-  if (!run || run.sessionId !== sessionId) {
-    return res.status(404).json({ error: 'Run not found' });
-  }
-
-  res.json({
-    runId: run.id,
-    buttonId: run.buttonId,
-    status: run.status,
-    output: run.output,
-    exitCode: run.exitCode,
-    startedAt: run.startedAt,
-    completedAt: run.completedAt,
-  });
-});
-
-// POST /api/sessions/:id/command-buttons/runs/:runId/kill - Kill running command
-router.post('/:id/command-buttons/runs/:runId/kill', requireSession, (req, res) => {
-  const sessionId = req.params.id;
-  const runId = req.params.runId;
-
-  console.log(`[KILL] Kill request for runId: ${runId}, sessionId: ${sessionId}`);
-
-  const killed = commandRunner.kill(runId);
-  console.log(`[KILL] Kill result: ${killed} for runId: ${runId}`);
-  if (!killed) {
-    return res.status(404).json({ error: 'Run not found or already completed' });
-  }
-
-  res.json({ success: true, runId });
 });
 
 export default router;

--- a/packages/server/src/middleware/requireSessionStatus.test.js
+++ b/packages/server/src/middleware/requireSessionStatus.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { requireSessionStatus } from './sessionLookup.js';
+
+describe('requireSessionStatus middleware', () => {
+  let mockReq, mockRes, mockNext;
+
+  beforeEach(() => {
+    mockReq = {
+      params: { id: 'session-123' },
+    };
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    mockNext = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  it('should return 500 if req.session_ is not set (middleware ordering error)', () => {
+    const middleware = requireSessionStatus(['waiting']);
+
+    middleware(mockReq, mockRes, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(500);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      error: 'requireSessionStatus must be used after requireSession',
+    });
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it('should call next when session status is in the allowed list', () => {
+    mockReq.session_ = { id: 'session-123', status: 'waiting' };
+    const middleware = requireSessionStatus(['waiting', 'stopped', 'error']);
+
+    middleware(mockReq, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockRes.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 when session status is not in the allowed list', () => {
+    mockReq.session_ = { id: 'session-123', status: 'running' };
+    const middleware = requireSessionStatus(['waiting', 'stopped', 'error']);
+
+    middleware(mockReq, mockRes, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      error: 'Session status must be one of: waiting, stopped, error',
+    });
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it('should use custom error message when provided', () => {
+    mockReq.session_ = { id: 'session-123', status: 'running' };
+    const middleware = requireSessionStatus(['waiting'], 'Session is not ready for input');
+
+    middleware(mockReq, mockRes, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      error: 'Session is not ready for input',
+    });
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it('should work with a single allowed status', () => {
+    mockReq.session_ = { id: 'session-123', status: 'waiting' };
+    const middleware = requireSessionStatus(['waiting']);
+
+    middleware(mockReq, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('should reject when status matches none of multiple allowed statuses', () => {
+    mockReq.session_ = { id: 'session-123', status: 'scheduled' };
+    const middleware = requireSessionStatus(['waiting', 'stopped', 'error']);
+
+    middleware(mockReq, mockRes, mockNext);
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it('should accept each status in the allowed list', () => {
+    const allowedStatuses = ['waiting', 'stopped', 'error'];
+
+    for (const status of allowedStatuses) {
+      vi.clearAllMocks();
+      mockReq.session_ = { id: 'session-123', status };
+      const middleware = requireSessionStatus(allowedStatuses);
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/server/src/middleware/sessionLookup.js
+++ b/packages/server/src/middleware/sessionLookup.js
@@ -19,6 +19,26 @@ export function requireSession(req, res, next) {
  * Returns 404 if either is not found.
  * Also resolves req.workingDirectory (gitWorktree || project.workingDirectory).
  */
+/**
+ * Middleware factory: Validates that req.session_.status is one of the allowed statuses.
+ * Must be used AFTER requireSession or requireSessionAndProject middleware.
+ * @param {string[]} allowedStatuses - Array of allowed status strings
+ * @param {string} [errorMessage] - Optional custom error message
+ * @returns {Function} Express middleware
+ */
+export function requireSessionStatus(allowedStatuses, errorMessage) {
+  return (req, res, next) => {
+    if (!req.session_) {
+      return res.status(500).json({ error: 'requireSessionStatus must be used after requireSession' });
+    }
+    if (!allowedStatuses.includes(req.session_.status)) {
+      const message = errorMessage || `Session status must be one of: ${allowedStatuses.join(', ')}`;
+      return res.status(400).json({ error: message });
+    }
+    next();
+  };
+}
+
 export function requireSessionAndProject(req, res, next) {
   const session = sessions.getById(req.params.id);
   if (!session) {

--- a/packages/server/src/services/draftSessionService.js
+++ b/packages/server/src/services/draftSessionService.js
@@ -1,0 +1,152 @@
+import { sessions, messages, projects, conversations, attachments } from '../database.js';
+import { broadcastToSession, broadcastToProject } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+import * as slashCommandService from './slashCommandService.js';
+
+/**
+ * Validates that a session is a draft (waiting status with no assistant messages).
+ * @param {object} session - The session object
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateDraftSession(session) {
+  if (session.status !== 'waiting') {
+    return { valid: false, error: 'Session must be in waiting status to start' };
+  }
+
+  const allMessages = messages.getBySessionId(session.id);
+  const hasAssistantMessages = allMessages.some(msg => msg.role === 'assistant');
+  if (hasAssistantMessages) {
+    return { valid: false, error: 'Session is not a draft - it already has responses' };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Starts a draft session by resolving the prompt, creating messages if needed,
+ * and kicking off the session manager.
+ *
+ * @param {object} session - The session object (from req.session_)
+ * @param {object} options
+ * @param {string} [options.prompt] - Optional new prompt to use/override
+ * @param {string} [options.model] - Optional model override
+ * @returns {Promise<object>} The updated session
+ */
+export async function startDraft(session, options = {}) {
+  const project = projects.getById(session.projectId);
+  if (!project) {
+    throw new DraftSessionError('Project not found', 404);
+  }
+
+  // Use gitWorktree if set, otherwise use project's working directory
+  const workingDirectory = session.gitWorktree || project.workingDirectory;
+
+  // Model to use for this session (optional - SDK will use default if not provided)
+  // Fallback chain: explicit request body > pendingModel (set at draft creation) > session.model > null (SDK default)
+  const model = options.model || session.pendingModel || session.model || null;
+
+  // Get all messages to find user messages
+  const allMessages = messages.getBySessionId(session.id);
+
+  // Get or create the initial user message (prompt)
+  let userMessages = allMessages.filter(msg => msg.role === 'user');
+  let initialMessage;
+
+  if (userMessages.length === 0) {
+    // For draft/scheduled sessions, there may not be an initial message yet
+    // Create it from the provided prompt or pendingPrompt
+    const promptToUse = options.prompt || session.pendingPrompt;
+    if (!promptToUse || typeof promptToUse !== 'string' || promptToUse.trim() === '') {
+      throw new DraftSessionError('No initial prompt found', 400);
+    }
+
+    // Get the active conversation
+    const activeConv = conversations.getActiveBySessionId(session.id);
+    if (!activeConv) {
+      throw new DraftSessionError('No active conversation found', 500);
+    }
+
+    // Create the initial message
+    initialMessage = messages.create(session.id, 'user', promptToUse, null, activeConv.id);
+
+    // Clear pendingPrompt since we've created the message
+    sessions.update(session.id, { pendingPrompt: null });
+
+    // Broadcast the new message
+    broadcastToSession(session.id, WS_MESSAGE_TYPES.MESSAGE_CREATED, {
+      sessionId: session.id,
+      message: initialMessage,
+    });
+  } else {
+    initialMessage = userMessages[0];
+
+    // If a new prompt is provided, update the message
+    if (options.prompt !== undefined) {
+      // Validate provided prompt
+      if (!options.prompt || typeof options.prompt !== 'string' || options.prompt.trim() === '') {
+        throw new DraftSessionError('Prompt must be a non-empty string', 400);
+      }
+      // Update the message with the new prompt
+      const updatedMessage = messages.updateContent(initialMessage.id, options.prompt);
+      initialMessage = updatedMessage;
+
+      // Broadcast the update to session subscribers
+      broadcastToSession(session.id, WS_MESSAGE_TYPES.MESSAGE_UPDATED, {
+        sessionId: session.id,
+        message: updatedMessage,
+      });
+    }
+  }
+
+  const finalPrompt = initialMessage.content;
+
+  // Get session attachments for context
+  const sessionAttachments = attachments.getBySessionId(session.id);
+
+  // Update session status to starting and clear pendingModel (mirrors pendingPrompt cleanup above)
+  sessions.update(session.id, { status: 'starting', pendingModel: null });
+
+  // Resolve skill/command invocations so skill body goes into system prompt
+  const resolved = await slashCommandService.resolvePromptSkillOrCommand(
+    workingDirectory, finalPrompt, project.systemPrompt
+  );
+  const effectivePrompt = resolved ? resolved.userMessage : finalPrompt;
+  const effectiveSystemPrompt = resolved ? resolved.systemPrompt : project.systemPrompt;
+
+  // Start session manager (non-blocking)
+  const { runSession } = await import('./sessionManager.js');
+  runSession(session.id, effectivePrompt, workingDirectory, effectiveSystemPrompt, sessionAttachments, model).catch((error) => {
+    console.error('Session error:', error);
+    sessions.update(session.id, { status: 'error', error: error.message });
+  });
+
+  // Broadcast status update
+  broadcastToSession(session.id, WS_MESSAGE_TYPES.SESSION_STATUS, {
+    sessionId: session.id,
+    status: 'starting',
+  });
+
+  // Broadcast to project subscribers
+  broadcastToProject(session.projectId, WS_MESSAGE_TYPES.SESSION_UPDATED, {
+    projectId: session.projectId,
+    sessionId: session.id,
+    session: sessions.getById(session.id),
+  });
+
+  return sessions.getById(session.id);
+}
+
+/**
+ * Custom error class for draft session operations, includes HTTP status code.
+ */
+export class DraftSessionError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} statusCode
+   */
+  constructor(message, statusCode) {
+    super(message);
+    this.name = 'DraftSessionError';
+    this.statusCode = statusCode;
+  }
+}

--- a/packages/server/src/services/draftSessionService.test.js
+++ b/packages/server/src/services/draftSessionService.test.js
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { validateDraftSession, startDraft, DraftSessionError } from './draftSessionService.js';
+import { sessions, messages, projects, conversations, attachments } from '../database.js';
+
+// Mock database
+vi.mock('../database.js', () => ({
+  sessions: {
+    getById: vi.fn(),
+    update: vi.fn(),
+  },
+  messages: {
+    getBySessionId: vi.fn(),
+    create: vi.fn(),
+    updateContent: vi.fn(),
+  },
+  projects: {
+    getById: vi.fn(),
+  },
+  conversations: {
+    getActiveBySessionId: vi.fn(),
+  },
+  attachments: {
+    getBySessionId: vi.fn(),
+  },
+}));
+
+// Mock websocket
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock slashCommandService
+vi.mock('./slashCommandService.js', () => ({
+  resolvePromptSkillOrCommand: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock sessionManager
+vi.mock('./sessionManager.js', () => ({
+  runSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('draftSessionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('validateDraftSession', () => {
+    it('returns valid for a waiting session with no assistant messages', () => {
+      const session = { id: 's1', status: 'waiting' };
+      messages.getBySessionId.mockReturnValue([
+        { id: 'm1', role: 'user', content: 'Hello' },
+      ]);
+
+      const result = validateDraftSession(session);
+
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns invalid when session is not in waiting status', () => {
+      const session = { id: 's1', status: 'running' };
+
+      const result = validateDraftSession(session);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Session must be in waiting status to start');
+    });
+
+    it('returns invalid when session has assistant messages', () => {
+      const session = { id: 's1', status: 'waiting' };
+      messages.getBySessionId.mockReturnValue([
+        { id: 'm1', role: 'user', content: 'Hello' },
+        { id: 'm2', role: 'assistant', content: 'Hi there' },
+      ]);
+
+      const result = validateDraftSession(session);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Session is not a draft - it already has responses');
+    });
+
+    it('returns invalid for stopped status', () => {
+      const session = { id: 's1', status: 'stopped' };
+
+      const result = validateDraftSession(session);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('returns invalid for error status', () => {
+      const session = { id: 's1', status: 'error' };
+
+      const result = validateDraftSession(session);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('startDraft', () => {
+    const mockProject = { id: 'p1', workingDirectory: '/tmp/test', systemPrompt: 'You are helpful' };
+    const mockSession = {
+      id: 's1',
+      projectId: 'p1',
+      status: 'waiting',
+      pendingPrompt: null,
+      pendingModel: null,
+      model: null,
+      gitWorktree: null,
+    };
+    const mockConversation = { id: 'c1', sessionId: 's1' };
+    const mockMessage = { id: 'm1', role: 'user', content: 'Hello' };
+
+    beforeEach(() => {
+      projects.getById.mockReturnValue(mockProject);
+      conversations.getActiveBySessionId.mockReturnValue(mockConversation);
+      attachments.getBySessionId.mockReturnValue([]);
+      sessions.update.mockReturnValue({ ...mockSession, status: 'starting' });
+      sessions.getById.mockReturnValue({ ...mockSession, status: 'starting' });
+    });
+
+    it('throws DraftSessionError with 404 when project not found', async () => {
+      projects.getById.mockReturnValue(null);
+
+      await expect(startDraft(mockSession))
+        .rejects.toThrow(DraftSessionError);
+
+      try {
+        await startDraft(mockSession);
+      } catch (error) {
+        expect(error.statusCode).toBe(404);
+        expect(error.message).toBe('Project not found');
+      }
+    });
+
+    it('creates initial message from pendingPrompt when no user messages exist', async () => {
+      messages.getBySessionId.mockReturnValue([]);
+      const sessionWithPending = { ...mockSession, pendingPrompt: 'My pending prompt' };
+      messages.create.mockReturnValue({ id: 'new-m1', role: 'user', content: 'My pending prompt' });
+
+      await startDraft(sessionWithPending);
+
+      expect(messages.create).toHaveBeenCalledWith(
+        's1', 'user', 'My pending prompt', null, 'c1'
+      );
+      expect(sessions.update).toHaveBeenCalledWith('s1', { pendingPrompt: null });
+    });
+
+    it('creates initial message from options.prompt when provided and no user messages exist', async () => {
+      messages.getBySessionId.mockReturnValue([]);
+      const sessionWithPending = { ...mockSession, pendingPrompt: 'fallback' };
+      messages.create.mockReturnValue({ id: 'new-m1', role: 'user', content: 'explicit prompt' });
+
+      await startDraft(sessionWithPending, { prompt: 'explicit prompt' });
+
+      expect(messages.create).toHaveBeenCalledWith(
+        's1', 'user', 'explicit prompt', null, 'c1'
+      );
+    });
+
+    it('throws DraftSessionError with 400 when no prompt available and no user messages', async () => {
+      messages.getBySessionId.mockReturnValue([]);
+
+      await expect(startDraft(mockSession))
+        .rejects.toThrow(DraftSessionError);
+
+      try {
+        await startDraft(mockSession);
+      } catch (error) {
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe('No initial prompt found');
+      }
+    });
+
+    it('throws DraftSessionError with 500 when no active conversation found', async () => {
+      messages.getBySessionId.mockReturnValue([]);
+      conversations.getActiveBySessionId.mockReturnValue(null);
+      const sessionWithPending = { ...mockSession, pendingPrompt: 'Some prompt' };
+
+      await expect(startDraft(sessionWithPending))
+        .rejects.toThrow(DraftSessionError);
+
+      try {
+        await startDraft(sessionWithPending);
+      } catch (error) {
+        expect(error.statusCode).toBe(500);
+        expect(error.message).toBe('No active conversation found');
+      }
+    });
+
+    it('uses existing user message when messages already exist', async () => {
+      messages.getBySessionId.mockReturnValue([mockMessage]);
+
+      await startDraft(mockSession);
+
+      expect(messages.create).not.toHaveBeenCalled();
+      expect(sessions.update).toHaveBeenCalledWith('s1', {
+        status: 'starting',
+        pendingModel: null,
+      });
+    });
+
+    it('updates existing user message when options.prompt is provided and messages exist', async () => {
+      messages.getBySessionId.mockReturnValue([mockMessage]);
+      const updatedMsg = { ...mockMessage, content: 'Updated prompt' };
+      messages.updateContent.mockReturnValue(updatedMsg);
+
+      await startDraft(mockSession, { prompt: 'Updated prompt' });
+
+      expect(messages.updateContent).toHaveBeenCalledWith('m1', 'Updated prompt');
+    });
+
+    it('throws DraftSessionError with 400 when prompt option is empty string', async () => {
+      messages.getBySessionId.mockReturnValue([mockMessage]);
+
+      await expect(startDraft(mockSession, { prompt: '' }))
+        .rejects.toThrow(DraftSessionError);
+
+      try {
+        await startDraft(mockSession, { prompt: '' });
+      } catch (error) {
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe('Prompt must be a non-empty string');
+      }
+    });
+
+    it('uses model fallback chain: options.model > pendingModel > session.model', async () => {
+      messages.getBySessionId.mockReturnValue([mockMessage]);
+
+      const sessionWithModel = {
+        ...mockSession,
+        pendingModel: 'claude-3-haiku',
+        model: 'claude-3-sonnet',
+      };
+
+      // options.model takes priority
+      await startDraft(sessionWithModel, { model: 'claude-3-opus' });
+
+      // The runSession call should get the model from options
+      const { runSession } = await import('./sessionManager.js');
+      const lastCallArgs = runSession.mock.calls[runSession.mock.calls.length - 1];
+      expect(lastCallArgs[5]).toBe('claude-3-opus');
+    });
+
+    it('uses gitWorktree as working directory when set', async () => {
+      messages.getBySessionId.mockReturnValue([mockMessage]);
+
+      const sessionWithWorktree = {
+        ...mockSession,
+        gitWorktree: '/tmp/worktree',
+      };
+
+      await startDraft(sessionWithWorktree);
+
+      const { runSession } = await import('./sessionManager.js');
+      const lastCallArgs = runSession.mock.calls[runSession.mock.calls.length - 1];
+      expect(lastCallArgs[2]).toBe('/tmp/worktree');
+    });
+
+    it('returns updated session', async () => {
+      messages.getBySessionId.mockReturnValue([mockMessage]);
+
+      const result = await startDraft(mockSession);
+
+      expect(result).toEqual({ ...mockSession, status: 'starting' });
+    });
+  });
+
+  describe('DraftSessionError', () => {
+    it('has correct name', () => {
+      const error = new DraftSessionError('test', 400);
+      expect(error.name).toBe('DraftSessionError');
+    });
+
+    it('carries statusCode', () => {
+      const error = new DraftSessionError('not found', 404);
+      expect(error.statusCode).toBe(404);
+      expect(error.message).toBe('not found');
+    });
+
+    it('is an instance of Error', () => {
+      const error = new DraftSessionError('test', 400);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/packages/server/src/services/scheduleService.js
+++ b/packages/server/src/services/scheduleService.js
@@ -1,0 +1,106 @@
+import { sessions } from '../database.js';
+import { broadcastToSession, broadcastToProject } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@claudetools/shared';
+
+/**
+ * Custom error class for schedule operations, includes HTTP status code.
+ */
+export class ScheduleError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} statusCode
+   */
+  constructor(message, statusCode) {
+    super(message);
+    this.name = 'ScheduleError';
+    this.statusCode = statusCode;
+  }
+}
+
+/**
+ * Configures a schedule for a follow-up message on an existing session.
+ *
+ * @param {object} session - The session object (from req.session_)
+ * @param {object} scheduleData
+ * @param {number} scheduleData.scheduledAt - Future timestamp in ms
+ * @param {string} [scheduleData.pendingModel] - Model to use when scheduled run fires
+ * @param {boolean} [scheduleData.autoRescheduleEnabled] - Enable auto-rescheduling
+ * @param {number} [scheduleData.rescheduleDelayMinutes] - Delay between reschedules
+ * @param {boolean} [scheduleData.rescheduleOnTokenLimit] - Reschedule on token limit errors
+ * @param {boolean} [scheduleData.rescheduleOnServiceError] - Reschedule on service errors
+ * @param {number|null} [scheduleData.maxRescheduleCount] - Max number of reschedules
+ * @param {number|null} [scheduleData.maxTotalTokens] - Max total tokens before stopping
+ * @param {number|null} [scheduleData.rescheduleAtTokenCount] - Token count trigger for reschedule
+ * @returns {object} The updated session
+ */
+export function configureSchedule(session, scheduleData) {
+  // Validate session status
+  if (!['waiting', 'stopped', 'error'].includes(session.status)) {
+    throw new ScheduleError('Session must be in waiting, stopped, or error state to schedule', 400);
+  }
+
+  const { scheduledAt } = scheduleData;
+
+  // DEBUG: Log incoming scheduledAt value
+  console.log('[DEBUG] Schedule API - scheduledAt from request:', scheduledAt, 'type:', typeof scheduledAt);
+  console.log('[DEBUG] Schedule API - Date.now():', Date.now());
+
+  // Validate scheduledAt is provided and in the future
+  if (!scheduledAt || scheduledAt <= Date.now()) {
+    throw new ScheduleError('scheduledAt must be a future timestamp', 400);
+  }
+
+  // Validate that pendingPrompt exists and is not empty
+  if (!session.pendingPrompt || session.pendingPrompt.trim() === '') {
+    throw new ScheduleError('pendingPrompt must be set before scheduling', 400);
+  }
+
+  // Build update data
+  const updateData = {
+    status: 'scheduled',
+    scheduledAt,
+  };
+
+  // Apply scheduling options if provided
+  if (scheduleData.autoRescheduleEnabled !== undefined) {
+    updateData.autoRescheduleEnabled = Boolean(scheduleData.autoRescheduleEnabled);
+  }
+  if (scheduleData.rescheduleDelayMinutes !== undefined) {
+    updateData.rescheduleDelayMinutes = parseInt(scheduleData.rescheduleDelayMinutes, 10);
+  }
+  if (scheduleData.rescheduleOnTokenLimit !== undefined) {
+    updateData.rescheduleOnTokenLimit = Boolean(scheduleData.rescheduleOnTokenLimit);
+  }
+  if (scheduleData.rescheduleOnServiceError !== undefined) {
+    updateData.rescheduleOnServiceError = Boolean(scheduleData.rescheduleOnServiceError);
+  }
+  if (scheduleData.maxRescheduleCount !== undefined) {
+    updateData.maxRescheduleCount = scheduleData.maxRescheduleCount ? parseInt(scheduleData.maxRescheduleCount, 10) : null;
+  }
+  if (scheduleData.maxTotalTokens !== undefined) {
+    updateData.maxTotalTokens = scheduleData.maxTotalTokens ? parseInt(scheduleData.maxTotalTokens, 10) : null;
+  }
+  if (scheduleData.rescheduleAtTokenCount !== undefined) {
+    updateData.rescheduleAtTokenCount = scheduleData.rescheduleAtTokenCount ? parseInt(scheduleData.rescheduleAtTokenCount, 10) : null;
+  }
+  if (scheduleData.pendingModel !== undefined) {
+    updateData.pendingModel = scheduleData.pendingModel;
+  }
+
+  const updated = sessions.update(session.id, updateData);
+
+  // Broadcast status update
+  broadcastToSession(session.id, WS_MESSAGE_TYPES.SESSION_STATUS, {
+    sessionId: session.id,
+    status: 'scheduled',
+  });
+
+  // Broadcast session update to project subscribers
+  broadcastToProject(session.projectId, WS_MESSAGE_TYPES.SESSION_UPDATED, {
+    projectId: session.projectId,
+    sessionId: session.id,
+    session: updated,
+  });
+
+  return updated;
+}

--- a/packages/server/src/services/scheduleService.test.js
+++ b/packages/server/src/services/scheduleService.test.js
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { configureSchedule, ScheduleError } from './scheduleService.js';
+import { sessions } from '../database.js';
+
+// Mock database
+vi.mock('../database.js', () => ({
+  sessions: {
+    update: vi.fn(),
+  },
+}));
+
+// Mock websocket
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+describe('scheduleService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('configureSchedule', () => {
+    const baseSession = {
+      id: 's1',
+      projectId: 'p1',
+      status: 'waiting',
+      pendingPrompt: 'Continue working on the feature',
+    };
+
+    const futureTimestamp = Date.now() + 60_000; // 1 minute from now
+
+    it('schedules a session with valid data', () => {
+      const updatedSession = { ...baseSession, status: 'scheduled', scheduledAt: futureTimestamp };
+      sessions.update.mockReturnValue(updatedSession);
+
+      const result = configureSchedule(baseSession, { scheduledAt: futureTimestamp });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        status: 'scheduled',
+        scheduledAt: futureTimestamp,
+      }));
+      expect(result).toEqual(updatedSession);
+    });
+
+    it('throws ScheduleError when session is not in an allowed status', () => {
+      const runningSession = { ...baseSession, status: 'running' };
+
+      expect(() => configureSchedule(runningSession, { scheduledAt: futureTimestamp }))
+        .toThrow(ScheduleError);
+
+      try {
+        configureSchedule(runningSession, { scheduledAt: futureTimestamp });
+      } catch (error) {
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe('Session must be in waiting, stopped, or error state to schedule');
+      }
+    });
+
+    it('allows scheduling from waiting status', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      expect(() => configureSchedule(
+        { ...baseSession, status: 'waiting' },
+        { scheduledAt: futureTimestamp }
+      )).not.toThrow();
+    });
+
+    it('allows scheduling from stopped status', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      expect(() => configureSchedule(
+        { ...baseSession, status: 'stopped' },
+        { scheduledAt: futureTimestamp }
+      )).not.toThrow();
+    });
+
+    it('allows scheduling from error status', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      expect(() => configureSchedule(
+        { ...baseSession, status: 'error' },
+        { scheduledAt: futureTimestamp }
+      )).not.toThrow();
+    });
+
+    it('throws ScheduleError when scheduledAt is missing', () => {
+      expect(() => configureSchedule(baseSession, {}))
+        .toThrow(ScheduleError);
+
+      try {
+        configureSchedule(baseSession, {});
+      } catch (error) {
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe('scheduledAt must be a future timestamp');
+      }
+    });
+
+    it('throws ScheduleError when scheduledAt is in the past', () => {
+      const pastTimestamp = Date.now() - 60_000;
+
+      expect(() => configureSchedule(baseSession, { scheduledAt: pastTimestamp }))
+        .toThrow(ScheduleError);
+
+      try {
+        configureSchedule(baseSession, { scheduledAt: pastTimestamp });
+      } catch (error) {
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe('scheduledAt must be a future timestamp');
+      }
+    });
+
+    it('throws ScheduleError when pendingPrompt is empty', () => {
+      const sessionWithoutPrompt = { ...baseSession, pendingPrompt: '' };
+
+      expect(() => configureSchedule(sessionWithoutPrompt, { scheduledAt: futureTimestamp }))
+        .toThrow(ScheduleError);
+
+      try {
+        configureSchedule(sessionWithoutPrompt, { scheduledAt: futureTimestamp });
+      } catch (error) {
+        expect(error.statusCode).toBe(400);
+        expect(error.message).toBe('pendingPrompt must be set before scheduling');
+      }
+    });
+
+    it('throws ScheduleError when pendingPrompt is null', () => {
+      const sessionWithoutPrompt = { ...baseSession, pendingPrompt: null };
+
+      expect(() => configureSchedule(sessionWithoutPrompt, { scheduledAt: futureTimestamp }))
+        .toThrow(ScheduleError);
+    });
+
+    it('applies autoRescheduleEnabled option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        autoRescheduleEnabled: true,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        autoRescheduleEnabled: true,
+      }));
+    });
+
+    it('applies rescheduleDelayMinutes option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        rescheduleDelayMinutes: 30,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        rescheduleDelayMinutes: 30,
+      }));
+    });
+
+    it('applies rescheduleOnTokenLimit option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        rescheduleOnTokenLimit: true,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        rescheduleOnTokenLimit: true,
+      }));
+    });
+
+    it('applies rescheduleOnServiceError option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        rescheduleOnServiceError: true,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        rescheduleOnServiceError: true,
+      }));
+    });
+
+    it('applies maxRescheduleCount option as integer', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        maxRescheduleCount: 5,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        maxRescheduleCount: 5,
+      }));
+    });
+
+    it('sets maxRescheduleCount to null when falsy', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        maxRescheduleCount: 0,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        maxRescheduleCount: null,
+      }));
+    });
+
+    it('applies maxTotalTokens option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        maxTotalTokens: 100000,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        maxTotalTokens: 100000,
+      }));
+    });
+
+    it('applies rescheduleAtTokenCount option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        rescheduleAtTokenCount: 50000,
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        rescheduleAtTokenCount: 50000,
+      }));
+    });
+
+    it('applies pendingModel option', () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+
+      configureSchedule(baseSession, {
+        scheduledAt: futureTimestamp,
+        pendingModel: 'claude-3-opus',
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('s1', expect.objectContaining({
+        pendingModel: 'claude-3-opus',
+      }));
+    });
+
+    it('broadcasts status and session updates', async () => {
+      sessions.update.mockReturnValue({ ...baseSession, status: 'scheduled' });
+      const { broadcastToSession, broadcastToProject } = await import('../websocket.js');
+
+      configureSchedule(baseSession, { scheduledAt: futureTimestamp });
+
+      expect(broadcastToSession).toHaveBeenCalledWith('s1', expect.any(String), expect.objectContaining({
+        sessionId: 's1',
+        status: 'scheduled',
+      }));
+
+      expect(broadcastToProject).toHaveBeenCalledWith('p1', expect.any(String), expect.objectContaining({
+        projectId: 'p1',
+        sessionId: 's1',
+      }));
+    });
+  });
+
+  describe('ScheduleError', () => {
+    it('has correct name', () => {
+      const error = new ScheduleError('test', 400);
+      expect(error.name).toBe('ScheduleError');
+    });
+
+    it('carries statusCode', () => {
+      const error = new ScheduleError('bad request', 400);
+      expect(error.statusCode).toBe(400);
+      expect(error.message).toBe('bad request');
+    });
+
+    it('is an instance of Error', () => {
+      const error = new ScheduleError('test', 400);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/packages/shared/src/contracts/sessions.js
+++ b/packages/shared/src/contracts/sessions.js
@@ -24,6 +24,11 @@ export const UpdateSessionRequest = z.object({
   name: z.string().min(1).optional(),
   manuallyNamed: z.boolean().optional(),
   thinkingEnabled: z.boolean().optional(),
+  status: z.enum(['starting', 'running', 'waiting', 'error', 'stopped', 'scheduled']).optional(),
+  mode: z.enum(['plan', 'standard', 'yolo']).optional(),
+  model: z.string().nullable().optional(),
+  pendingModel: z.string().nullable().optional(),
+  providerId: z.string().uuid().nullable().optional(),
   nextTemplateId: z.string().uuid().nullable().optional(),
   // PR URL - GitHub PR URL (e.g., https://github.com/owner/repo/pull/123) or null to clear
   prUrl: z.string().url().regex(/^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/).nullable().optional(),


### PR DESCRIPTION
## Summary

- **Extracted 3 route group files** from the monolithic `sessions.js` (1,442 → 842 lines, -42%):
  - `sessions-notes.js` — 4 notes CRUD routes
  - `sessions-conversations.js` — 7 conversation routes (list, create, get, update, delete, summary, branch)
  - `sessions-commands.js` — 4 command button routes (run, list runs, get run, kill)
- **Extracted 2 service modules** to move inline business logic out of route handlers:
  - `DraftSessionService` — `validateDraftSession()` + `startDraft()` (extracted from `POST /:id/start`, 116 lines of inline logic)
  - `ScheduleService` — `configureSchedule()` (extracted from `POST /:id/schedule`, 99 lines of inline logic)
- **Added `requireSessionStatus` middleware factory** to `sessionLookup.js` for reusable status validation
- **Extended `UpdateSessionRequest` Zod schema** with `status`, `mode`, `model`, `pendingModel`, `providerId` fields
- **Added 90 new tests** across 6 test files covering all extracted modules

## Test plan

- [x] All 2973 existing server tests pass (0 regressions)
- [x] All 231 shared package tests pass
- [x] Lint passes clean (0 errors)
- [x] 90 new tests cover:
  - `requireSessionStatus` middleware (7 tests)
  - `DraftSessionService` (19 tests)
  - `ScheduleService` (22 tests)
  - Notes routes (13 tests)
  - Conversation routes (19 tests)
  - Command routes (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)