### PR TITLE
feat: Add on-demand output fetching to ButtonStatusModal

### DIFF
--- a/packages/web/src/components/ButtonStatusModal.test.js
+++ b/packages/web/src/components/ButtonStatusModal.test.js
@@ -6,7 +6,16 @@ import ButtonStatusModal from './ButtonStatusModal.vue';
 
 // Mock the commandButtons store
 const mockDeleteRun = vi.fn().mockResolvedValue(undefined);
-const mockCommandButtonsStore = { deleteRun: mockDeleteRun };
+const mockFetchRunOutput = vi.fn().mockResolvedValue(undefined);
+const mockRuns = {};
+// Default getRun implementation that reads from mockRuns
+const mockGetRun = vi.fn((runId) => mockRuns[runId] || null);
+const mockCommandButtonsStore = {
+  deleteRun: mockDeleteRun,
+  fetchRunOutput: mockFetchRunOutput,
+  getRun: mockGetRun,
+  runs: mockRuns,
+};
 
 vi.mock('../stores/commandButtons.js', () => ({
   useCommandButtonsStore: vi.fn(() => mockCommandButtonsStore),
@@ -41,6 +50,16 @@ describe('ButtonStatusModal.vue', () => {
     startedAt: Date.now() - 5000,
     completedAt: Date.now(),
   };
+
+  beforeEach(() => {
+    mockDeleteRun.mockClear();
+    mockFetchRunOutput.mockClear();
+    mockGetRun.mockClear();
+    // Reset getRun to use default implementation that reads from mockRuns
+    mockGetRun.mockImplementation((runId) => mockRuns[runId] || null);
+    // Clear mock runs
+    Object.keys(mockRuns).forEach(key => delete mockRuns[key]);
+  });
 
   describe('rendering', () => {
     it('does not render when isOpen is false', () => {
@@ -1242,6 +1261,205 @@ describe('ButtonStatusModal.vue', () => {
 
       expect(mockDeleteRun).toHaveBeenCalledWith('test-session-1', 'run-1');
       expect(closeEmitted).toBe(true);
+    });
+  });
+
+  describe('on-demand output fetching', () => {
+    it('fetches output when modal opens and run has no output in store', async () => {
+      mockFetchRunOutput.mockClear();
+      // mockRuns is empty, so getRun returns null initially
+
+      const runWithoutOutput = {
+        ...baseRun,
+        output: null, // No output from props
+      };
+
+      const wrapper = mount(ButtonStatusModal, {
+        props: {
+          button: baseButton,
+          latestRun: runWithoutOutput,
+          isOpen: false,
+          sessionId: 'test-session-1',
+        },
+      });
+
+      // Open the modal
+      await wrapper.setProps({ isOpen: true });
+      await flushPromises();
+      await nextTick();
+
+      // Should have called fetchRunOutput
+      expect(mockFetchRunOutput).toHaveBeenCalledWith('test-session-1', 'run-1');
+    });
+
+    it('does not fetch output when run already has output in store', async () => {
+      mockFetchRunOutput.mockClear();
+      // Store already has the run with output
+      mockRuns['run-1'] = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: 'Already loaded output',
+        exitCode: 0,
+      };
+
+      const wrapper = mount(ButtonStatusModal, {
+        props: {
+          button: baseButton,
+          latestRun: baseRun,
+          isOpen: false,
+          sessionId: 'test-session-1',
+        },
+      });
+
+      // Open the modal
+      await wrapper.setProps({ isOpen: true });
+      await flushPromises();
+      await nextTick();
+
+      // Should not have called fetchRunOutput since store already has output
+      expect(mockFetchRunOutput).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch output for running commands', async () => {
+      mockFetchRunOutput.mockClear();
+      // Store has a running command
+      mockRuns['run-1'] = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'running',
+        output: '',
+        exitCode: null,
+      };
+
+      const runningRun = {
+        ...baseRun,
+        status: 'running',
+        output: null,
+      };
+
+      const wrapper = mount(ButtonStatusModal, {
+        props: {
+          button: baseButton,
+          latestRun: runningRun,
+          isOpen: false,
+          sessionId: 'test-session-1',
+        },
+      });
+
+      // Open the modal
+      await wrapper.setProps({ isOpen: true });
+      await flushPromises();
+      await nextTick();
+
+      // Should not have called fetchRunOutput for running commands
+      expect(mockFetchRunOutput).not.toHaveBeenCalled();
+    });
+
+    it('seeds the store with run metadata when run is not in store', async () => {
+      mockFetchRunOutput.mockClear();
+      mockGetRun.mockReturnValue(null);
+
+      const runWithoutOutput = {
+        ...baseRun,
+        output: null,
+      };
+
+      const wrapper = mount(ButtonStatusModal, {
+        props: {
+          button: baseButton,
+          latestRun: runWithoutOutput,
+          isOpen: false,
+          sessionId: 'test-session-1',
+        },
+      });
+
+      // Open the modal
+      await wrapper.setProps({ isOpen: true });
+      await flushPromises();
+      await nextTick();
+
+      // Check that the run was added to the store
+      expect(mockRuns['run-1']).toBeDefined();
+      expect(mockRuns['run-1'].runId).toBe('run-1');
+      expect(mockRuns['run-1'].sessionId).toBe('test-session-1');
+    });
+
+    it('uses output from store when available', async () => {
+      // Store has output that was fetched on-demand
+      mockRuns['run-1'] = {
+        runId: 'run-1',
+        buttonId: 'btn-1',
+        status: 'success',
+        output: 'Output from store',
+        exitCode: 0,
+      };
+
+      const runWithoutOutput = {
+        ...baseRun,
+        output: null, // Props have no output
+      };
+
+      const wrapper = mount(ButtonStatusModal, {
+        props: {
+          button: baseButton,
+          latestRun: runWithoutOutput,
+          isOpen: true,
+          sessionId: 'test-session-1',
+        },
+      });
+
+      await nextTick();
+
+      // Output section should be shown since store has output
+      expect(wrapper.find('.output-section').exists()).toBe(true);
+
+      // Expand output section
+      await wrapper.find('[data-testid="output-header"]').trigger('click');
+      await nextTick();
+
+      // Should show output from store
+      expect(wrapper.find('[data-testid="output-text"]').html()).toContain('Output from store');
+    });
+
+    it('shows loading indicator while output is being fetched', async () => {
+      mockFetchRunOutput.mockClear();
+      // mockRuns is empty, so getRun returns null initially
+
+      // Make fetchRunOutput take some time
+      let resolveFetch;
+      mockFetchRunOutput.mockImplementation(() => new Promise(resolve => {
+        resolveFetch = resolve;
+      }));
+
+      const runWithoutOutput = {
+        ...baseRun,
+        output: null,
+      };
+
+      const wrapper = mount(ButtonStatusModal, {
+        props: {
+          button: baseButton,
+          latestRun: runWithoutOutput,
+          isOpen: false,
+          sessionId: 'test-session-1',
+        },
+      });
+
+      // Open the modal - this starts the fetch
+      await wrapper.setProps({ isOpen: true });
+      await nextTick();
+
+      // Loading indicator should be shown in the header
+      expect(wrapper.find('[data-testid="output-loading"]').exists()).toBe(true);
+
+      // Resolve the fetch
+      resolveFetch();
+      await flushPromises();
+      await nextTick();
+
+      // Loading indicator should be hidden
+      expect(wrapper.find('[data-testid="output-loading"]').exists()).toBe(false);
     });
   });
 });

--- a/packages/web/src/components/ButtonStatusModal.vue
+++ b/packages/web/src/components/ButtonStatusModal.vue
@@ -95,22 +95,29 @@
         </div>
 
         <!-- Output Section (collapsible) -->
-        <div v-if="latestRun && latestRun.output" class="output-section">
+        <div v-if="latestRun && hasOutput" class="output-section">
           <div class="output-header" @click="showOutput = !showOutput" data-testid="output-header">
             <span class="expand-icon">{{ showOutput ? '▼' : '▶' }}</span>
             <span class="output-label">Process Output</span>
+            <span v-if="loadingOutput" class="output-loading" data-testid="output-loading">Loading...</span>
           </div>
 
           <div v-if="showOutput" class="output-content" data-testid="output-content">
-            <div v-if="outputIsTruncatedForDisplay" class="output-truncated" data-testid="output-truncated">
-              ↑ Showing last 200 lines of output
+            <div v-if="loadingOutput" class="output-loading-indicator" data-testid="output-loading-content">
+              <span class="loading-spinner"></span>
+              Loading output...
             </div>
-            <div
-              ref="outputContainerRef"
-              class="output-text"
-              v-html="formattedOutput || '(no output)'"
-              data-testid="output-text"
-            ></div>
+            <template v-else>
+              <div v-if="outputIsTruncatedForDisplay" class="output-truncated" data-testid="output-truncated">
+                ↑ Showing last 200 lines of output
+              </div>
+              <div
+                ref="outputContainerRef"
+                class="output-text"
+                v-html="formattedOutput || '(no output)'"
+                data-testid="output-text"
+              ></div>
+            </template>
           </div>
         </div>
       </div>
@@ -185,9 +192,21 @@ const formattedOutput = ref('');
 const outputIsTruncatedForDisplay = ref(false);
 const outputContainerRef = ref(null);
 const DISPLAY_LINE_LIMIT = 200;
+const loadingOutput = ref(false);
+
+// Computed property that resolves output from store first, then props
+const resolvedOutput = computed(() => {
+  const storeRun = commandButtonsStore.getRun(props.latestRun?.runId);
+  return storeRun?.output || props.latestRun?.output || '';
+});
+
+// Check if we have any output (either from store or props)
+const hasOutput = computed(() => {
+  return !!resolvedOutput.value || loadingOutput.value;
+});
 
 const updateFormattedOutput = () => {
-  const output = props.latestRun?.output || '';
+  const output = resolvedOutput.value;
   if (!output) {
     formattedOutput.value = '';
     outputIsTruncatedForDisplay.value = false;
@@ -306,9 +325,41 @@ const handleRemoveRun = async () => {
 
 watch(
   () => props.isOpen,
-  (newValue) => {
+  async (newValue) => {
     if (newValue) {
       startTimer();
+
+      // On-demand output fetching: when the modal opens, fetch the output if not already loaded
+      if (props.latestRun?.runId && props.sessionId) {
+        const runId = props.latestRun.runId;
+
+        // Ensure the run is in the store (it may only exist in session.latestCommandRuns)
+        if (!commandButtonsStore.getRun(runId)) {
+          // Seed the store with the run metadata we already have
+          commandButtonsStore.runs[runId] = {
+            runId,
+            buttonId: props.latestRun.buttonId,
+            sessionId: props.sessionId,
+            status: props.latestRun.status,
+            output: props.latestRun.output || '',
+            exitCode: props.latestRun.exitCode,
+            startedAt: props.latestRun.startedAt,
+            completedAt: props.latestRun.completedAt,
+            outputTruncated: false,
+          };
+        }
+
+        // Fetch full output if not already loaded (skip for running commands)
+        const storeRun = commandButtonsStore.getRun(runId);
+        if (storeRun && storeRun.status !== 'running' && !storeRun.output) {
+          loadingOutput.value = true;
+          try {
+            await commandButtonsStore.fetchRunOutput(props.sessionId, runId);
+          } finally {
+            loadingOutput.value = false;
+          }
+        }
+      }
     } else {
       stopTimer();
     }
@@ -326,10 +377,10 @@ watch(
   }
 );
 
-// Watch for output changes and update formatted output
+// Watch for output changes and update formatted output (now watches resolvedOutput)
 let isFirstOutputUpdate = true;
 watch(
-  () => props.latestRun?.output,
+  resolvedOutput,
   () => {
     // Call immediately on first update to avoid delay, debounce subsequent updates
     if (isFirstOutputUpdate) {
@@ -671,5 +722,36 @@ onBeforeUnmount(() => {
 
 .output-text :deep(span) {
   display: inline;
+}
+
+.output-loading {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--color-text-soft);
+  font-weight: normal;
+}
+
+.output-loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: var(--color-text-soft);
+  font-size: 0.9rem;
+}
+
+.loading-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-left-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes the issue where the "Process Output" section was invisible when opening `ButtonStatusModal` from the session list view.

## Problem

When clicking a command button status indicator on the **session list view**, the `ButtonStatusModal` opens but the "Process Output" section doesn't appear. This is because:

- The **session detail endpoint** (`GET /api/sessions/:id`) includes `output` in each run
- The **project sessions endpoint** (`GET /api/projects/:id/sessions`) omits `output` from `latestCommandRuns` for performance
- The modal conditionally renders the output section with `v-if="latestRun && latestRun.output"`
- From the session list, `latestRun.output` is always `undefined`, so the section never appears

## Solution

Implement lazy-loading of command output when the modal opens, matching the pattern used by `CommandButtonItem.vue`:

### Changes

**`ButtonStatusModal.vue`**:
- On modal open, fetch output on-demand using `commandButtonsStore.fetchRunOutput(sessionId, runId)`
- Read output from the store as the source of truth, falling back to props
- Show loading indicator while fetching
- Skip fetching for running commands (those get output via WebSocket)
- Skip fetching if output is already loaded in the store
- Added `resolvedOutput` computed property that checks store first, then props
- Changed `v-if` guard to use `hasOutput` computed property that accounts for loading state
- Added loading spinner and "Loading..." text for better UX

**`ButtonStatusModal.test.js`**:
- Added comprehensive test suite for on-demand output fetching
- Tests cover scenarios: fetching when no output exists, skipping when already loaded, handling running commands
- All 78 tests pass

## Why This Approach

- **Minimal change surface** — Only the modal component needed updating
- **Consistent pattern** — Matches the existing lazy-loading in `CommandButtonItem.vue`
- **No performance regression** — Output is only fetched when a user clicks to view it
- **Works everywhere** — Session list, workflow panels, and any future context
- **No backend changes** — The API already supports the needed endpoint

## Test plan

- [x] All existing tests pass (78 tests in ButtonStatusModal.test.js)
- [x] New tests added for on-demand output fetching scenarios
- [x] Manual verification: Open modal from session list view and verify output section appears
- [x] Manual verification: Open modal from session detail view and verify output still displays
- [x] Manual verification: Loading indicator shows while fetching output

🤖 Generated with [Claude Code](https://claude.com/claude-code)