### PR TITLE
Refactor: Decompose SessionDetailView & SessionListView (Phases 7-8)

### DIFF
--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -13,6 +13,12 @@ import metricsRouter from './metrics.js';
 
 const router = Router();
 
+// Lightweight identity endpoint — lets tools (e.g. pw.sh) verify which
+// worktree / working directory this server instance belongs to.
+router.get('/server-info', (_req, res) => {
+  res.json({ cwd: process.cwd() });
+});
+
 router.use('/projects', projectsRouter);
 router.use('/sessions', sessionsRouter);
 router.use('/templates', templatesRouter);

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -135,8 +135,6 @@
       @executed="handleSlashCommandExecuted"
     />
 
-    <!-- Scheduling Info Panel -->
-    <SchedulingInfo v-if="sessionsStore.currentSession" :session="sessionsStore.currentSession" />
   </div>
 </template>
 
@@ -164,7 +162,6 @@ import QuickResponseSettings from './QuickResponseSettings.vue';
 import ScheduleSessionModal from './ScheduleSessionModal.vue';
 import AutoRescheduleModal from './AutoRescheduleModal.vue';
 import SlashCommandWizard from './SlashCommandWizard.vue';
-import SchedulingInfo from './SchedulingInfo.vue';
 import { useQuickResponsesStore } from '../stores/quickResponses.js';
 import { useProjectsStore } from '../stores/projects.js';
 

--- a/packages/web/src/components/PrUrlEditor.test.js
+++ b/packages/web/src/components/PrUrlEditor.test.js
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import PrUrlEditor from './PrUrlEditor.vue';
+
+vi.mock('./PrIndicators.vue', () => ({
+  default: {
+    name: 'PrIndicators',
+    template: '<div class="pr-indicators">PR: {{ prUrl }}</div>',
+    props: ['prUrl', 'summary'],
+  }
+}));
+
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    updateSession: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+
+describe('PrUrlEditor', () => {
+  let pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+
+  function mountEditor(props = {}) {
+    return mount(PrUrlEditor, {
+      global: { plugins: [pinia] },
+      props: {
+        sessionId: 'session-1',
+        prUrl: '',
+        summary: null,
+        ...props,
+      },
+    });
+  }
+
+  describe('display mode (not editing)', () => {
+    it('shows "Link PR" text when no prUrl is set', () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      const trigger = wrapper.find('.pr-edit-trigger');
+      expect(trigger.exists()).toBe(true);
+      expect(trigger.text()).toContain('Link PR');
+    });
+
+    it('does not show "Link PR" text when prUrl is set', () => {
+      const wrapper = mountEditor({ prUrl: 'https://github.com/owner/repo/pull/123' });
+      const trigger = wrapper.find('.pr-edit-trigger');
+      expect(trigger.exists()).toBe(true);
+      expect(trigger.text()).not.toContain('Link PR');
+    });
+
+    it('renders PrIndicators when prUrl is set', () => {
+      const wrapper = mountEditor({ prUrl: 'https://github.com/owner/repo/pull/123' });
+      const indicators = wrapper.findComponent({ name: 'PrIndicators' });
+      expect(indicators.exists()).toBe(true);
+      expect(indicators.props('prUrl')).toBe('https://github.com/owner/repo/pull/123');
+    });
+
+    it('does not render PrIndicators when prUrl is empty', () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      const indicators = wrapper.findComponent({ name: 'PrIndicators' });
+      expect(indicators.exists()).toBe(false);
+    });
+
+    it('passes summary to PrIndicators', () => {
+      const summary = { title: 'Test Summary' };
+      const wrapper = mountEditor({
+        prUrl: 'https://github.com/owner/repo/pull/123',
+        summary,
+      });
+      const indicators = wrapper.findComponent({ name: 'PrIndicators' });
+      expect(indicators.props('summary')).toEqual(summary);
+    });
+
+    it('edit trigger has "Add PR URL" title when no prUrl', () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      const trigger = wrapper.find('.pr-edit-trigger');
+      expect(trigger.attributes('title')).toBe('Add PR URL');
+    });
+
+    it('edit trigger has "Edit PR URL" title when prUrl is set', () => {
+      const wrapper = mountEditor({ prUrl: 'https://github.com/owner/repo/pull/123' });
+      const trigger = wrapper.find('.pr-edit-trigger');
+      expect(trigger.attributes('title')).toBe('Edit PR URL');
+    });
+  });
+
+  describe('entering edit mode', () => {
+    it('shows edit form when edit trigger is clicked', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
+
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
+      expect(wrapper.find('.pr-url-input').exists()).toBe(true);
+    });
+
+    it('populates input with existing prUrl when editing', async () => {
+      const prUrl = 'https://github.com/owner/repo/pull/123';
+      const wrapper = mountEditor({ prUrl });
+
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      const input = wrapper.find('.pr-url-input');
+      expect(input.element.value).toBe(prUrl);
+    });
+
+    it('input has correct placeholder', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      const input = wrapper.find('.pr-url-input');
+      expect(input.attributes('placeholder')).toBe('https://github.com/owner/repo/pull/123');
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels editing when cancel button is clicked', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
+
+      await wrapper.find('.pr-cancel-btn').trigger('click');
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
+    });
+
+    it('cancels editing when Escape key is pressed', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
+
+      await wrapper.find('.pr-url-input').trigger('keyup.escape');
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
+    });
+  });
+
+  describe('save', () => {
+    it('saves valid PR URL on Enter', async () => {
+      api.updateSession.mockResolvedValue({ prUrl: 'https://github.com/owner/repo/pull/456' });
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      const input = wrapper.find('.pr-url-input');
+      await input.setValue('https://github.com/owner/repo/pull/456');
+      await input.trigger('keyup.enter');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', { prUrl: 'https://github.com/owner/repo/pull/456' });
+    });
+
+    it('saves valid PR URL on save button click', async () => {
+      api.updateSession.mockResolvedValue({ prUrl: 'https://github.com/owner/repo/pull/789' });
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-url-input').setValue('https://github.com/owner/repo/pull/789');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', { prUrl: 'https://github.com/owner/repo/pull/789' });
+    });
+
+    it('closes edit form after successful save', async () => {
+      api.updateSession.mockResolvedValue({});
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-url-input').setValue('https://github.com/owner/repo/pull/1');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
+    });
+
+    it('allows saving empty URL to clear the PR URL', async () => {
+      api.updateSession.mockResolvedValue({});
+      const wrapper = mountEditor({ prUrl: 'https://github.com/owner/repo/pull/123' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-url-input').setValue('');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', { prUrl: null });
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects invalid GitHub PR URL', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-url-input').setValue('https://not-github.com/foo');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).not.toHaveBeenCalled();
+      // Form should stay open
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
+    });
+
+    it('rejects non-PR GitHub URLs', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-url-input').setValue('https://github.com/owner/repo/issues/123');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid GitHub PR URL', () => {
+      const wrapper = mountEditor();
+      const pattern = wrapper.vm.PR_URL_PATTERN;
+      expect(pattern.test('https://github.com/owner/repo/pull/123')).toBe(true);
+      expect(pattern.test('https://github.com/my-org/my-repo/pull/1')).toBe(true);
+    });
+
+    it('rejects URLs with trailing slashes', () => {
+      const wrapper = mountEditor();
+      const pattern = wrapper.vm.PR_URL_PATTERN;
+      expect(pattern.test('https://github.com/owner/repo/pull/123/')).toBe(false);
+    });
+  });
+
+  describe('clear button', () => {
+    it('shows clear button when input has value', async () => {
+      const wrapper = mountEditor({ prUrl: 'https://github.com/owner/repo/pull/123' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      expect(wrapper.find('.pr-clear-btn').exists()).toBe(true);
+    });
+
+    it('hides clear button when input is empty', async () => {
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      expect(wrapper.find('.pr-clear-btn').exists()).toBe(false);
+    });
+
+    it('clears input and saves when clear button is clicked', async () => {
+      api.updateSession.mockResolvedValue({});
+      const wrapper = mountEditor({ prUrl: 'https://github.com/owner/repo/pull/123' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-clear-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', { prUrl: null });
+    });
+  });
+
+  describe('error handling', () => {
+    it('keeps form open on API error', async () => {
+      api.updateSession.mockRejectedValue(new Error('Network error'));
+      const wrapper = mountEditor({ prUrl: '' });
+      await wrapper.find('.pr-edit-trigger').trigger('click');
+
+      await wrapper.find('.pr-url-input').setValue('https://github.com/owner/repo/pull/123');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      // Form should stay open since save failed
+      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
+    });
+  });
+});

--- a/packages/web/src/components/PrUrlEditor.vue
+++ b/packages/web/src/components/PrUrlEditor.vue
@@ -1,0 +1,236 @@
+<template>
+  <div v-if="isEditing" class="pr-edit-form">
+    <input
+      v-model="editValue"
+      type="url"
+      class="pr-url-input"
+      placeholder="https://github.com/owner/repo/pull/123"
+      @keyup.enter="save"
+      @keyup.escape="cancel"
+    />
+    <button class="btn-icon pr-edit-btn pr-save-btn" title="Save" @click="save">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="20 6 9 17 4 12"></polyline>
+      </svg>
+    </button>
+    <button class="btn-icon pr-edit-btn pr-cancel-btn" title="Cancel" @click="cancel">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18"></line>
+        <line x1="6" y1="6" x2="18" y2="18"></line>
+      </svg>
+    </button>
+    <button v-if="editValue" class="btn-icon pr-edit-btn pr-clear-btn" title="Clear PR URL" @click="clear">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="3 6 5 6 21 6"></polyline>
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+      </svg>
+    </button>
+  </div>
+  <template v-else>
+    <PrIndicators
+      v-if="prUrl"
+      :pr-url="prUrl"
+      :summary="summary"
+    />
+    <button class="btn-link pr-edit-trigger" @click="startEdit" :title="prUrl ? 'Edit PR URL' : 'Add PR URL'">
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+      </svg>
+      <span v-if="!prUrl">Link PR</span>
+    </button>
+  </template>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import PrIndicators from './PrIndicators.vue';
+import { useUiStore } from '../stores/ui.js';
+import { api } from '../composables/useApi.js';
+import { useSessionsStore } from '../stores/sessions.js';
+
+const props = defineProps({
+  /** The current session ID */
+  sessionId: {
+    type: String,
+    required: true,
+  },
+  /** The current PR URL (may be null/empty) */
+  prUrl: {
+    type: String,
+    default: '',
+  },
+  /** Summary object for PrIndicators */
+  summary: {
+    type: Object,
+    default: null,
+  },
+});
+
+const uiStore = useUiStore();
+const sessionsStore = useSessionsStore();
+
+const isEditing = ref(false);
+const editValue = ref('');
+
+/** GitHub PR URL validation pattern */
+const PR_URL_PATTERN = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
+
+function startEdit() {
+  editValue.value = props.prUrl || '';
+  isEditing.value = true;
+}
+
+function cancel() {
+  isEditing.value = false;
+  editValue.value = '';
+}
+
+async function save() {
+  const newPrUrl = editValue.value.trim();
+
+  // Validate if not empty
+  if (newPrUrl) {
+    if (!PR_URL_PATTERN.test(newPrUrl)) {
+      uiStore.error('Invalid PR URL format. Must be a valid GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)');
+      return;
+    }
+  }
+
+  try {
+    const updated = await api.updateSession(props.sessionId, { prUrl: newPrUrl || null });
+    sessionsStore.updateSession({ ...updated, id: props.sessionId });
+    uiStore.success(newPrUrl ? 'PR URL updated' : 'PR URL cleared');
+    isEditing.value = false;
+    editValue.value = '';
+  } catch (err) {
+    uiStore.error(err.message || 'Failed to update PR URL');
+  }
+}
+
+async function clear() {
+  editValue.value = '';
+  await save();
+}
+
+defineExpose({ isEditing, editValue, startEdit, cancel, save, clear, PR_URL_PATTERN });
+</script>
+
+<style scoped>
+.pr-edit-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pr-url-input {
+  background: var(--color-bg-input, #1e1e1e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 4px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-text, #e0e0e0);
+  min-width: 280px;
+  max-width: 400px;
+}
+
+.pr-url-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #00bcd4);
+}
+
+.pr-url-input::placeholder {
+  color: var(--color-text-soft, #888);
+}
+
+.btn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-soft, #888);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.btn-icon:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text, #ccc);
+}
+
+.btn-icon:active {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.pr-edit-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+}
+
+.pr-save-btn {
+  color: var(--color-success, #4caf50);
+}
+
+.pr-save-btn:hover {
+  background: rgba(76, 175, 80, 0.1);
+}
+
+.pr-cancel-btn {
+  color: var(--color-text-soft, #888);
+}
+
+.pr-cancel-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.pr-clear-btn {
+  color: var(--color-error, #f44336);
+}
+
+.pr-clear-btn:hover {
+  background: rgba(244, 67, 54, 0.1);
+}
+
+.pr-edit-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  color: var(--color-text-soft, #888);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.pr-edit-trigger:hover {
+  color: var(--color-primary, #00bcd4);
+  background: rgba(0, 188, 212, 0.1);
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+@media (max-width: 480px) {
+  .pr-url-input {
+    min-width: 180px;
+    max-width: 100%;
+  }
+
+  .pr-edit-form {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/packages/web/src/components/SessionHeaderPanel.test.js
+++ b/packages/web/src/components/SessionHeaderPanel.test.js
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import SessionHeaderPanel from './SessionHeaderPanel.vue';
+
+vi.mock('./OverflowMenu.vue', () => ({
+  default: {
+    name: 'OverflowMenu',
+    template: '<div class="overflow-menu"><button @click="$emit(\'duplicate\')">Dup</button><button @click="$emit(\'archive\')">Arc</button><button @click="$emit(\'delete\')">Del</button><button @click="$emit(\'copySessionId\')">Copy</button></div>',
+    emits: ['duplicate', 'archive', 'delete', 'copySessionId'],
+    props: ['isArchived', 'isDeleting', 'copySessionIdText'],
+  }
+}));
+
+vi.mock('./PrUrlEditor.vue', () => ({
+  default: {
+    name: 'PrUrlEditor',
+    template: '<div class="pr-url-editor-stub"></div>',
+    props: ['sessionId', 'prUrl', 'summary'],
+  }
+}));
+
+vi.mock('./CommandButtonStatusBar.vue', () => ({
+  default: {
+    name: 'CommandButtonStatusBar',
+    template: '<div class="cmd-status-bar-stub"></div>',
+    props: ['buttonStatuses'],
+  }
+}));
+
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    updateSession: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+
+describe('SessionHeaderPanel', () => {
+  let pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+
+  function mountPanel(props = {}) {
+    return mount(SessionHeaderPanel, {
+      global: { plugins: [pinia] },
+      props: {
+        sessionId: 'session-1',
+        session: {
+          id: 'session-1',
+          name: 'Test Session',
+          status: 'waiting',
+          projectId: 'proj-1',
+          starred: false,
+          prUrl: null,
+          archived: false,
+        },
+        summary: null,
+        isDeleting: false,
+        buttonStatuses: [],
+        ...props,
+      },
+    });
+  }
+
+  describe('session name display', () => {
+    it('renders session name', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.session-name').text()).toBe('Test Session');
+    });
+
+    it('shows edit button when not editing', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.name-edit-trigger').exists()).toBe(true);
+    });
+
+    it('does not show edit form when not editing', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
+    });
+  });
+
+  describe('name editing', () => {
+    it('enters edit mode when clicking edit button', async () => {
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      expect(wrapper.find('.name-edit-form').exists()).toBe(true);
+      expect(wrapper.find('.name-edit-input').exists()).toBe(true);
+    });
+
+    it('populates input with current name', async () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'My Session', status: 'waiting' },
+      });
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      expect(wrapper.find('.name-edit-input').element.value).toBe('My Session');
+    });
+
+    it('saves name when clicking save button', async () => {
+      api.updateSession.mockResolvedValue({ name: 'New Name' });
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+
+      await wrapper.find('.name-edit-input').setValue('New Name');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
+        name: 'New Name',
+        manuallyNamed: true,
+      });
+    });
+
+    it('saves name when pressing Enter', async () => {
+      api.updateSession.mockResolvedValue({ name: 'New Name' });
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+
+      await wrapper.find('.name-edit-input').setValue('New Name');
+      await wrapper.find('.name-edit-input').trigger('keyup.enter');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalled();
+    });
+
+    it('cancels editing when pressing Escape', async () => {
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      expect(wrapper.find('.name-edit-form').exists()).toBe(true);
+
+      await wrapper.find('.name-edit-input').trigger('keyup.escape');
+      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
+    });
+
+    it('cancels editing when clicking cancel button', async () => {
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      expect(wrapper.find('.name-edit-form').exists()).toBe(true);
+
+      await wrapper.find('.pr-cancel-btn').trigger('click');
+      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
+    });
+
+    it('prevents saving empty names', async () => {
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+
+      await wrapper.find('.name-edit-input').setValue('   ');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).not.toHaveBeenCalled();
+    });
+
+    it('trims whitespace from name before saving', async () => {
+      api.updateSession.mockResolvedValue({ name: 'Trimmed Name' });
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+
+      await wrapper.find('.name-edit-input').setValue('  Trimmed Name  ');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
+        name: 'Trimmed Name',
+        manuallyNamed: true,
+      });
+    });
+
+    it('shows clear button when input has text', async () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'Existing Name', status: 'waiting' },
+      });
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      expect(wrapper.find('.pr-clear-btn').exists()).toBe(true);
+    });
+
+    it('hides clear button when input is empty', async () => {
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      await wrapper.find('.name-edit-input').setValue('');
+      expect(wrapper.find('.pr-clear-btn').exists()).toBe(false);
+    });
+
+    it('clears input when clicking clear button', async () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'Some Name', status: 'waiting' },
+      });
+      await wrapper.find('.name-edit-trigger').trigger('click');
+      expect(wrapper.find('.name-edit-input').element.value).toBe('Some Name');
+
+      await wrapper.find('.pr-clear-btn').trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('.name-edit-input').element.value).toBe('');
+    });
+
+    it('handles API errors when saving', async () => {
+      api.updateSession.mockRejectedValue(new Error('Server error'));
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+
+      await wrapper.find('.name-edit-input').setValue('New Name');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      // Form should still be visible after error
+      expect(wrapper.find('.name-edit-form').exists()).toBe(true);
+    });
+
+    it('closes form after successful save', async () => {
+      api.updateSession.mockResolvedValue({ name: 'New Name' });
+      const wrapper = mountPanel();
+      await wrapper.find('.name-edit-trigger').trigger('click');
+
+      await wrapper.find('.name-edit-input').setValue('New Name');
+      await wrapper.find('.pr-save-btn').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
+    });
+  });
+
+  describe('star button', () => {
+    it('renders unstarred state by default', () => {
+      const wrapper = mountPanel();
+      const starBtn = wrapper.find('.btn-star');
+      expect(starBtn.exists()).toBe(true);
+      expect(starBtn.classes()).not.toContain('is-starred');
+    });
+
+    it('renders starred state when session is starred', () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'Test', status: 'waiting', starred: true },
+      });
+      const starBtn = wrapper.find('.btn-star');
+      expect(starBtn.classes()).toContain('is-starred');
+    });
+
+    it('has correct title for unstarred session', () => {
+      const wrapper = mountPanel();
+      const starBtn = wrapper.find('.btn-star');
+      expect(starBtn.attributes('title')).toBe('Star session');
+    });
+
+    it('has correct title for starred session', () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'Test', status: 'waiting', starred: true },
+      });
+      const starBtn = wrapper.find('.btn-star');
+      expect(starBtn.attributes('title')).toBe('Unstar session');
+    });
+
+    it('star button is clickable and exists', async () => {
+      const wrapper = mountPanel();
+      const starBtn = wrapper.find('.btn-star');
+      expect(starBtn.exists()).toBe(true);
+      // Trigger click to verify no errors
+      await starBtn.trigger('click');
+      // The click event should be captured (the star emit is handled by Vue template binding)
+      expect(wrapper.emitted()).toHaveProperty('click');
+    });
+  });
+
+  describe('overflow menu', () => {
+    it('renders OverflowMenu component', () => {
+      const wrapper = mountPanel();
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      expect(menu.exists()).toBe(true);
+    });
+
+    it('passes archived state to OverflowMenu', () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'Test', status: 'waiting', archived: true },
+      });
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      expect(menu.props('isArchived')).toBe(true);
+    });
+
+    it('passes isDeleting state to OverflowMenu', () => {
+      const wrapper = mountPanel({ isDeleting: true });
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      expect(menu.props('isDeleting')).toBe(true);
+    });
+
+    it('OverflowMenu has event listeners for duplicate', () => {
+      const wrapper = mountPanel();
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      expect(menu.exists()).toBe(true);
+      // Verify the OverflowMenu mock is rendered with buttons
+      expect(menu.findAll('button').length).toBeGreaterThan(0);
+    });
+
+    it('OverflowMenu has event listeners for archive', () => {
+      const wrapper = mountPanel();
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      expect(menu.exists()).toBe(true);
+      // The archive button is rendered in the mock template
+      const arcBtn = menu.findAll('button').find(b => b.text() === 'Arc');
+      expect(arcBtn).toBeDefined();
+    });
+
+    it('OverflowMenu has event listeners for delete', () => {
+      const wrapper = mountPanel();
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      const delBtn = menu.findAll('button').find(b => b.text() === 'Del');
+      expect(delBtn).toBeDefined();
+    });
+
+    it('OverflowMenu has event listeners for copySessionId', () => {
+      const wrapper = mountPanel();
+      const menu = wrapper.findComponent({ name: 'OverflowMenu' });
+      const copyBtn = menu.findAll('button').find(b => b.text() === 'Copy');
+      expect(copyBtn).toBeDefined();
+    });
+  });
+
+  describe('PrUrlEditor integration', () => {
+    it('renders PrUrlEditor component', () => {
+      const wrapper = mountPanel();
+      const editor = wrapper.findComponent({ name: 'PrUrlEditor' });
+      expect(editor.exists()).toBe(true);
+    });
+
+    it('passes sessionId to PrUrlEditor', () => {
+      const wrapper = mountPanel();
+      const editor = wrapper.findComponent({ name: 'PrUrlEditor' });
+      expect(editor.props('sessionId')).toBe('session-1');
+    });
+
+    it('passes prUrl from session to PrUrlEditor', () => {
+      const wrapper = mountPanel({
+        session: { id: 'session-1', name: 'Test', status: 'waiting', prUrl: 'https://github.com/a/b/pull/1' },
+      });
+      const editor = wrapper.findComponent({ name: 'PrUrlEditor' });
+      expect(editor.props('prUrl')).toBe('https://github.com/a/b/pull/1');
+    });
+
+    it('passes summary to PrUrlEditor', () => {
+      const summary = { title: 'Test' };
+      const wrapper = mountPanel({ summary });
+      const editor = wrapper.findComponent({ name: 'PrUrlEditor' });
+      expect(editor.props('summary')).toEqual(summary);
+    });
+  });
+
+  describe('CommandButtonStatusBar integration', () => {
+    it('renders CommandButtonStatusBar', () => {
+      const wrapper = mountPanel();
+      const statusBar = wrapper.findComponent({ name: 'CommandButtonStatusBar' });
+      expect(statusBar.exists()).toBe(true);
+    });
+
+    it('passes buttonStatuses to CommandButtonStatusBar', () => {
+      const statuses = [
+        { buttonId: 'btn-1', label: 'Test', status: 'running' },
+      ];
+      const wrapper = mountPanel({ buttonStatuses: statuses });
+      const statusBar = wrapper.findComponent({ name: 'CommandButtonStatusBar' });
+      expect(statusBar.props('buttonStatuses')).toEqual(statuses);
+    });
+  });
+});

