### PR TITLE
fix: Add dropdown indicators to sub-navigation selects

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -330,6 +330,7 @@ input, textarea, select {
 
 .tab-select {
   flex: 1;
+  width: 100%;
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);

--- a/packages/web/src/views/SessionListView.css
+++ b/packages/web/src/views/SessionListView.css
@@ -72,17 +72,6 @@
   width: 100%;
 }
 
-.tab-select {
-  width: 100%;
-  padding: 0.75rem;
-  font-size: 0.9rem;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius);
-  cursor: pointer;
-}
-
 .tabs-left {
   display: flex;
   gap: 0;

--- a/packages/web/src/views/SettingsView.vue
+++ b/packages/web/src/views/SettingsView.vue
@@ -115,17 +115,6 @@ h1 {
   width: 100%;
 }
 
-.tab-select {
-  width: 100%;
-  padding: 0.75rem;
-  font-size: 0.9rem;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius);
-  cursor: pointer;
-}
-
 @media (max-width: 480px) {
   .tabs-desktop {
     display: none !important;


### PR DESCRIPTION
## Summary
Fixed select elements used for sub-navigation to display dropdown indicators (chevrons) by removing duplicate CSS definitions that were overriding global styles.

## Problem
Select elements in sub-navigation (SessionListView, SettingsView, and SessionTabsPanel) lacked visual indicators that they are dropdowns, making them appear as plain text inputs rather than interactive dropdown menus.

## Root Cause
The global `main.css` already had a well-styled `.tab-select` class with chevron SVG indicators, but duplicate `.tab-select` definitions in `SessionListView.css` and `SettingsView.vue` were overriding those styles without the chevron indicators.

## Solution
- Removed duplicate `.tab-select` CSS block from `SessionListView.css`
- Removed duplicate `.tab-select` CSS block from `SettingsView.vue`
- Added `width: 100%` to the global `.tab-select` rule in `main.css` to maintain full width

## Test Plan
- [x] Build succeeds with no errors
- [x] All 22 unit tests pass
- [x] Visual verification: dropdown indicators now appear on all tab selects

## Files Modified
- `packages/web/src/assets/main.css` - Added width property
- `packages/web/src/views/SessionListView.css` - Removed duplicate styles
- `packages/web/src/views/SettingsView.vue` - Removed duplicate styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)