### PR TITLE
fix: Remove error status indicator from child sessions in session list view

### DIFF
--- a/packages/web/src/components/WorkflowSessionItem.test.js
+++ b/packages/web/src/components/WorkflowSessionItem.test.js
@@ -145,11 +145,9 @@ describe('WorkflowSessionItem', () => {
       expect(statusEl.text()).toBe('⏰ Scheduled');
     });
 
-    it('shows "⚠ Error" for error status', () => {
+    it('does not show status label for error status', () => {
       const wrapper = mountComponent({ status: 'error' });
-      const statusEl = wrapper.find('.workflow-session-status');
-      expect(statusEl.exists()).toBe(true);
-      expect(statusEl.text()).toBe('⚠ Error');
+      expect(wrapper.find('.workflow-session-status').exists()).toBe(false);
     });
 
     it('does not show status label for waiting status', () => {

--- a/packages/web/src/components/WorkflowSessionItem.vue
+++ b/packages/web/src/components/WorkflowSessionItem.vue
@@ -101,8 +101,7 @@ const statusLabel = computed(() => {
   const status = props.session.status;
   if (status === 'running' || status === 'starting') return '● Running';
   if (status === 'scheduled') return '⏰ Scheduled';
-  if (status === 'error') return '⚠ Error';
-  // Remove "waiting" status - don't show a label for waiting sessions
+  // Remove "waiting" and "error" status - don't show a label for these sessions
   return null;
 });
 


### PR DESCRIPTION
## Summary

- Removed the `'⚠ Error'` status label from `WorkflowSessionItem`'s `statusLabel` computed property so child sessions in error state no longer display a red error badge in the session list view
- Updated the corresponding test to assert that no status label is shown for error status

## Test plan

- [x] Run `yarn workspace @claudetools/web test src/components/WorkflowSessionItem.test.js` — all 35 tests pass
- [ ] Verify visually that child sessions in error state no longer show the red "⚠ Error" badge in the session list

🤖 Generated with [Claude Code](https://claude.com/claude-code)