### PR TITLE
fix: Respect global disableSessionSummaries setting in onSessionComplete

### DIFF
--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -312,6 +312,22 @@ export function onSessionActivity(sessionId) {
  * @param {string} sessionId
  */
 export function onSessionComplete(sessionId) {
+  // Early exit if session summaries are disabled globally
+  const globalSettings = settings.getSummarySettings();
+  if (globalSettings?.disableSessionSummaries) {
+    // Still schedule CI checks below, but skip all summary work
+    const session = sessions.getById(sessionId);
+    if (session?.prUrl) {
+      const scheduleCiCheck = async () => {
+        const prStatusService = await import('./prStatusService.js');
+        prStatusService.checkSessionCiStatusNow(sessionId);
+      };
+      setTimeout(scheduleCiCheck, 2 * 60 * 1000);
+      setTimeout(scheduleCiCheck, 5 * 60 * 1000);
+    }
+    return;
+  }
+
   // Lightweight outcome update: if summary exists and is current,
   // just update the outcome field without calling the LLM
   const existingSummary = sessionSummaries.getBySessionId(sessionId);

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -2563,7 +2563,7 @@ describe('summaryService', () => {
       settings.setSummarySettings({ disableSessionSummaries: false });
     });
 
-    it('onSessionComplete does lightweight outcome update when disabled but skips LLM', async () => {
+    it('onSessionComplete skips lightweight outcome update when disabled', async () => {
       // Get the current session state to create a matching non-stale summary
       const allMessages = messages.getBySessionId(sessionId);
       const lastMessage = allMessages.length > 0 ? allMessages[allMessages.length - 1] : null;
@@ -2586,18 +2586,18 @@ describe('summaryService', () => {
       // Disable session summaries
       settings.setSummarySettings({ disableSessionSummaries: true });
 
-      // Call onSessionComplete - should do lightweight update but skip LLM
+      // Call onSessionComplete - should skip ALL summary work (including lightweight path)
       summaryService.onSessionComplete(sessionId);
 
       // Wait for any async operations
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // Verify outcome was updated to 'completed' (lightweight path ran)
+      // Verify outcome was NOT updated (early return skipped the lightweight path)
       const updatedSummary = sessionSummaries.getBySessionId(sessionId);
       expect(updatedSummary).not.toBeNull();
-      expect(updatedSummary.outcome).toBe('completed');
+      expect(updatedSummary.outcome).toBe('in_progress'); // unchanged
 
-      // Verify no new LLM call was made (summary content should be unchanged)
+      // Verify no new LLM call was made
       expect(updatedSummary.fullSummary).toBe('Full test summary content');
 
       // Re-enable for other tests
@@ -2623,6 +2623,70 @@ describe('summaryService', () => {
 
       // Re-enable for other tests
       settings.setSummarySettings({ disableSessionSummaries: false });
+    });
+
+    it('onSessionComplete skips all summary work for child sessions when disabled', async () => {
+      // Create a child session
+      const childSession = sessions.create(projectId, 'Child Session', 'Child prompt', 'standard');
+      sessions.update(childSession.id, { parentSessionId: sessionId });
+
+      // Add enough messages for the child
+      messages.create(childSession.id, 'assistant', 'Child response 1');
+      messages.create(childSession.id, 'user', 'Child follow-up');
+
+      // Disable session summaries
+      settings.setSummarySettings({ disableSessionSummaries: true });
+
+      // Complete the child session
+      sessions.update(childSession.id, { status: 'completed' });
+      summaryService.onSessionComplete(childSession.id);
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify no summary was generated for the child
+      const childSummary = sessionSummaries.getBySessionId(childSession.id);
+      expect(childSummary).toBeNull();
+
+      // Verify no summary was generated for the parent either
+      const parentSummary = sessionSummaries.getBySessionId(sessionId);
+      expect(parentSummary).toBeNull();
+
+      // Re-enable for other tests
+      settings.setSummarySettings({ disableSessionSummaries: false });
+
+      // Clean up
+      summaryService.cleanupSession(childSession.id);
+    });
+
+    it('propagateToParent does not generate parent summary when disabled', async () => {
+      // Create a child session
+      const childSession = sessions.create(projectId, 'Child Session', 'Child prompt', 'standard');
+      sessions.update(childSession.id, { parentSessionId: sessionId });
+
+      // Disable session summaries
+      settings.setSummarySettings({ disableSessionSummaries: true });
+
+      vi.clearAllMocks();
+
+      // Call propagateToParent directly
+      await summaryService.propagateToParent(childSession.id);
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // No LLM calls should have been made
+      expect(agentCallLogger.startCall).not.toHaveBeenCalled();
+
+      // No summary should exist for the parent
+      const parentSummary = sessionSummaries.getBySessionId(sessionId);
+      expect(parentSummary).toBeNull();
+
+      // Re-enable for other tests
+      settings.setSummarySettings({ disableSessionSummaries: false });
+
+      // Clean up
+      summaryService.cleanupSession(childSession.id);
     });
   });
 


### PR DESCRIPTION
## Summary
Fixed a bug where session summaries were being generated even when the global `disableSessionSummaries` setting was enabled. The `onSessionComplete()` function's lightweight outcome-update path was bypassing the global disable check, causing summaries to be updated and broadcast when they shouldn't be.

## Problem
When a user disabled session summaries globally (via app_settings), the system would still:
- Update summary outcomes in the lightweight path
- Broadcast summary updates via WebSocket
- Process summary work unnecessarily

The root cause was that the lightweight outcome-update path in `onSessionComplete()` (lines ~914-936) had no disable check, while all other entry points properly respected the global setting.

## Changes
- Added early return at the start of `onSessionComplete()` to check global `disableSessionSummaries` setting
- Preserved CI status check scheduling for sessions with PR URLs (checks still run even when summaries are disabled)
- Updated tests to verify no summary work occurs when disabled
- Added test coverage for child session behavior when summaries are disabled

## Test Plan
- ✅ All 2988 tests pass across 111 test files
- ✅ New test verifies `onSessionComplete()` skips lightweight outcome update when disabled
- ✅ New test verifies child sessions don't generate summaries when disabled
- ✅ New test verifies `propagateToParent()` doesn't generate parent summaries when disabled

## Files Changed
- `packages/server/src/services/summaryService.js` - Added early return with global check
- `packages/server/src/services/summaryService.test.js` - Updated and added tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)