### PR TITLE
Move session active spinner from sub nav to tree handle

### DIFF
--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -36,8 +36,6 @@ describe('SessionTabsPanel', () => {
         tabs: defaultTabs,
         hasChanges: false,
         canvasCount: 0,
-        isSessionActive: false,
-        sessionStatus: '',
         ...props,
       },
     });
@@ -102,31 +100,6 @@ describe('SessionTabsPanel', () => {
     });
   });
 
-  describe('session active indicator', () => {
-    it('shows active spinner when isSessionActive is true', () => {
-      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'running' });
-      expect(wrapper.find('.session-active-indicator').exists()).toBe(true);
-      expect(wrapper.find('.active-spinner').exists()).toBe(true);
-    });
-
-    it('hides active spinner when isSessionActive is false', () => {
-      const wrapper = mountPanel({ isSessionActive: false, sessionStatus: 'completed' });
-      expect(wrapper.find('.session-active-indicator').exists()).toBe(false);
-    });
-
-    it('shows "Session running..." tooltip when status is running', () => {
-      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'running' });
-      const indicator = wrapper.find('.session-active-indicator');
-      expect(indicator.attributes('title')).toBe('Session running...');
-    });
-
-    it('shows "Session starting..." tooltip when status is starting', () => {
-      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'starting' });
-      const indicator = wrapper.find('.session-active-indicator');
-      expect(indicator.attributes('title')).toBe('Session starting...');
-    });
-  });
-
   describe('mobile dropdown', () => {
     it('shows dot indicator for changes in mobile', () => {
       const wrapper = mountPanel({ hasChanges: true });
@@ -138,34 +111,6 @@ describe('SessionTabsPanel', () => {
       const wrapper = mountPanel({ canvasCount: 2 });
       const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Canvas'));
       expect(option.text()).toContain('\u2022');
-    });
-
-    it('shows ellipsis for active session in mobile', () => {
-      const wrapper = mountPanel({ isSessionActive: true });
-      const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Conversations'));
-      expect(option.text()).toContain('...');
-    });
-
-    it('shows loading spinner when isSessionActive is true in mobile', () => {
-      const wrapper = mountPanel({ isSessionActive: true });
-      expect(wrapper.find('.tabs-mobile .loading-spinner').exists()).toBe(true);
-    });
-
-    it('hides loading spinner when isSessionActive is false in mobile', () => {
-      const wrapper = mountPanel({ isSessionActive: false });
-      expect(wrapper.find('.tabs-mobile .loading-spinner').exists()).toBe(false);
-    });
-
-    it('shows "Session running..." tooltip when status is running', () => {
-      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'running' });
-      const spinner = wrapper.find('.tabs-mobile .loading-spinner');
-      expect(spinner.attributes('title')).toBe('Session running...');
-    });
-
-    it('shows "Session starting..." tooltip when status is starting', () => {
-      const wrapper = mountPanel({ isSessionActive: true, sessionStatus: 'starting' });
-      const spinner = wrapper.find('.tabs-mobile .loading-spinner');
-      expect(spinner.attributes('title')).toBe('Session starting...');
     });
 
     it('navigates when mobile select changes', async () => {

--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -27,28 +27,14 @@
           class="canvas-indicator"
           title="Canvas contains files"
         ></span>
-        <span
-          v-if="tab.id === 'conversation' && isSessionActive"
-          class="session-active-indicator"
-          :title="sessionStatus === 'starting'
-            ? 'Session starting...' : 'Session running...'"
-        >
-          <span class="active-spinner"></span>
-        </span>
       </router-link>
     </div>
 
     <!-- Mobile dropdown -->
     <div class="tabs-mobile">
-      <span
-        v-if="isSessionActive"
-        class="loading-spinner"
-        :title="sessionStatus === 'starting'
-          ? 'Session starting...' : 'Session running...'"
-      ></span>
       <select :value="activeTab" @change="navigateToTab($event.target.value)" class="tab-select">
         <option v-for="tab in tabs" :key="tab.id" :value="tab.id">
-          {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' \u2022' : '' }}{{ tab.id === 'canvas' && canvasCount > 0 ? ' \u2022' : '' }}{{ tab.id === 'conversation' && isSessionActive ? ' ...' : '' }}
+          {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' \u2022' : '' }}{{ tab.id === 'canvas' && canvasCount > 0 ? ' \u2022' : '' }}
         </option>
       </select>
     </div>
@@ -90,16 +76,6 @@ const props = defineProps({
     type: Number,
     default: 0,
   },
-  /** Whether the session is actively running/starting */
-  isSessionActive: {
-    type: Boolean,
-    default: false,
-  },
-  /** The session status string (for tooltip text) */
-  sessionStatus: {
-    type: String,
-    default: '',
-  },
 });
 
 const router = useRouter();
@@ -130,34 +106,8 @@ function navigateToTab(tabId) {
   vertical-align: middle;
 }
 
-.session-active-indicator {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 0.5rem;
-}
-
-.active-spinner {
-  display: inline-block;
-  width: 0.75rem;
-  height: 0.75rem;
-  border: 2px solid rgba(0, 188, 212, 0.2);
-  border-top-color: #00bcd4;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 .tabs-mobile {
   align-items: center;
   gap: 0.5rem;
-}
-
-.tabs-mobile .loading-spinner {
-  flex-shrink: 0;
 }
 </style>

--- a/packages/web/src/components/SessionTreeHandle.test.js
+++ b/packages/web/src/components/SessionTreeHandle.test.js
@@ -7,8 +7,10 @@ describe('SessionTreeHandle', () => {
     vi.clearAllMocks();
   });
 
-  function mountComponent() {
-    return mount(SessionTreeHandle);
+  function mountComponent(props = {}) {
+    return mount(SessionTreeHandle, {
+      props: { ...props }
+    });
   }
 
   describe('rendering', () => {
@@ -47,6 +49,42 @@ describe('SessionTreeHandle', () => {
       // The z-index is applied through the scoped CSS class
       // Verify the class exists which applies z-index: 900
       expect(handle.classes()).toContain('session-tree-handle');
+    });
+  });
+
+  describe('session active spinner', () => {
+    it('shows spinner when isSessionActive is true', () => {
+      const wrapper = mountComponent({ isSessionActive: true, sessionStatus: 'running' });
+      expect(wrapper.find('.active-spinner').exists()).toBe(true);
+    });
+
+    it('hides spinner when isSessionActive is false', () => {
+      const wrapper = mountComponent({ isSessionActive: false, sessionStatus: 'completed' });
+      expect(wrapper.find('.active-spinner').exists()).toBe(false);
+    });
+
+    it('shows correct tooltip when session is running', () => {
+      const wrapper = mountComponent({ isSessionActive: true, sessionStatus: 'running' });
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.attributes('title')).toBe('Session running...');
+    });
+
+    it('shows correct tooltip when session is starting', () => {
+      const wrapper = mountComponent({ isSessionActive: true, sessionStatus: 'starting' });
+      const spinner = wrapper.find('.active-spinner');
+      expect(spinner.attributes('title')).toBe('Session starting...');
+    });
+
+    it('updates handle tooltip when session is active', () => {
+      const wrapper = mountComponent({ isSessionActive: true, sessionStatus: 'running' });
+      const handle = wrapper.find('.session-tree-handle');
+      expect(handle.attributes('title')).toBe('Session running...');
+    });
+
+    it('shows default tooltip when session is not active', () => {
+      const wrapper = mountComponent({ isSessionActive: false });
+      const handle = wrapper.find('.session-tree-handle');
+      expect(handle.attributes('title')).toBe('Open session tree');
     });
   });
 

--- a/packages/web/src/components/SessionTreeHandle.vue
+++ b/packages/web/src/components/SessionTreeHandle.vue
@@ -3,7 +3,12 @@
     class="session-tree-handle"
     tabindex="0"
     role="button"
-    aria-label="Open session tree"
+    :aria-label="isSessionActive
+      ? (sessionStatus === 'starting' ? 'Session starting...' : 'Session running...')
+      : 'Open session tree'"
+    :title="isSessionActive
+      ? (sessionStatus === 'starting' ? 'Session starting...' : 'Session running...')
+      : 'Open session tree'"
     data-testid="session-tree-handle"
     @click="handleOpen"
     @keydown.enter.prevent="handleOpen"
@@ -26,11 +31,27 @@
         stroke-linejoin="round"
       />
     </svg>
+    <span
+      v-if="isSessionActive"
+      class="active-spinner"
+      :title="sessionStatus === 'starting' ? 'Session starting...' : 'Session running...'"
+    ></span>
   </div>
 </template>
 
 <script setup>
 const emit = defineEmits(['open']);
+
+defineProps({
+  isSessionActive: {
+    type: Boolean,
+    default: false,
+  },
+  sessionStatus: {
+    type: String,
+    default: '',
+  },
+});
 
 function handleOpen() {
   emit('open');
@@ -46,8 +67,10 @@ function handleOpen() {
   width: 40px;
   height: 100px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
   background: rgba(55, 65, 81, 0.8);
   border-radius: 8px 0 0 8px;
   cursor: pointer;
@@ -74,5 +97,20 @@ function handleOpen() {
 
 .session-tree-handle:hover .handle-icon {
   color: #fff;
+}
+
+.active-spinner {
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid rgba(6, 182, 212, 0.3);
+  border-top-color: #06b6d4;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -2481,7 +2481,7 @@ describe('SessionDetailView', () => {
   });
 
   describe('session active indicator', () => {
-    it('passes isSessionActive=true to SessionTabsPanel when running', async () => {
+    it('passes isSessionActive=true to SessionTreeHandle when running', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2508,12 +2508,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('isSessionActive')).toBe(true);
-      expect(tabsPanel.props('sessionStatus')).toBe('running');
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(true);
+      expect(treeHandle.props('sessionStatus')).toBe('running');
     });
 
-    it('passes isSessionActive=true to SessionTabsPanel when starting', async () => {
+    it('passes isSessionActive=true to SessionTreeHandle when starting', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2540,12 +2540,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('isSessionActive')).toBe(true);
-      expect(tabsPanel.props('sessionStatus')).toBe('starting');
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(true);
+      expect(treeHandle.props('sessionStatus')).toBe('starting');
     });
 
-    it('passes isSessionActive=false to SessionTabsPanel when completed', async () => {
+    it('passes isSessionActive=false to SessionTreeHandle when completed', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2572,11 +2572,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('isSessionActive')).toBe(false);
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
-    it('passes isSessionActive=false to SessionTabsPanel when waiting', async () => {
+    it('passes isSessionActive=false to SessionTreeHandle when waiting', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2603,11 +2603,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('isSessionActive')).toBe(false);
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
-    it('passes isSessionActive=false to SessionTabsPanel when error', async () => {
+    it('passes isSessionActive=false to SessionTreeHandle when error', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2634,11 +2634,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('isSessionActive')).toBe(false);
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
-    it('passes sessionStatus=running to SessionTabsPanel for running status', async () => {
+    it('passes sessionStatus=running to SessionTreeHandle for running status', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2665,11 +2665,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('sessionStatus')).toBe('running');
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('sessionStatus')).toBe('running');
     });
 
-    it('passes sessionStatus=starting to SessionTabsPanel for starting status', async () => {
+    it('passes sessionStatus=starting to SessionTreeHandle for starting status', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2696,8 +2696,8 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
-      expect(tabsPanel.props('sessionStatus')).toBe('starting');
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('sessionStatus')).toBe('starting');
     });
   });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -42,8 +42,6 @@
         :tabs="tabs"
         :has-changes="hasChanges"
         :canvas-count="canvasStore.groupedItems.length"
-        :is-session-active="isSessionActive"
-        :session-status="sessionsStore.currentSession?.status"
       />
 
       <div class="tab-content">
@@ -58,6 +56,8 @@
 
       <!-- Session Tree Handle -->
       <SessionTreeHandle
+        :is-session-active="isSessionActive"
+        :session-status="sessionsStore.currentSession?.status"
         @open="treeOverlayOpen = true"
       />
 


### PR DESCRIPTION
## Summary
Move the session active spinner from the "Conversations" tab in the sub nav to the session tree handle on the right side of the screen. This provides better visibility of session activity regardless of which tab is active.

## Changes
- **SessionTreeHandle.vue**: Added spinner display with vertical layout below the tree icon
  - Added `isSessionActive` and `sessionStatus` props
  - Spinner appears when session is running or starting
  - Updated CSS with `flex-direction: column` and `gap: 0.5rem`
  - Handle width stays static at 40px; height adjusts to accommodate spinner
  
- **SessionTabsPanel.vue**: Removed spinner display and props
  - Removed desktop and mobile spinner elements
  - Removed `isSessionActive` and `sessionStatus` props (no longer needed)
  - Removed spinner-related CSS

- **SessionDetailView.vue**: Updated prop passing
  - Now passes `isSessionActive` and `sessionStatus` to SessionTreeHandle
  - Removed these props from SessionTabsPanel

- **Tests**: Updated all related tests
  - SessionTabsPanel.test.js: Removed spinner test suite
  - SessionTreeHandle.test.js: Added comprehensive spinner tests
  - SessionDetailView.test.js: Updated to test SessionTreeHandle props

## Test Results
✅ All tests passing (115 tests: 114 passed, 1 skipped)

## Design Notes
- Spinner uses vertical layout (icon on top, spinner below)
- Handle maintains static width of 40px
- Height may increase slightly to accommodate spinner with gap spacing
- Spinner is visible on all screen sizes (handle has no responsive CSS)
- Tooltips show "Session running..." or "Session starting..." based on status

## Benefits
- Spinner is always visible regardless of active tab
- Better UX: activity indicator doesn't require looking at specific tab
- Cleaner sub nav with fewer UI elements
🤖 Generated with [Claude Code](https://claude.com/claude-code)