### PR TITLE
Fix command button modal scrolling with large output

### DIFF
--- a/packages/web/src/components/ButtonStatusModal.vue
+++ b/packages/web/src/components/ButtonStatusModal.vue
@@ -373,6 +373,9 @@ onBeforeUnmount(() => {
   border-radius: var(--border-radius);
   max-width: 600px;
   width: 90%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
@@ -414,6 +417,9 @@ onBeforeUnmount(() => {
 .modal-body {
   padding: 1.5rem 1.25rem;
   color: var(--color-text);
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .command-section {

--- a/tests/e2e/command-button-modal.spec.ts
+++ b/tests/e2e/command-button-modal.spec.ts
@@ -201,4 +201,117 @@ test.describe('Command Button Status Modal', () => {
     await page.locator('.modal-overlay').click({ position: { x: 10, y: 10 } });
     await expect(page.locator('[data-testid="button-status-modal"]')).not.toBeVisible();
   });
+
+  test('modal height is constrained to viewport with large output', async ({ page }) => {
+    // Create command with large output (> 200 lines)
+    const largeOutput = Array.from({ length: 200 }, (_, i) => `Line ${i + 1}: Output text here`).join('\n');
+    const button = await seedCommandButton(project.id, {
+      label: 'Large Output Test',
+      command: `echo "${largeOutput}"`,
+      showOnList: true,
+    });
+
+    const { runId } = await runCommandButton(session.id, button.id);
+    await waitForCommandRunComplete(session.id, runId);
+
+    await navigateAndWait(page, `/sessions/${session.id}`);
+    await page.click('[data-testid="button-status-indicator"]');
+    await expect(page.locator('[data-testid="button-status-modal"]')).toBeVisible();
+
+    // Expand output
+    await page.click('[data-testid="output-header"]');
+    await expect(page.locator('[data-testid="output-content"]')).toBeVisible();
+
+    // Verify modal height is constrained
+    const modalInfo = await page.evaluate(() => {
+      const modal = document.querySelector('.modal-dialog');
+      if (!modal) return null;
+      const rect = modal.getBoundingClientRect();
+      return {
+        height: rect.height,
+        viewportHeight: window.innerHeight,
+        maxHeightRatio: rect.height / window.innerHeight
+      };
+    });
+
+    expect(modalInfo).not.toBeNull();
+    expect(modalInfo!.maxHeightRatio).toBeLessThanOrEqual(0.9); // ≤ 90vh
+
+    // Verify footer buttons are visible and clickable
+    await expect(page.locator('.modal-footer .btn-primary')).toBeVisible();
+    await expect(page.locator('.modal-footer .btn-danger')).toBeVisible();
+  });
+
+  test('modal body is scrollable when content overflows', async ({ page }) => {
+    // Create command with very large output
+    const largeOutput = Array.from({ length: 300 }, (_, i) => `Line ${i + 1}: Output text here`).join('\n');
+    const button = await seedCommandButton(project.id, {
+      label: 'Scrollable Body Test',
+      command: `echo "${largeOutput}"`,
+      showOnList: true,
+    });
+
+    const { runId } = await runCommandButton(session.id, button.id);
+    await waitForCommandRunComplete(session.id, runId);
+
+    await navigateAndWait(page, `/sessions/${session.id}`);
+    await page.click('[data-testid="button-status-indicator"]');
+    await expect(page.locator('[data-testid="button-status-modal"]')).toBeVisible();
+
+    // Verify modal-body is scrollable
+    const bodyInfo = await page.evaluate(() => {
+      const body = document.querySelector('.modal-body');
+      if (!body) return null;
+      return {
+        scrollHeight: body.scrollHeight,
+        clientHeight: body.clientHeight,
+        isScrollable: body.scrollHeight > body.clientHeight,
+        overflowY: window.getComputedStyle(body).overflowY
+      };
+    });
+
+    expect(bodyInfo).not.toBeNull();
+    expect(bodyInfo!.isScrollable).toBe(true);
+    expect(bodyInfo!.overflowY).toBe('auto');
+  });
+
+  test('footer buttons are always accessible regardless of content size', async ({ page }) => {
+    const largeOutput = Array.from({ length: 500 }, (_, i) => `Line ${i + 1}: Output text here`).join('\n');
+    const button = await seedCommandButton(project.id, {
+      label: 'Footer Accessibility Test',
+      command: `echo "${largeOutput}"`,
+      showOnList: true,
+    });
+
+    const { runId } = await runCommandButton(session.id, button.id);
+    await waitForCommandRunComplete(session.id, runId);
+
+    await navigateAndWait(page, `/sessions/${session.id}`);
+    await page.click('[data-testid="button-status-indicator"]');
+    await expect(page.locator('[data-testid="button-status-modal"]')).toBeVisible();
+
+    // Expand output to maximize content
+    await page.click('[data-testid="output-header"]');
+
+    // Verify footer is within viewport
+    const footerPosition = await page.evaluate(() => {
+      const modal = document.querySelector('.modal-dialog');
+      const footer = document.querySelector('.modal-footer');
+      if (!modal || !footer) return null;
+      const modalRect = modal.getBoundingClientRect();
+      const footerRect = footer.getBoundingClientRect();
+      return {
+        footerBottom: footerRect.bottom,
+        modalBottom: modalRect.bottom,
+        footerWithinModal: footerRect.bottom <= modalRect.bottom
+      };
+    });
+
+    expect(footerPosition).not.toBeNull();
+    expect(footerPosition!.footerWithinModal).toBe(true);
+
+    // Verify buttons are clickable
+    await page.click('.modal-footer .btn-primary');
+    await expect(page.locator('[data-testid="button-status-modal"]')).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
Fixes an issue where the `ButtonStatusModal` component would grow vertically without limit when displaying large command outputs, pushing the footer buttons (Close, Remove Run) off-screen and making it impossible to close the modal.

## Problem
When a command produces large output (>200 lines), the modal grows beyond the viewport height, causing the footer buttons to be pushed off-screen. This creates a critical usability issue where users cannot close the modal.

## Solution
Implemented CSS fixes using a proven pattern already used in other modals (e.g., `ScheduleSessionModal`):

### Changes to `ButtonStatusModal.vue`:
- **`.modal-dialog`**: Added `max-height: 90vh`, `display: flex`, and `flex-direction: column` to constrain modal height and enable flexbox layout
- **`.modal-body`**: Added `flex: 1`, `overflow-y: auto`, and `min-height: 0` to make the body scrollable while keeping header/footer fixed

### New E2E Tests:
Added three comprehensive tests to `tests/e2e/command-button-modal.spec.ts`:
1. **Modal height constrained with large output** (200 lines) - Verifies modal never exceeds 90vh
2. **Modal body is scrollable** (300 lines) - Verifies scrolling behavior when content overflows
3. **Footer always accessible** (500 lines) - Verifies footer buttons remain visible and clickable

## Benefits
✅ Modal never exceeds 90% of viewport height  
✅ Header (title, close button) always visible  
✅ Footer (Close, Remove Run buttons) always accessible  
✅ Body content scrolls when needed  
✅ Consistent with other modals in the codebase  
✅ Preserves existing output section scrolling behavior (nested scrolling with 400px max)

## Test Results
All 9 tests passed (6 existing + 3 new) in 10.4 seconds

## Files Changed
- `packages/web/src/components/ButtonStatusModal.vue` - CSS style updates
- `tests/e2e/command-button-modal.spec.ts` - Added 3 new E2E tests

Co-Authored-By: Claude <noreply@anthropic.com>