### PR TITLE
Fix: Extract PR URL before generating summary on error path

### DIFF
--- a/packages/server/src/services/streamEventHandler.js
+++ b/packages/server/src/services/streamEventHandler.js
@@ -494,6 +494,8 @@ function handleResultError(sessionId, event) {
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: event.error });
   // Broadcast error status to project subscribers for session list updates
   broadcastSessionStatus(sessionId, 'error');
+  // Extract PR URL before generating summary (PR may have been created before error)
+  summaryService.extractPrUrlIfNeeded(sessionId);
   // Generate summary on error
   summaryService.onSessionComplete(sessionId);
 }
@@ -816,6 +818,8 @@ export async function handleSessionError(sessionId, error, options = {}) {
       broadcastSessionStatus(sessionId, 'error');
     }
 
+    // Extract PR URL before generating summary (PR may have been created before error)
+    summaryService.extractPrUrlIfNeeded(sessionId);
     // Trigger summary generation on error
     summaryService.onSessionComplete(sessionId);
   }

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -677,6 +677,65 @@ describe('streamEventHandler', () => {
       expect(consoleSpy).toHaveBeenCalledWith('Continue session error:', error);
       consoleSpy.mockRestore();
     });
+
+    it('calls extractPrUrlIfNeeded before onSessionComplete', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('Failed after creating PR');
+      sessions.getById.mockReturnValue({ autoRescheduleEnabled: false });
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, {
+        controller,
+        shouldRescheduleOnError: mockShouldReschedule,
+        schedulerService: mockScheduler,
+      });
+
+      expect(summaryService.extractPrUrlIfNeeded).toHaveBeenCalledWith('sess-1');
+      expect(summaryService.onSessionComplete).toHaveBeenCalledWith('sess-1');
+      // Verify call order: extractPrUrlIfNeeded should be called before onSessionComplete
+      expect(summaryService.extractPrUrlIfNeeded.mock.invocationCallOrder[0]).toBeLessThan(
+        summaryService.onSessionComplete.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('does not call extractPrUrlIfNeeded when controller is aborted', async () => {
+      const controller = { signal: { aborted: true } };
+      const error = new Error('Aborted');
+
+      const mockShouldReschedule = vi.fn();
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, {
+        controller,
+        shouldRescheduleOnError: mockShouldReschedule,
+        schedulerService: mockScheduler,
+      });
+
+      expect(summaryService.extractPrUrlIfNeeded).not.toHaveBeenCalled();
+      expect(summaryService.onSessionComplete).not.toHaveBeenCalled();
+    });
+
+    it('does not call extractPrUrlIfNeeded when session is rescheduled', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('token limit exceeded');
+      const mockSession = { autoRescheduleEnabled: true, rescheduleOnTokenLimit: true };
+      sessions.getById.mockReturnValue(mockSession);
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(true);
+      const mockScheduler = { rescheduleSession: vi.fn().mockResolvedValue(true) };
+
+      const result = await handleSessionError('sess-1', error, {
+        controller,
+        shouldRescheduleOnError: mockShouldReschedule,
+        schedulerService: mockScheduler,
+      });
+
+      expect(result).toBe(true);
+      expect(summaryService.extractPrUrlIfNeeded).not.toHaveBeenCalled();
+      expect(summaryService.onSessionComplete).not.toHaveBeenCalled();
+    });
   });
 
   // ── Module-level Maps ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Problem**: When a session errors out after successfully creating a PR, the PR URL was never extracted because `extractPrUrlIfNeeded` was only called in the success path
- **Solution**: Added `extractPrUrlIfNeeded` calls to both error paths in `streamEventHandler.js` before `onSessionComplete`
- **Impact**: PR URLs are now correctly captured and propagated to parent sessions even when the Claude Code process errors after PR creation

## Changes

- Modified `handleSessionError()` to extract PR URL before generating summary
- Modified `result.error` case in `handleStreamEvent()` to extract PR URL before generating summary
- Added unit tests to verify `extractPrUrlIfNeeded` is called in the correct order

## Test plan

- [x] Run stream event handler tests: `yarn workspace @claudetools/server test src/services/streamEventHandler.test.js`
- [x] Verify tests pass for new error path PR extraction behavior
- [x] Run full server test suite: `yarn workspace @claudetools/server test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)