### PR TITLE
Fix command output display and major refactoring

### DIFF
--- a/packages/web/src/components/CommandButtonItem.test.js
+++ b/packages/web/src/components/CommandButtonItem.test.js
@@ -4,6 +4,7 @@ import { mount, flushPromises } from '@vue/test-utils';
 import { ref, nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import CommandButtonItem from './CommandButtonItem.vue';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 
 describe('CommandButtonItem', () => {
   // Set up a fresh Pinia instance before each test
@@ -479,7 +480,7 @@ describe('CommandButtonItem', () => {
       expect(actionMenu.exists()).toBe(false);
     });
 
-    it('does not display ActionMenu when no output is available', async () => {
+    it('displays ActionMenu for completed run even without output', async () => {
       const runWithoutOutput = { ...mockRun, output: null };
 
       const wrapper = mount(CommandButtonItem, {
@@ -490,9 +491,9 @@ describe('CommandButtonItem', () => {
         }
       });
 
-      // Should not have ActionMenu
+      // ActionMenu should be visible for any completed run (relaxed v-if)
       const actionMenu = wrapper.findComponent({ name: 'ActionMenu' });
-      expect(actionMenu.exists()).toBe(false);
+      expect(actionMenu.exists()).toBe(true);
     });
 
     it('passes correct menu items to ActionMenu', async () => {
@@ -531,6 +532,10 @@ describe('CommandButtonItem', () => {
           run: mockRun
         }
       });
+
+      // Populate the store's runs so handleCopyOutput can read from it
+      const store = useCommandButtonsStore();
+      store.runs[mockRun.runId] = { ...mockRun };
 
       await wrapper.vm.handleCopyOutput();
       await nextTick();
@@ -577,6 +582,10 @@ describe('CommandButtonItem', () => {
           run: mockRun
         }
       });
+
+      // Populate the store's runs so handleCopyOutput can read from it
+      const store = useCommandButtonsStore();
+      store.runs[mockRun.runId] = { ...mockRun };
 
       // Test that handleMenuAction with 'copy-output' calls clipboard API
       await wrapper.vm.handleMenuAction('copy-output');
@@ -626,11 +635,195 @@ describe('CommandButtonItem', () => {
         }
       });
 
+      // Populate the store's runs so handleCopyOutput can read from it
+      const store = useCommandButtonsStore();
+      store.runs[runWithColor.runId] = { ...runWithColor };
+
       await wrapper.vm.handleCopyOutput();
       await nextTick();
 
       // Should strip ANSI codes before copying
       expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('Error message');
+    });
+  });
+
+  describe('ActionMenu visibility (relaxed v-if)', () => {
+    it('displays ActionMenu for completed run without output', () => {
+      const runWithoutOutput = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: '',
+        exitCode: 0,
+        outputTruncated: false,
+      };
+
+      const wrapper = mount(CommandButtonItem, {
+        props: {
+          button: mockButton,
+          sessionId: 'session-1',
+          run: runWithoutOutput
+        }
+      });
+
+      const actionMenu = wrapper.findComponent({ name: 'ActionMenu' });
+      expect(actionMenu.exists()).toBe(true);
+    });
+
+    it('hides ActionMenu while running', () => {
+      const runningRun = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'running',
+        output: 'partial',
+        exitCode: null,
+        outputTruncated: false,
+      };
+
+      const wrapper = mount(CommandButtonItem, {
+        props: {
+          button: mockButton,
+          sessionId: 'session-1',
+          run: runningRun
+        }
+      });
+
+      const actionMenu = wrapper.findComponent({ name: 'ActionMenu' });
+      expect(actionMenu.exists()).toBe(false);
+    });
+  });
+
+  describe('on-demand output fetching', () => {
+    beforeEach(() => {
+      global.navigator.clipboard = {
+        writeText: vi.fn().mockResolvedValue(undefined)
+      };
+    });
+
+    it('expand triggers fetchRunOutput when output is empty', async () => {
+      const runWithoutOutput = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: '',
+        exitCode: 0,
+        outputTruncated: false,
+      };
+
+      const wrapper = mount(CommandButtonItem, {
+        props: {
+          button: mockButton,
+          sessionId: 'session-1',
+          run: runWithoutOutput
+        }
+      });
+
+      const store = useCommandButtonsStore();
+      const fetchSpy = vi.spyOn(store, 'fetchRunOutput').mockResolvedValue(undefined);
+
+      // Click to expand output
+      const outputHeader = wrapper.find('.output-header');
+      await outputHeader.trigger('click');
+      await nextTick();
+
+      expect(fetchSpy).toHaveBeenCalledWith('session-1', 'run-1');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('handleCopyOutput fetches output if not loaded', async () => {
+      const runWithoutOutput = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: '',
+        exitCode: 0,
+        outputTruncated: false,
+      };
+
+      const wrapper = mount(CommandButtonItem, {
+        props: {
+          button: mockButton,
+          sessionId: 'session-1',
+          run: runWithoutOutput
+        }
+      });
+
+      const store = useCommandButtonsStore();
+      // Set up the run in store so fetchRunOutput can populate it
+      store.runs['run-1'] = { ...runWithoutOutput };
+      const fetchSpy = vi.spyOn(store, 'fetchRunOutput').mockImplementation(async () => {
+        store.runs['run-1'] = { ...store.runs['run-1'], output: 'fetched output' };
+      });
+
+      await wrapper.vm.handleCopyOutput();
+      await nextTick();
+
+      expect(fetchSpy).toHaveBeenCalledWith('session-1', 'run-1');
+      expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith('fetched output');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('handleSendToCanvas calls fetchRunOutput when output is empty', async () => {
+      const runWithoutOutput = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: '',
+        exitCode: 0,
+        outputTruncated: false,
+      };
+
+      const store = useCommandButtonsStore();
+      store.runs['run-1'] = { ...runWithoutOutput };
+
+      const wrapper = mount(CommandButtonItem, {
+        props: {
+          button: mockButton,
+          sessionId: 'session-1',
+          run: runWithoutOutput
+        }
+      });
+
+      const fetchSpy = vi.spyOn(store, 'fetchRunOutput').mockResolvedValue(undefined);
+
+      await wrapper.vm.handleSendToCanvas();
+      await nextTick();
+
+      expect(fetchSpy).toHaveBeenCalledWith('session-1', 'run-1');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('handleSendToCanvas reads output from store', async () => {
+      const store = useCommandButtonsStore();
+      store.runs['run-1'] = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: 'stored output',
+        exitCode: 0,
+        outputTruncated: false,
+      };
+
+      const wrapper = mount(CommandButtonItem, {
+        props: {
+          button: mockButton,
+          sessionId: 'session-1',
+          run: {
+            runId: 'run-1',
+            buttonId: 'btn-1',
+            status: 'success',
+            output: 'stored output',
+            exitCode: 0,
+            outputTruncated: false,
+          }
+        }
+      });
+
+      // handleSendToCanvas should not throw when output is available in store
+      await expect(wrapper.vm.handleSendToCanvas()).resolves.not.toThrow();
     });
   });
 });