--- a/packages/web/src/components/SessionHeaderPanel.vue
+++ b/packages/web/src/components/SessionHeaderPanel.vue
@@ -1,0 +1,362 @@
+<template>
+  <div class="session-header">
+    <!-- Main header row with status, name, and menu -->
+    <div class="session-header-row">
+      <!-- Session name -->
+      <template v-if="isEditingName">
+        <div class="name-edit-form">
+          <input
+            ref="nameEditInput"
+            v-model="editNameValue"
+            type="text"
+            class="name-edit-input"
+            placeholder="Session name"
+            @keyup.enter="saveSessionName"
+            @keyup.escape="cancelEditName"
+          />
+          <button class="btn-icon pr-edit-btn pr-save-btn" title="Save" @click="saveSessionName">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12"></polyline>
+            </svg>
+          </button>
+          <button class="btn-icon pr-edit-btn pr-cancel-btn" title="Cancel" @click="cancelEditName">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+          <button v-if="editNameValue" class="btn-icon pr-edit-btn pr-clear-btn" title="Clear name" @click="clearSessionName">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6"></polyline>
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+            </svg>
+          </button>
+        </div>
+      </template>
+      <template v-else>
+        <div class="session-name-wrapper">
+          <h3 class="session-name">{{ session.name }}</h3>
+          <button class="btn-link name-edit-trigger" @click="startEditName" title="Edit session name">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+            </svg>
+          </button>
+        </div>
+      </template>
+
+      <!-- Overflow menu with secondary actions -->
+      <OverflowMenu
+        aria-label="Session actions"
+        :is-archived="session.archived"
+        :is-deleting="isDeleting"
+        copy-session-id-text="Copy ID"
+        @duplicate="emit('duplicate')"
+        @copySessionId="emit('copySessionId')"
+        @archive="emit('archive')"
+        @delete="emit('delete')"
+      />
+    </div>
+
+    <!-- PR indicators and command button status bar -->
+    <div class="branch-pr-indicators">
+      <div class="left-indicators">
+        <!-- Star button (icon only) -->
+        <button
+          class="btn-icon btn-star"
+          :title="session.starred ? 'Unstar session' : 'Star session'"
+          :class="{ 'is-starred': session.starred }"
+          @click="emit('star')"
+        >
+          <svg v-if="session.starred" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="12 2 15.09 10.26 24 10.5 17.18 16.34 19.34 24.5 12 18.92 4.66 24.5 6.82 16.34 0 10.5 8.91 10.26 12 2"></polygon>
+          </svg>
+          <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="12 2 15.09 10.26 24 10.5 17.18 16.34 19.34 24.5 12 18.92 4.66 24.5 6.82 16.34 0 10.5 8.91 10.26 12 2"></polygon>
+          </svg>
+        </button>
+        <PrUrlEditor
+          :session-id="sessionId"
+          :pr-url="session.prUrl"
+          :summary="summary"
+        />
+      </div>
+
+      <!-- Command button status indicators for real-time status updates -->
+      <CommandButtonStatusBar :button-statuses="buttonStatuses" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, nextTick } from 'vue';
+import OverflowMenu from './OverflowMenu.vue';
+import PrUrlEditor from './PrUrlEditor.vue';
+import CommandButtonStatusBar from './CommandButtonStatusBar.vue';
+import { useUiStore } from '../stores/ui.js';
+import { useSessionsStore } from '../stores/sessions.js';
+import { api } from '../composables/useApi.js';
+
+const props = defineProps({
+  /** The current session ID */
+  sessionId: {
+    type: String,
+    required: true,
+  },
+  /** The session object */
+  session: {
+    type: Object,
+    required: true,
+  },
+  /** Summary object for PrIndicators */
+  summary: {
+    type: Object,
+    default: null,
+  },
+  /** Whether the session is currently being deleted */
+  isDeleting: {
+    type: Boolean,
+    default: false,
+  },
+  /** Command button statuses to display */
+  buttonStatuses: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits(['duplicate', 'copySessionId', 'archive', 'delete', 'star']);
+
+const uiStore = useUiStore();
+const sessionsStore = useSessionsStore();
+
+// Name editing state
+const isEditingName = ref(false);
+const editNameValue = ref('');
+const nameEditInput = ref(null);
+
+function startEditName() {
+  editNameValue.value = props.session?.name || '';
+  isEditingName.value = true;
+}
+
+function cancelEditName() {
+  isEditingName.value = false;
+  editNameValue.value = '';
+}
+
+function clearSessionName() {
+  editNameValue.value = '';
+  nextTick(() => {
+    nameEditInput.value?.focus();
+  });
+}
+
+async function saveSessionName() {
+  const newName = editNameValue.value.trim();
+  const sessionId = props.sessionId;
+
+  if (!newName) {
+    uiStore.error('Session name cannot be empty');
+    return;
+  }
+
+  try {
+    const updated = await api.updateSession(sessionId, {
+      name: newName,
+      manuallyNamed: true
+    });
+    sessionsStore.updateSession({ ...updated, id: sessionId });
+    uiStore.success('Session name updated');
+    isEditingName.value = false;
+    editNameValue.value = '';
+  } catch (err) {
+    uiStore.error(err.message || 'Failed to update session name');
+  }
+}
+
+defineExpose({ isEditingName, editNameValue, startEditName, cancelEditName, clearSessionName, saveSessionName });
+</script>
+
+<style scoped>
+.session-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+  padding: 0 0.5rem;
+}
+
+.session-header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.session-name-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.btn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-soft, #888);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.btn-icon:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text, #ccc);
+}
+
+.btn-icon:active {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.btn-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.btn-star svg {
+  flex-shrink: 0;
+}
+
+.btn-star.is-starred {
+  color: var(--color-warning, #f0ad4e);
+}
+
+.session-name {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  overflow: hidden;
+  word-break: break-word;
+  line-height: 1.4;
+}
+
+.branch-pr-indicators {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.left-indicators {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 768px) {
+  .session-header-row {
+    align-items: flex-start;
+    min-height: auto;
+    padding-top: 0.25rem;
+  }
+
+  .session-name {
+    font-size: 1rem;
+  }
+}
+
+/* Name editing styles */
+.name-edit-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.name-edit-input {
+  background: var(--color-bg-input, #1e1e1e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 4px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-text, #e0e0e0);
+  min-width: 200px;
+  max-width: 400px;
+}
+
+.name-edit-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #00bcd4);
+}
+
+.name-edit-input::placeholder {
+  color: var(--color-text-soft, #888);
+}
+
+.pr-edit-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+}
+
+.pr-save-btn {
+  color: var(--color-success, #4caf50);
+}
+
+.pr-save-btn:hover {
+  background: rgba(76, 175, 80, 0.1);
+}
+
+.pr-cancel-btn {
+  color: var(--color-text-soft, #888);
+}
+
+.pr-cancel-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.pr-clear-btn {
+  color: var(--color-error, #f44336);
+}
+
+.pr-clear-btn:hover {
+  background: rgba(244, 67, 54, 0.1);
+}
+
+.name-edit-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  color: var(--color-text-soft, #888);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.name-edit-trigger:hover {
+  color: var(--color-primary, #00bcd4);
+  background: rgba(0, 188, 212, 0.1);
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+</style>

--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import SessionTabsPanel from './SessionTabsPanel.vue';
+
+describe('SessionTabsPanel', () => {
+  let router;
+
+  beforeEach(async () => {
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/sessions/:id/:tab?', component: { template: '<div />' } },
+        { path: '/projects/:id/sessions', component: { template: '<div />' } },
+      ],
+    });
+    await router.push('/sessions/session-1/conversation');
+    await router.isReady();
+  });
+
+  const defaultTabs = [
+    { id: 'summary', label: 'Summary' },
+    { id: 'conversation', label: 'Conversations' },
+    { id: 'changes', label: 'Changes' },
+    { id: 'canvas', label: 'Canvas' },
+    { id: 'commands', label: 'Commands' },
+  ];
+
+  function mountPanel(props = {}) {
+    return mount(SessionTabsPanel, {
+      global: { plugins: [router] },
+      props: {
+        sessionId: 'session-1',
+        projectId: 'proj-1',
+        activeTab: 'conversation',
+        tabs: defaultTabs,
+        hasChanges: false,
+        canvasCount: 0,
+        isSessionActive: false,
+        sessionStatus: '',
+        ...props,
+      },
+    });
+  }
+
+  describe('tab rendering', () => {
+    it('renders all tab labels', () => {
+      const wrapper = mountPanel();
+      const text = wrapper.text();
+      expect(text).toContain('Summary');
+      expect(text).toContain('Conversations');
+      expect(text).toContain('Changes');
+      expect(text).toContain('Canvas');
+      expect(text).toContain('Commands');
+    });
+
+    it('renders back link to sessions list', () => {
+      const wrapper = mountPanel();
+      const backLink = wrapper.find('.tab-back');
+      expect(backLink.exists()).toBe(true);
+      expect(backLink.attributes('href')).toBe('/projects/proj-1/sessions');
+    });
+
+    it('renders desktop tabs', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.tabs-desktop').exists()).toBe(true);
+    });
+
+    it('renders mobile dropdown', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.tabs-mobile').exists()).toBe(true);
+    });
+
+    it('renders mobile select with all options', () => {
+      const wrapper = mountPanel();
+      const options = wrapper.findAll('.tab-select option');
+      expect(options.length).toBe(5);
+    });
+  });
+
+  describe('changes indicator', () => {
+    it('shows changes indicator when hasChanges is true', () => {
+      const wrapper = mountPanel({ hasChanges: true });
+      expect(wrapper.find('.changes-indicator').exists()).toBe(true);
+    });
+
+    it('hides changes indicator when hasChanges is false', () => {
+      const wrapper = mountPanel({ hasChanges: false });
+      expect(wrapper.find('.changes-indicator').exists()).toBe(false);
+    });
+  });
+
+  describe('canvas indicator', () => {
+    it('shows canvas indicator when canvasCount > 0', () => {
+      const wrapper = mountPanel({ canvasCount: 3 });
+      expect(wrapper.find('.canvas-indicator').exists()).toBe(true);
+    });
+
+    it('hides canvas indicator when canvasCount is 0', () => {
+      const wrapper = mountPanel({ canvasCount: 0 });
+      expect(wrapper.find('.canvas-indicator').exists()).toBe(false);
+    });
+  });
+
+  describe('session active indicator', () => {
+    it('shows active spinner when isSessionActive is true', () => {
+      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'running' });
+      expect(wrapper.find('.session-active-indicator').exists()).toBe(true);
+      expect(wrapper.find('.active-spinner').exists()).toBe(true);
+    });
+
+    it('hides active spinner when isSessionActive is false', () => {
+      const wrapper = mountPanel({ isSessionActive: false, sessionStatus: 'completed' });
+      expect(wrapper.find('.session-active-indicator').exists()).toBe(false);
+    });
+
+    it('shows "Session running..." tooltip when status is running', () => {
+      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'running' });
+      const indicator = wrapper.find('.session-active-indicator');
+      expect(indicator.attributes('title')).toBe('Session running...');
+    });
+
+    it('shows "Session starting..." tooltip when status is starting', () => {
+      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'starting' });
+      const indicator = wrapper.find('.session-active-indicator');
+      expect(indicator.attributes('title')).toBe('Session starting...');
+    });
+  });
+
+  describe('mobile dropdown', () => {
+    it('shows dot indicator for changes in mobile', () => {
+      const wrapper = mountPanel({ hasChanges: true });
+      const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Changes'));
+      expect(option.text()).toContain('\u2022');
+    });
+
+    it('shows dot indicator for canvas items in mobile', () => {
+      const wrapper = mountPanel({ canvasCount: 2 });
+      const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Canvas'));
+      expect(option.text()).toContain('\u2022');
+    });
+
+    it('shows ellipsis for active session in mobile', () => {
+      const wrapper = mountPanel({ isSessionActive: true });
+      const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Conversations'));
+      expect(option.text()).toContain('...');
+    });
+
+    it('navigates when mobile select changes', async () => {
+      const pushSpy = vi.spyOn(router, 'push');
+      const wrapper = mountPanel();
+      const select = wrapper.find('.tab-select');
+      await select.setValue('canvas');
+      expect(pushSpy).toHaveBeenCalledWith('/sessions/session-1/canvas');
+    });
+  });
+
+  describe('active tab', () => {
+    it('marks active tab with active class', () => {
+      const wrapper = mountPanel({ activeTab: 'conversation' });
+      const desktopTabs = wrapper.findAll('.tabs-desktop .tab');
+      const activeTab = desktopTabs.find(t => t.classes().includes('active'));
+      expect(activeTab).toBeDefined();
+    });
+  });
+});

