### PR TITLE
Fix skills without argumentHint auto-firing without user context

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -129,10 +129,9 @@
     <!-- Slash Command Wizard Modal -->
     <SlashCommandWizard
       v-model:isOpen="showSlashCommandWizard"
-      :sessionId="sessionId"
       :workingDirectory="workingDirectory"
-      mode="execute"
-      @executed="handleSlashCommandExecuted"
+      mode="insert"
+      @insert="handleSlashCommandInsert"
     />
 
   </div>
@@ -564,8 +563,26 @@ function closeScheduleModal() {
   showScheduleModal.value = false;
 }
 
-function handleSlashCommandExecuted({ command, args }) {
-  scrollToBottom(true);
+function handleSlashCommandInsert({ text }) {
+  // Insert the slash command text into the input field instead of auto-executing
+  const existing = input.value.trim();
+  if (existing) {
+    input.value = text + ' ' + existing;
+  } else {
+    input.value = text + ' ';
+  }
+
+  // Sync to textarea DOM and focus so user can add context before submitting
+  nextTick(() => {
+    const textareaRef = inputFormRef.value?.textareaRef;
+    if (textareaRef) {
+      textareaRef.value = input.value;
+      textareaRef.focus();
+      textareaRef.selectionStart = textareaRef.selectionEnd = input.value.length;
+      // Trigger input event so ResizableTextarea auto-resizes
+      textareaRef.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  });
 }
 
 // Branching methods

--- a/packages/web/src/components/SlashCommandWizard.test.js
+++ b/packages/web/src/components/SlashCommandWizard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import SlashCommandWizard from './SlashCommandWizard.vue';
 import CommandGrid from './slash-commands/CommandGrid.vue';
@@ -227,11 +227,17 @@ describe('SlashCommandWizard.vue', () => {
 
       commandsStore.commands = [skill];
 
+      // Use an onInsert listener via attrs since wrapper.emitted() doesn't work
+      // reliably with Teleport stubs
+      const insertSpy = vi.fn();
       const wrapper = mount(SlashCommandWizard, {
         props: {
           isOpen: true,
           workingDirectory: '/test',
           mode: 'insert',
+        },
+        attrs: {
+          onInsert: insertSpy,
         },
         global: { stubs: { Teleport: true } },
       });
@@ -241,14 +247,25 @@ describe('SlashCommandWizard.vue', () => {
       grid.vm.$emit('select', skill);
       await wrapper.vm.$nextTick();
 
-      // Submit from args form
+      // Verify step 2 is showing
       const argsForm = wrapper.findComponent(ArgumentsForm);
-      argsForm.vm.$emit('submit', { _raw: 'build a login page' });
-      await wrapper.vm.$nextTick();
+      expect(argsForm.exists()).toBe(true);
+
+      // Type into the skill args input
+      const input = argsForm.find('[data-testid="skill-args-input"]');
+      await input.setValue('build a login page');
+
+      // Submit via the form
+      await argsForm.find('form').trigger('submit');
+      await flushPromises();
 
       // Should emit insert with command string built by buildInsertString()
-      expect(wrapper.emitted('insert')).toBeTruthy();
-      expect(wrapper.emitted('insert')[0][0].text).toBe('/frontend-design build a login page');
+      expect(insertSpy).toHaveBeenCalledTimes(1);
+      expect(insertSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: '/frontend-design build a login page',
+        })
+      );
     });
   });
 });

--- a/packages/web/src/components/SlashCommandWizard.test.js
+++ b/packages/web/src/components/SlashCommandWizard.test.js
@@ -187,5 +187,68 @@ describe('SlashCommandWizard.vue', () => {
         _raw: 'codebase',
       });
     });
+
+    it('shows ArgumentsForm for skills WITHOUT argumentHint (does not auto-execute)', async () => {
+      const skill = {
+        name: 'my-skill',
+        source: 'project-skill',
+        isSkill: true,
+        description: 'A test skill',
+        // No argumentHint
+      };
+
+      commandsStore.commands = [skill];
+
+      const wrapper = mount(SlashCommandWizard, {
+        props: {
+          isOpen: true,
+          workingDirectory: '/test',
+          mode: 'insert',
+        },
+        global: { stubs: { Teleport: true } },
+      });
+
+      const grid = wrapper.findComponent(CommandGrid);
+      grid.vm.$emit('select', skill);
+      await wrapper.vm.$nextTick();
+
+      // Should show ArgumentsForm, not auto-execute
+      const argsForm = wrapper.findComponent(ArgumentsForm);
+      expect(argsForm.exists()).toBe(true);
+    });
+
+    it('emits insert event with correct text when skill args form is submitted', async () => {
+      const skill = {
+        name: 'frontend-design',
+        source: 'project-skill',
+        isSkill: true,
+        description: 'Create interfaces',
+      };
+
+      commandsStore.commands = [skill];
+
+      const wrapper = mount(SlashCommandWizard, {
+        props: {
+          isOpen: true,
+          workingDirectory: '/test',
+          mode: 'insert',
+        },
+        global: { stubs: { Teleport: true } },
+      });
+
+      // Select skill -> goes to step 2
+      const grid = wrapper.findComponent(CommandGrid);
+      grid.vm.$emit('select', skill);
+      await wrapper.vm.$nextTick();
+
+      // Submit from args form
+      const argsForm = wrapper.findComponent(ArgumentsForm);
+      argsForm.vm.$emit('submit', { _raw: 'build a login page' });
+      await wrapper.vm.$nextTick();
+
+      // Should emit insert with command string built by buildInsertString()
+      expect(wrapper.emitted('insert')).toBeTruthy();
+      expect(wrapper.emitted('insert')[0][0].text).toBe('/frontend-design build a login page');
+    });
   });
 });

--- a/packages/web/src/components/SlashCommandWizard.vue
+++ b/packages/web/src/components/SlashCommandWizard.vue
@@ -130,15 +130,9 @@ function close() {
 function selectCommand(cmd) {
   selectedCommand.value = cmd;
 
-  // For skills: check if it has argumentHint to determine if we need args form
+  // For skills: always show the args form so the user can provide context
   if (cmd.isSkill) {
-    if (cmd.argumentHint) {
-      // Show args form for skills with argument hint
-      step.value = 2;
-    } else {
-      // Execute immediately for skills without args
-      handleExecute({ _raw: '' });
-    }
+    step.value = 2;
     return;
   }
 


### PR DESCRIPTION
## Summary
- **Fixed** the slash command wizard so skills without `argumentHint` (e.g., `frontend-design`) always show the arguments form instead of auto-executing with empty context
- **Switched** `ConversationTab` to insert mode so skill text is placed in the input field, letting users review and add context before sending
- **Added** two new unit tests covering skills without `argumentHint` and the insert event flow

## Test plan
- [ ] Open slash command wizard and select a skill without `argumentHint` (e.g., `frontend-design`) — should show arguments form
- [ ] Enter context text and submit — skill command text should appear in the message input
- [ ] Select a skill with `argumentHint` — should still show arguments form as before
- [ ] Verify all 8 SlashCommandWizard tests pass (`yarn workspace @claudetools/web test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)