### PR TITLE
feat: Show live output from running child sessions on parent cards

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -1011,6 +1011,210 @@ describe('SessionCard', () => {
     });
   });
 
+  describe('child session log stream', () => {
+    it('shows child session log stream when parent is idle and has a running child', async () => {
+      const { useSessionsStore } = await import('../stores/sessions.js');
+      vi.mocked(useSessionsStore).mockReturnValue({
+        sessions: [],
+        isSessionExpanded: vi.fn(() => false),
+        toggleSessionExpanded: vi.fn(),
+        saveExpandedState: vi.fn(),
+        getWorkflowAggregatedStatus: vi.fn(() => ({
+          effectiveStatus: 'completed',
+          runningCount: 1,
+          scheduledCount: 0,
+          waitingCount: 0,
+          completedCount: 1,
+          totalCount: 2,
+          hasScheduledDescendant: false,
+          rootIsScheduled: false,
+        })),
+        getAllDescendants: vi.fn(() => [
+          { id: 'child-1', status: 'running', name: 'Child Session' },
+        ]),
+        getSessionPath: vi.fn(() => []),
+      });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+        children: [{ id: 'child-1', name: 'Child Session' }],
+      });
+
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').attributes('data-session-id')).toBe('child-1');
+    });
+
+    it('does NOT show child log stream when parent is running (parent output takes precedence)', async () => {
+      const { useSessionsStore } = await import('../stores/sessions.js');
+      vi.mocked(useSessionsStore).mockReturnValue({
+        sessions: [],
+        isSessionExpanded: vi.fn(() => false),
+        toggleSessionExpanded: vi.fn(),
+        saveExpandedState: vi.fn(),
+        getWorkflowAggregatedStatus: vi.fn(() => ({
+          effectiveStatus: 'running',
+          runningCount: 2,
+          scheduledCount: 0,
+          waitingCount: 0,
+          completedCount: 0,
+          totalCount: 2,
+          hasScheduledDescendant: false,
+          rootIsScheduled: false,
+        })),
+        getAllDescendants: vi.fn(() => [
+          { id: 'child-1', status: 'running', name: 'Child Session' },
+        ]),
+        getSessionPath: vi.fn(() => []),
+      });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+        children: [{ id: 'child-1', name: 'Child Session' }],
+      });
+
+      expect(wrapper.find('[data-testid="session-log-stream"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').exists()).toBe(false);
+    });
+
+    it('does NOT show child log stream when parent card is expanded', async () => {
+      const { useSessionsStore } = await import('../stores/sessions.js');
+      vi.mocked(useSessionsStore).mockReturnValue({
+        sessions: [],
+        isSessionExpanded: vi.fn(() => true),
+        toggleSessionExpanded: vi.fn(),
+        saveExpandedState: vi.fn(),
+        getWorkflowAggregatedStatus: vi.fn(() => ({
+          effectiveStatus: 'completed',
+          runningCount: 1,
+          scheduledCount: 0,
+          waitingCount: 0,
+          completedCount: 1,
+          totalCount: 2,
+          hasScheduledDescendant: false,
+          rootIsScheduled: false,
+        })),
+        getAllDescendants: vi.fn(() => [
+          { id: 'child-1', status: 'running', name: 'Child Session' },
+        ]),
+        getSessionPath: vi.fn(() => []),
+      });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+        children: [{ id: 'child-1', name: 'Child Session' }],
+      });
+
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').exists()).toBe(false);
+    });
+
+    it('does NOT show child log stream when no children are running', async () => {
+      const { useSessionsStore } = await import('../stores/sessions.js');
+      vi.mocked(useSessionsStore).mockReturnValue({
+        sessions: [],
+        isSessionExpanded: vi.fn(() => false),
+        toggleSessionExpanded: vi.fn(),
+        saveExpandedState: vi.fn(),
+        getWorkflowAggregatedStatus: vi.fn(() => ({
+          effectiveStatus: 'completed',
+          runningCount: 0,
+          scheduledCount: 0,
+          waitingCount: 0,
+          completedCount: 2,
+          totalCount: 2,
+          hasScheduledDescendant: false,
+          rootIsScheduled: false,
+        })),
+        getAllDescendants: vi.fn(() => [
+          { id: 'child-1', status: 'completed', name: 'Child Session' },
+        ]),
+        getSessionPath: vi.fn(() => []),
+      });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+        children: [{ id: 'child-1', name: 'Child Session' }],
+      });
+
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').exists()).toBe(false);
+    });
+
+    it('does NOT show child log stream when there are no children at all', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+        children: [],
+      });
+
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').exists()).toBe(false);
+    });
+
+    it('shows child log stream for deeply nested running descendant (grandchild)', async () => {
+      const { useSessionsStore } = await import('../stores/sessions.js');
+      vi.mocked(useSessionsStore).mockReturnValue({
+        sessions: [],
+        isSessionExpanded: vi.fn(() => false),
+        toggleSessionExpanded: vi.fn(),
+        saveExpandedState: vi.fn(),
+        getWorkflowAggregatedStatus: vi.fn(() => ({
+          effectiveStatus: 'completed',
+          runningCount: 1,
+          scheduledCount: 0,
+          waitingCount: 0,
+          completedCount: 2,
+          totalCount: 3,
+          hasScheduledDescendant: false,
+          rootIsScheduled: false,
+        })),
+        getAllDescendants: vi.fn(() => [
+          { id: 'child-1', status: 'completed', name: 'Child Session' },
+          { id: 'grandchild-1', status: 'running', name: 'Grandchild Session' },
+        ]),
+        getSessionPath: vi.fn(() => []),
+      });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+        children: [{ id: 'child-1', name: 'Child Session' }],
+      });
+
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="child-session-log-stream"]').attributes('data-session-id')).toBe('grandchild-1');
+    });
+
+    it('picks the first running descendant when multiple are running', async () => {
+      const { useSessionsStore } = await import('../stores/sessions.js');
+      vi.mocked(useSessionsStore).mockReturnValue({
+        sessions: [],
+        isSessionExpanded: vi.fn(() => false),
+        toggleSessionExpanded: vi.fn(),
+        saveExpandedState: vi.fn(),
+        getWorkflowAggregatedStatus: vi.fn(() => ({
+          effectiveStatus: 'completed',
+          runningCount: 2,
+          scheduledCount: 0,
+          waitingCount: 0,
+          completedCount: 1,
+          totalCount: 3,
+          hasScheduledDescendant: false,
+          rootIsScheduled: false,
+        })),
+        getAllDescendants: vi.fn(() => [
+          { id: 'child-1', status: 'running', name: 'Child Session 1' },
+          { id: 'child-2', status: 'running', name: 'Child Session 2' },
+        ]),
+        getSessionPath: vi.fn(() => []),
+      });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+        children: [{ id: 'child-1', name: 'Child Session 1' }, { id: 'child-2', name: 'Child Session 2' }],
+      });
+
+      const childStreams = wrapper.findAll('[data-testid="child-session-log-stream"]');
+      expect(childStreams.length).toBe(1);
+      expect(childStreams[0].attributes('data-session-id')).toBe('child-1');
+    });
+  });
+
   describe('scheduled time display', () => {
     it('shows scheduled time when session status is "scheduled" and scheduledAt is set', () => {
       // Schedule for 2 hours in the future

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -109,6 +109,13 @@
         data-testid="session-log-stream"
       />
 
+      <!-- Live output from a running child session (when parent is collapsed & not running itself) -->
+      <SessionLogStream
+        v-if="runningChildSessionId"
+        :session-id="runningChildSessionId"
+        data-testid="child-session-log-stream"
+      />
+
       <!-- Expand/collapse toggle for sessions with children -->
       <div v-if="hasChildren && !isChild" class="expand-toggle-row">
         <button
@@ -236,6 +243,18 @@ const dateToShow = computed(() => {
 const hasChildren = computed(() => props.children && props.children.length > 0);
 
 const isExpanded = computed(() => sessionsStore.isSessionExpanded(props.session.id));
+
+// Find first running child/descendant session to show live output on parent card
+const runningChildSessionId = computed(() => {
+  if (isRunning.value) return null;       // Parent is already showing its own output
+  if (isExpanded.value) return null;      // Children are visible in expanded panel
+  if (!hasChildren.value) return null;    // No children to show
+
+  // Find first running/starting child from all descendants
+  const descendants = sessionsStore.getAllDescendants(props.session.id);
+  const running = descendants.find(s => ['running', 'starting'].includes(s.status));
+  return running?.id || null;
+});
 
 // Get aggregated workflow status for display
 const workflowStatus = computed(() => {

--- a/packages/web/src/composables/useRunningSessionSubscriptions.js
+++ b/packages/web/src/composables/useRunningSessionSubscriptions.js
@@ -18,6 +18,59 @@ export function useRunningSessionSubscriptions() {
   // Track pending clear timeouts so stale ones can be cancelled: { [sessionId]: timeoutId }
   const clearTimeouts = {};
 
+  // Track pending hydration retry timeouts: { [sessionId]: timeoutId }
+  const hydrationRetryTimeouts = {};
+
+  /**
+   * Fetch streaming state from the server and hydrate the store.
+   * If the initial fetch returns no data and the session is still running,
+   * retry once after a delay to cover the race where a child session
+   * has just started but hasn't populated its streaming state yet.
+   * @param {string} sessionId
+   */
+  function hydrateStreamingState(sessionId) {
+    fetch(`/api/sessions/${sessionId}/streaming-state`)
+      .then(res => res.ok ? res.json() : null)
+      .then(snapshot => {
+        if (snapshot && (snapshot.workLogs?.length || snapshot.partialText || snapshot.thinking)) {
+          streamingStore.hydrateSessionState(sessionId, snapshot);
+        } else {
+          // No data yet — schedule a retry for sessions that just started.
+          // This covers the race where a child session was just created
+          // but hasn't emitted any streaming events yet.
+          scheduleHydrationRetry(sessionId);
+        }
+      })
+      .catch(() => {
+        // Hydration failure is non-fatal — retry in case the session
+        // hasn't registered streaming state on the server yet.
+        scheduleHydrationRetry(sessionId);
+      });
+  }
+
+  /**
+   * Retry hydration after a delay if the session is still running/starting.
+   * @param {string} sessionId
+   */
+  function scheduleHydrationRetry(sessionId) {
+    hydrationRetryTimeouts[sessionId] = setTimeout(() => {
+      delete hydrationRetryTimeouts[sessionId];
+      // Only retry if still subscribed and the session is still active
+      if (!activeSubscriptions.value[sessionId]) return;
+      const session = sessionsStore.sessions.find(s => s.id === sessionId);
+      if (session && ['running', 'starting'].includes(session.status)) {
+        fetch(`/api/sessions/${sessionId}/streaming-state`)
+          .then(res => res.ok ? res.json() : null)
+          .then(retrySnapshot => {
+            if (retrySnapshot) {
+              streamingStore.hydrateSessionState(sessionId, retrySnapshot);
+            }
+          })
+          .catch(() => { /* Retry failure is non-fatal */ });
+      }
+    }, 1500);
+  }
+
   function subscribeToSession(sessionId) {
     if (activeSubscriptions.value[sessionId]) return; // already subscribed
 
@@ -67,17 +120,6 @@ export function useRunningSessionSubscriptions() {
 
     sub.subscribe();
 
-    // Hydrate current streaming state from the server (fire-and-forget).
-    // This ensures we see content for sessions already running before we subscribed.
-    fetch(`/api/sessions/${sessionId}/streaming-state`)
-      .then(res => res.ok ? res.json() : null)
-      .then(snapshot => {
-        if (snapshot) {
-          streamingStore.hydrateSessionState(sessionId, snapshot);
-        }
-      })
-      .catch(() => { /* Hydration failure is non-fatal */ });
-
     activeSubscriptions.value[sessionId] = {
       subscription: sub,
       cleanup: () => {
@@ -85,6 +127,11 @@ export function useRunningSessionSubscriptions() {
         sub.unsubscribe();
       },
     };
+
+    // Hydrate current streaming state from the server (fire-and-forget).
+    // This ensures we see content for sessions already running before we subscribed.
+    // Uses retry logic to handle child sessions that just started.
+    hydrateStreamingState(sessionId);
   }
 
   function unsubscribeFromSession(sessionId) {
@@ -97,6 +144,11 @@ export function useRunningSessionSubscriptions() {
     if (clearTimeouts[sessionId]) {
       clearTimeout(clearTimeouts[sessionId]);
       delete clearTimeouts[sessionId];
+    }
+    // Cancel any pending hydration retry
+    if (hydrationRetryTimeouts[sessionId]) {
+      clearTimeout(hydrationRetryTimeouts[sessionId]);
+      delete hydrationRetryTimeouts[sessionId];
     }
   }
 

--- a/packages/web/src/composables/useRunningSessionSubscriptions.test.js
+++ b/packages/web/src/composables/useRunningSessionSubscriptions.test.js
@@ -430,4 +430,344 @@ describe('useRunningSessionSubscriptions', () => {
     expect(sub1.unsubscribe).toHaveBeenCalled();
     expect(sub2.unsubscribe).toHaveBeenCalled();
   });
+
+  describe('hydration retry logic', () => {
+    it('retries hydration after 1.5s when initial fetch returns empty data', async () => {
+      let fetchCallCount = 0;
+      const retrySnapshot = {
+        workLogs: [{ id: '1', type: 'tool_use', content: 'test' }],
+        partialText: 'hello',
+        thinking: null,
+      };
+
+      globalThis.fetch = vi.fn(() => {
+        fetchCallCount++;
+        if (fetchCallCount === 1) {
+          // First call: return empty data
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ workLogs: [], partialText: '', thinking: null }),
+          });
+        }
+        // Retry call: return data
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(retrySnapshot),
+        });
+      });
+
+      mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+      // Wait for the initial fetch promise chain to resolve
+      await vi.waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      // hydrateSessionState should NOT have been called yet (empty data)
+      expect(mockStreamingStore.hydrateSessionState).not.toHaveBeenCalled();
+
+      // Advance past the 1.5s retry delay — use advanceTimersByTimeAsync
+      // so that microtasks (Promise callbacks) within the timer are flushed
+      await vi.advanceTimersByTimeAsync(1500);
+
+      // Wait for retry fetch promise to resolve
+      await vi.waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      });
+      await vi.waitFor(() => {
+        expect(mockStreamingStore.hydrateSessionState).toHaveBeenCalledWith('session-1', retrySnapshot);
+      });
+    });
+
+    it('retries hydration after 1.5s when initial fetch fails', async () => {
+      let fetchCallCount = 0;
+      const retrySnapshot = {
+        workLogs: [{ id: '1', type: 'tool_use', content: 'retry data' }],
+        partialText: 'retried',
+        thinking: null,
+      };
+
+      globalThis.fetch = vi.fn(() => {
+        fetchCallCount++;
+        if (fetchCallCount === 1) {
+          return Promise.reject(new Error('Network error'));
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(retrySnapshot),
+        });
+      });
+
+      mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+      // Wait for the initial fetch rejection to be handled
+      await vi.waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      // Advance past the 1.5s retry delay
+      vi.advanceTimersByTime(1500);
+
+      await vi.waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      });
+      await vi.waitFor(() => {
+        expect(mockStreamingStore.hydrateSessionState).toHaveBeenCalledWith('session-1', retrySnapshot);
+      });
+    });
+
+    it('does not retry hydration if session is no longer running', async () => {
+      globalThis.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ workLogs: [], partialText: '', thinking: null }),
+        })
+      );
+
+      mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+      await vi.waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      // Session becomes completed before retry fires
+      mockSessionsStore.sessions = [{ id: 'session-1', status: 'completed' }];
+      await nextTick();
+
+      // Advance past the 1.5s retry delay
+      vi.advanceTimersByTime(1500);
+
+      // Should NOT have made a second fetch because session stopped and was unsubscribed
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry hydration when initial fetch returns data with content', async () => {
+      const snapshot = {
+        workLogs: [{ id: '1', type: 'tool_use', content: 'test' }],
+        partialText: 'hello',
+        thinking: null,
+      };
+
+      globalThis.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(snapshot),
+        })
+      );
+
+      mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+      await vi.waitFor(() => {
+        expect(mockStreamingStore.hydrateSessionState).toHaveBeenCalledWith('session-1', snapshot);
+      });
+
+      // Advance past potential retry delay
+      vi.advanceTimersByTime(2000);
+
+      // Should have only called fetch once (no retry needed)
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles hydration fetch failure without breaking real-time updates', async () => {
+      // Both initial and retry fail
+      globalThis.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
+
+      mockSessionsStore.sessions = [{ id: 'session-1', status: 'running' }];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+
+      // Subscription should still work
+      const sub = mockSubscriptionInstances['session-1'];
+      expect(sub.subscribe).toHaveBeenCalled();
+
+      // Advance past retry delay
+      vi.advanceTimersByTime(1500);
+
+      // Wait for retry promise to resolve (and fail)
+      await nextTick();
+      await nextTick();
+
+      // Real-time callbacks should still function
+      const workLogHandler = sub._handlers.onWorkLog[0];
+      const log = { id: '1', type: 'tool_use', tool: 'Read' };
+      workLogHandler(log);
+
+      expect(mockStreamingStore.addSessionWorkLog).toHaveBeenCalledWith('session-1', log);
+    });
+  });
+
+  describe('child session subscription', () => {
+    it('subscribes to child session when it appears in store with "starting" status', async () => {
+      mockSessionsStore.sessions = [];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+
+      // Add a child session with starting status
+      mockSessionsStore.sessions = [
+        { id: 'parent-1', status: 'waiting', parentSessionId: null },
+        { id: 'child-1', status: 'starting', parentSessionId: 'parent-1' },
+      ];
+
+      await nextTick();
+
+      expect(useSessionSubscription).toHaveBeenCalledWith('child-1');
+      expect(mockSubscriptionInstances['child-1'].subscribe).toHaveBeenCalled();
+      // Parent should not be subscribed (status is 'waiting')
+      expect(useSessionSubscription).not.toHaveBeenCalledWith('parent-1');
+    });
+
+    it('subscribes to child session when its status transitions from "waiting" to "running"', async () => {
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'waiting', parentSessionId: 'parent-1' },
+      ];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+
+      // Should not subscribe while waiting
+      expect(useSessionSubscription).not.toHaveBeenCalledWith('child-1');
+
+      // Update status to running
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'running', parentSessionId: 'parent-1' },
+      ];
+
+      await nextTick();
+
+      expect(useSessionSubscription).toHaveBeenCalledWith('child-1');
+      expect(mockSubscriptionInstances['child-1'].subscribe).toHaveBeenCalled();
+    });
+
+    it('unsubscribes when child session transitions from "running" to "completed"', async () => {
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'running', parentSessionId: 'parent-1' },
+      ];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+
+      const sub = mockSubscriptionInstances['child-1'];
+      expect(sub.subscribe).toHaveBeenCalled();
+
+      // Child session completes
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'completed', parentSessionId: 'parent-1' },
+      ];
+
+      await nextTick();
+
+      expect(sub.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('hydrates streaming state for newly subscribed child session', async () => {
+      const snapshot = {
+        workLogs: [{ id: '1', type: 'tool_use', content: 'child work' }],
+        partialText: 'hello from child',
+        thinking: null,
+      };
+
+      globalThis.fetch = vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(snapshot),
+        })
+      );
+
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'running', parentSessionId: 'parent-1' },
+      ];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+      await vi.waitFor(() => {
+        expect(mockStreamingStore.hydrateSessionState).toHaveBeenCalledWith('child-1', snapshot);
+      });
+    });
+
+    it('does not double-subscribe when child session is already subscribed', async () => {
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'running', parentSessionId: 'parent-1' },
+      ];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+
+      // Trigger the watch again with the same running child session
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'running', parentSessionId: 'parent-1' },
+        { id: 'some-other', status: 'completed' },
+      ];
+
+      await nextTick();
+
+      const callsForChild = useSessionSubscription.mock.calls.filter(c => c[0] === 'child-1');
+      expect(callsForChild).toHaveLength(1);
+    });
+
+    it('clears child session streaming state after 2s delay when child session stops', async () => {
+      mockSessionsStore.sessions = [
+        { id: 'child-1', status: 'running', parentSessionId: 'parent-1' },
+      ];
+
+      wrapper = mount(testComponent, {
+        global: { plugins: [createPinia()] },
+      });
+
+      await nextTick();
+
+      const sub = mockSubscriptionInstances['child-1'];
+      const statusHandler = sub._handlers.onStatus[0];
+
+      // Child session completes
+      statusHandler('completed');
+
+      // Should not clear immediately
+      expect(mockStreamingStore.clearSessionStreamingState).not.toHaveBeenCalled();
+
+      // After 2 seconds
+      vi.advanceTimersByTime(2000);
+
+      expect(mockStreamingStore.clearSessionStreamingState).toHaveBeenCalledWith('child-1');
+    });
+  });
 });