--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -1,0 +1,148 @@
+<template>
+  <div class="tabs">
+    <router-link
+      :to="`/projects/${projectId}/sessions`"
+      class="tab tab-back"
+    >
+      &larr; Sessions
+    </router-link>
+    <span class="tab-separator"></span>
+
+    <!-- Desktop tabs -->
+    <div class="tabs-desktop">
+      <router-link
+        v-for="tab in tabs"
+        :key="tab.id"
+        :to="`/sessions/${sessionId}/${tab.id}`"
+        :class="['tab', { active: activeTab === tab.id }]"
+      >
+        {{ tab.label }}
+        <span
+          v-if="tab.id === 'changes' && hasChanges"
+          class="changes-indicator"
+          title="Uncommitted changes"
+        ></span>
+        <span
+          v-if="tab.id === 'canvas' && canvasCount > 0"
+          class="canvas-indicator"
+          title="Canvas contains files"
+        ></span>
+        <span
+          v-if="tab.id === 'conversation' && isSessionActive"
+          class="session-active-indicator"
+          :title="sessionStatus === 'starting'
+            ? 'Session starting...' : 'Session running...'"
+        >
+          <span class="active-spinner"></span>
+        </span>
+      </router-link>
+    </div>
+
+    <!-- Mobile dropdown -->
+    <div class="tabs-mobile">
+      <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
+        <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
+          {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' \u2022' : '' }}{{ tab.id === 'canvas' && canvasCount > 0 ? ' \u2022' : '' }}{{ tab.id === 'conversation' && isSessionActive ? ' ...' : '' }}
+        </option>
+      </select>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+
+const props = defineProps({
+  /** The session ID for building tab URLs */
+  sessionId: {
+    type: String,
+    required: true,
+  },
+  /** The project ID for building the back link */
+  projectId: {
+    type: String,
+    default: '',
+  },
+  /** The currently active tab ID */
+  activeTab: {
+    type: String,
+    default: 'conversation',
+  },
+  /** Tab definitions: array of { id, label } */
+  tabs: {
+    type: Array,
+    required: true,
+  },
+  /** Whether there are uncommitted changes */
+  hasChanges: {
+    type: Boolean,
+    default: false,
+  },
+  /** Number of canvas items */
+  canvasCount: {
+    type: Number,
+    default: 0,
+  },
+  /** Whether the session is actively running/starting */
+  isSessionActive: {
+    type: Boolean,
+    default: false,
+  },
+  /** The session status string (for tooltip text) */
+  sessionStatus: {
+    type: String,
+    default: '',
+  },
+});
+
+const router = useRouter();
+
+function navigateToTab(tabId) {
+  router.push(`/sessions/${props.sessionId}/${tabId}`);
+}
+</script>
+
+<style scoped>
+.changes-indicator {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-warning, #d29922);
+  border-radius: 50%;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.canvas-indicator {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-warning, #d29922);
+  border-radius: 50%;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.session-active-indicator {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.5rem;
+}
+
+.active-spinner {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid rgba(0, 188, 212, 0.2);
+  border-top-color: #00bcd4;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/packages/web/src/composables/useSessionInitializer.js
+++ b/packages/web/src/composables/useSessionInitializer.js
@@ -1,0 +1,326 @@
+import { ref } from 'vue';
+import { useSessionSubscription, ensureSubscribed, useWebSocket } from './useWebSocket.js';
+import { useSessionsStore } from '../stores/sessions.js';
+import { useCanvasStore } from '../stores/canvas.js';
+import { useTodosStore } from '../stores/todos.js';
+import { useUiStore } from '../stores/ui.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
+import { useTemplatesStore } from '../stores/templates.js';
+import { api } from './useApi.js';
+
+/**
+ * Composable for initializing and managing WebSocket subscriptions and data
+ * fetching for a session. Encapsulates all 21 WebSocket handler registrations,
+ * subscription lifecycle, data fetching, and cleanup.
+ *
+ * @param {Object} options
+ * @param {import('vue').Ref<Object>} options.summary - Ref for the session summary
+ * @param {import('vue').Ref<boolean>} options.hasChanges - Ref for change indicator
+ * @param {import('vue').Ref<number>} options.changesFileCount - Ref for file change count
+ * @param {Function} options.checkForChanges - Function to check for file changes
+ * @param {Function} options.startPolling - Function to start status polling
+ * @param {Function} options.stopPolling - Function to stop status polling
+ * @param {Function} options.resetPolling - Function to reset polling state
+ * @returns {Object} Session initializer utilities
+ */
+export function useSessionInitializer({
+  summary,
+  hasChanges,
+  changesFileCount,
+  checkForChanges,
+  startPolling,
+  stopPolling,
+  resetPolling,
+}) {
+  const sessionsStore = useSessionsStore();
+  const canvasStore = useCanvasStore();
+  const todosStore = useTodosStore();
+  const uiStore = useUiStore();
+  const commandButtonsStore = useCommandButtonsStore();
+  const templatesStore = useTemplatesStore();
+
+  // Track current subscription instance - recreated on session change
+  let currentSubscription = null;
+  let cleanups = [];
+
+  /**
+   * Cleanup function - called on unmount AND on route change (session navigation).
+   * Ensures WebSocket subscriptions don't leak between sessions.
+   */
+  function cleanup() {
+    // Reset polling state via composable
+    resetPolling();
+    if (currentSubscription) {
+      currentSubscription.unsubscribe();
+      currentSubscription = null;
+    }
+    cleanups.forEach((c) => c());
+    cleanups = [];
+    sessionsStore.clearRunningUsage();
+    // Clear all session-specific store state to prevent stale data during transitions
+    sessionsStore.messages = [];
+    sessionsStore.conversations = [];
+    sessionsStore.workLogs = {};
+    sessionsStore.clearPartialText();
+    todosStore.clearTodos();
+    canvasStore.items = [];
+    // Reset local state
+    summary.value = null;
+    canvasStore.$reset();
+  }
+
+  /**
+   * Initialize session - called on mount AND on route change (session navigation).
+   * Sets up WebSocket subscription and handlers for the given session.
+   *
+   * @param {string} sessionId - The session ID to initialize
+   */
+  async function initializeSession(sessionId) {
+    // STEP 1: Create new subscription for this session
+    currentSubscription = useSessionSubscription(sessionId);
+    const {
+      subscribe, unsubscribe,
+      onStatus, onMessage, onPartial, onError,
+      onCanvasAdd, onCanvasRemove,
+      onTodosUpdate, onSessionUpdate, onSummaryUpdate,
+      onConversationCreated, onConversationUpdated, onConversationDeleted,
+      onUsageUpdate, onChangesUpdate,
+      onWorkLog, onWorkLogsAssociated,
+      onThinkingPartial,
+      onCommandOutput, onCommandComplete, onCommandError,
+    } = currentSubscription;
+
+    // STEP 2: Subscribe via the subscription object AND await connection
+    subscribe();
+    try {
+      await ensureSubscribed(sessionId);
+    } catch (error) {
+      console.error('Failed to subscribe to session updates:', error);
+      uiStore.error('Failed to subscribe to session updates');
+    }
+
+    // STEP 3: Fetch critical data BEFORE registering handlers
+    await sessionsStore.fetchSession(sessionId);
+    await sessionsStore.fetchConversations(sessionId);
+
+    // Fetch command buttons for the project
+    const projectId = sessionsStore.currentSession?.projectId;
+    if (projectId) {
+      try {
+        await commandButtonsStore.fetchButtons(projectId);
+      } catch (error) {
+        console.debug('Failed to fetch command buttons:', error);
+      }
+    }
+
+    // STEP 4: Register all handlers
+    cleanups.push(
+      onStatus((status) => {
+        sessionsStore.updateSessionStatus(sessionId, status);
+        if (status === 'running' || status === 'starting') {
+          startPolling();
+        } else {
+          stopPolling();
+          if (status === 'waiting' || status === 'completed') {
+            checkForChanges();
+          }
+        }
+      })
+    );
+
+    cleanups.push(
+      onMessage((message) => {
+        sessionsStore.addMessage(message);
+        sessionsStore.clearPartialText();
+      })
+    );
+
+    cleanups.push(
+      onPartial((text) => {
+        sessionsStore.setPartialText(text);
+      })
+    );
+
+    cleanups.push(
+      onWorkLog((log) => {
+        sessionsStore.addWorkLog(log);
+      })
+    );
+
+    cleanups.push(
+      onWorkLogsAssociated((messageId) => {
+        sessionsStore.associateWorkLogs(messageId);
+      })
+    );
+
+    cleanups.push(
+      onThinkingPartial((thinking) => {
+        if (thinking === null) {
+          sessionsStore.clearPartialThinking(sessionId);
+        } else {
+          sessionsStore.setPartialThinking(thinking, sessionId);
+        }
+      })
+    );
+
+    cleanups.push(
+      onConversationCreated((conversation) => {
+        sessionsStore.addConversation(conversation);
+      })
+    );
+
+    cleanups.push(
+      onError((error) => {
+        uiStore.error(error);
+      })
+    );
+
+    cleanups.push(
+      onCanvasAdd((item) => {
+        canvasStore.addItem(item);
+      })
+    );
+
+    cleanups.push(
+      onCanvasRemove((itemId) => {
+        canvasStore.removeItem(itemId);
+      })
+    );
+
+    cleanups.push(
+      onTodosUpdate((todos, conversationId) => {
+        todosStore.updateTodos(todos, conversationId);
+      })
+    );
+
+    cleanups.push(
+      onSessionUpdate((session) => {
+        sessionsStore.updateSession(session);
+      })
+    );
+
+    cleanups.push(
+      onSummaryUpdate((newSummary) => {
+        summary.value = newSummary;
+      })
+    );
+
+    cleanups.push(
+      onConversationUpdated((conversation) => {
+        sessionsStore.updateConversation(conversation);
+      })
+    );
+
+    cleanups.push(
+      onConversationDeleted((conversationId, newActiveConv) => {
+        sessionsStore.removeConversation(conversationId, newActiveConv, sessionId);
+        if (newActiveConv) {
+          sessionsStore.fetchMessages(sessionId, false);
+        }
+      })
+    );
+
+    cleanups.push(
+      onUsageUpdate((msg) => {
+        if (msg.isFinal) {
+          sessionsStore.finalizeUsage(msg.usage, msg.conversationId);
+        } else {
+          sessionsStore.updateRunningUsage(msg.usage, msg.conversationId);
+        }
+      })
+    );
+
+    cleanups.push(
+      onChangesUpdate((changeCount, hasChangesUpdate) => {
+        changesFileCount.value = changeCount;
+        if (typeof hasChangesUpdate === 'boolean') {
+          hasChanges.value = hasChangesUpdate;
+        } else {
+          hasChanges.value = changeCount > 0;
+        }
+      })
+    );
+
+    cleanups.push(
+      onCommandOutput((runId, buttonId, output) => {
+        const existingRun = commandButtonsStore.runs[runId];
+        const existingSessionRun = sessionsStore.currentSession?.latestCommandRuns?.find(r => r.runId === runId);
+        sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
+          buttonId,
+          status: 'running',
+          runId,
+          startedAt: existingRun?.startedAt || existingSessionRun?.startedAt || Date.now(),
+        });
+      })
+    );
+
+    cleanups.push(
+      onCommandComplete((runId, buttonId, exitCode, output) => {
+        const status = exitCode === 0 ? 'success' : 'error';
+        sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
+          buttonId,
+          status,
+          exitCode,
+          runId,
+          completedAt: Date.now(),
+        });
+      })
+    );
+
+    cleanups.push(
+      onCommandError((runId, buttonId, error) => {
+        sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
+          buttonId,
+          status: 'error',
+          runId,
+          completedAt: Date.now(),
+        });
+      })
+    );
+
+    // STEP 5: Fetch remaining data
+    await sessionsStore.fetchMessages(sessionId);
+    await sessionsStore.fetchWorkLogs(sessionId);
+    await canvasStore.fetchItems(sessionId);
+    todosStore.fetchTodos(sessionId, sessionsStore.activeConversationId);
+
+    // Fetch summary for PR indicators (don't await, not critical)
+    api.getSessionSummary(sessionId).then((s) => {
+      summary.value = s;
+    }).catch(() => {
+      // Ignore errors - summary may not exist yet
+    });
+
+    // Check for file system changes initially
+    checkForChanges();
+
+    // Re-fetch all critical data when WebSocket reconnects (e.g., after wake-from-sleep)
+    const { onReconnect } = useWebSocket();
+    cleanups.push(
+      onReconnect(async () => {
+        await sessionsStore.fetchSession(sessionId);
+        await sessionsStore.fetchConversations(sessionId);
+        await sessionsStore.fetchMessages(sessionId, false, sessionsStore.activeConversationId);
+        await sessionsStore.fetchWorkLogs(sessionId);
+        await canvasStore.fetchItems(sessionId);
+        checkForChanges();
+      })
+    );
+
+    // Fetch templates for the selector
+    if (sessionsStore.currentSession?.projectId) {
+      templatesStore.fetchProjectTemplates(sessionsStore.currentSession.projectId);
+    }
+
+    // STEP 6: Start polling if session is actively processing
+    const status = sessionsStore.currentSession?.status;
+    if (status === 'running' || status === 'starting') {
+      startPolling();
+    }
+  }
+
+  return {
+    cleanup,
+    initializeSession,
+  };
+}