--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -15,7 +15,7 @@
 
         <!-- Action Menu (copy/canvas/copy-command) -->
         <ActionMenu
-          v-if="run?.output && run.status !== 'running'"
+          v-if="run && run.status !== 'running'"
           :items="menuItems"
           aria-label="Command output actions"
           @action-click="handleMenuAction"
@@ -270,6 +270,15 @@ const updateFormattedOutput = debounceLeading((output) => {
 watch(
   () => [props.run?.output, showOutput.value],
   ([newOutput, isVisible]) => {
+    // Fetch output from server if pane is expanded but output isn't loaded yet.
+    // Note: empty string is falsy, so this triggers for runs loaded from list
+    // queries (which exclude output). Runs that genuinely produced no output
+    // will re-fetch each time, which is an acceptable single lightweight GET.
+    if (isVisible && !newOutput && props.run?.runId && props.run?.status !== 'running') {
+      commandButtonsStore.fetchRunOutput(props.sessionId, props.run.runId);
+      return; // Output will arrive reactively once fetch completes, triggering this watcher again
+    }
+
     if (!newOutput) {
       formattedOutput.value = '';
       outputIsTruncatedForDisplay.value = false;
@@ -415,11 +424,16 @@ const handleMenuAction = async (action) => {
  * Shows toast notification on success
  */
 const handleCopyOutput = async () => {
-  if (!props.run?.output) {
-    return;
+  // Fetch output if not loaded yet
+  if (!props.run?.output && props.run?.runId) {
+    await commandButtonsStore.fetchRunOutput(props.sessionId, props.run.runId);
   }
+  // Read from store directly to avoid reactivity timing issues with props
+  const runData = commandButtonsStore.runs[props.run?.runId];
+  const output = runData?.output;
+  if (!output) return;
 
-  const textToCopy = stripAnsi(props.run.output);
+  const textToCopy = stripAnsi(output);
   let copySucceeded = false;
 
   // Try modern Clipboard API first
@@ -459,8 +473,16 @@ const handleCopyOutput = async () => {
  * Send command output to canvas
  * Toast is shown in parent component (CommandsTab.vue)
  */
-const handleSendToCanvas = () => {
-  emit('send-to-canvas', props.button.label, props.run.output);
+const handleSendToCanvas = async () => {
+  // Fetch output if not loaded yet
+  if (!props.run?.output && props.run?.runId) {
+    await commandButtonsStore.fetchRunOutput(props.sessionId, props.run.runId);
+  }
+  const runData = commandButtonsStore.runs[props.run?.runId];
+  const output = runData?.output;
+  if (!output) return;
+
+  emit('send-to-canvas', props.button.label, output);
 };
 
 /**

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -367,6 +367,26 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
+    async fetchRunOutput(sessionId, runId) {
+      const existing = this.runs[runId];
+      if (!existing || existing.status === 'running') return; // Don't fetch for running commands (streaming via WS)
+      if (existing.output && existing.output.length > 0) return; // Already have output, skip
+
+      try {
+        const run = await api.getCommandRun(sessionId, runId);
+        if (run.output && this.runs[runId]) {
+          const { output, truncated } = this._truncateOutput(run.output);
+          this.runs[runId] = {
+            ...this.runs[runId],
+            output,
+            outputTruncated: truncated,
+          };
+        }
+      } catch (err) {
+        console.warn(`[commandButtons] Failed to fetch output for run ${runId}:`, err.message);
+      }
+    },
+
     setOutputCollapsed(runId, isCollapsed) {
       this.collapsedStates[runId] = isCollapsed;
     },

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -11,6 +11,8 @@ vi.mock('../composables/useApi.js', () => ({
     runCommandButton: vi.fn(),
     getActiveRuns: vi.fn(),
     killCommandRun: vi.fn(),
+    getCommandRun: vi.fn(),
+    getLatestRunsForProject: vi.fn(),
   },
 }));
 
@@ -1075,6 +1077,145 @@ describe('CommandButtons Store', () => {
       await store.fetchActiveRuns('sess-123');
 
       expect(store.runs['run-1'].completedAt).toBeUndefined();
+    });
+  });
+
+  describe('fetchRunOutput', () => {
+    it('fetches output and merges into store', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'r1': {
+          runId: 'r1',
+          buttonId: 'b1',
+          sessionId: 'sess-1',
+          status: 'success',
+          output: '',
+          exitCode: 0,
+          outputTruncated: false,
+        },
+      };
+
+      api.getCommandRun.mockResolvedValue({
+        runId: 'r1',
+        buttonId: 'b1',
+        status: 'success',
+        output: 'fetched output',
+        exitCode: 0,
+        startedAt: Date.now(),
+        completedAt: Date.now(),
+      });
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      expect(store.runs['r1'].output).toBe('fetched output');
+      expect(store.runs['r1'].outputTruncated).toBe(false);
+    });
+
+    it('skips fetch when run is currently running', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'r1': {
+          runId: 'r1',
+          buttonId: 'b1',
+          sessionId: 'sess-1',
+          status: 'running',
+          output: '',
+          exitCode: null,
+          outputTruncated: false,
+        },
+      };
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      expect(api.getCommandRun).not.toHaveBeenCalled();
+    });
+
+    it('skips fetch when output is already loaded', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'r1': {
+          runId: 'r1',
+          buttonId: 'b1',
+          sessionId: 'sess-1',
+          status: 'success',
+          output: 'already loaded',
+          exitCode: 0,
+          outputTruncated: false,
+        },
+      };
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      expect(api.getCommandRun).not.toHaveBeenCalled();
+    });
+
+    it('handles API error gracefully', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'r1': {
+          runId: 'r1',
+          buttonId: 'b1',
+          sessionId: 'sess-1',
+          status: 'success',
+          output: '',
+          exitCode: 0,
+          outputTruncated: false,
+        },
+      };
+
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      api.getCommandRun.mockRejectedValue(new Error('Network error'));
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('r1'),
+        expect.any(String)
+      );
+      // Existing run data should be preserved
+      expect(store.runs['r1'].output).toBe('');
+      expect(store.runs['r1'].status).toBe('success');
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('truncates long output', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'r1': {
+          runId: 'r1',
+          buttonId: 'b1',
+          sessionId: 'sess-1',
+          status: 'success',
+          output: '',
+          exitCode: 0,
+          outputTruncated: false,
+        },
+      };
+
+      // Create output with more than 2000 lines
+      const longOutput = Array.from({ length: 2500 }, (_, i) => `Line ${i + 1}`).join('\n');
+      api.getCommandRun.mockResolvedValue({
+        runId: 'r1',
+        buttonId: 'b1',
+        status: 'success',
+        output: longOutput,
+        exitCode: 0,
+      });
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      const outputLines = store.runs['r1'].output.split('\n');
+      expect(outputLines.length).toBeLessThanOrEqual(2000);
+      expect(store.runs['r1'].outputTruncated).toBe(true);
+    });
+
+    it('no-op when run does not exist in store', async () => {
+      const store = useCommandButtonsStore();
+
+      await store.fetchRunOutput('sess-1', 'nonexistent-run-id');
+
+      expect(api.getCommandRun).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

This PR includes multiple improvements and bug fixes accumulated across several features:

### 🐛 Bug Fix: Command Output Display

**Fixed issue where command button output sometimes wasn't displayed after completion.**

The problem was introduced by PR #630, which removed the `output` column from list queries for performance reasons. Rather than reverting that optimization, this PR implements an on-demand fetch approach:

- Added `fetchRunOutput()` to commandButtons store to fetch individual run output via existing GET /runs/:runId API
- Modified CommandButtonItem to trigger fetch when:
  - Pane is expanded but output isn't loaded
  - User clicks copy output button
  - User clicks send to canvas button
- Relaxed ActionMenu visibility to display menu for any completed run (not just runs with pre-loaded output)

**Result**: Preserves the performance optimization from PR #630 while ensuring output is available when users interact with commands.

### 🔧 Major Refactoring

#### API Client Refactoring
- Split monolithic `ApiClient.js` (1300+ lines) into 10 focused resource modules
- Each module has its own test file for better coverage
- Used mixin pattern to share common functionality
- Modules: Canvas, CommandButtons, Conversations, Misc, Projects, Providers, QuickResponses, Sessions, Settings, Templates

#### Summary Services Refactoring
- Eliminated circular dependency between summary services
- Added concurrency guards to prevent duplicate summary operations
- Added stale summary detection and refresh mechanism
- Improved test coverage

#### SessionListView Refactoring
- Extracted `useProjectSessionSubscription` composable for WebSocket subscriptions
- Extracted `useSessionFiltering` composable for filter logic
- Added comprehensive test coverage for new components:
  - ArchivedTabContent
  - ScheduledTabContent
  - SessionFiltersPanel

## Test Coverage

All new features and refactored code include comprehensive unit tests:
- ✅ fetchRunOutput store action (fetch, skip conditions, error handling, truncation)
- ✅ On-demand fetch in CommandButtonItem component (expand, copy, send to canvas)
- ✅ All 10 new API resource modules
- ✅ Refactored summary services
- ✅ New composables and components

## Files Changed

- 52 files changed, 7061 insertions(+), 2065 deletions(-)
- All changes include corresponding test updates
- No breaking changes to existing APIs or user-facing functionality

## Test Plan

- [x] All unit tests pass (`yarn test`)
- [x] Manual testing of command button output display (expand, copy, send to canvas)
- [x] Verified no performance regression from PR #630 optimization
- [x] Verified existing functionality still works (navigation, filtering, WebSocket updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)