### PR TITLE
feat: Add streaming state hydration for running sessions

### DIFF
--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -16,6 +16,7 @@ import { duplicateSession } from '../services/sessionDuplicator.js';
 import * as slashCommandService from '../services/slashCommandService.js';
 import { validateDraftSession, startDraft, DraftSessionError } from '../services/draftSessionService.js';
 import { configureSchedule, ScheduleError } from '../services/scheduleService.js';
+import { textAccumulators, thinkingAccumulators } from '../services/streamEventHandler.js';
 
 // Import sub-routers
 import notesRouter from './sessions-notes.js';
@@ -306,6 +307,21 @@ router.get('/:id/work-logs', requireSession, (req, res) => {
   // Return work logs grouped by message ID
   const grouped = workLogs.getBySessionIdGrouped(req.params.id);
   res.json(grouped);
+});
+
+// GET /api/sessions/:id/streaming-state - Get current streaming snapshot for a running session
+// Returns recent pending work logs, accumulated partial text, and thinking
+router.get('/:id/streaming-state', requireSession, (req, res) => {
+  const sessionId = req.params.id;
+  const pendingWorkLogs = workLogs.getRecentPendingBySessionId(sessionId);
+  const partialText = textAccumulators.get(sessionId) || '';
+  const thinking = thinkingAccumulators.get(sessionId) || null;
+
+  res.json({
+    workLogs: pendingWorkLogs,
+    partialText,
+    thinking,
+  });
 });
 
 // POST /api/sessions/:id/work-logs - Create work log (for testing)

--- a/packages/server/src/api/sessions.streamingState.test.js
+++ b/packages/server/src/api/sessions.streamingState.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, workLogs } from '../database.js';
+import { textAccumulators, thinkingAccumulators } from '../services/streamEventHandler.js';
+
+// Mock websocket before importing the router
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock sessionManager
+vi.mock('../services/sessionManager.js', () => ({
+  runSession: vi.fn().mockResolvedValue(undefined),
+  continueSession: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn(),
+  restartSession: vi.fn(),
+  cleanupActiveSession: vi.fn(),
+}));
+
+// Mock summaryService
+vi.mock('../services/summaryService.js', () => ({
+  getSummary: vi.fn().mockResolvedValue(null),
+  generateSummary: vi.fn().mockResolvedValue('mock summary'),
+  generateConversationSummary: vi.fn().mockResolvedValue('mock conversation summary'),
+  onSessionActivity: vi.fn(),
+  cleanupSession: vi.fn(),
+}));
+
+// Mock diffService
+vi.mock('../services/diffService.js', () => ({
+  getDiff: vi.fn().mockResolvedValue({ staged: [], unstaged: [] }),
+}));
+
+// Import after mocks are set up
+import sessionsRouter from './sessions.js';
+
+describe('Sessions API - streaming-state', () => {
+  let app;
+  let project;
+  let session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    // Create test project and session
+    project = projects.create('Test Project', '/tmp/test');
+    session = sessions.create(project.id, 'Test Session', 'Initial prompt', 'standard');
+    sessions.update(session.id, { status: 'running' });
+
+    // Clean up accumulators
+    textAccumulators.clear();
+    thinkingAccumulators.clear();
+  });
+
+  afterEach(() => {
+    textAccumulators.clear();
+    thinkingAccumulators.clear();
+  });
+
+  it('returns 404 for non-existent session', async () => {
+    const res = await request(app).get('/api/sessions/non-existent-id/streaming-state');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Session not found');
+  });
+
+  it('returns empty state when no active streaming', async () => {
+    const res = await request(app).get(`/api/sessions/${session.id}/streaming-state`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workLogs).toEqual([]);
+    expect(res.body.partialText).toBe('');
+    expect(res.body.thinking).toBeNull();
+  });
+
+  it('returns pending work logs when they exist', async () => {
+    // Create pending (unassociated) work logs
+    workLogs.create(session.id, 'tool_input', 'Reading file...', { toolName: 'Read' });
+    workLogs.create(session.id, 'tool_output', 'File contents', { toolName: 'Read' });
+
+    const res = await request(app).get(`/api/sessions/${session.id}/streaming-state`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workLogs).toHaveLength(2);
+    // Both work logs should be present (order may vary when timestamps are the same)
+    const contents = res.body.workLogs.map(l => l.content);
+    expect(contents).toContain('Reading file...');
+    expect(contents).toContain('File contents');
+  });
+
+  it('returns accumulated text from textAccumulators', async () => {
+    textAccumulators.set(session.id, 'Hello, I am currently working on...');
+
+    const res = await request(app).get(`/api/sessions/${session.id}/streaming-state`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.partialText).toBe('Hello, I am currently working on...');
+  });
+
+  it('returns accumulated thinking from thinkingAccumulators', async () => {
+    thinkingAccumulators.set(session.id, 'Let me think about this...');
+
+    const res = await request(app).get(`/api/sessions/${session.id}/streaming-state`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.thinking).toBe('Let me think about this...');
+  });
+
+  it('returns all fields together when streaming is active', async () => {
+    workLogs.create(session.id, 'thinking', 'Thinking log');
+    textAccumulators.set(session.id, 'Partial text content');
+    thinkingAccumulators.set(session.id, 'Thinking content');
+
+    const res = await request(app).get(`/api/sessions/${session.id}/streaming-state`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.workLogs).toHaveLength(1);
+    expect(res.body.partialText).toBe('Partial text content');
+    expect(res.body.thinking).toBe('Thinking content');
+  });
+});