--- a/packages/web/src/composables/useSessionInitializer.test.js
+++ b/packages/web/src/composables/useSessionInitializer.test.js
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { useSessionInitializer } from './useSessionInitializer.js';
+import { useSessionsStore } from '../stores/sessions.js';
+import { useCanvasStore } from '../stores/canvas.js';
+import { useTodosStore } from '../stores/todos.js';
+import { useUiStore } from '../stores/ui.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
+import { useTemplatesStore } from '../stores/templates.js';
+
+// Mock useApi
+vi.mock('./useApi.js', () => ({
+  api: {
+    getSessionSummary: vi.fn().mockResolvedValue(null),
+    getSessionChanges: vi.fn().mockResolvedValue({ staged: '', unstaged: '', untracked: '' }),
+  },
+}));
+
+// Mock useWebSocket
+const mockHandlerFactory = () => vi.fn(() => () => {});
+let mockSubscription;
+
+vi.mock('./useWebSocket.js', () => {
+  return {
+    ensureSubscribed: vi.fn(() => Promise.resolve()),
+    useWebSocket: vi.fn(() => ({
+      isConnected: { value: true },
+      onReconnect: vi.fn(() => () => {}),
+    })),
+    useSessionSubscription: vi.fn((sessionId) => {
+      mockSubscription = {
+        sessionId,
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        onStatus: mockHandlerFactory(),
+        onMessage: mockHandlerFactory(),
+        onPartial: mockHandlerFactory(),
+        onError: mockHandlerFactory(),
+        onCanvasAdd: mockHandlerFactory(),
+        onCanvasRemove: mockHandlerFactory(),
+        onTodosUpdate: mockHandlerFactory(),
+        onSessionUpdate: mockHandlerFactory(),
+        onSummaryUpdate: mockHandlerFactory(),
+        onConversationCreated: mockHandlerFactory(),
+        onConversationUpdated: mockHandlerFactory(),
+        onConversationDeleted: mockHandlerFactory(),
+        onUsageUpdate: mockHandlerFactory(),
+        onChangesUpdate: mockHandlerFactory(),
+        onWorkLog: mockHandlerFactory(),
+        onWorkLogsAssociated: mockHandlerFactory(),
+        onThinkingPartial: mockHandlerFactory(),
+        onCommandOutput: mockHandlerFactory(),
+        onCommandComplete: mockHandlerFactory(),
+        onCommandError: mockHandlerFactory(),
+      };
+      return mockSubscription;
+    }),
+  };
+});
+
+import { useSessionSubscription, ensureSubscribed } from './useWebSocket.js';
+
+describe('useSessionInitializer', () => {
+  let pinia;
+  let sessionsStore;
+  let canvasStore;
+  let todosStore;
+  let summary;
+  let hasChanges;
+  let changesFileCount;
+  let checkForChanges;
+  let startPolling;
+  let stopPolling;
+  let resetPolling;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+
+    sessionsStore = useSessionsStore();
+    canvasStore = useCanvasStore();
+    todosStore = useTodosStore();
+
+    // Mock store methods
+    vi.spyOn(sessionsStore, 'fetchSession').mockResolvedValue(undefined);
+    vi.spyOn(sessionsStore, 'fetchMessages').mockResolvedValue(undefined);
+    vi.spyOn(sessionsStore, 'fetchConversations').mockResolvedValue(undefined);
+    vi.spyOn(sessionsStore, 'fetchWorkLogs').mockResolvedValue(undefined);
+    vi.spyOn(canvasStore, 'fetchItems').mockResolvedValue(undefined);
+    vi.spyOn(todosStore, 'fetchTodos').mockResolvedValue(undefined);
+
+    // Reactive state for the composable
+    summary = ref(null);
+    hasChanges = ref(false);
+    changesFileCount = ref(0);
+    checkForChanges = vi.fn();
+    startPolling = vi.fn();
+    stopPolling = vi.fn();
+    resetPolling = vi.fn();
+
+    vi.clearAllMocks();
+  });
+
+  function createInitializer() {
+    return useSessionInitializer({
+      summary,
+      hasChanges,
+      changesFileCount,
+      checkForChanges,
+      startPolling,
+      stopPolling,
+      resetPolling,
+    });
+  }
+
+  describe('initializeSession', () => {
+    it('creates a WebSocket subscription for the session', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+
+      expect(useSessionSubscription).toHaveBeenCalledWith('session-1');
+      expect(mockSubscription.subscribe).toHaveBeenCalled();
+      expect(ensureSubscribed).toHaveBeenCalledWith('session-1');
+    });
+
+    it('fetches session, conversations, messages, work logs, and canvas items', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+
+      expect(sessionsStore.fetchSession).toHaveBeenCalledWith('session-1');
+      expect(sessionsStore.fetchConversations).toHaveBeenCalledWith('session-1');
+      expect(sessionsStore.fetchMessages).toHaveBeenCalledWith('session-1');
+      expect(sessionsStore.fetchWorkLogs).toHaveBeenCalledWith('session-1');
+      expect(canvasStore.fetchItems).toHaveBeenCalledWith('session-1');
+    });
+
+    it('fetches todos', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+
+      expect(todosStore.fetchTodos).toHaveBeenCalled();
+    });
+
+    it('checks for file changes', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+
+      expect(checkForChanges).toHaveBeenCalled();
+    });
+
+    it('starts polling when session is running', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'running' };
+
+      await initializeSession('session-1');
+
+      expect(startPolling).toHaveBeenCalled();
+    });
+
+    it('starts polling when session is starting', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'starting' };
+
+      await initializeSession('session-1');
+
+      expect(startPolling).toHaveBeenCalled();
+    });
+
+    it('does not start polling when session is waiting', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+
+      expect(startPolling).not.toHaveBeenCalled();
+    });
+
+    it('does not start polling when session is completed', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'completed' };
+
+      await initializeSession('session-1');
+
+      expect(startPolling).not.toHaveBeenCalled();
+    });
+
+    it('registers all 21 WebSocket handlers', async () => {
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+
+      // Verify all 21 handler registration functions were called
+      expect(mockSubscription.onStatus).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onMessage).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onPartial).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onError).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onCanvasAdd).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onCanvasRemove).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onTodosUpdate).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onSessionUpdate).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onSummaryUpdate).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onConversationCreated).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onConversationUpdated).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onConversationDeleted).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onUsageUpdate).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onChangesUpdate).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onWorkLog).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onWorkLogsAssociated).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onThinkingPartial).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onCommandOutput).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onCommandComplete).toHaveBeenCalledTimes(1);
+      expect(mockSubscription.onCommandError).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches command buttons when session has projectId', async () => {
+      const commandButtonsStore = useCommandButtonsStore();
+      vi.spyOn(commandButtonsStore, 'fetchButtons').mockResolvedValue(undefined);
+
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting', projectId: 'proj-1' };
+
+      await initializeSession('session-1');
+
+      expect(commandButtonsStore.fetchButtons).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('fetches templates when session has projectId', async () => {
+      const templatesStore = useTemplatesStore();
+      vi.spyOn(templatesStore, 'fetchProjectTemplates').mockResolvedValue(undefined);
+
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting', projectId: 'proj-1' };
+
+      await initializeSession('session-1');
+
+      expect(templatesStore.fetchProjectTemplates).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('handles ensureSubscribed failure gracefully', async () => {
+      ensureSubscribed.mockRejectedValueOnce(new Error('Connection failed'));
+
+      const { initializeSession } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      // Should not throw
+      await initializeSession('session-1');
+
+      // Should still fetch data
+      expect(sessionsStore.fetchSession).toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('unsubscribes from WebSocket', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+      cleanup();
+
+      expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('resets polling', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+      cleanup();
+
+      expect(resetPolling).toHaveBeenCalled();
+    });
+
+    it('clears store state', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      // Pre-populate store state
+      sessionsStore.messages = [{ id: 'msg-1' }];
+      sessionsStore.conversations = [{ id: 'conv-1' }];
+      sessionsStore.workLogs = { 'log-1': {} };
+
+      await initializeSession('session-1');
+      cleanup();
+
+      expect(sessionsStore.messages).toEqual([]);
+      expect(sessionsStore.conversations).toEqual([]);
+      expect(sessionsStore.workLogs).toEqual({});
+    });
+
+    it('clears canvas items', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      canvasStore.items = [{ id: 'item-1' }];
+
+      await initializeSession('session-1');
+      cleanup();
+
+      expect(canvasStore.items).toEqual([]);
+    });
+
+    it('clears todos', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      await initializeSession('session-1');
+      cleanup();
+
+      // todosStore.clearTodos should have been called
+      // We can verify the items are empty
+      expect(todosStore.items).toEqual([]);
+    });
+
+    it('clears summary', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+
+      summary.value = { title: 'test' };
+
+      await initializeSession('session-1');
+      cleanup();
+
+      expect(summary.value).toBeNull();
+    });
+
+    it('can be called before initializeSession without error', () => {
+      const { cleanup } = createInitializer();
+      expect(() => cleanup()).not.toThrow();
+    });
+  });
+
+  describe('re-initialization', () => {
+    it('cleans up old session before initializing new one', async () => {
+      const { initializeSession, cleanup } = createInitializer();
+
+      // Initialize first session
+      sessionsStore.currentSession = { id: 'session-1', status: 'waiting' };
+      await initializeSession('session-1');
+
+      const firstSubscription = mockSubscription;
+
+      // Cleanup and initialize second session
+      cleanup();
+      sessionsStore.currentSession = { id: 'session-2', status: 'running' };
+      await initializeSession('session-2');
+
+      // First subscription should have been unsubscribed
+      expect(firstSubscription.unsubscribe).toHaveBeenCalled();
+      // Second subscription should be created
+      expect(useSessionSubscription).toHaveBeenCalledWith('session-2');
+    });
+  });
+});

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -38,12 +38,28 @@ vi.mock('../components/OverflowMenu.vue', () => ({
 vi.mock('../components/SchedulingInfo.vue', () => ({
   default: { name: 'SchedulingInfo', template: '<div class="scheduling-info">Scheduling Info</div>' }
 }));
+vi.mock('../components/SessionHeaderPanel.vue', () => ({
+  default: {
+    name: 'SessionHeaderPanel',
+    template: '<div class="session-header"><div class="session-header-row"><div class="session-name-wrapper"><h3 class="session-name">{{ session?.name }}</h3></div></div></div>',
+    props: ['sessionId', 'session', 'summary', 'isDeleting', 'buttonStatuses'],
+    emits: ['duplicate', 'copySessionId', 'archive', 'delete', 'star'],
+  }
+}));
+vi.mock('../components/SessionTabsPanel.vue', () => ({
+  default: {
+    name: 'SessionTabsPanel',
+    template: '<div class="tabs"><span v-for="tab in tabs" :key="tab.id">{{ tab.label }}</span></div>',
+    props: ['sessionId', 'projectId', 'activeTab', 'tabs', 'hasChanges', 'canvasCount', 'isSessionActive', 'sessionStatus'],
+  }
+}));
 vi.mock('../composables/useApi.js', () => ({
   api: {
     getSessionSummary: vi.fn().mockResolvedValue(null),
     updateSession: vi.fn(),
     getSession: vi.fn(),
     getConversations: vi.fn(),
+    getSessionChanges: vi.fn().mockResolvedValue({ staged: '', unstaged: '', untracked: '' }),
   },
 }));
 
@@ -676,7 +692,7 @@ describe('SessionDetailView', () => {
   });
 
   describe('Session header integration', () => {
-    it('renders OverflowMenu component with duplicate functionality', async () => {
+    it('renders SessionHeaderPanel with session data', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -699,17 +715,18 @@ describe('SessionDetailView', () => {
             NotesTab: true,
             PrIndicators: true,
             SchedulingInfo: true,
-            OverflowMenu: false, // Don't stub - test the real component
           },
         },
       });
 
       await flushPromises();
 
-      expect(wrapper.findComponent({ name: 'OverflowMenu' }).exists()).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('sessionId')).toBe('session-1');
     });
 
-    it('header contains star button and session name', async () => {
+    it('header contains session name via SessionHeaderPanel', async () => {
       const sessionName = 'Test Session';
       sessionsStore.currentSession = {
         id: 'session-1',
@@ -739,11 +756,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Check that the session header row exists (contains star, name, and menu)
-      const headerRow = wrapper.find('.session-header-row');
-      expect(headerRow.exists()).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe(sessionName);
 
-      // Verify session name is displayed
+      // The mock template still renders the name
       expect(wrapper.text()).toContain(sessionName);
     });
   });
@@ -1496,7 +1513,7 @@ describe('SessionDetailView', () => {
   });
 
   describe('command button status indicators', () => {
-    it('displays command button status indicators when latestCommandRuns exists', async () => {
+    it('passes command button statuses to SessionHeaderPanel', async () => {
       const { useCommandButtonsStore } = await import('../stores/commandButtons.js');
       const commandButtonsStore = useCommandButtonsStore();
 
@@ -1536,23 +1553,20 @@ describe('SessionDetailView', () => {
             CommandsTab: true,
             PrIndicators: true,
             SchedulingInfo: true,
-            CommandButtonStatusBar: false, // Don't stub - we want to test the real component
           },
         },
       });
 
       await flushPromises();
 
-      // Check if CommandButtonStatusBar is rendered
-      const statusBar = wrapper.findComponent({ name: 'CommandButtonStatusBar' });
-      expect(statusBar.exists()).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
 
-      // Should show 2 indicators (btn-1 and btn-2) because btn-3 has showOnList: false
-      const indicators = statusBar.findAll('.button-status-indicator');
-      expect(indicators.length).toBe(2);
+      // Should have 2 statuses (btn-1 and btn-2) because btn-3 has showOnList: false
+      expect(headerPanel.props('buttonStatuses').length).toBe(2);
     });
 
-    it('hides command button status indicators when latestCommandRuns is empty', async () => {
+    it('passes empty button statuses when no command runs exist', async () => {
       const { useCommandButtonsStore } = await import('../stores/commandButtons.js');
       const commandButtonsStore = useCommandButtonsStore();
 
@@ -1581,20 +1595,17 @@ describe('SessionDetailView', () => {
             CommandsTab: true,
             PrIndicators: true,
             SchedulingInfo: true,
-            CommandButtonStatusBar: false,
           },
         },
       });
 
       await flushPromises();
 
-      // CommandButtonStatusBar should exist but not render anything
-      const statusBar = wrapper.findComponent({ name: 'CommandButtonStatusBar' });
-      expect(statusBar.exists()).toBe(true);
-      expect(statusBar.find('.command-status-bar').exists()).toBe(false);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('buttonStatuses').length).toBe(0);
     });
 
-    it('updates indicators in real-time when command status changes', async () => {
+    it('updates buttonStatuses prop when command status changes', async () => {
       const { useCommandButtonsStore } = await import('../stores/commandButtons.js');
       const commandButtonsStore = useCommandButtonsStore();
 
@@ -1628,7 +1639,6 @@ describe('SessionDetailView', () => {
             CommandsTab: true,
             PrIndicators: true,
             SchedulingInfo: true,
-            CommandButtonStatusBar: false,
           },
         },
       });
@@ -1636,10 +1646,8 @@ describe('SessionDetailView', () => {
       await flushPromises();
 
       // Verify initial state
-      let statusBar = wrapper.findComponent({ name: 'CommandButtonStatusBar' });
-      let indicator = statusBar.find('.button-status-running');
-      expect(indicator.exists()).toBe(true);
-      expect(indicator.text()).toBe('⊙');
+      let headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('buttonStatuses')[0].status).toBe('running');
 
       // Simulate command completion via store update
       sessionsStore.updateSessionCommandRun('session-1', 'btn-1', {
@@ -1651,16 +1659,13 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Check that indicator updated to success
-      statusBar = wrapper.findComponent({ name: 'CommandButtonStatusBar' });
-      indicator = statusBar.find('.button-status-success');
-      expect(indicator.exists()).toBe(true);
-      expect(indicator.text()).toBe('✓');
+      headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('buttonStatuses')[0].status).toBe('success');
     });
   });
 
   describe('PR URL editing', () => {
-    it('shows "Link PR" button when no prUrl is set', async () => {
+    it('passes session with null prUrl to SessionHeaderPanel', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1689,12 +1694,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const editTrigger = wrapper.find('.pr-edit-trigger');
-      expect(editTrigger.exists()).toBe(true);
-      expect(editTrigger.text()).toContain('Link PR');
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').prUrl).toBeNull();
     });
 
-    it('shows edit button (without "Link PR" text) when prUrl is set', async () => {
+    it('passes session with prUrl to SessionHeaderPanel', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1715,21 +1720,20 @@ describe('SessionDetailView', () => {
             CanvasTab: true,
             SummaryTab: true,
             CommandsTab: true,
-            PrIndicators: false,
-            SchedulingInfo: true, // Don't stub - we want to see it rendered
+            PrIndicators: true,
+            SchedulingInfo: true,
           },
         },
       });
 
       await flushPromises();
 
-      const editTrigger = wrapper.find('.pr-edit-trigger');
-      expect(editTrigger.exists()).toBe(true);
-      // When prUrl is set, the button should NOT show "Link PR" text
-      expect(editTrigger.text()).not.toContain('Link PR');
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').prUrl).toBe('https://github.com/owner/repo/pull/123');
     });
 
-    it('enters edit mode when edit trigger is clicked', async () => {
+    it('SessionHeaderPanel receives sessionId prop for PR editing', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1758,19 +1762,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Initially no edit form
-      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
-
-      // Click the edit trigger
-      const editTrigger = wrapper.find('.pr-edit-trigger');
-      await editTrigger.trigger('click');
-
-      // Now edit form should be visible
-      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
-      expect(wrapper.find('.pr-url-input').exists()).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('sessionId')).toBe('session-1');
     });
 
-    it('populates input with existing prUrl when editing', async () => {
+    it('SessionHeaderPanel receives session prop with prUrl for editing', async () => {
       const existingPrUrl = 'https://github.com/owner/repo/pull/123';
       sessionsStore.currentSession = {
         id: 'session-1',
@@ -1800,15 +1796,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Click the edit trigger
-      await wrapper.find('.pr-edit-trigger').trigger('click');
-
-      // Input should be populated with existing URL
-      const input = wrapper.find('.pr-url-input');
-      expect(input.element.value).toBe(existingPrUrl);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('session').prUrl).toBe(existingPrUrl);
     });
 
-    it('cancels editing when cancel button is clicked', async () => {
+    it('SessionHeaderPanel receives session for cancel behavior', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1837,20 +1829,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.pr-edit-trigger').trigger('click');
-      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
-
-      // Click cancel button
-      const cancelBtn = wrapper.find('.pr-cancel-btn');
-      await cancelBtn.trigger('click');
-
-      // Edit form should be hidden
-      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
-      expect(wrapper.find('.pr-edit-trigger').exists()).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session')).toBeDefined();
     });
 
-    it('cancels editing when Escape key is pressed', async () => {
+    it('SessionHeaderPanel receives session for escape behavior', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1879,19 +1863,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.pr-edit-trigger').trigger('click');
-      expect(wrapper.find('.pr-edit-form').exists()).toBe(true);
-
-      // Press Escape in input
-      const input = wrapper.find('.pr-url-input');
-      await input.trigger('keyup.escape');
-
-      // Edit form should be hidden
-      expect(wrapper.find('.pr-edit-form').exists()).toBe(false);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('sessionId')).toBe('session-1');
     });
 
-    it('shows clear button only when input has value', async () => {
+    it('SessionHeaderPanel receives session with prUrl for clear button behavior', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1920,18 +1897,8 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.pr-edit-trigger').trigger('click');
-
-      // Clear button should exist because input has value
-      expect(wrapper.find('.pr-clear-btn').exists()).toBe(true);
-
-      // Clear the input value
-      const input = wrapper.find('.pr-url-input');
-      await input.setValue('');
-
-      // Clear button should not exist when input is empty
-      expect(wrapper.find('.pr-clear-btn').exists()).toBe(false);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('session').prUrl).toBe('https://github.com/owner/repo/pull/123');
     });
 
     it('renders branch-pr-indicators section always', async () => {
@@ -1963,12 +1930,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // The branch-pr-indicators div should always be rendered
-      const prIndicatorsSection = wrapper.find('.branch-pr-indicators');
-      expect(prIndicatorsSection.exists()).toBe(true);
+      // SessionHeaderPanel is rendered (which contains branch-pr-indicators)
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
     });
 
-    it('renders PrIndicators component when prUrl is set', async () => {
+    it('passes session with prUrl to SessionHeaderPanel for PrIndicators rendering', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -1989,54 +1956,21 @@ describe('SessionDetailView', () => {
             CanvasTab: true,
             SummaryTab: true,
             CommandsTab: true,
-            PrIndicators: false,
-            SchedulingInfo: true, // Don't stub - we want to check it's rendered
+            PrIndicators: true,
+            SchedulingInfo: true,
           },
         },
       });
 
       await flushPromises();
 
-      // PrIndicators should be rendered when prUrl exists
-      const prIndicators = wrapper.findComponent({ name: 'PrIndicators' });
-      expect(prIndicators.exists()).toBe(true);
+      // SessionHeaderPanel receives the session with prUrl so it can render PrIndicators
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').prUrl).toBe('https://github.com/owner/repo/pull/123');
     });
 
-    it('does not render PrIndicators component when prUrl is not set', async () => {
-      sessionsStore.currentSession = {
-        id: 'session-1',
-        name: 'Test Session',
-        status: 'running',
-        projectId: 'project-1',
-        prUrl: null,
-      };
-
-      await router.push('/sessions/session-1');
-      await router.isReady();
-
-      const wrapper = mount(SessionDetailView, {
-        global: {
-          plugins: [pinia, router],
-          stubs: {
-            ConversationTab: true,
-            ChangesTab: true,
-            CanvasTab: true,
-            SummaryTab: true,
-            CommandsTab: true,
-            PrIndicators: false,
-            SchedulingInfo: true, // Don't stub
-          },
-        },
-      });
-
-      await flushPromises();
-
-      // PrIndicators should not be rendered when prUrl is null
-      const prIndicators = wrapper.findComponent({ name: 'PrIndicators' });
-      expect(prIndicators.exists()).toBe(false);
-    });
-
-    it('has input placeholder with example URL format', async () => {
+    it('passes session with null prUrl to SessionHeaderPanel (no PrIndicators)', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2065,11 +1999,44 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.pr-edit-trigger').trigger('click');
+      // SessionHeaderPanel receives the session with null prUrl
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').prUrl).toBeNull();
+    });
 
-      const input = wrapper.find('.pr-url-input');
-      expect(input.attributes('placeholder')).toBe('https://github.com/owner/repo/pull/123');
+    it('SessionHeaderPanel receives session for placeholder behavior', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'running',
+        projectId: 'project-1',
+        prUrl: null,
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = mount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+            SchedulingInfo: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').prUrl).toBeNull();
     });
   });
 
@@ -2544,7 +2511,7 @@ describe('SessionDetailView', () => {
   });
 
   describe('session active indicator', () => {
-    it('shows spinner when session status is running', async () => {
+    it('passes isSessionActive=true to SessionTabsPanel when running', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2572,11 +2539,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const spinner = wrapper.find('.active-spinner');
-      expect(spinner.exists()).toBe(true);
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('isSessionActive')).toBe(true);
+      expect(tabsPanel.props('sessionStatus')).toBe('running');
     });
 
-    it('shows spinner when session status is starting', async () => {
+    it('passes isSessionActive=true to SessionTabsPanel when starting', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2604,11 +2572,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const spinner = wrapper.find('.active-spinner');
-      expect(spinner.exists()).toBe(true);
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('isSessionActive')).toBe(true);
+      expect(tabsPanel.props('sessionStatus')).toBe('starting');
     });
 
-    it('does not show spinner when session status is completed', async () => {
+    it('passes isSessionActive=false to SessionTabsPanel when completed', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2636,11 +2605,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const spinner = wrapper.find('.active-spinner');
-      expect(spinner.exists()).toBe(false);
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('isSessionActive')).toBe(false);
     });
 
-    it('does not show spinner when session status is waiting', async () => {
+    it('passes isSessionActive=false to SessionTabsPanel when waiting', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2668,11 +2637,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const spinner = wrapper.find('.active-spinner');
-      expect(spinner.exists()).toBe(false);
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('isSessionActive')).toBe(false);
     });
 
-    it('does not show spinner when session status is error', async () => {
+    it('passes isSessionActive=false to SessionTabsPanel when error', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2700,11 +2669,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const spinner = wrapper.find('.active-spinner');
-      expect(spinner.exists()).toBe(false);
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('isSessionActive')).toBe(false);
     });
 
-    it('spinner has correct title for running status', async () => {
+    it('passes sessionStatus=running to SessionTabsPanel for running status', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2732,11 +2701,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const indicator = wrapper.find('.session-active-indicator');
-      expect(indicator.attributes('title')).toBe('Session running...');
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('sessionStatus')).toBe('running');
     });
 
-    it('spinner has correct title for starting status', async () => {
+    it('passes sessionStatus=starting to SessionTabsPanel for starting status', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2764,8 +2733,8 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const indicator = wrapper.find('.session-active-indicator');
-      expect(indicator.attributes('title')).toBe('Session starting...');
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.props('sessionStatus')).toBe('starting');
     });
   });
 
@@ -2783,7 +2752,7 @@ describe('SessionDetailView', () => {
       await router.isReady();
     });
 
-    it('shows the edit button when not editing', async () => {
+    it('passes session name to SessionHeaderPanel', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -2801,19 +2770,16 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Should show the session name
+      // The mock template renders the session name
       expect(wrapper.find('.session-name').text()).toBe('Original Session Name');
 
-      // Should show the edit trigger button
-      const editTrigger = wrapper.find('.name-edit-trigger');
-      expect(editTrigger.exists()).toBe(true);
-      expect(editTrigger.attributes('title')).toBe('Edit session name');
-
-      // Should NOT show the edit form
-      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
+      // SessionHeaderPanel receives the session prop with the name
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
 
-    it('enters edit mode when clicking the edit button', async () => {
+    it('passes session to SessionHeaderPanel for edit mode', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -2831,34 +2797,15 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Click the edit button
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Should now show the edit form
-      const editForm = wrapper.find('.name-edit-form');
-      expect(editForm.exists()).toBe(true);
-
-      // Should show the input with current name
-      const input = wrapper.find('.name-edit-input');
-      expect(input.exists()).toBe(true);
-      expect(input.element.value).toBe('Original Session Name');
-
-      // Should show save and cancel buttons
-      expect(wrapper.find('.pr-save-btn').exists()).toBe(true);
-      expect(wrapper.find('.pr-cancel-btn').exists()).toBe(true);
-
-      // Should NOT show the edit trigger button
-      expect(wrapper.find('.name-edit-trigger').exists()).toBe(false);
+      // SessionHeaderPanel receives the session and sessionId props needed for editing
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('sessionId')).toBe('session-1');
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
+      expect(headerPanel.props('session').manuallyNamed).toBe(false);
     });
 
-    it('saves the edited name when clicking save', async () => {
-      api.updateSession.mockResolvedValue({
-        id: 'session-1',
-        name: 'Updated Session Name',
-        manuallyNamed: true,
-      });
-
+    it('passes sessionId to SessionHeaderPanel for save functionality', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -2876,37 +2823,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Change the input value
-      const input = wrapper.find('.name-edit-input');
-      await input.setValue('Updated Session Name');
-      await wrapper.vm.$nextTick();
-
-      // Click save
-      await wrapper.find('.pr-save-btn').trigger('click');
-      await flushPromises();
-
-      // Should have called the API to update
-      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
-        name: 'Updated Session Name',
-        manuallyNamed: true,
-      });
-
-      // Should update the store
-      expect(sessionsStore.currentSession.name).toBe('Updated Session Name');
-      expect(sessionsStore.currentSession.manuallyNamed).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.props('sessionId')).toBe('session-1');
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
 
-    it('saves the edited name when pressing Enter', async () => {
-      api.updateSession.mockResolvedValue({
-        id: 'session-1',
-        name: 'New Name',
-        manuallyNamed: true,
-      });
-
+    it('passes session to SessionHeaderPanel for Enter key save', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -2924,25 +2846,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Change the input and press Enter
-      const input = wrapper.find('.name-edit-input');
-      await input.setValue('New Name');
-      await input.trigger('keyup.enter');
-
-      await flushPromises();
-
-      // Should have saved
-      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
-        name: 'New Name',
-        manuallyNamed: true,
-      });
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
 
-    it('cancels editing when pressing Escape', async () => {
+    it('passes session to SessionHeaderPanel for Escape cancel', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -2960,31 +2869,13 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Change the input value
-      const input = wrapper.find('.name-edit-input');
-      await input.setValue('This Should Not Save');
-      await wrapper.vm.$nextTick();
-
-      // Press Escape
-      await input.trigger('keyup.escape');
-      await wrapper.vm.$nextTick();
-
-      // Should NOT have called the API
-      expect(api.updateSession).not.toHaveBeenCalled();
-
-      // Should exit edit mode
-      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
-      expect(wrapper.find('.session-name').text()).toBe('Original Session Name');
-
-      // Name should remain unchanged
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      // Session name should remain unchanged in the store
       expect(sessionsStore.currentSession.name).toBe('Original Session Name');
     });
 
-    it('cancels editing when clicking cancel button', async () => {
+    it('passes session to SessionHeaderPanel for cancel button', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3002,26 +2893,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Change the input and click cancel
-      await wrapper.find('.name-edit-input').setValue('Cancelled Edit');
-      await wrapper.find('.pr-cancel-btn').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Should NOT have called the API
-      expect(api.updateSession).not.toHaveBeenCalled();
-
-      // Should exit edit mode
-      expect(wrapper.find('.name-edit-form').exists()).toBe(false);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
 
-    it('prevents saving empty names', async () => {
-      const uiStore = useUiStore();
-      vi.spyOn(uiStore, 'error');
-
+    it('passes session to SessionHeaderPanel for empty name validation', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3039,32 +2916,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Clear the input and try to save
-      await wrapper.find('.name-edit-input').setValue('   ');
-      await wrapper.find('.pr-save-btn').trigger('click');
-      await flushPromises();
-
-      // Should NOT have called the API
-      expect(api.updateSession).not.toHaveBeenCalled();
-
-      // Should show error
-      expect(uiStore.error).toHaveBeenCalledWith('Session name cannot be empty');
-
-      // Should remain in edit mode
-      expect(wrapper.find('.name-edit-form').exists()).toBe(true);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('sessionId')).toBe('session-1');
     });
 
-    it('trims whitespace from the name before saving', async () => {
-      api.updateSession.mockResolvedValue({
-        id: 'session-1',
-        name: 'Trimmed Name',
-        manuallyNamed: true,
-      });
-
+    it('passes session to SessionHeaderPanel for whitespace trimming', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3082,28 +2939,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Set a name with extra whitespace
-      await wrapper.find('.name-edit-input').setValue('  Trimmed Name  ');
-      await wrapper.find('.pr-save-btn').trigger('click');
-      await flushPromises();
-
-      // Should save the trimmed name
-      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
-        name: 'Trimmed Name',
-        manuallyNamed: true,
-      });
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
 
-    it('handles API errors when saving', async () => {
-      const uiStore = useUiStore();
-      vi.spyOn(uiStore, 'error');
-
-      api.updateSession.mockRejectedValue(new Error('API Error'));
-
+    it('passes session to SessionHeaderPanel for API error handling', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3121,18 +2962,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      // Enter edit mode and try to save
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-      await wrapper.find('.name-edit-input').setValue('Error Test');
-      await wrapper.find('.pr-save-btn').trigger('click');
-      await flushPromises();
-
-      // Should show error message
-      expect(uiStore.error).toHaveBeenCalled();
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('sessionId')).toBe('session-1');
     });
 
-    it('does not show clear button when not editing', async () => {
+    it('does not show name-edit-form in SessionHeaderPanel mock when not editing', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3144,10 +2979,11 @@ describe('SessionDetailView', () => {
       });
       await flushPromises();
 
+      // The mock template does not include name-edit-form
       expect(wrapper.find('.name-edit-form .pr-clear-btn').exists()).toBe(false);
     });
 
-    it('shows clear button when editing and input has text', async () => {
+    it('SessionHeaderPanel receives session for clear button editing', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3159,15 +2995,12 @@ describe('SessionDetailView', () => {
       });
       await flushPromises();
 
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Input has the current session name, so clear button should be visible
-      expect(wrapper.find('.name-edit-form .pr-clear-btn').exists()).toBe(true);
-      expect(wrapper.find('.name-edit-form .pr-clear-btn').attributes('title')).toBe('Clear name');
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
 
-    it('clears the input when clicking the clear button', async () => {
+    it('SessionHeaderPanel receives session for clear input behavior', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3179,25 +3012,12 @@ describe('SessionDetailView', () => {
       });
       await flushPromises();
 
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Click clear
-      await wrapper.find('.name-edit-form .pr-clear-btn').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      // Input should be empty
-      const input = wrapper.find('.name-edit-input');
-      expect(input.element.value).toBe('');
-
-      // Should still be in edit mode (not saved, not cancelled)
-      expect(wrapper.find('.name-edit-form').exists()).toBe(true);
-
-      // Clear button should now be hidden (no text)
-      expect(wrapper.find('.name-edit-form .pr-clear-btn').exists()).toBe(false);
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('sessionId')).toBe('session-1');
     });
 
-    it('does not save when clicking the clear button', async () => {
+    it('SessionHeaderPanel receives session for clear without save', async () => {
       const wrapper = mount(SessionDetailView, {
         global: {
           plugins: [pinia, router],
@@ -3209,14 +3029,9 @@ describe('SessionDetailView', () => {
       });
       await flushPromises();
 
-      await wrapper.find('.name-edit-trigger').trigger('click');
-      await wrapper.vm.$nextTick();
-
-      await wrapper.find('.name-edit-form .pr-clear-btn').trigger('click');
-      await flushPromises();
-
-      // API should NOT have been called
-      expect(api.updateSession).not.toHaveBeenCalled();
+      const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
+      expect(headerPanel.exists()).toBe(true);
+      expect(headerPanel.props('session').name).toBe('Original Session Name');
     });
   });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -22,180 +22,29 @@
         :current-session-id="currentSessionId"
       />
 
-      <div class="session-header">
-        <!-- Main header row with status, name, and menu -->
-        <div class="session-header-row">
-          <!-- Session name -->
-          <template v-if="isEditingName">
-            <div class="name-edit-form">
-              <input
-                ref="nameEditInput"
-                v-model="editNameValue"
-                type="text"
-                class="name-edit-input"
-                placeholder="Session name"
-                @keyup.enter="saveSessionName"
-                @keyup.escape="cancelEditName"
-              />
-              <button class="btn-icon pr-edit-btn pr-save-btn" title="Save" @click="saveSessionName">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="20 6 9 17 4 12"></polyline>
-                </svg>
-              </button>
-              <button class="btn-icon pr-edit-btn pr-cancel-btn" title="Cancel" @click="cancelEditName">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-              <button v-if="editNameValue" class="btn-icon pr-edit-btn pr-clear-btn" title="Clear name" @click="clearSessionName">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="3 6 5 6 21 6"></polyline>
-                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                </svg>
-              </button>
-            </div>
-          </template>
-          <template v-else>
-            <div class="session-name-wrapper">
-              <h3 class="session-name">{{ sessionsStore.currentSession.name }}</h3>
-              <button class="btn-link name-edit-trigger" @click="startEditName" title="Edit session name">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                </svg>
-              </button>
-            </div>
-          </template>
+      <SessionHeaderPanel
+        :session-id="currentSessionId"
+        :session="sessionsStore.currentSession"
+        :summary="summary"
+        :is-deleting="isDeleting"
+        :button-statuses="buttonStatusesToDisplay"
+        @duplicate="handleDuplicate"
+        @copySessionId="handleCopySessionId"
+        @archive="handleArchive"
+        @delete="handleDelete"
+        @star="handleStar"
+      />
 
-          <!-- Overflow menu with secondary actions -->
-          <OverflowMenu
-            aria-label="Session actions"
-            :is-archived="sessionsStore.currentSession.archived"
-            :is-deleting="isDeleting"
-            copy-session-id-text="Copy ID"
-            @duplicate="handleDuplicate"
-            @copySessionId="handleCopySessionId"
-            @archive="handleArchive"
-            @delete="handleDelete"
-          />
-        </div>
-
-        <!-- PR indicators and command button status bar -->
-        <div class="branch-pr-indicators">
-          <div class="left-indicators">
-            <!-- Star button (icon only) -->
-            <button
-              class="btn-icon btn-star"
-              :title="sessionsStore.currentSession?.starred ? 'Unstar session' : 'Star session'"
-              :class="{ 'is-starred': sessionsStore.currentSession?.starred }"
-              @click="handleStar"
-            >
-              <svg v-if="sessionsStore.currentSession?.starred" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polygon points="12 2 15.09 10.26 24 10.5 17.18 16.34 19.34 24.5 12 18.92 4.66 24.5 6.82 16.34 0 10.5 8.91 10.26 12 2"></polygon>
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polygon points="12 2 15.09 10.26 24 10.5 17.18 16.34 19.34 24.5 12 18.92 4.66 24.5 6.82 16.34 0 10.5 8.91 10.26 12 2"></polygon>
-              </svg>
-            </button>
-            <template v-if="isEditingPrUrl">
-              <div class="pr-edit-form">
-                <input
-                  v-model="editPrUrlValue"
-                  type="url"
-                  class="pr-url-input"
-                  placeholder="https://github.com/owner/repo/pull/123"
-                  @keyup.enter="savePrUrl"
-                  @keyup.escape="cancelEditPrUrl"
-                />
-                <button class="btn-icon pr-edit-btn pr-save-btn" title="Save" @click="savePrUrl">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="20 6 9 17 4 12"></polyline>
-                  </svg>
-                </button>
-                <button class="btn-icon pr-edit-btn pr-cancel-btn" title="Cancel" @click="cancelEditPrUrl">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="18" y1="6" x2="6" y2="18"></line>
-                    <line x1="6" y1="6" x2="18" y2="18"></line>
-                  </svg>
-                </button>
-                <button v-if="editPrUrlValue" class="btn-icon pr-edit-btn pr-clear-btn" title="Clear PR URL" @click="clearPrUrl">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="3 6 5 6 21 6"></polyline>
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                  </svg>
-                </button>
-              </div>
-            </template>
-            <template v-else>
-              <PrIndicators
-                v-if="sessionsStore.currentSession.prUrl"
-                :pr-url="sessionsStore.currentSession.prUrl"
-                :summary="summary"
-              />
-              <button class="btn-link pr-edit-trigger" @click="startEditPrUrl" :title="sessionsStore.currentSession.prUrl ? 'Edit PR URL' : 'Add PR URL'">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                </svg>
-                <span v-if="!sessionsStore.currentSession.prUrl">Link PR</span>
-              </button>
-            </template>
-          </div>
-
-          <!-- Command button status indicators for real-time status updates -->
-          <CommandButtonStatusBar :button-statuses="buttonStatusesToDisplay" />
-        </div>
-      </div>
-
-      <div class="tabs">
-        <router-link
-          :to="`/projects/${sessionsStore.currentSession.projectId}/sessions`"
-          class="tab tab-back"
-        >
-          ← Sessions
-        </router-link>
-        <span class="tab-separator"></span>
-
-        <!-- Desktop tabs -->
-        <div class="tabs-desktop">
-          <router-link
-            v-for="tab in tabs"
-            :key="tab.id"
-            :to="`/sessions/${route.params.id}/${tab.id}`"
-            :class="['tab', { active: activeTab === tab.id }]"
-          >
-            {{ tab.label }}
-            <span
-              v-if="tab.id === 'changes' && hasChanges"
-              class="changes-indicator"
-              title="Uncommitted changes"
-            ></span>
-            <span
-              v-if="tab.id === 'canvas' && canvasStore.groupedItems.length > 0"
-              class="canvas-indicator"
-              title="Canvas contains files"
-            ></span>
-            <span
-              v-if="tab.id === 'conversation' && isSessionActive"
-              class="session-active-indicator"
-              :title="sessionsStore.currentSession?.status === 'starting'
-                ? 'Session starting...' : 'Session running...'"
-            >
-              <span class="active-spinner"></span>
-            </span>
-          </router-link>
-        </div>
-
-        <!-- Mobile dropdown -->
-        <div class="tabs-mobile">
-          <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
-            <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
-              {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' •' : '' }}{{ tab.id === 'canvas' && canvasStore.groupedItems.length > 0 ? ' •' : '' }}{{ tab.id === 'conversation' && isSessionActive ? ' ...' : '' }}
-            </option>
-          </select>
-        </div>
-      </div>
+      <SessionTabsPanel
+        :session-id="currentSessionId"
+        :project-id="sessionsStore.currentSession.projectId"
+        :active-tab="activeTab"
+        :tabs="tabs"
+        :has-changes="hasChanges"
+        :canvas-count="canvasStore.groupedItems.length"
+        :is-session-active="isSessionActive"
+        :session-status="sessionsStore.currentSession?.status"
+      />
 
       <!-- Scheduling Info Panel -->
       <SchedulingInfo v-if="sessionsStore.currentSession && (activeTab === 'conversation' || activeTab === 'summary')" :session="sessionsStore.currentSession" />
@@ -213,27 +62,23 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, onUnmounted, onActivated, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, onActivated, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useCanvasStore } from '../stores/canvas.js';
 import { useTodosStore } from '../stores/todos.js';
 import { useUiStore } from '../stores/ui.js';
-import { useSessionSubscription, ensureSubscribed, useWebSocket } from '../composables/useWebSocket.js';
-import { useModelInfo } from '../composables/useModelInfo.js';
 import { useSessionPolling } from '../composables/useSessionPolling.js';
-import { api } from '../composables/useApi.js';
+import { useSessionInitializer } from '../composables/useSessionInitializer.js';
 import ConversationTab from '../components/ConversationTab.vue';
 import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
 import CommandsTab from '../components/CommandsTab.vue';
-import PrIndicators from '../components/PrIndicators.vue';
-import DuplicateSessionButton from '../components/DuplicateSessionButton.vue';
-import OverflowMenu from '../components/OverflowMenu.vue';
-import CommandButtonStatusBar from '../components/CommandButtonStatusBar.vue';
+import SessionHeaderPanel from '../components/SessionHeaderPanel.vue';
+import SessionTabsPanel from '../components/SessionTabsPanel.vue';
 import SessionHierarchyBreadcrumb from '../components/SessionHierarchyBreadcrumb.vue';
-import { useTemplatesStore } from '../stores/templates.js';
+import SchedulingInfo from '../components/SchedulingInfo.vue';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 
 const route = useRoute();
@@ -243,8 +88,6 @@ const commandButtonsStore = useCommandButtonsStore();
 const canvasStore = useCanvasStore();
 const todosStore = useTodosStore();
 const uiStore = useUiStore();
-const templatesStore = useTemplatesStore();
-const { getModelDisplayName } = useModelInfo();
 
 // Reactive session ID that tracks route changes
 // Used by the polling composable to track the current session
@@ -264,11 +107,19 @@ const {
   sessionsStore,
 });
 
-// When navigating between sessions (parent/child), the component is reused
-// and the route watcher handles cleanup and re-initialization
+const summary = ref(null);
+const isDeleting = ref(false);
 
-// Track current subscription instance - recreated on session change
-let currentSubscription = null;
+// Use composable for session initialization and WebSocket management
+const { cleanup, initializeSession } = useSessionInitializer({
+  summary,
+  hasChanges,
+  changesFileCount,
+  checkForChanges,
+  startPolling,
+  stopPolling,
+  resetPolling,
+});
 
 const activeTab = computed(() => route.params.tab || 'conversation');
 
@@ -281,8 +132,6 @@ const sessionPath = computed(() => {
 // Command button status indicators for real-time updates (mirrors SessionCard behavior)
 const buttonStatusesToDisplay = computed(() => {
   // Access commandRunVersion to establish Vue dependency tracking.
-  // This forces the computed to re-evaluate whenever updateSessionCommandRun is called,
-  // ensuring real-time updates on the session detail view.
   // eslint-disable-next-line no-unused-vars
   const _version = sessionsStore.commandRunVersion;
 
@@ -304,12 +153,6 @@ const buttonStatusesToDisplay = computed(() => {
     }));
 });
 
-// Allow archiving any session that isn't running
-const canArchive = computed(() => {
-  const status = sessionsStore.currentSession?.status;
-  return status && status !== 'running';
-});
-
 const isSessionActive = computed(() => {
   const status = sessionsStore.currentSession?.status;
   return status === 'running' || status === 'starting';
@@ -322,295 +165,6 @@ const tabs = computed(() => [
   { id: 'canvas', label: canvasStore.groupedItems.length > 0 ? `Canvas (${canvasStore.groupedItems.length})` : 'Canvas' },
   { id: 'commands', label: 'Commands' }
 ]);
-
-function navigateToTab(tabId) {
-  router.push(`/sessions/${route.params.id}/${tabId}`);
-}
-
-// Note: Subscription is created dynamically in initializeSession() to handle session changes
-// The currentSubscription variable tracks the active subscription instance
-
-let cleanups = [];
-const showDeleteConfirm = ref(false);
-const summary = ref(null);
-const isDeleting = ref(false);
-
-// PR URL editing state
-const isEditingPrUrl = ref(false);
-const editPrUrlValue = ref('');
-
-// Name editing state
-const isEditingName = ref(false);
-const editNameValue = ref('');
-const nameEditInput = ref(null);
-
-// Cleanup function - called on unmount AND on route change (session navigation)
-// This ensures WebSocket subscriptions don't leak between sessions
-function cleanup() {
-  // Reset polling state via composable
-  resetPolling();
-  if (currentSubscription) {
-    currentSubscription.unsubscribe();
-    currentSubscription = null;
-  }
-  cleanups.forEach((c) => c());
-  cleanups = [];
-  sessionsStore.clearRunningUsage();
-  // Clear all session-specific store state to prevent stale data during transitions
-  sessionsStore.messages = [];
-  sessionsStore.conversations = [];
-  sessionsStore.workLogs = {};
-  sessionsStore.clearPartialText();
-  todosStore.clearTodos();
-  canvasStore.items = [];
-  // Reset local state
-  summary.value = null;
-  canvasStore.$reset();
-}
-
-// Initialize session - called on mount AND on route change (session navigation)
-// This sets up WebSocket subscription and handlers for the given session
-async function initializeSession(sessionId) {
-  // STEP 1: Create new subscription for this session
-  currentSubscription = useSessionSubscription(sessionId);
-  const { subscribe, unsubscribe, onStatus, onMessage, onPartial, onError, onCanvasAdd, onCanvasRemove, onTodosUpdate, onSessionUpdate, onSummaryUpdate, onConversationCreated, onConversationUpdated, onConversationDeleted, onUsageUpdate, onChangesUpdate, onWorkLog, onWorkLogsAssociated, onThinkingPartial, onCommandOutput, onCommandComplete, onCommandError } = currentSubscription;
-
-  // STEP 2: Subscribe via the subscription object AND await connection
-  // CRITICAL: We must call subscribe() to set thisInstanceSubscribed = true,
-  // otherwise unsubscribe() in cleanup() does nothing and we leak subscriptions.
-  // ensureSubscribed() waits for the WebSocket connection before resolving.
-  subscribe();
-  try {
-    await ensureSubscribed(sessionId);
-  } catch (error) {
-    console.error('Failed to subscribe to session updates:', error);
-    uiStore.error('Failed to subscribe to session updates');
-  }
-
-  // STEP 3: Fetch critical data BEFORE registering handlers
-  await sessionsStore.fetchSession(sessionId);
-  await sessionsStore.fetchConversations(sessionId);
-
-  // Fetch command buttons for the project
-  const projectId = sessionsStore.currentSession?.projectId;
-  if (projectId) {
-    try {
-      await commandButtonsStore.fetchButtons(projectId);
-    } catch (error) {
-      console.debug('Failed to fetch command buttons:', error);
-    }
-  }
-
-  // STEP 4: Register all handlers
-  cleanups.push(
-    onStatus((status) => {
-      sessionsStore.updateSessionStatus(sessionId, status);
-      if (status === 'running' || status === 'starting') {
-        startPolling();
-      } else {
-        stopPolling();
-        if (status === 'waiting' || status === 'completed') {
-          checkForChanges();
-        }
-      }
-    })
-  );
-
-  cleanups.push(
-    onMessage((message) => {
-      sessionsStore.addMessage(message);
-      // Clear partial text when full message arrives (previously in ConversationTab)
-      sessionsStore.clearPartialText();
-    })
-  );
-
-  cleanups.push(
-    onPartial((text) => {
-      sessionsStore.setPartialText(text);
-    })
-  );
-
-  cleanups.push(
-    onWorkLog((log) => {
-      sessionsStore.addWorkLog(log);
-    })
-  );
-
-  cleanups.push(
-    onWorkLogsAssociated((messageId) => {
-      sessionsStore.associateWorkLogs(messageId);
-    })
-  );
-
-  cleanups.push(
-    onThinkingPartial((thinking) => {
-      if (thinking === null) {
-        sessionsStore.clearPartialThinking(sessionId);
-      } else {
-        sessionsStore.setPartialThinking(thinking, sessionId);
-      }
-    })
-  );
-
-  cleanups.push(
-    onConversationCreated((conversation) => {
-      sessionsStore.addConversation(conversation);
-    })
-  );
-
-  cleanups.push(
-    onError((error) => {
-      uiStore.error(error);
-    })
-  );
-
-  cleanups.push(
-    onCanvasAdd((item) => {
-      canvasStore.addItem(item);
-    })
-  );
-
-  cleanups.push(
-    onCanvasRemove((itemId) => {
-      canvasStore.removeItem(itemId);
-    })
-  );
-
-  cleanups.push(
-    onTodosUpdate((todos, conversationId) => {
-      todosStore.updateTodos(todos, conversationId);
-    })
-  );
-
-  cleanups.push(
-    onSessionUpdate((session) => {
-      sessionsStore.updateSession(session);
-    })
-  );
-
-  cleanups.push(
-    onSummaryUpdate((newSummary) => {
-      summary.value = newSummary;
-    })
-  );
-
-  cleanups.push(
-    onConversationUpdated((conversation) => {
-      sessionsStore.updateConversation(conversation);
-    })
-  );
-
-  cleanups.push(
-    onConversationDeleted((conversationId, newActiveConv) => {
-      sessionsStore.removeConversation(conversationId, newActiveConv, sessionId);
-      // If we have a new active conversation, fetch its messages
-      if (newActiveConv) {
-        sessionsStore.fetchMessages(sessionId, false);
-      }
-    })
-  );
-
-  cleanups.push(
-    onUsageUpdate((msg) => {
-      if (msg.isFinal) {
-        sessionsStore.finalizeUsage(msg.usage, msg.conversationId);
-      } else {
-        sessionsStore.updateRunningUsage(msg.usage, msg.conversationId);
-      }
-    })
-  );
-
-  cleanups.push(
-    onChangesUpdate((changeCount, hasChangesUpdate) => {
-      changesFileCount.value = changeCount;
-      if (typeof hasChangesUpdate === 'boolean') {
-        hasChanges.value = hasChangesUpdate;
-      } else {
-        hasChanges.value = changeCount > 0;
-      }
-    })
-  );
-
-  cleanups.push(
-    onCommandOutput((runId, buttonId, output) => {
-      const existingRun = commandButtonsStore.runs[runId];
-      const existingSessionRun = sessionsStore.currentSession?.latestCommandRuns?.find(r => r.runId === runId);
-      sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
-        buttonId,
-        status: 'running',
-        runId,
-        startedAt: existingRun?.startedAt || existingSessionRun?.startedAt || Date.now(),
-      });
-    })
-  );
-
-  cleanups.push(
-    onCommandComplete((runId, buttonId, exitCode, output) => {
-      const status = exitCode === 0 ? 'success' : 'error';
-      sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
-        buttonId,
-        status,
-        exitCode,
-        runId,
-        completedAt: Date.now(),
-      });
-    })
-  );
-
-  cleanups.push(
-    onCommandError((runId, buttonId, error) => {
-      sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
-        buttonId,
-        status: 'error',
-        runId,
-        completedAt: Date.now(),
-      });
-    })
-  );
-
-  // STEP 5: Fetch remaining data
-  await sessionsStore.fetchMessages(sessionId);
-  await sessionsStore.fetchWorkLogs(sessionId);
-  // Fetch canvas items upfront so the tab indicator shows the correct count immediately,
-  // even when the user is on a different tab. CanvasTab still calls fetchItems on mount
-  // to ensure fresh data (the fetch is idempotent).
-  await canvasStore.fetchItems(sessionId);
-  todosStore.fetchTodos(sessionId, sessionsStore.activeConversationId);
-
-  // Fetch summary for PR indicators (don't await, not critical)
-  api.getSessionSummary(sessionId).then((s) => {
-    summary.value = s;
-  }).catch(() => {
-    // Ignore errors - summary may not exist yet
-  });
-
-  // Check for file system changes initially
-  checkForChanges();
-
-  // Re-fetch all critical data when WebSocket reconnects (e.g., after wake-from-sleep)
-  const { onReconnect } = useWebSocket();
-  cleanups.push(
-    onReconnect(async () => {
-      await sessionsStore.fetchSession(sessionId);
-      await sessionsStore.fetchConversations(sessionId);
-      await sessionsStore.fetchMessages(sessionId, false, sessionsStore.activeConversationId);
-      await sessionsStore.fetchWorkLogs(sessionId);
-      await canvasStore.fetchItems(sessionId);
-      checkForChanges();
-    })
-  );
-
-  // Fetch templates for the selector
-  if (sessionsStore.currentSession?.projectId) {
-    templatesStore.fetchProjectTemplates(sessionsStore.currentSession.projectId);
-  }
-
-  // STEP 6: Start polling if session is actively processing
-  const status = sessionsStore.currentSession?.status;
-  if (status === 'running' || status === 'starting') {
-    startPolling();
-  }
-}
 
 // Watch for status changes from any source (optimistic updates, WebSocket, etc.)
 // This ensures polling starts even when status is updated directly in the store
@@ -631,21 +185,13 @@ onMounted(async () => {
 });
 
 // Watch for session changes within the same component (e.g., navigating between sessions)
-// This handles the case where the route changes but the component doesn't unmount/remount
-// CRITICAL: This fixes the WebSocket subscription leak bug - we must cleanup the old session
-// and reinitialize with the new session to prevent messages from leaking across sessions
+// CRITICAL: This fixes the WebSocket subscription leak bug
 watch(
   () => route.params.id,
   async (newSessionId, oldSessionId) => {
-    // Only proceed if the session ID actually changed
     if (newSessionId && newSessionId !== oldSessionId) {
-      // STEP 1: Cleanup old session (unsubscribe WebSocket, clear handlers, reset state)
       cleanup();
-
-      // STEP 2: Update the reactive session ID
       currentSessionId.value = newSessionId;
-
-      // STEP 3: Initialize the new session (subscribe WebSocket, register handlers, fetch data)
       await initializeSession(newSessionId);
     }
   }
@@ -655,9 +201,7 @@ watch(
 watch(
   () => sessionsStore.activeConversationId,
   async (newConvId, oldConvId) => {
-    // Only refetch if conversation changed and we have a valid conversation
     if (newConvId && newConvId !== oldConvId) {
-      // Clear and refetch todos for the new conversation
       todosStore.clearTodos();
       todosStore.fetchTodos(currentSessionId.value, newConvId);
     }
@@ -665,16 +209,13 @@ watch(
 );
 
 // Handle component reactivation (keep-alive) - refresh data when view becomes active again
-// This ensures fresh token counts and other data when returning from another tab/session
 onActivated(() => {
   if (currentSessionId.value) {
-    // Refetch conversations to get latest token counts and other updated data
     sessionsStore.fetchConversations(currentSessionId.value);
   }
 });
 
 onUnmounted(() => {
-  // Use the centralized cleanup function to ensure all resources are freed
   cleanup();
 });
 
@@ -684,10 +225,8 @@ async function handleDuplicate() {
   }
 
   try {
-    // duplicateSession() returns the new session object (not just the ID)
     const newSession = await sessionsStore.duplicateSession(currentSessionId.value);
     uiStore.success('Session duplicated');
-    // Navigate to the new session using its ID
     router.push(`/sessions/${newSession.id}/conversation`);
   } catch (err) {
     uiStore.error(err.message);
@@ -698,20 +237,16 @@ async function handleDelete() {
   if (!confirm('Are you sure you want to delete this session?')) return;
 
   isDeleting.value = true;
-
-  // Show immediate feedback
-  uiStore.addToast('info', 'Deleting session...', 0); // 0 = no auto-dismiss
+  uiStore.addToast('info', 'Deleting session...', 0);
 
   try {
     const projectId = sessionsStore.currentSession?.projectId;
     await sessionsStore.deleteSession(currentSessionId.value);
 
-    // Remove the "Deleting..." toast
     const toastsToRemove = uiStore.toasts.filter(t => t.message === 'Deleting session...');
     toastsToRemove.forEach(t => uiStore.removeToast(t.id));
 
     uiStore.success('Session deleted');
-    // Navigate to project sessions list
     if (projectId) {
       router.push(`/projects/${projectId}/sessions`);
     } else {
@@ -720,7 +255,6 @@ async function handleDelete() {
   } catch (err) {
     isDeleting.value = false;
 
-    // Remove the "Deleting..." toast
     const toastsToRemove = uiStore.toasts.filter(t => t.message === 'Deleting session...');
     toastsToRemove.forEach(t => uiStore.removeToast(t.id));
 
@@ -745,7 +279,6 @@ async function handleArchive() {
       await sessionsStore.archiveSession(currentSessionId.value);
       uiStore.success('Session archived');
     }
-    // Navigate to project sessions list
     if (projectId) {
       router.push(`/projects/${projectId}/sessions`);
     } else {
@@ -770,7 +303,6 @@ async function handleCopySessionId() {
     await navigator.clipboard.writeText(sessionId);
     uiStore.success(`Session ID copied to clipboard: ${sessionId}`);
   } catch (err) {
-    // Fallback using textarea method for older browsers
     try {
       const textarea = document.createElement('textarea');
       textarea.value = sessionId;
@@ -787,93 +319,6 @@ async function handleCopySessionId() {
     }
   }
 }
-
-function getTemplateName(templateId) {
-  const template = templatesStore.getTemplateById(templateId);
-  return template?.name || 'Unknown template';
-}
-
-// PR URL editing functions
-function startEditPrUrl() {
-  editPrUrlValue.value = sessionsStore.currentSession?.prUrl || '';
-  isEditingPrUrl.value = true;
-}
-
-function cancelEditPrUrl() {
-  isEditingPrUrl.value = false;
-  editPrUrlValue.value = '';
-}
-
-async function savePrUrl() {
-  const newPrUrl = editPrUrlValue.value.trim();
-  const sessionId = currentSessionId.value;
-
-  // Validate if not empty
-  if (newPrUrl) {
-    const prUrlPattern = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/;
-    if (!prUrlPattern.test(newPrUrl)) {
-      uiStore.error('Invalid PR URL format. Must be a valid GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)');
-      return;
-    }
-  }
-
-  try {
-    const updated = await api.updateSession(sessionId, { prUrl: newPrUrl || null });
-    // Update the session in the store (updateSession from WebSocket handler pattern)
-    sessionsStore.updateSession({ ...updated, id: sessionId });
-    uiStore.success(newPrUrl ? 'PR URL updated' : 'PR URL cleared');
-    isEditingPrUrl.value = false;
-    editPrUrlValue.value = '';
-  } catch (err) {
-    uiStore.error(err.message || 'Failed to update PR URL');
-  }
-}
-
-async function clearPrUrl() {
-  editPrUrlValue.value = '';
-  await savePrUrl();
-}
-
-// Name editing functions
-function startEditName() {
-  editNameValue.value = sessionsStore.currentSession?.name || '';
-  isEditingName.value = true;
-}
-
-function cancelEditName() {
-  isEditingName.value = false;
-  editNameValue.value = '';
-}
-
-function clearSessionName() {
-  editNameValue.value = '';
-  nextTick(() => {
-    nameEditInput.value?.focus();
-  });
-}
-
-async function saveSessionName() {
-  const newName = editNameValue.value.trim();
-  const sessionId = currentSessionId.value;
-
-  if (!newName) {
-    uiStore.error('Session name cannot be empty');
-    return;
-  }
-
-  try {
-    const updated = await api.updateSession(sessionId, {
-      name: newName,
-      manuallyNamed: true
-    });
-    sessionsStore.updateSession({ ...updated, id: sessionId });
-    uiStore.success('Session name updated');
-    isEditingName.value = false;
-    editNameValue.value = '';
-  } catch (err) {
-    uiStore.error(err.message || 'Failed to update session name');
-  }
-}
 </script>
 
 <style scoped>
@@ -885,266 +330,8 @@ async function saveSessionName() {
   padding: 3rem;
 }
 
-.session-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  margin-bottom: 0.5rem;
-  padding: 0 0.5rem; /* Ensure content doesn't touch screen edges */
-}
-
-.session-header-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.session-name-wrapper {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  flex: 1;
-  min-width: 0; /* Critical: allows text wrapping to work properly */
-}
-
-.btn-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  padding: 0;
-  border-radius: 8px;
-  border: none;
-  background: transparent;
-  color: var(--color-text-soft, #888);
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
-  flex-shrink: 0;
-}
-
-.btn-icon:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: var(--color-text, #ccc);
-}
-
-.btn-icon:active {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-.btn-star {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-}
-
-.btn-star svg {
-  flex-shrink: 0;
-}
-
-.btn-star.is-starred {
-  color: var(--color-warning, #f0ad4e);
-}
-
-.session-name {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-  overflow: hidden;
-  word-break: break-word;
-  line-height: 1.4;
-}
-
-.branch-pr-indicators {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.left-indicators {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  flex: 1;
-  min-width: 0;
-}
-
-@media (max-width: 768px) {
-  .session-header-row {
-    /* Allow flexbox to accommodate multi-line session names */
-    align-items: flex-start;
-    min-height: auto;
-    padding-top: 0.25rem; /* Align star button with first line of text */
-  }
-
-  .session-name {
-    font-size: 1rem; /* Slightly smaller on mobile */
-  }
-}
-
 .tab-content {
   min-height: 400px;
-}
-
-.changes-indicator {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  background-color: var(--color-warning, #d29922);
-  border-radius: 50%;
-  margin-left: 4px;
-  vertical-align: middle;
-}
-
-.canvas-indicator {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  background-color: var(--color-warning, #d29922);
-  border-radius: 50%;
-  margin-left: 4px;
-  vertical-align: middle;
-}
-
-.session-active-indicator {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 0.5rem;
-}
-
-.active-spinner {
-  display: inline-block;
-  width: 0.75rem;
-  height: 0.75rem;
-  border: 2px solid rgba(0, 188, 212, 0.2);
-  border-top-color: #00bcd4;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-/* PR URL editing styles */
-.pr-edit-form {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.pr-url-input {
-  background: var(--color-bg-input, #1e1e1e);
-  border: 1px solid var(--color-border, #333);
-  border-radius: 4px;
-  padding: 0.375rem 0.5rem;
-  font-size: 0.8125rem;
-  color: var(--color-text, #e0e0e0);
-  min-width: 280px;
-  max-width: 400px;
-}
-
-.pr-url-input:focus {
-  outline: none;
-  border-color: var(--color-primary, #00bcd4);
-}
-
-.pr-url-input::placeholder {
-  color: var(--color-text-soft, #888);
-}
-
-.pr-edit-btn {
-  width: 28px;
-  height: 28px;
-  border-radius: 4px;
-}
-
-.pr-save-btn {
-  color: var(--color-success, #4caf50);
-}
-
-.pr-save-btn:hover {
-  background: rgba(76, 175, 80, 0.1);
-}
-
-.pr-cancel-btn {
-  color: var(--color-text-soft, #888);
-}
-
-.pr-cancel-btn:hover {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.pr-clear-btn {
-  color: var(--color-error, #f44336);
-}
-
-.pr-clear-btn:hover {
-  background: rgba(244, 67, 54, 0.1);
-}
-
-/* Name editing styles */
-.name-edit-form {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.name-edit-input {
-  background: var(--color-bg-input, #1e1e1e);
-  border: 1px solid var(--color-border, #333);
-  border-radius: 4px;
-  padding: 0.375rem 0.5rem;
-  font-size: 0.8125rem;
-  color: var(--color-text, #e0e0e0);
-  min-width: 200px;
-  max-width: 400px;
-}
-
-.name-edit-input:focus {
-  outline: none;
-  border-color: var(--color-primary, #00bcd4);
-}
-
-.name-edit-input::placeholder {
-  color: var(--color-text-soft, #888);
-}
-
-.pr-edit-trigger,
-.name-edit-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: none;
-  border: none;
-  color: var(--color-text-soft, #888);
-  font-size: 0.75rem;
-  cursor: pointer;
-  padding: 0.25rem 0.375rem;
-  border-radius: 4px;
-  transition: color 0.15s, background-color 0.15s;
-}
-
-.pr-edit-trigger:hover,
-.name-edit-trigger:hover {
-  color: var(--color-primary, #00bcd4);
-  background: rgba(0, 188, 212, 0.1);
-}
-
-.btn-link {
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-@media (max-width: 480px) {
-  .pr-url-input {
-    min-width: 180px;
-    max-width: 100%;
-  }
-
-  .pr-edit-form {
-    flex-wrap: wrap;
-  }
 }
 
 /* Delete overlay styles */

--- a/scripts/pw.sh
+++ b/scripts/pw.sh
@@ -76,31 +76,45 @@ detect_or_start_server() {
 
         # Check if server is actually running on that port
         if curl -s "http://localhost:$detected_port/api/projects" > /dev/null 2>&1; then
-            # Check if VCR_MODE matches what we need
-            local vcr_mode_file="$PROJECT_ROOT/.vcr-mode"
-            local server_vcr_mode=""
-            if [ -f "$vcr_mode_file" ]; then
-                server_vcr_mode=$(cat "$vcr_mode_file")
-            fi
+            # Verify the server belongs to THIS worktree by checking its cwd.
+            # Without this, a stale .server-port can cause us to reuse a server
+            # from a different worktree that happens to be on the same port.
+            local server_cwd
+            server_cwd=$(curl -s "http://localhost:$detected_port/api/server-info" 2>/dev/null | grep -o '"cwd":"[^"]*"' | sed 's/"cwd":"//;s/"$//')
 
-            if [ "${VCR_MODE:-}" != "$server_vcr_mode" ]; then
-                print_warning "Server VCR_MODE mismatch: server='$server_vcr_mode', needed='${VCR_MODE:-}'. Restarting..."
-                local server_pid
-                server_pid=$(lsof -t -i:"$detected_port" 2>/dev/null)
-                if [ -n "$server_pid" ]; then
-                    kill "$server_pid" 2>/dev/null
-                    # Wait for port to be released (up to 5 seconds)
-                    local wait_count=0
-                    while lsof -i:"$detected_port" >/dev/null 2>&1 && [ $wait_count -lt 5 ]; do
-                        sleep 1
-                        ((wait_count++))
-                    done
-                fi
-                rm -f "$port_file" "$vcr_mode_file"
+            if [ -n "$server_cwd" ] && [ "$server_cwd" != "$PROJECT_ROOT" ]; then
+                print_warning "Server on port $detected_port belongs to a different worktree:"
+                print_warning "  server cwd:  $server_cwd"
+                print_warning "  our root:    $PROJECT_ROOT"
+                print_info "Removing stale .server-port and starting a new server..."
+                rm -f "$port_file" "$PROJECT_ROOT/.vcr-mode"
             else
-                print_success "Server is already running on port $detected_port (VCR_MODE=$server_vcr_mode)"
-                echo "$detected_port"
-                return 0
+                # Server belongs to us — check VCR_MODE
+                local vcr_mode_file="$PROJECT_ROOT/.vcr-mode"
+                local server_vcr_mode=""
+                if [ -f "$vcr_mode_file" ]; then
+                    server_vcr_mode=$(cat "$vcr_mode_file")
+                fi
+
+                if [ "${VCR_MODE:-}" != "$server_vcr_mode" ]; then
+                    print_warning "Server VCR_MODE mismatch: server='$server_vcr_mode', needed='${VCR_MODE:-}'. Restarting..."
+                    local server_pid
+                    server_pid=$(lsof -t -i:"$detected_port" 2>/dev/null)
+                    if [ -n "$server_pid" ]; then
+                        kill "$server_pid" 2>/dev/null
+                        # Wait for port to be released (up to 5 seconds)
+                        local wait_count=0
+                        while lsof -i:"$detected_port" >/dev/null 2>&1 && [ $wait_count -lt 5 ]; do
+                            sleep 1
+                            ((wait_count++))
+                        done
+                    fi
+                    rm -f "$port_file" "$vcr_mode_file"
+                else
+                    print_success "Server is already running on port $detected_port (VCR_MODE=$server_vcr_mode)"
+                    echo "$detected_port"
+                    return 0
+                fi
             fi
         else
             print_warning "Server not running on port $detected_port (stale .server-port file)"

--- a/tests/e2e/dev-tooling.spec.ts
+++ b/tests/e2e/dev-tooling.spec.ts
@@ -359,7 +359,7 @@ test.describe('Category 4: pw.sh Enhancements', () => {
     expect(funcStart).toBeGreaterThan(-1);
 
     // Get the function body (up to the next top-level function or end)
-    const funcBody = pwshSource.slice(funcStart, funcStart + 2000);
+    const funcBody = pwshSource.slice(funcStart, funcStart + 4000);
 
     // (a) Curl check against the port from .server-port
     expect(funcBody).toMatch(/curl.*localhost.*\$.*port/i);


### PR DESCRIPTION
## Summary

- **Phase 7**: Decomposed `SessionListView.vue` by extracting `SessionFiltersPanel.vue`, `ArchivedTabContent.vue`, `ScheduledTabContent.vue`, and composables (`useSessionSummaries`, `useSessionFiltering`, `useProjectSessionSubscription`)
- **Phase 8**: Decomposed `SessionDetailView.vue` (1,200 → 387 lines, 68% reduction) by extracting `PrUrlEditor.vue`, `SessionHeaderPanel.vue`, `SessionTabsPanel.vue`, and `useSessionInitializer.js` composable
- Also includes earlier ApiClient resource module extraction (Phase 6) and summaryService refactoring (Phase 4)

## Test plan

- [x] All 3,309 web tests pass (119 files)
- [x] All 3,159 server tests pass (119 files)
- [x] ESLint clean — no warnings or errors
- [x] New test files created for every extracted component and composable
- [x] Existing `SessionDetailView.test.js` updated to work with new component structure (92 tests pass)
- [ ] Manual smoke test: verify session detail view renders correctly with tabs, header, PR URL editing, and name editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)