### PR TITLE
Add loading spinner next to mobile select dropdown

### DIFF
--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -146,6 +146,28 @@ describe('SessionTabsPanel', () => {
       expect(option.text()).toContain('...');
     });
 
+    it('shows loading spinner when isSessionActive is true in mobile', () => {
+      const wrapper = mountPanel({ isSessionActive: true });
+      expect(wrapper.find('.tabs-mobile .loading-spinner').exists()).toBe(true);
+    });
+
+    it('hides loading spinner when isSessionActive is false in mobile', () => {
+      const wrapper = mountPanel({ isSessionActive: false });
+      expect(wrapper.find('.tabs-mobile .loading-spinner').exists()).toBe(false);
+    });
+
+    it('shows "Session running..." tooltip when status is running', () => {
+      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'running' });
+      const spinner = wrapper.find('.tabs-mobile .loading-spinner');
+      expect(spinner.attributes('title')).toBe('Session running...');
+    });
+
+    it('shows "Session starting..." tooltip when status is starting', () => {
+      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'starting' });
+      const spinner = wrapper.find('.tabs-mobile .loading-spinner');
+      expect(spinner.attributes('title')).toBe('Session starting...');
+    });
+
     it('navigates when mobile select changes', async () => {
       const pushSpy = vi.spyOn(router, 'push');
       const wrapper = mountPanel();

--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -40,6 +40,12 @@
 
     <!-- Mobile dropdown -->
     <div class="tabs-mobile">
+      <span
+        v-if="isSessionActive"
+        class="loading-spinner"
+        :title="sessionStatus === 'starting'
+          ? 'Session starting...' : 'Session running...'"
+      ></span>
       <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
         <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
           {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' \u2022' : '' }}{{ tab.id === 'canvas' && canvasCount > 0 ? ' \u2022' : '' }}{{ tab.id === 'conversation' && isSessionActive ? ' ...' : '' }}
@@ -144,5 +150,14 @@ function navigateToTab(tabId) {
   to {
     transform: rotate(360deg);
   }
+}
+
+.tabs-mobile {
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tabs-mobile .loading-spinner {
+  flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- Added a loading spinner next to the mobile select dropdown in the session detail view
- Spinner appears to the left of the select input when the agent is working (session status is 'running' or 'starting')
- Reuses the existing `.loading-spinner` class from main.css for consistency
- Added dynamic tooltip based on session status ("Session starting..." or "Session running...")
- Matches desktop tabs behavior pattern

## Changes
- **SessionTabsPanel.vue**: Added spinner element in `.tabs-mobile` with conditional rendering based on `isSessionActive`
- **SessionTabsPanel.vue**: Added scoped CSS for proper alignment (`align-items: center`, `gap: 0.5rem`)
- **SessionTabsPanel.test.js**: Added 4 new tests to verify spinner visibility and tooltips

## Technical Details
- The spinner automatically inherits responsive behavior since it's inside `.tabs-mobile`
- Desktop (>640px): Desktop tabs visible with their existing spinner
- Mobile (≤640px): Select dropdown visible with spinner to the left when agent is working
- Uses existing `isSessionActive` and `sessionStatus` props (no new state tracking)

## Test Plan
- [x] All 22 unit tests passing (including 4 new mobile spinner tests)
- [x] Manual testing: Spinner appears next to select on mobile when agent is working
- [x] Manual testing: Spinner is aligned and properly spaced (0.5rem gap)
- [x] Manual testing: Responsive behavior works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)