--- a/packages/server/src/db/WorkLogRepository.js
+++ b/packages/server/src/db/WorkLogRepository.js
@@ -99,6 +99,20 @@ export class WorkLogRepository extends BaseRepository {
   }
 
   /**
+   * Get recent pending (unassociated) work logs for a session.
+   * These are logs from the current turn that haven't been finalized to a message yet.
+   * @param {string} sessionId - Session ID
+   * @param {number} limit - Maximum number of logs to return (default 15)
+   * @returns {Array} Work logs ordered by timestamp DESC, limited
+   */
+  getRecentPendingBySessionId(sessionId, limit = 15) {
+    const rows = this.db
+      .prepare('SELECT * FROM work_logs WHERE session_id = ? AND message_id IS NULL ORDER BY timestamp DESC LIMIT ?')
+      .all(sessionId, limit);
+    return this.mapAll(rows);
+  }
+
+  /**
    * Delete all work logs for a session
    * @param {string} sessionId - Session ID
    */

--- a/packages/server/src/db/WorkLogRepository.test.js
+++ b/packages/server/src/db/WorkLogRepository.test.js
@@ -192,6 +192,69 @@ describe('WorkLogRepository', () => {
     });
   });
 
+  describe('getRecentPendingBySessionId', () => {
+    it('returns only work logs with message_id IS NULL', () => {
+      repo.create(sessionId, 'thinking', 'Pending 1');
+      repo.create(sessionId, 'thinking', 'Pending 2');
+      repo.create(sessionId, 'thinking', 'Associated', { messageId });
+
+      const pending = repo.getRecentPendingBySessionId(sessionId);
+      expect(pending).toHaveLength(2);
+      expect(pending.every(l => l.messageId === null)).toBe(true);
+    });
+
+    it('does not return work logs that have a message_id set', () => {
+      repo.create(sessionId, 'thinking', 'Associated 1', { messageId });
+      repo.create(sessionId, 'thinking', 'Associated 2', { messageId });
+
+      const pending = repo.getRecentPendingBySessionId(sessionId);
+      expect(pending).toEqual([]);
+    });
+
+    it('respects the limit parameter', () => {
+      for (let i = 0; i < 20; i++) {
+        repo.create(sessionId, 'thinking', `Pending ${i}`);
+      }
+
+      const pending = repo.getRecentPendingBySessionId(sessionId);
+      expect(pending).toHaveLength(15); // default limit
+    });
+
+    it('returns results ordered by timestamp DESC (newest first)', () => {
+      // Insert logs with explicit different timestamps to ensure ordering
+      const db = databaseManager.get();
+      const baseTime = Date.now();
+      const ids = [databaseManager.generateId(), databaseManager.generateId(), databaseManager.generateId()];
+
+      db.prepare('INSERT INTO work_logs (id, session_id, message_id, type, tool_name, content, timestamp) VALUES (?, ?, NULL, ?, NULL, ?, ?)').run(ids[0], sessionId, 'thinking', 'First', baseTime);
+      db.prepare('INSERT INTO work_logs (id, session_id, message_id, type, tool_name, content, timestamp) VALUES (?, ?, NULL, ?, NULL, ?, ?)').run(ids[1], sessionId, 'thinking', 'Second', baseTime + 1000);
+      db.prepare('INSERT INTO work_logs (id, session_id, message_id, type, tool_name, content, timestamp) VALUES (?, ?, NULL, ?, NULL, ?, ?)').run(ids[2], sessionId, 'thinking', 'Third', baseTime + 2000);
+
+      const pending = repo.getRecentPendingBySessionId(sessionId);
+      // Newest first
+      expect(pending[0].content).toBe('Third');
+      expect(pending[1].content).toBe('Second');
+      expect(pending[2].content).toBe('First');
+    });
+
+    it('returns empty array when all logs are associated with messages', () => {
+      repo.create(sessionId, 'thinking', 'Log 1', { messageId });
+      repo.create(sessionId, 'thinking', 'Log 2', { messageId });
+
+      const pending = repo.getRecentPendingBySessionId(sessionId);
+      expect(pending).toEqual([]);
+    });
+
+    it('allows custom limit', () => {
+      for (let i = 0; i < 10; i++) {
+        repo.create(sessionId, 'thinking', `Pending ${i}`);
+      }
+
+      const pending = repo.getRecentPendingBySessionId(sessionId, 3);
+      expect(pending).toHaveLength(3);
+    });
+  });
+
   describe('deleteBySessionId', () => {
     it('deletes all logs for a session', () => {
       repo.create(sessionId, 'thinking', 'Log 1');

--- a/packages/web/src/composables/useRunningSessionSubscriptions.js
+++ b/packages/web/src/composables/useRunningSessionSubscriptions.js
@@ -67,6 +67,17 @@ export function useRunningSessionSubscriptions() {
 
     sub.subscribe();
 
+    // Hydrate current streaming state from the server (fire-and-forget).
+    // This ensures we see content for sessions already running before we subscribed.
+    fetch(`/api/sessions/${sessionId}/streaming-state`)
+      .then(res => res.ok ? res.json() : null)
+      .then(snapshot => {
+        if (snapshot) {
+          streamingStore.hydrateSessionState(sessionId, snapshot);
+        }
+      })
+      .catch(() => { /* Hydration failure is non-fatal */ });
+
     activeSubscriptions.value[sessionId] = {
       subscription: sub,
       cleanup: () => {

--- a/packages/web/src/composables/useRunningSessionSubscriptions.test.js
+++ b/packages/web/src/composables/useRunningSessionSubscriptions.test.js
@@ -14,6 +14,7 @@ const mockStreamingStore = {
   setPartialThinking: vi.fn(),
   setSessionFileCount: vi.fn(),
   clearSessionStreamingState: vi.fn(),
+  hydrateSessionState: vi.fn(),
 };
 
 // Mock useSessionSubscription - track instances by sessionId
@@ -73,6 +74,15 @@ describe('useRunningSessionSubscriptions', () => {
     mockStreamingStore.setPartialThinking.mockReset();
     mockStreamingStore.setSessionFileCount.mockReset();
     mockStreamingStore.clearSessionStreamingState.mockReset();
+    mockStreamingStore.hydrateSessionState.mockReset();
+
+    // Default fetch mock: returns empty streaming state
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ workLogs: [], partialText: '', thinking: null }),
+      })
+    );
 
     // Create test component to use the composable
     testComponent = {
@@ -336,6 +346,63 @@ describe('useRunningSessionSubscriptions', () => {
     vi.advanceTimersByTime(2000);
 
     expect(mockStreamingStore.clearSessionStreamingState).toHaveBeenCalledWith('session-1');
+  });
+
+  it('makes a REST call to /api/sessions/:id/streaming-state after subscribing', async () => {
+    mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+    wrapper = mount(testComponent, {
+      global: { plugins: [createPinia()] },
+    });
+
+    await nextTick();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/sessions/session-1/streaming-state');
+  });
+
+  it('calls hydrateSessionState when streaming-state REST call resolves', async () => {
+    const snapshot = {
+      workLogs: [{ id: '1', type: 'tool_use', content: 'test' }],
+      partialText: 'hello',
+      thinking: 'hmm',
+    };
+
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(snapshot),
+      })
+    );
+
+    mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+    wrapper = mount(testComponent, {
+      global: { plugins: [createPinia()] },
+    });
+
+    await nextTick();
+    // Wait for fetch promise chain to resolve
+    await vi.waitFor(() => {
+      expect(mockStreamingStore.hydrateSessionState).toHaveBeenCalledWith('session-1', snapshot);
+    });
+  });
+
+  it('does not throw when streaming-state REST call fails', async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
+
+    mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+    wrapper = mount(testComponent, {
+      global: { plugins: [createPinia()] },
+    });
+
+    await nextTick();
+
+    // Should not throw or break the subscription
+    const sub = mockSubscriptionInstances['session-1'];
+    expect(sub.subscribe).toHaveBeenCalled();
+    // hydrateSessionState should not have been called
+    expect(mockStreamingStore.hydrateSessionState).not.toHaveBeenCalled();
   });
 
   it('cleans up all subscriptions on unmount', async () => {

--- a/packages/web/src/stores/sessionStreaming.js
+++ b/packages/web/src/stores/sessionStreaming.js
@@ -100,16 +100,15 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
 
     /**
      * Set partial thinking content for streaming display (per-session).
-     * Ignores null/empty updates to keep the last visible thinking.
+     * Empty/null/falsy values clear the thinking (set to null).
      * @param {string} thinking - The thinking content
      * @param {string} sessionId - Session ID
      */
     setPartialThinking(thinking, sessionId) {
       if (!sessionId) return;
-      if (!thinking) return;
       this.partialThinkingBySession = {
         ...this.partialThinkingBySession,
-        [sessionId]: thinking,
+        [sessionId]: thinking || null,
       };
     },
 
@@ -152,15 +151,14 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
 
     /**
      * Set partial text for a session (list view).
-     * Ignores empty-string updates to keep the last visible text.
+     * Empty/null/falsy values clear the text (set to '').
      * @param {string} sessionId
      * @param {string} text
      */
     setSessionPartialText(sessionId, text) {
-      if (!text) return;
       this.sessionPartialText = {
         ...this.sessionPartialText,
-        [sessionId]: text,
+        [sessionId]: text || '',
       };
     },
 
@@ -174,6 +172,31 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
         ...this.sessionFileCounts,
         [sessionId]: count,
       };
+    },
+
+    /**
+     * Hydrate streaming state from a REST snapshot (used when subscribing to a running session).
+     * Only populates if the store doesn't already have data for that session,
+     * to avoid overwriting more recent WebSocket data.
+     * @param {string} sessionId
+     * @param {{ workLogs?: Array, partialText?: string, thinking?: string|null }} snapshot
+     */
+    hydrateSessionState(sessionId, { workLogs, partialText, thinking } = {}) {
+      if (!this.sessionWorkLogs[sessionId]?.length) {
+        if (workLogs?.length) {
+          this.sessionWorkLogs = { ...this.sessionWorkLogs, [sessionId]: workLogs };
+        }
+      }
+      if (!this.sessionPartialText[sessionId]) {
+        if (partialText) {
+          this.sessionPartialText = { ...this.sessionPartialText, [sessionId]: partialText };
+        }
+      }
+      if (!this.partialThinkingBySession[sessionId]) {
+        if (thinking) {
+          this.partialThinkingBySession = { ...this.partialThinkingBySession, [sessionId]: thinking };
+        }
+      }
     },
 
     /**

--- a/packages/web/src/stores/sessionStreaming.test.js
+++ b/packages/web/src/stores/sessionStreaming.test.js
@@ -113,18 +113,18 @@ describe('SessionStreaming Store', () => {
       expect(store.partialThinkingBySession).toEqual({});
     });
 
-    it('ignores null updates — keeps the previous thinking value', () => {
+    it('clears thinking when null is passed', () => {
       const store = useSessionStreamingStore();
       store.setPartialThinking('Previous thinking', 'session-1');
       store.setPartialThinking(null, 'session-1');
-      expect(store.getPartialThinking('session-1')).toBe('Previous thinking');
+      expect(store.getPartialThinking('session-1')).toBeNull();
     });
 
-    it('ignores empty string updates — keeps the previous thinking value', () => {
+    it('clears thinking when empty string is passed', () => {
       const store = useSessionStreamingStore();
       store.setPartialThinking('Previous thinking', 'session-1');
       store.setPartialThinking('', 'session-1');
-      expect(store.getPartialThinking('session-1')).toBe('Previous thinking');
+      expect(store.getPartialThinking('session-1')).toBeNull();
     });
 
     it('updates thinking normally for non-null non-empty strings', () => {
@@ -198,11 +198,25 @@ describe('SessionStreaming Store', () => {
       expect(store.getSessionPartialText('session-2')).toBe('Text 2');
     });
 
-    it('ignores empty string updates — keeps the previous value', () => {
+    it('clears text when empty string is passed', () => {
       const store = useSessionStreamingStore();
       store.setSessionPartialText('session-1', 'Visible text');
       store.setSessionPartialText('session-1', '');
-      expect(store.getSessionPartialText('session-1')).toBe('Visible text');
+      expect(store.getSessionPartialText('session-1')).toBe('');
+    });
+
+    it('clears text when null is passed', () => {
+      const store = useSessionStreamingStore();
+      store.setSessionPartialText('session-1', 'Visible text');
+      store.setSessionPartialText('session-1', null);
+      expect(store.getSessionPartialText('session-1')).toBe('');
+    });
+
+    it('clears text when undefined is passed', () => {
+      const store = useSessionStreamingStore();
+      store.setSessionPartialText('session-1', 'Visible text');
+      store.setSessionPartialText('session-1', undefined);
+      expect(store.getSessionPartialText('session-1')).toBe('');
     });
 
     it('sets text normally for non-empty strings', () => {
@@ -367,6 +381,67 @@ describe('SessionStreaming Store', () => {
     it('returns false for uncollapsed session', () => {
       const store = useSessionStreamingStore();
       expect(store.isSessionLogCollapsed('session-1')).toBe(false);
+    });
+  });
+
+  describe('hydrateSessionState', () => {
+    it('populates workLogs, partialText, and thinking when store is empty for that session', () => {
+      const store = useSessionStreamingStore();
+      const workLogs = [{ id: '1', type: 'tool_use', content: 'test' }];
+      store.hydrateSessionState('session-1', { workLogs, partialText: 'hello', thinking: 'hmm' });
+
+      expect(store.getSessionWorkLogs('session-1')).toEqual(workLogs);
+      expect(store.getSessionPartialText('session-1')).toBe('hello');
+      expect(store.getPartialThinking('session-1')).toBe('hmm');
+    });
+
+    it('does NOT overwrite existing workLogs if WebSocket data already arrived', () => {
+      const store = useSessionStreamingStore();
+      store.addSessionWorkLog('session-1', { id: 'ws-1', type: 'tool_use', content: 'ws data' });
+
+      store.hydrateSessionState('session-1', {
+        workLogs: [{ id: 'rest-1', type: 'tool_use', content: 'rest data' }],
+        partialText: 'rest text',
+        thinking: 'rest thinking',
+      });
+
+      // Work logs should NOT be overwritten
+      expect(store.getSessionWorkLogs('session-1')).toHaveLength(1);
+      expect(store.getSessionWorkLogs('session-1')[0].id).toBe('ws-1');
+    });
+
+    it('does NOT overwrite existing partialText if WebSocket data already arrived', () => {
+      const store = useSessionStreamingStore();
+      store.setSessionPartialText('session-1', 'ws text');
+
+      store.hydrateSessionState('session-1', { partialText: 'rest text' });
+
+      expect(store.getSessionPartialText('session-1')).toBe('ws text');
+    });
+
+    it('does NOT overwrite existing thinking if WebSocket data already arrived', () => {
+      const store = useSessionStreamingStore();
+      store.setPartialThinking('ws thinking', 'session-1');
+
+      store.hydrateSessionState('session-1', { thinking: 'rest thinking' });
+
+      expect(store.getPartialThinking('session-1')).toBe('ws thinking');
+    });
+
+    it('handles null/empty snapshot fields gracefully', () => {
+      const store = useSessionStreamingStore();
+      store.hydrateSessionState('session-1', { workLogs: [], partialText: '', thinking: null });
+
+      expect(store.getSessionWorkLogs('session-1')).toEqual([]);
+      expect(store.getSessionPartialText('session-1')).toBe('');
+      expect(store.getPartialThinking('session-1')).toBeNull();
+    });
+
+    it('handles undefined snapshot gracefully', () => {
+      const store = useSessionStreamingStore();
+      // Should not throw
+      store.hydrateSessionState('session-1');
+      expect(store.getSessionWorkLogs('session-1')).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

When viewing a session that's already running, users now see live output immediately instead of waiting for new WebSocket messages to arrive.

## Changes

- **New API endpoint**: `GET /api/sessions/:id/streaming-state`
  - Returns a snapshot of current streaming state including:
    - Pending work logs (recent tool runs)
    - Partial text (accumulated response content)
    - Thinking content (if enabled)

- **Frontend hydration**: When subscribing to a running session, the frontend now fetches and populates the current streaming state
  - Ensures users see existing activity immediately upon navigation
  - Non-fatal failure (hydration doesn't block WebSocket subscription)

- **Store behavior fixes**:
  - `setPartialThinking()`: Empty values now clear thinking (previously ignored)
  - `setSessionPartialText()`: Empty values now clear text (previously ignored)
  - New `hydrateSessionState()` method for REST-based state initialization

## Test plan

- [x] Unit tests added for streaming state endpoint
- [x] Unit tests added for hydration behavior in composable
- [x] Unit tests updated for session streaming store changes
- [x] Manual testing: Navigate to a running session and verify live output appears immediately
- [x] Verify empty text/thinking values correctly clear previous content

🤖 Generated with [Claude Code](https://claude.com/claude-code)