--- a/tests/e2e/command-button-modal.spec.ts
+++ b/tests/e2e/command-button-modal.spec.ts
@@ -172,8 +172,8 @@ test.describe('Command Button Status Modal', () => {
     await page.click('[data-testid="button-status-indicator"]');
     await expect(page.locator('[data-testid="button-status-modal"]')).toBeVisible({ timeout: 5000 });
 
-    // Click close button in footer
-    await page.click('.modal-footer .btn');
+    // Click close button in footer (use btn-primary to avoid hitting "Remove Run" button)
+    await page.click('.modal-footer .btn-primary');
     await expect(page.locator('[data-testid="button-status-modal"]')).not.toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Implements live output display for running child sessions on their parent cards in the session list. When a parent session is idle but has running child sessions, the child's live log stream is now shown on the parent card, providing visibility into active work without requiring users to expand the parent session.

## Changes

- **SessionCard.vue**: Added `runningChildSessionId` computed property to find the first running descendant session and conditionally render child session log stream
- **useRunningSessionSubscriptions.js**: Implemented hydration retry logic that retries after 1.5s if initial fetch returns empty data, covering the race where a child session has just started but hasn't populated its streaming state yet
- **Comprehensive test coverage**: Added tests for child session subscription, hydration retry logic, and all edge cases
- **E2E test fix**: Corrected selector in command button modal test

## Root Cause Analysis

The original issue was that child session logs weren't displaying properly. Investigation revealed that the problem wasn't in the rendering layer but in the subscription management layer: when subscriptions are dynamically created/destroyed in the watch callback, the timing and cleanup of WebSocket subscriptions may not properly synchronize with the rendering lifecycle.

## Test Plan

- [x] Unit tests for SessionCard child log stream rendering (7 scenarios)
- [x] Unit tests for hydration retry logic (5 scenarios)
- [x] Unit tests for child session subscription lifecycle (5 scenarios)
- [x] E2E tests for command button modal interaction

## Testing

Run tests with:
```bash
yarn test                                   # All unit tests
yarn workspace @claudetools/web test src/components/SessionCard.test.js
yarn workspace @claudetools/web test src/composables/useRunningSessionSubscriptions.test.js
./scripts/pw.sh test tests/e2e/command-button-modal.spec.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)