### PR TITLE
Adapt E2E tests to use conversation overlay for message access

### DIFF
--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -135,7 +135,7 @@ const { cleanup, initializeSession } = useSessionInitializer({
   resetPolling,
 });
 
-const activeTab = computed(() => route.params.tab || 'conversation');
+const activeTab = computed(() => route.params.tab || 'summary');
 
 // Get the session hierarchy path (for breadcrumbs)
 const sessionPath = computed(() => {

--- a/plan-adapt-tests-to-conversation-overlay.md
+++ b/plan-adapt-tests-to-conversation-overlay.md
@@ -1,0 +1,253 @@
+# Plan: Adapt Failing E2E Tests to Use Conversation Overlay
+
+## Context
+
+The **Conversation tab** in `SessionDetailView` is being removed. Conversations will only be accessible via the **SessionTreeOverlay** (the slide-in panel triggered by the handle on the right side of the page). The default tab will change from `conversation` to `summary`.
+
+This means any E2E test that currently:
+- Navigates to `/sessions/:id` expecting to see messages (currently defaults to conversation tab)
+- Navigates to `/sessions/:id/conversation` explicitly
+- Looks for message selectors, running state, or work log panels on the main page
+
+...will need to **open the overlay first** before those elements are visible in the DOM.
+
+---
+
+## Step 0: Add a Shared Helper to `tests/e2e/helpers.ts`
+
+Create a reusable `openConversationOverlay()` helper that all adapted tests can use:
+
+```typescript
+export async function openConversationOverlay(page: Page, sessionId: string) {
+  await navigateAndWait(page, `/sessions/${sessionId}`, {
+    waitFor: '.session-detail',
+    timeout: 15000,
+  });
+  const handle = page.locator('[data-testid="session-tree-handle"]');
+  await expect(handle).toBeVisible({ timeout: 10000 });
+  await handle.click();
+  const overlay = page.locator('[data-testid="session-tree-overlay"]');
+  await expect(overlay).toBeVisible({ timeout: 5000 });
+  return overlay;
+}
+```
+
+All message/conversation selectors should then be **scoped to the overlay**:
+```typescript
+const overlay = await openConversationOverlay(page, session.id);
+// Instead of: page.locator('[data-testid="message-assistant"]')
+// Use:        overlay.locator('[data-testid="message-assistant"]')
+```
+
+---
+
+## Step 1: `work-log-panels.spec.ts` (14 tests)
+
+**File:** `tests/e2e/work-log-panels.spec.ts`
+
+### What needs to change
+
+These tests navigate to `/sessions/${id}` and immediately look for:
+- `.running-state` / `.running-title` / `.live-work-log-panel` (live work log tests)
+- `[data-testid="message-assistant"]` / `[data-testid="message-user"]` (completed message tests)
+- `.work-log-panel`, `.work-log-header`, `.work-log-count`, etc.
+
+### Adaptation
+
+**For all 14 tests:**
+1. Replace direct `page.goto()` with `openConversationOverlay(page, session.id)`
+2. Scope all message/work-log selectors to the returned overlay locator
+3. For running-state tests: the overlay must render `RunningState` when the session is running -- verify this is the case since `ConversationTab` (embedded in the overlay) renders it
+
+**Example before:**
+```typescript
+await page.goto(`${API_URL}/sessions/${session.id}`);
+await page.waitForSelector('.running-state', { timeout: 10000 });
+```
+
+**Example after:**
+```typescript
+const overlay = await openConversationOverlay(page, session.id);
+await expect(overlay.locator('.running-state')).toBeVisible({ timeout: 10000 });
+```
+
+---
+
+## Step 2: `session-message-persistence.spec.ts` (4 tests)
+
+**File:** `tests/e2e/session-message-persistence.spec.ts`
+
+### What needs to change
+
+Tests navigate to `/sessions/${id}` and check for:
+- `[data-testid="message-assistant"]`
+- `[data-testid="message-user"]`
+- `.message-content`
+- Message count before/after page refresh
+
+### Adaptation
+
+1. Use `openConversationOverlay()` instead of `page.goto()`
+2. Scope all message selectors to the overlay
+3. **Page refresh test**: After `page.reload()`, the overlay will close. Must re-open the overlay and re-scope selectors before counting messages again.
+
+**Special attention:** The "message count before refresh matches after refresh" test needs:
+```typescript
+// Count messages in overlay
+const overlay1 = await openConversationOverlay(page, session.id);
+const countBefore = await overlay1.locator('[data-testid="message-assistant"]').count();
+
+// Refresh closes the overlay
+await page.reload();
+
+// Re-open overlay and re-count
+const overlay2 = await openConversationOverlay(page, session.id);
+const countAfter = await overlay2.locator('[data-testid="message-assistant"]').count();
+
+expect(countAfter).toBe(countBefore);
+```
+
+---
+
+## Step 3: `sessions.spec.ts` (1 test)
+
+**File:** `tests/e2e/sessions.spec.ts`
+
+### What needs to change
+
+The "displays session messages" test navigates to `/sessions/${id}` and checks for `.message-content`.
+
+### Adaptation
+
+1. Use `openConversationOverlay()` to access messages
+2. Scope `.message-content` selector to the overlay
+3. If the test also navigates to `/sessions/${id}/conversation` explicitly, change that to open the overlay instead
+
+---
+
+## Step 4: `websocket-recovery.spec.ts` (3 tests)
+
+**File:** `tests/e2e/websocket-recovery.spec.ts`
+
+### What needs to change
+
+Tests navigate to `/sessions/${id}` and check for:
+- `text=hello` (literal text matcher for messages)
+- `text=message-after-wake` (text after reconnect)
+- `.toast.toast-error`
+
+### Adaptation
+
+1. Use `openConversationOverlay()` for session detail tests
+2. Scope message text locators to the overlay
+3. **Toast selectors** (`.toast.toast-error`) should remain page-scoped since toasts render at the body level
+4. **Session list test** ("session list recovers project subscription after sleep") does NOT need overlay changes -- it tests the session list page, not session detail
+
+**Special attention:** The sleep/wake simulation may close the overlay. After simulating wake, the test may need to:
+- Check if overlay is still open
+- Re-open if closed
+- Then verify messages appear
+
+---
+
+## Step 5: `work-log-dedup.spec.ts` (2 tests)
+
+**File:** `tests/e2e/work-log-dedup.spec.ts`
+
+### What needs to change
+
+Tests navigate to `/sessions/${id}`, wait for `[data-testid="message-assistant"]`, then use `page.evaluate()` to access the Pinia store directly.
+
+### Adaptation
+
+1. Use `openConversationOverlay()` to make messages visible
+2. Scope the `[data-testid="message-assistant"]` wait to the overlay
+3. **Store access via `page.evaluate()`** can remain page-scoped since the Pinia store is a global singleton -- it doesn't matter whether the overlay is the active context
+
+---
+
+## Step 6: `scheduling-ui.spec.ts` (4 tests)
+
+**File:** `tests/e2e/scheduling-ui.spec.ts`
+
+### What needs to change
+
+Tests look for `.orchestration-panel .panel-header` which is currently rendered inside `ConversationTab`.
+
+### Decision needed
+
+The orchestration panel is part of the `ConversationTab` component. When the conversation tab is removed from the main view, the orchestration panel will only exist inside the overlay (since the overlay embeds `ConversationTab`).
+
+### Adaptation
+
+1. Use `openConversationOverlay()` to access the orchestration panel
+2. Scope `.orchestration-panel` selectors to the overlay
+3. Scope `textarea`, `.btn-schedule`, and modal selectors appropriately
+4. **Modal selectors** (`.modal-backdrop`, `input[type="datetime-local"]`) may render at body level via Teleport -- keep those page-scoped
+
+**Alternative**: If the orchestration panel is moved to the main session detail view (outside the overlay), these tests won't need overlay changes. This depends on the UI design decision.
+
+---
+
+## Step 7: `session-summaries.spec.ts` (7 tests)
+
+**File:** `tests/e2e/session-summaries.spec.ts`
+
+### What needs to change
+
+These tests navigate directly to `/sessions/${id}/summary` and interact with summary-specific selectors. They do **NOT** interact with the conversation view.
+
+### Adaptation
+
+**Likely NO conversation overlay changes needed.** These tests already navigate to the summary tab explicitly. Their failures are caused by the separate WebSocket status overwrite issue (documented in the failing tests analysis), not by the conversation tab.
+
+**However**, verify that:
+- Summary tab still renders correctly when it becomes the default tab
+- No selectors depend on the conversation tab being present in the DOM
+
+---
+
+## Step 8: `summary-regenerate.spec.ts` (2 tests)
+
+**File:** `tests/e2e/summary-regenerate.spec.ts`
+
+### What needs to change
+
+Same as session-summaries -- these navigate to `/sessions/${id}/summary` explicitly.
+
+### Adaptation
+
+**Likely NO conversation overlay changes needed.** These failures are from the WebSocket status overwrite issue, not conversation tab removal.
+
+---
+
+## Summary of Changes by File
+
+| File | Tests | Overlay Change Needed? | Key Selectors to Scope |
+|------|-------|----------------------|----------------------|
+| `work-log-panels.spec.ts` | 14 | Yes | `.running-state`, `[data-testid="message-*"]`, `.work-log-panel`, `.live-work-log-panel` |
+| `session-message-persistence.spec.ts` | 4 | Yes | `[data-testid="message-*"]`, `.message-content` |
+| `sessions.spec.ts` | 1 | Yes | `.message-content` |
+| `websocket-recovery.spec.ts` | 2 of 3 | Yes | `text=hello`, `text=message-after-wake` |
+| `work-log-dedup.spec.ts` | 2 | Yes | `[data-testid="message-assistant"]`, `.work-log-panel` |
+| `scheduling-ui.spec.ts` | 4 | Yes (if panel stays in ConversationTab) | `.orchestration-panel`, `.btn-schedule` |
+| `session-summaries.spec.ts` | 7 | No | N/A (summary tab) |
+| `summary-regenerate.spec.ts` | 2 | No | N/A (summary tab) |
+
+**Total tests requiring overlay adaptation: ~27 of 37**
+
+---
+
+## Risks & Edge Cases
+
+1. **Overlay animations**: The overlay uses a `slide-left` CSS transition. Tests may need small waits or `toBeVisible()` assertions before interacting with overlay content.
+
+2. **Page reload closes overlay**: Any test that refreshes the page will need to re-open the overlay afterward.
+
+3. **WebSocket events while overlay is open**: The overlay's ConversationTab should still receive store updates. Verify that WebSocket-driven changes (status updates, new messages) are reflected inside the overlay.
+
+4. **Orchestration panel location**: Need a design decision on whether the orchestration panel stays in the overlay or moves to the main page. This affects 4 scheduling tests.
+
+5. **Other test files**: The failing tests document covers 8 files, but there may be other passing tests that navigate to `/sessions/:id` expecting conversation content. A grep for `page.goto.*\/sessions\/.*` and `/conversation` across all E2E tests should catch these.
+
+6. **Default tab change**: Tests in `filtering-navigation.spec.ts` currently test "session detail defaults to conversation tab" -- this test will need to be updated to expect the summary tab as the default.

--- a/tests/e2e/effort-level.spec.ts
+++ b/tests/e2e/effort-level.spec.ts
@@ -15,6 +15,7 @@ import {
   navigateAndWait,
   API_URL,
   waitForSessionToExist,
+  openConversationOverlay,
 } from './helpers';
 
 /**
@@ -431,10 +432,10 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         effortLevel: 'high',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}`);
+      const overlay = await openConversationOverlay(page, session.id);
 
       // Check that effort level dropdown is visible in input form
-      const dropdown = page.locator('.input-form #effort-select');
+      const dropdown = overlay.locator('.input-form #effort-select');
       await expect(dropdown).toBeVisible();
     });
 
@@ -445,10 +446,10 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         effortLevel: 'medium',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}`);
+      const overlay = await openConversationOverlay(page, session.id);
 
       // Check that dropdown shows "medium"
-      const dropdown = page.locator('.input-form #effort-select');
+      const dropdown = overlay.locator('.input-form #effort-select');
       const value = await dropdown.inputValue();
       expect(value).toBe('medium');
     });
@@ -460,10 +461,10 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         // effortLevel defaults to null (auto)
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}`);
+      const overlay = await openConversationOverlay(page, session.id);
 
       // Check that dropdown shows "auto"
-      const dropdown = page.locator('.input-form #effort-select');
+      const dropdown = overlay.locator('.input-form #effort-select');
       const value = await dropdown.inputValue();
       expect(value).toBe('auto');
     });
@@ -475,10 +476,10 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         effortLevel: 'low',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}`);
+      const overlay = await openConversationOverlay(page, session.id);
 
       // Change dropdown to "max"
-      await page.locator('.input-form #effort-select').selectOption('max');
+      await overlay.locator('.input-form #effort-select').selectOption('max');
 
       // Wait for session update via polling (more reliable than waitForResponse)
       const startTime = Date.now();
@@ -503,10 +504,10 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         effortLevel: 'high',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}`);
+      const overlay = await openConversationOverlay(page, session.id);
 
       // Change dropdown to "low"
-      await page.locator('.input-form #effort-select').selectOption('low');
+      await overlay.locator('.input-form #effort-select').selectOption('low');
 
       // Wait for session update via polling
       const startTime = Date.now();
@@ -530,10 +531,10 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         effortLevel: 'medium',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}`);
+      let overlay = await openConversationOverlay(page, session.id);
 
       // Change dropdown to "high"
-      await page.locator('.input-form #effort-select').selectOption('high');
+      await overlay.locator('.input-form #effort-select').selectOption('high');
 
       // Wait for session update via polling
       const startTime = Date.now();
@@ -545,14 +546,12 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         await new Promise(resolve => setTimeout(resolve, 100));
       }
 
-      // Reload page
+      // Reload page and re-open overlay
       await page.reload();
-
-      // Wait for page to be ready
-      await page.waitForSelector('.input-form #effort-select');
+      overlay = await openConversationOverlay(page, session.id);
 
       // Check that dropdown still shows "high"
-      const dropdown = page.locator('.input-form #effort-select');
+      const dropdown = overlay.locator('.input-form #effort-select');
       const value = await dropdown.inputValue();
       expect(value).toBe('high');
 
@@ -877,9 +876,9 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         startImmediately: false,
       });
 
-      await navigateAndWait(page, `${API_URL}/sessions/${session.id}`);
+      const overlay = await openConversationOverlay(page, session.id);
 
-      const dropdown = page.locator('.input-form #effort-select');
+      const dropdown = overlay.locator('.input-form #effort-select');
 
       // Check for aria-label
       const ariaLabel = await dropdown.getAttribute('aria-label');

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -574,13 +574,13 @@ test.describe('Session Detail Tab Navigation', () => {
     await cleanupCreatedResources();
   });
 
-  test('session detail defaults to conversation tab', async ({ page }) => {
+  test('session detail defaults to summary tab', async ({ page }) => {
     await navigateAndWait(page, `/sessions/${session.id}`);
 
     // The route uses optional :tab? param, so URL stays at /sessions/:id
-    // but the Conversations tab should be active by default
-    const conversationsTab = page.locator('.tabs-desktop .tab').filter({ hasText: 'Conversations' });
-    await expect(conversationsTab).toHaveClass(/active/);
+    // but the Summary tab should be active by default (conversation is now in overlay)
+    const summaryTab = page.locator('.tabs-desktop .tab').filter({ hasText: 'Summary' });
+    await expect(summaryTab).toHaveClass(/active/);
   });
 
   test('clicking each tab navigates and updates URL', async ({ page }) => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { readFileSync, existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
@@ -2490,6 +2490,36 @@ export async function getAgentCallFilterOptions() {
  * Seed a kanban lane for testing
  * Lanes are cleaned up automatically when the project is deleted (CASCADE)
  */
+// ============================================================
+// Conversation Overlay Helpers
+// ============================================================
+
+/**
+ * Opens the conversation overlay (session tree overlay) for a session.
+ * Since the conversation tab was removed from the main view, conversation content
+ * is only accessible via this overlay.
+ *
+ * @param page - Playwright page object
+ * @param sessionId - The session ID to navigate to
+ * @returns The overlay locator for scoping further queries
+ */
+export async function openConversationOverlay(page: Page, sessionId: string) {
+  await navigateAndWait(page, `/sessions/${sessionId}`, {
+    waitFor: '.session-detail',
+    timeout: 15000,
+  });
+  const handle = page.locator('[data-testid="session-tree-handle"]');
+  await expect(handle).toBeVisible({ timeout: 10000 });
+  await handle.click();
+  const overlay = page.locator('[data-testid="session-tree-overlay"]');
+  await expect(overlay).toBeVisible({ timeout: 5000 });
+  return overlay;
+}
+
+// ============================================================
+// Kanban Helpers
+// ============================================================
+
 export async function seedKanbanLane(
   projectId: string,
   data: {

--- a/tests/e2e/messaging-chat.spec.ts
+++ b/tests/e2e/messaging-chat.spec.ts
@@ -11,6 +11,7 @@ import {
   seedConversationHistory,
   seedWorkLog,
   getSessionMessages,
+  openConversationOverlay,
 } from './helpers';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
@@ -36,11 +37,10 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
-    // Wait for message content to render before checking specific elements
-    await page.locator('.message-assistant .message-content').first().waitFor({ timeout: 10000 });
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     await expect(messageContent.locator('h1')).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('h2')).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('h3')).toBeVisible({ timeout: 10000 });
@@ -55,10 +55,11 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     await expect(messageContent.locator('pre')).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('pre code')).toBeVisible({ timeout: 10000 });
   });
@@ -72,10 +73,11 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     const inlineCode = messageContent.locator('code').first();
     await expect(inlineCode).toBeVisible({ timeout: 10000 });
     await expect(inlineCode).toContainText('console.log');
@@ -90,11 +92,10 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
-    // Wait for message content to render before checking specific elements
-    await page.locator('.message-assistant .message-content').first().waitFor({ timeout: 10000 });
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     await expect(messageContent.locator('ul')).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('ul li').first()).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('ol')).toBeVisible({ timeout: 10000 });
@@ -110,10 +111,11 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     const link = messageContent.locator('a[href="https://example.com"]');
     await expect(link).toBeVisible({ timeout: 10000 });
     await expect(link).toContainText('Example');
@@ -128,10 +130,11 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     await expect(messageContent.locator('table')).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('th').first()).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('td').first()).toBeVisible({ timeout: 10000 });
@@ -146,10 +149,11 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const messageContent = page.locator('.message-assistant .message-content').first();
+    const messageContent = overlay.locator('.message-assistant .message-content').first();
     await expect(messageContent.locator('strong')).toBeVisible({ timeout: 10000 });
     await expect(messageContent.locator('em')).toBeVisible({ timeout: 10000 });
   });
@@ -177,10 +181,11 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const toolsSection = page.locator('.message-assistant .message-tools').first();
+    const toolsSection = overlay.locator('.message-assistant .message-tools').first();
     await expect(toolsSection).toBeVisible({ timeout: 10000 });
   });
 
@@ -194,10 +199,11 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const toolDetails = page.locator('.message-assistant .message-tools details').first();
+    const toolDetails = overlay.locator('.message-assistant .message-tools details').first();
     await expect(toolDetails).toBeVisible({ timeout: 10000 });
 
     // Click the summary to expand the details
@@ -219,10 +225,11 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const toolsSection = page.locator('.message-assistant .message-tools').first();
+    const toolsSection = overlay.locator('.message-assistant .message-tools').first();
     await expect(toolsSection).toContainText('Bash', { timeout: 10000 });
   });
 
@@ -236,10 +243,11 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const toolDetails = page.locator('.message-assistant .message-tools details').first();
+    const toolDetails = overlay.locator('.message-assistant .message-tools details').first();
     const summary = toolDetails.locator('summary').first();
     await summary.click();
 
@@ -261,10 +269,11 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const toolBlocks = page.locator('.message-assistant .message-tools details');
+    const toolBlocks = overlay.locator('.message-assistant .message-tools details');
     await expect(toolBlocks).toHaveCount(2, { timeout: 10000 });
   });
 });
@@ -298,10 +307,11 @@ test.describe('Work Log UI Panels', () => {
     });
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const workLogPanel = page.locator('.message-assistant .work-log-panel').first();
+    const workLogPanel = overlay.locator('.message-assistant .work-log-panel').first();
     await expect(workLogPanel).toBeVisible({ timeout: 10000 });
   });
 
@@ -315,14 +325,15 @@ test.describe('Work Log UI Panels', () => {
     });
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const workLogHeader = page.locator('.message-assistant .work-log-panel summary').first();
+    const workLogHeader = overlay.locator('.message-assistant .work-log-panel summary').first();
     await expect(workLogHeader).toBeVisible({ timeout: 10000 });
     await workLogHeader.click();
 
-    const thinkingBlock = page.locator('.message-assistant .thinking-block').first();
+    const thinkingBlock = overlay.locator('.message-assistant .thinking-block').first();
     await expect(thinkingBlock).toBeVisible({ timeout: 5000 });
     await expect(thinkingBlock).toContainText('Let me analyze this carefully');
   });
@@ -338,19 +349,20 @@ test.describe('Work Log UI Panels', () => {
     });
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const workLogHeader = page.locator('.message-assistant .work-log-panel summary').first();
+    const workLogHeader = overlay.locator('.message-assistant .work-log-panel summary').first();
     await expect(workLogHeader).toBeVisible({ timeout: 10000 });
     await workLogHeader.click();
 
-    const showMoreBtn = page.locator('.message-assistant .show-more-btn').first();
+    const showMoreBtn = overlay.locator('.message-assistant .show-more-btn').first();
     await expect(showMoreBtn).toBeVisible({ timeout: 5000 });
     await expect(showMoreBtn).toContainText('Show more');
 
     await showMoreBtn.click();
-    const thinkingBlock = page.locator('.message-assistant .thinking-block').first();
+    const thinkingBlock = overlay.locator('.message-assistant .thinking-block').first();
     await expect(thinkingBlock).toContainText('This is my thinking process.');
   });
 });
@@ -372,11 +384,12 @@ test.describe('Jump Navigation Buttons', () => {
     seedAssistantMessage(session.id, 'Hello! How can I help you?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    // Button should not be visible when at bottom (hasNewMessages starts false)
-    const jumpBtn = page.locator('.jump-to-latest');
+    // Button should not be visible when at bottom (hasNewMessages starts false) - scoped to overlay
+    const jumpBtn = overlay.locator('.jump-to-latest');
     await expect(jumpBtn).not.toBeVisible({ timeout: 5000 });
   });
 
@@ -385,11 +398,12 @@ test.describe('Jump Navigation Buttons', () => {
     seedConversationHistory(session.id, 30);
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(800);
 
-    // On initial load, page auto-scrolls to bottom; hasNewMessages is false
-    const jumpBtn = page.locator('.jump-to-latest');
+    // On initial load, page auto-scrolls to bottom; hasNewMessages is false - scoped to overlay
+    const jumpBtn = overlay.locator('.jump-to-latest');
     await expect(jumpBtn).not.toBeVisible({ timeout: 5000 });
   });
 
@@ -399,11 +413,12 @@ test.describe('Jump Navigation Buttons', () => {
     seedAssistantMessage(session.id, 'Sure, I can help you with that!', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    // hasAssistantMessages=true, isNearBottom=true (loaded at bottom), isUsersTurn=true (waiting)
-    const scrollToClaudeBtn = page.locator('.scroll-to-claude-btn');
+    // hasAssistantMessages=true, isNearBottom=true (loaded at bottom), isUsersTurn=true (waiting) - scoped to overlay
+    const scrollToClaudeBtn = overlay.locator('.scroll-to-claude-btn');
     await expect(scrollToClaudeBtn).toBeVisible({ timeout: 10000 });
   });
 
@@ -412,11 +427,12 @@ test.describe('Jump Navigation Buttons', () => {
     seedAssistantMessage(session.id, 'I am currently working...', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    // isUsersTurn = false when running
-    const scrollToClaudeBtn = page.locator('.scroll-to-claude-btn');
+    // isUsersTurn = false when running - scoped to overlay
+    const scrollToClaudeBtn = overlay.locator('.scroll-to-claude-btn');
     await expect(scrollToClaudeBtn).not.toBeVisible({ timeout: 5000 });
   });
 
@@ -424,10 +440,11 @@ test.describe('Jump Navigation Buttons', () => {
     // Draft session = waiting status with no assistant messages
     const session = await seedSession(project.id, { prompt: 'Hello there, draft session', name: 'No Assistant Test' , startImmediately: false });
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const scrollToClaudeBtn = page.locator('.scroll-to-claude-btn');
+    const scrollToClaudeBtn = overlay.locator('.scroll-to-claude-btn');
     await expect(scrollToClaudeBtn).not.toBeVisible({ timeout: 5000 });
   });
 });
@@ -450,10 +467,11 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'Hello! How can I help?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const textarea = page.locator('.input-form textarea');
+    const textarea = overlay.locator('.input-form textarea');
     await expect(textarea).toBeVisible({ timeout: 10000 });
   });
 
@@ -462,10 +480,11 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'How can I help?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const textarea = page.locator('.input-form textarea');
+    const textarea = overlay.locator('.input-form textarea');
     await expect(textarea).toBeVisible({ timeout: 10000 });
     await textarea.fill('This is a test message for the textarea');
     await expect(textarea).toHaveValue('This is a test message for the textarea');
@@ -476,10 +495,11 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'How can I help?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const textarea = page.locator('.input-form textarea');
+    const textarea = overlay.locator('.input-form textarea');
     await expect(textarea).toBeVisible({ timeout: 10000 });
     await textarea.fill('My follow-up question');
 
@@ -500,14 +520,15 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'I am here.', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
     // Clear the textarea (pendingPrompt is pre-filled for startImmediately=false sessions)
-    const textarea = page.locator('.input-form textarea');
+    const textarea = overlay.locator('.input-form textarea');
     await textarea.fill('');
 
-    const sendBtn = page.locator('.btn-send-full').first();
+    const sendBtn = overlay.locator('.btn-send-full').first();
     await expect(sendBtn).toBeDisabled({ timeout: 10000 });
   });
 
@@ -516,13 +537,14 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'I am here.', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const textarea = page.locator('.input-form textarea');
+    const textarea = overlay.locator('.input-form textarea');
     await textarea.fill('Some message content');
 
-    const sendBtn = page.locator('.btn-send-full').first();
+    const sendBtn = overlay.locator('.btn-send-full').first();
     await expect(sendBtn).not.toBeDisabled({ timeout: 10000 });
   });
 });
@@ -544,10 +566,11 @@ test.describe('Model Name Display', () => {
     seedAssistantMessage(session.id, 'I am Claude Sonnet.', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const assistantMsg = page.locator('[data-testid="message-assistant"]').first();
+    const assistantMsg = overlay.locator('[data-testid="message-assistant"]').first();
     const modelDisplay = assistantMsg.locator('.message-model');
     await expect(modelDisplay).toBeVisible({ timeout: 10000 });
   });
@@ -558,10 +581,11 @@ test.describe('Model Name Display', () => {
     seedAssistantMessage(session.id, 'Got it!', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const userMsg = page.locator('[data-testid="message-user"]').first();
+    const userMsg = overlay.locator('[data-testid="message-user"]').first();
     const modelDisplay = userMsg.locator('.message-model');
     await expect(modelDisplay).not.toBeVisible({ timeout: 5000 });
   });
@@ -572,10 +596,11 @@ test.describe('Model Name Display', () => {
     seedAssistantMessage(session.id, 'I am Haiku.', 'claude-haiku-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const assistantMessages = page.locator('[data-testid="message-assistant"]');
+    const assistantMessages = overlay.locator('[data-testid="message-assistant"]');
     await expect(assistantMessages).toHaveCount(2, { timeout: 10000 });
 
     const firstModelDisplay = assistantMessages.nth(0).locator('.message-model');
@@ -609,10 +634,11 @@ test.describe('Message States & Error Handling', () => {
       name: 'Draft Session Test',
     });
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const textarea = page.locator('.input-form textarea');
+    const textarea = overlay.locator('.input-form textarea');
     await expect(textarea).toBeVisible({ timeout: 10000 });
   });
 
@@ -623,11 +649,12 @@ test.describe('Message States & Error Handling', () => {
       startImmediately: false, // Don't auto-start - keeps it as a true draft
     });
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    // Draft sessions hide messages in the template (v-if="!isDraft && !isScheduledDraft")
-    const messageItems = page.locator('[data-testid="message-user"], [data-testid="message-assistant"]');
+    // Draft sessions hide messages in the template (v-if="!isDraft && !isScheduledDraft") - scoped to overlay
+    const messageItems = overlay.locator('[data-testid="message-user"], [data-testid="message-assistant"]');
     await expect(messageItems).toHaveCount(0, { timeout: 10000 });
   });
 
@@ -637,10 +664,11 @@ test.describe('Message States & Error Handling', () => {
     seedAssistantMessage(session.id, 'Yes, I can help you!', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access input form
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const inputForm = page.locator('.input-form');
+    const inputForm = overlay.locator('.input-form');
     await expect(inputForm).toBeVisible({ timeout: 10000 });
   });
 
@@ -649,10 +677,11 @@ test.describe('Message States & Error Handling', () => {
     seedAssistantMessage(session.id, 'Processing...', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay to access running state
+    const overlay = await openConversationOverlay(page, session.id);
     await page.waitForTimeout(500);
 
-    const runningState = page.locator('.running-state');
+    const runningState = overlay.locator('.running-state');
     await expect(runningState).toBeVisible({ timeout: 10000 });
 
     const stopBtn = runningState.locator('.btn-stop');

--- a/tests/e2e/orchestration-panel.spec.ts
+++ b/tests/e2e/orchestration-panel.spec.ts
@@ -9,6 +9,7 @@ import {
   cleanupAll,
   cleanupTemplates,
   navigateAndWait,
+  openConversationOverlay,
 } from './helpers';
 
 // ============================================================
@@ -36,12 +37,12 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    const panel = page.locator('.orchestration-panel');
+    const panel = overlay.locator('.orchestration-panel');
     await expect(panel).toBeVisible();
 
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await expect(panelHeader).toBeVisible();
     await expect(panelHeader).toContainText('Orchestration');
   });
@@ -53,21 +54,21 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Panel content should NOT be visible (collapsed by default)
-    const content = page.locator('.orchestration-content');
+    const content = overlay.locator('.orchestration-content');
     await expect(content).not.toBeVisible();
 
     // Click the panel header to expand
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Now the content should be visible
     await expect(content).toBeVisible();
 
     // Toggle button should indicate expanded state (scoped to orchestration panel)
-    const toggleButton = page.locator('.orchestration-panel .toggle-button');
+    const toggleButton = overlay.locator('.orchestration-panel .toggle-button');
     await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
   });
 
@@ -81,13 +82,13 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
     // Enable auto-reschedule via API
     await updateSessionScheduling(session.id, { autoRescheduleEnabled: true });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Content should be visible without clicking (auto-expanded)
-    const content = page.locator('.orchestration-content');
+    const content = overlay.locator('.orchestration-content');
     await expect(content).toBeVisible();
 
-    const toggleButton = page.locator('.orchestration-panel .toggle-button');
+    const toggleButton = overlay.locator('.orchestration-panel .toggle-button');
     await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
   });
 
@@ -106,14 +107,14 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
     // Set next template via API
     await setNextTemplate(session.id, template.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Content should be visible without clicking (auto-expanded)
-    const content = page.locator('.orchestration-content');
+    const content = overlay.locator('.orchestration-content');
     await expect(content).toBeVisible();
 
     // Template selector should show the selected template
-    const templateSelect = page.locator('.template-selector select.form-input');
+    const templateSelect = overlay.locator('.template-selector select.form-input');
     await expect(templateSelect).toBeVisible();
   });
 });
@@ -143,19 +144,19 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Schedule button should be visible
-    const scheduleBtn = page.locator('.btn-schedule');
+    const scheduleBtn = overlay.locator('.btn-schedule');
     await expect(scheduleBtn).toBeVisible();
     await expect(scheduleBtn).toContainText('Scheduling');
 
     // Schedule row should be visible
-    const scheduleRow = page.locator('.schedule-row');
+    const scheduleRow = overlay.locator('.schedule-row');
     await expect(scheduleRow).toBeVisible();
   });
 
@@ -166,22 +167,22 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Clear the textarea (draft sessions pre-populate from pendingPrompt)
-    const textarea = page.locator('textarea');
+    const textarea = overlay.locator('textarea');
     await textarea.clear();
 
     // Schedule button should be disabled
-    const scheduleBtn = page.locator('.btn-schedule');
+    const scheduleBtn = overlay.locator('.btn-schedule');
     await expect(scheduleBtn).toBeDisabled();
 
     // Disabled hint should be visible
-    const hint = page.locator('.schedule-disabled-hint');
+    const hint = overlay.locator('.schedule-disabled-hint');
     await expect(hint).toBeVisible();
     await expect(hint).toContainText('Prompt is required before scheduling');
   });
@@ -193,18 +194,18 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // First clear the textarea
-    const textarea = page.locator('textarea');
+    const textarea = overlay.locator('textarea');
     await textarea.clear();
 
     // Verify it's disabled first
-    const scheduleBtn = page.locator('.btn-schedule');
+    const scheduleBtn = overlay.locator('.btn-schedule');
     await expect(scheduleBtn).toBeDisabled();
 
     // Now type content into the textarea
@@ -214,7 +215,7 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
     await expect(scheduleBtn).toBeEnabled();
 
     // Disabled hint should NOT be visible
-    const hint = page.locator('.schedule-disabled-hint');
+    const hint = overlay.locator('.schedule-disabled-hint');
     await expect(hint).not.toBeVisible();
   });
 });
@@ -244,19 +245,19 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Configure button should be visible
-    const configureBtn = page.locator('.btn-configure');
+    const configureBtn = overlay.locator('.btn-configure');
     await expect(configureBtn).toBeVisible();
     await expect(configureBtn).toContainText('Configure');
 
     // Status button should NOT be visible (auto-reschedule is disabled)
-    const statusBtn = page.locator('.btn-status');
+    const statusBtn = overlay.locator('.btn-status');
     await expect(statusBtn).not.toBeVisible();
   });
 
@@ -267,17 +268,17 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Click configure button
-    const configureBtn = page.locator('.btn-configure');
+    const configureBtn = overlay.locator('.btn-configure');
     await configureBtn.click();
 
-    // Modal should be visible
+    // Modal should be visible (modals are typically at page level, not overlay level)
     const modal = page.locator('.modal-backdrop');
     await expect(modal).toBeVisible();
 
@@ -301,12 +302,12 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand panel → click configure
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
-    await page.locator('.btn-configure').click();
+    await overlay.locator('.btn-configure').click();
 
     // Enable the toggle by clicking the toggle-switch label (checkbox is hidden via CSS)
     const toggleLabel = page.locator('.modal-content .toggle-switch');
@@ -332,12 +333,12 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand panel → click configure
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
-    await page.locator('.btn-configure').click();
+    await overlay.locator('.btn-configure').click();
 
     // Enable the toggle by clicking the toggle-switch label (checkbox is hidden via CSS)
     const toggleLabel = page.locator('.modal-content .toggle-switch');
@@ -352,17 +353,17 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
     await expect(modal).not.toBeVisible();
 
     // Panel should now show status button with "Enabled" badge
-    const statusBtn = page.locator('.btn-status');
+    const statusBtn = overlay.locator('.btn-status');
     await expect(statusBtn).toBeVisible();
 
-    const statusBadge = page.locator('.status-badge');
+    const statusBadge = overlay.locator('.status-badge');
     await expect(statusBadge).toContainText('Enabled');
 
-    const editLink = page.locator('.edit-link');
+    const editLink = overlay.locator('.edit-link');
     await expect(editLink).toContainText('Edit');
 
     // Configure button should no longer be visible
-    const configureBtn = page.locator('.btn-configure');
+    const configureBtn = overlay.locator('.btn-configure');
     await expect(configureBtn).not.toBeVisible();
 
     // Verify via API
@@ -380,14 +381,14 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
     // Enable auto-reschedule via API first
     await updateSessionScheduling(session.id, { autoRescheduleEnabled: true });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Panel should be expanded (auto-expanded because autoRescheduleEnabled)
-    const content = page.locator('.orchestration-content');
+    const content = overlay.locator('.orchestration-content');
     await expect(content).toBeVisible();
 
     // Click status button to open modal
-    const statusBtn = page.locator('.btn-status');
+    const statusBtn = overlay.locator('.btn-status');
     await expect(statusBtn).toBeVisible();
     await statusBtn.click();
 
@@ -404,11 +405,11 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
     await expect(modal).not.toBeVisible();
 
     // Panel should now show Configure button again
-    const configureBtn = page.locator('.btn-configure');
+    const configureBtn = overlay.locator('.btn-configure');
     await expect(configureBtn).toBeVisible();
 
     // Status button should no longer be visible
-    await expect(page.locator('.btn-status')).not.toBeVisible();
+    await expect(overlay.locator('.btn-status')).not.toBeVisible();
 
     // Verify via API
     const updatedSession = await getSession(session.id);
@@ -453,26 +454,26 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Template selector should be visible
-    const templateSelector = page.locator('.template-selector');
+    const templateSelector = overlay.locator('.template-selector');
     await expect(templateSelector).toBeVisible();
 
     // Label should be present
-    const label = page.locator('.selector-label');
+    const label = overlay.locator('.selector-label');
     await expect(label).toContainText('Next Template');
 
     // Dropdown should be visible
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
     await expect(dropdown).toBeVisible();
 
     // Help text should be visible (no template selected yet)
-    const helpText = page.locator('.selector-help');
+    const helpText = overlay.locator('.selector-help');
     await expect(helpText).toBeVisible();
   });
 
@@ -483,14 +484,14 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Verify template options are available
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
 
     // Check the default selected option
     const selectedText = await dropdown.locator('option:checked').textContent();
@@ -510,22 +511,22 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Select template A from dropdown using value (template ID)
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
     await dropdown.selectOption(template1.id);
 
     // Template preview should appear
-    const preview = page.locator('.template-preview');
+    const preview = overlay.locator('.template-preview');
     await expect(preview).toBeVisible({ timeout: 5000 });
 
     // Help text should no longer be visible
-    const helpText = page.locator('.selector-help');
+    const helpText = overlay.locator('.selector-help');
     await expect(helpText).not.toBeVisible();
 
     // Verify via API that the template was persisted
@@ -542,22 +543,22 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Select template A using value (template ID)
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
     await dropdown.selectOption(template1.id);
 
     // Wait for preview to appear (confirms selection went through)
-    const preview = page.locator('.template-preview');
+    const preview = overlay.locator('.template-preview');
     await expect(preview).toBeVisible({ timeout: 5000 });
 
     // Click the clear button
-    const clearBtn = page.locator('.btn-clear');
+    const clearBtn = overlay.locator('.btn-clear');
     await expect(clearBtn).toBeVisible();
     await clearBtn.click();
 
@@ -569,7 +570,7 @@ test.describe('Orchestration Panel - Template Selector', () => {
     await expect(preview).not.toBeVisible();
 
     // Help text should reappear
-    const helpText = page.locator('.selector-help');
+    const helpText = overlay.locator('.selector-help');
     await expect(helpText).toBeVisible();
 
     // Verify via API
@@ -592,18 +593,18 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Select template C (which chains to B) using its ID
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
     await dropdown.selectOption(templateC.id);
 
     // Chain indicator should be visible
-    const chainIndicator = page.locator('.chain-indicator');
+    const chainIndicator = overlay.locator('.chain-indicator');
     await expect(chainIndicator).toBeVisible({ timeout: 5000 });
 
     // Should contain reference to Template B
@@ -620,19 +621,19 @@ test.describe('Orchestration Panel - Template Selector', () => {
     // Set next template via API before navigating
     await setNextTemplate(session.id, template1.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Panel should be auto-expanded (because template is set)
-    const content = page.locator('.orchestration-content');
+    const content = overlay.locator('.orchestration-content');
     await expect(content).toBeVisible();
 
     // Template dropdown should show template A selected
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
     const selectedValue = await dropdown.inputValue();
     expect(selectedValue).toBe(template1.id);
 
     // Preview should be visible
-    const preview = page.locator('.template-preview');
+    const preview = overlay.locator('.template-preview');
     await expect(preview).toBeVisible();
   });
 });
@@ -664,26 +665,26 @@ test.describe('Orchestration Panel - Integration', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Schedule row with button
-    const scheduleRow = page.locator('.schedule-row');
+    const scheduleRow = overlay.locator('.schedule-row');
     await expect(scheduleRow).toBeVisible();
-    const scheduleBtn = page.locator('.btn-schedule');
+    const scheduleBtn = overlay.locator('.btn-schedule');
     await expect(scheduleBtn).toBeVisible();
 
     // Template row with selector
-    const templateRow = page.locator('.template-row');
+    const templateRow = overlay.locator('.template-row');
     await expect(templateRow).toBeVisible();
-    const templateSelector = page.locator('.template-selector');
+    const templateSelector = overlay.locator('.template-selector');
     await expect(templateSelector).toBeVisible();
 
     // Auto-reschedule row with button
-    const rescheduleRow = page.locator('.auto-reschedule-row');
+    const rescheduleRow = overlay.locator('.auto-reschedule-row');
     await expect(rescheduleRow).toBeVisible();
   });
 
@@ -699,22 +700,22 @@ test.describe('Orchestration Panel - Integration', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand the panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // 1) Select template using its ID
-    const dropdown = page.locator('.template-selector select.form-input');
+    const dropdown = overlay.locator('.template-selector select.form-input');
     await dropdown.selectOption(template.id);
 
     // Wait for template preview to appear
-    const preview = page.locator('.template-preview');
+    const preview = overlay.locator('.template-preview');
     await expect(preview).toBeVisible({ timeout: 5000 });
 
     // 2) Open auto-reschedule modal and enable
-    const configureBtn = page.locator('.btn-configure');
+    const configureBtn = overlay.locator('.btn-configure');
     await configureBtn.click();
 
     // Enable the toggle by clicking the toggle-switch label (checkbox is hidden via CSS)
@@ -734,7 +735,7 @@ test.describe('Orchestration Panel - Integration', () => {
     await expect(preview).toBeVisible();
 
     // - Auto-reschedule enabled badge
-    const statusBadge = page.locator('.status-badge');
+    const statusBadge = overlay.locator('.status-badge');
     await expect(statusBadge).toContainText('Enabled');
 
     // Verify via API
@@ -763,21 +764,21 @@ test.describe('Orchestration Panel - Integration', () => {
       rescheduleDelayMinutes: 15,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Panel should be auto-expanded (template + auto-reschedule set)
-    const content = page.locator('.orchestration-content');
+    const content = overlay.locator('.orchestration-content');
     await expect(content).toBeVisible();
 
     // Template selector should show the selected template with preview
-    const preview = page.locator('.template-preview');
+    const preview = overlay.locator('.template-preview');
     await expect(preview).toBeVisible();
 
     // Auto-reschedule should show enabled status
-    const statusBtn = page.locator('.btn-status');
+    const statusBtn = overlay.locator('.btn-status');
     await expect(statusBtn).toBeVisible();
 
-    const statusBadge = page.locator('.status-badge');
+    const statusBadge = overlay.locator('.status-badge');
     await expect(statusBadge).toContainText('Enabled');
   });
 });

--- a/tests/e2e/queue-prompt.spec.ts
+++ b/tests/e2e/queue-prompt.spec.ts
@@ -13,6 +13,7 @@ import {
   updateSessionStatus,
   updateSessionFields,
   updatePendingPrompt,
+  openConversationOverlay,
 } from './helpers';
 
 // ============================================================
@@ -40,9 +41,9 @@ test.describe('Queue Prompt - Input Form Visibility During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    const textarea = page.locator('textarea');
+    const textarea = overlay.locator('textarea');
     await expect(textarea).toBeVisible();
 
     await textarea.fill('My queued prompt');
@@ -101,12 +102,12 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    await page.locator('textarea').fill('My prompt');
+    await overlay.locator('textarea').fill('My prompt');
 
-    await expect(page.locator('.auto-send-row')).toBeVisible();
-    await expect(page.locator('.auto-send-text')).toContainText('Send automatically when Claude finishes');
+    await expect(overlay.locator('.auto-send-row')).toBeVisible();
+    await expect(overlay.locator('.auto-send-text')).toContainText('Send automatically when Claude finishes');
   });
 
   test('auto-send checkbox is hidden when textarea is empty during running', async ({ page }) => {
@@ -118,12 +119,12 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
     // Clear the pending prompt so the textarea starts empty
     await updatePendingPrompt(session.id, '');
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Ensure textarea is empty
-    await page.locator('textarea').fill('');
+    await overlay.locator('textarea').fill('');
 
-    await expect(page.locator('.auto-send-row')).not.toBeVisible();
+    await expect(overlay.locator('.auto-send-row')).not.toBeVisible();
   });
 
   test('auto-send checkbox is hidden when session is not running', async ({ page }) => {
@@ -133,11 +134,11 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
       startImmediately: false,
     });
     // Session stays in waiting state (startImmediately: false sets to waiting by default)
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    await page.locator('textarea').fill('Some content');
+    await overlay.locator('textarea').fill('Some content');
 
-    await expect(page.locator('.auto-send-row')).not.toBeVisible();
+    await expect(overlay.locator('.auto-send-row')).not.toBeVisible();
   });
 
   test('auto-send checkbox defaults to unchecked', async ({ page }) => {
@@ -147,11 +148,11 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    await page.locator('textarea').fill('Prompt');
+    await overlay.locator('textarea').fill('Prompt');
 
-    const checkbox = page.locator('.auto-send-checkbox');
+    const checkbox = overlay.locator('.auto-send-checkbox');
     await expect(checkbox).not.toBeChecked();
   });
 });
@@ -181,10 +182,10 @@ test.describe('Queue Prompt - Auto-Send Toggle Persistence', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    await page.locator('textarea').fill('My prompt');
-    await page.locator('.auto-send-checkbox').check();
+    await overlay.locator('textarea').fill('My prompt');
+    await overlay.locator('.auto-send-checkbox').check();
 
     // Wait for the API call to complete
     await page.waitForTimeout(1500);
@@ -202,12 +203,12 @@ test.describe('Queue Prompt - Auto-Send Toggle Persistence', () => {
     await updatePendingPrompt(session.id, 'test');
     await updateSessionFields(session.id, { autoSendPendingPrompt: true });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // The textarea should show the pendingPrompt, and checkbox should be checked
-    await expect(page.locator('.auto-send-checkbox')).toBeChecked();
+    await expect(overlay.locator('.auto-send-checkbox')).toBeChecked();
 
-    await page.locator('.auto-send-checkbox').uncheck();
+    await overlay.locator('.auto-send-checkbox').uncheck();
     await page.waitForTimeout(1500);
 
     const updatedSession = await getSession(session.id);
@@ -242,9 +243,9 @@ test.describe('Queue Prompt - OrchestrationPanel During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
-    await expect(page.locator('.orchestration-panel')).toBeVisible();
+    await expect(overlay.locator('.orchestration-panel')).toBeVisible();
   });
 
   test('template selector is interactive during running', async ({ page }) => {
@@ -258,14 +259,14 @@ test.describe('Queue Prompt - OrchestrationPanel During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Expand orchestration panel
-    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    const panelHeader = overlay.locator('.orchestration-panel .panel-header');
     await panelHeader.click();
 
     // Select the template
-    await page.locator('.template-selector select.form-input').selectOption(template.id);
+    await overlay.locator('.template-selector select.form-input').selectOption(template.id);
     await page.waitForTimeout(1500);
 
     const updatedSession = await getSession(session.id);
@@ -300,10 +301,10 @@ test.describe('Queue Prompt - Auto-Send Reset on Transitions', () => {
     await updatePendingPrompt(session.id, 'test');
     await updateSessionFields(session.id, { autoSendPendingPrompt: true });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Verify checkbox is checked
-    await expect(page.locator('.auto-send-checkbox')).toBeChecked();
+    await expect(overlay.locator('.auto-send-checkbox')).toBeChecked();
 
     // Stop the session (triggers WebSocket broadcast)
     await updateSessionStatus(session.id, 'stopped');
@@ -321,11 +322,11 @@ test.describe('Queue Prompt - Auto-Send Reset on Transitions', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Type a prompt and enable auto-send
-    await page.locator('textarea').fill('My important prompt');
-    await page.locator('.auto-send-checkbox').check();
+    await overlay.locator('textarea').fill('My important prompt');
+    await overlay.locator('.auto-send-checkbox').check();
     await page.waitForTimeout(500);
 
     // Stop the session — the pendingPrompt is still set on the server,
@@ -334,7 +335,7 @@ test.describe('Queue Prompt - Auto-Send Reset on Transitions', () => {
     await page.waitForTimeout(2000);
 
     // Prompt should still be in the textarea
-    await expect(page.locator('textarea')).toHaveValue('My important prompt');
+    await expect(overlay.locator('textarea')).toHaveValue('My important prompt');
   });
 });
 

--- a/tests/e2e/scheduling-reschedule.spec.ts
+++ b/tests/e2e/scheduling-reschedule.spec.ts
@@ -13,6 +13,7 @@ import {
   waitForPageReady,
   updatePendingPrompt,
   updateSessionStatus,
+  openConversationOverlay,
 } from './helpers';
 
 /**
@@ -537,16 +538,15 @@ test.describe('Category 5: Scheduling UI Components', () => {
       scheduledAt: Date.now() + 3600000,
     });
 
-    // Navigate to session detail
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    // Open conversation overlay
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Click "Edit Schedule" button
-    const editButton = page.getByRole('button', { name: 'Edit Schedule' });
+    const editButton = overlay.getByRole('button', { name: 'Edit Schedule' });
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
 
-    // Modal should be visible
-    // Look for a datetime input or modal
+    // Modal should be visible (modals are typically at page level)
     const modal = page.locator('[class*="modal"]').first();
     await expect(modal).toBeVisible({ timeout: 5000 });
 

--- a/tests/e2e/scheduling-ui.spec.ts
+++ b/tests/e2e/scheduling-ui.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { seedProject, seedSession, cleanupAll, navigateAndWait } from './helpers';
+import { seedProject, seedSession, cleanupAll, openConversationOverlay, navigateAndWait } from './helpers';
 
 test.describe('Scheduling UI', () => {
   test.describe.configure({ timeout: 60000 });
@@ -20,19 +20,19 @@ test.describe('Scheduling UI', () => {
       // Create a draft session with content (API requires non-empty prompt)
       const session = await seedSession(project.id, { prompt: 'Initial content', startImmediately: false });
 
-      // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}`);
+      // Open conversation overlay to access orchestration panel
+      const overlay = await openConversationOverlay(page, session.id);
 
-      // Expand the Orchestration panel
-      const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
+      // Expand the Orchestration panel (scoped to overlay)
+      const orchestrationPanel = overlay.locator('.orchestration-panel .panel-header');
       await orchestrationPanel.click();
 
-      // Clear the textarea content
-      const textarea = page.locator('textarea');
+      // Clear the textarea content (scoped to overlay)
+      const textarea = overlay.locator('textarea');
       await textarea.clear();
 
-      // Clock button should now be disabled (no content)
-      const clockButton = page.locator('.btn-schedule');
+      // Clock button should now be disabled (no content) - scoped to overlay
+      const clockButton = overlay.locator('.btn-schedule');
       await expect(clockButton).toBeDisabled();
     });
   });
@@ -42,21 +42,21 @@ test.describe('Scheduling UI', () => {
       // Create a draft session
       const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
 
-      // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}`);
+      // Open conversation overlay to access orchestration panel
+      const overlay = await openConversationOverlay(page, session.id);
 
-      // Expand the Orchestration panel
-      const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
+      // Expand the Orchestration panel (scoped to overlay)
+      const orchestrationPanel = overlay.locator('.orchestration-panel .panel-header');
       await orchestrationPanel.click();
 
-      // Click clock icon
-      await page.click('.btn-schedule');
+      // Click clock icon (scoped to overlay)
+      await overlay.locator('.btn-schedule').click();
 
-      // Verify modal opens
+      // Verify modal opens (modal renders at body level via Teleport, so page-scoped)
       const modal = page.locator('.modal-backdrop');
       await expect(modal).toBeVisible();
 
-      // Verify datetime picker exists
+      // Verify datetime picker exists (modal is page-scoped)
       const datetimePicker = page.locator('input[type="datetime-local"]');
       await expect(datetimePicker).toBeVisible();
     });
@@ -70,22 +70,22 @@ test.describe('Scheduling UI', () => {
       // Create a draft session
       const session = await seedSession(project.id, { prompt: 'Scheduled task: do something', startImmediately: false });
 
-      // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}`);
+      // Open conversation overlay to access orchestration panel
+      const overlay = await openConversationOverlay(page, session.id);
 
-      // Expand the Orchestration panel
-      const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
+      // Expand the Orchestration panel (scoped to overlay)
+      const orchestrationPanel = overlay.locator('.orchestration-panel .panel-header');
       await orchestrationPanel.click();
 
-      // Click clock icon
-      await page.click('.btn-schedule');
+      // Click clock icon (scoped to overlay)
+      await overlay.locator('.btn-schedule').click();
 
-      // Set a time in the future (1 hour from now)
+      // Set a time in the future (1 hour from now) - modal is page-scoped
       const futureTime = new Date(Date.now() + 3600000);
       const timeString = futureTime.toISOString().slice(0, 16);
       await page.fill('input[type="datetime-local"]', timeString);
 
-      // Wait for Schedule button to be enabled
+      // Wait for Schedule button to be enabled (modal is page-scoped)
       const scheduleButton = page.locator('button:has-text("Schedule")');
       await expect(scheduleButton).toBeEnabled({ timeout: 3000 });
 
@@ -103,22 +103,22 @@ test.describe('Scheduling UI', () => {
       // Create a draft session
       const session = await seedSession(project.id, { prompt: 'Test scheduled time display', startImmediately: false });
 
-      // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}`);
+      // Open conversation overlay to access orchestration panel
+      const overlay = await openConversationOverlay(page, session.id);
 
-      // Expand the Orchestration panel
-      const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
+      // Expand the Orchestration panel (scoped to overlay)
+      const orchestrationPanel = overlay.locator('.orchestration-panel .panel-header');
       await orchestrationPanel.click();
 
-      // Click clock icon to open scheduling modal
-      await page.click('.btn-schedule');
+      // Click clock icon to open scheduling modal (scoped to overlay)
+      await overlay.locator('.btn-schedule').click();
 
-      // Set a time in the future (1 hour from now)
+      // Set a time in the future (1 hour from now) - modal is page-scoped
       const futureTime = new Date(Date.now() + 3600000); // 1 hour from now
       const timeString = futureTime.toISOString().slice(0, 16);
       await page.fill('input[type="datetime-local"]', timeString);
 
-      // Wait for Schedule button to be enabled
+      // Wait for Schedule button to be enabled (modal is page-scoped)
       const scheduleButton = page.locator('button:has-text("Schedule")');
       await expect(scheduleButton).toBeEnabled({ timeout: 3000 });
 
@@ -133,12 +133,12 @@ test.describe('Scheduling UI', () => {
       // Expected: Should show "in about 1 hour" or similar future time
       // Actual (bug): Shows "56 years ago" or other incorrect past time
 
-      // Wait for the scheduling info panel to appear
-      const schedulingPanel = page.locator('.scheduling-info.scheduled-panel');
+      // Wait for the scheduling info panel to appear (scoped to overlay)
+      const schedulingPanel = overlay.locator('.scheduling-info.scheduled-panel');
       await expect(schedulingPanel).toBeVisible({ timeout: 5000 });
 
-      // Get the countdown text element
-      const countdownText = page.locator('.countdown-text strong');
+      // Get the countdown text element (scoped to overlay)
+      const countdownText = overlay.locator('.countdown-text strong');
       await expect(countdownText).toBeVisible({ timeout: 3000 });
 
       // Get the text content
@@ -153,10 +153,14 @@ test.describe('Scheduling UI', () => {
       expect(timeText).toMatch(/in/i);
 
       // Verify via page reload that the time is still correct
+      // After reload, overlay closes - re-open it to check
       await page.reload();
       await page.waitForLoadState('networkidle');
 
-      const countdownTextAfterReload = page.locator('.countdown-text strong');
+      // Re-open the conversation overlay after reload
+      const overlayAfterReload = await openConversationOverlay(page, session.id);
+
+      const countdownTextAfterReload = overlayAfterReload.locator('.countdown-text strong');
       await expect(countdownTextAfterReload).toBeVisible({ timeout: 5000 });
 
       const timeTextAfterReload = await countdownTextAfterReload.textContent();

--- a/tests/e2e/session-message-persistence.spec.ts
+++ b/tests/e2e/session-message-persistence.spec.ts
@@ -26,6 +26,7 @@ import {
   getSession,
   BASE_URL,
   API_URL,
+  openConversationOverlay,
 } from './helpers';
 
 test.describe('Session Message Persistence After Response Completes', () => {
@@ -49,13 +50,12 @@ test.describe('Session Message Persistence After Response Completes', () => {
       prompt: 'Reply with exactly: "Hello, persistence test complete." Nothing else.',
     });
 
-    // Step 2: Navigate to the session page while it's running
-    await page.goto(`${BASE_URL}/sessions/${session.id}`);
-    await page.waitForLoadState('networkidle');
+    // Step 2: Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
-    // Step 3: Wait for streaming content to appear in the UI
+    // Step 3: Wait for streaming content to appear in the overlay
     // Either the streaming indicator or a committed assistant message should appear
-    const streamingOrMessage = page.locator('.message-streaming, [data-testid="message-assistant"]');
+    const streamingOrMessage = overlay.locator('.message-streaming, [data-testid="message-assistant"]');
     await expect(streamingOrMessage.first()).toBeVisible({ timeout: 60000 });
 
     // Step 4: Wait for the session to finish (reach 'waiting' status)
@@ -66,8 +66,8 @@ test.describe('Session Message Persistence After Response Completes', () => {
     // a message refetch that can clear the messages from the store
     await page.waitForTimeout(3000);
 
-    // Step 6: THE CRITICAL ASSERTION — messages should still be visible
-    const assistantMessages = page.locator('[data-testid="message-assistant"]');
+    // Step 6: THE CRITICAL ASSERTION — messages should still be visible (scoped to overlay)
+    const assistantMessages = overlay.locator('[data-testid="message-assistant"]');
     await expect(assistantMessages.first()).toBeVisible({ timeout: 10000 });
 
     // Verify the assistant message has actual content (not empty)
@@ -76,8 +76,8 @@ test.describe('Session Message Persistence After Response Completes', () => {
     const text = await messageContent.textContent();
     expect(text!.trim().length).toBeGreaterThan(0);
 
-    // User message should also still be visible
-    const userMessages = page.locator('[data-testid="message-user"]');
+    // User message should also still be visible (scoped to overlay)
+    const userMessages = overlay.locator('[data-testid="message-user"]');
     await expect(userMessages.first()).toBeVisible({ timeout: 5000 });
   });
 
@@ -115,9 +115,12 @@ test.describe('Session Message Persistence After Response Completes', () => {
     const apiAssistant = apiMessages.filter((m: any) => m.role === 'assistant');
     expect(apiAssistant.length).toBeGreaterThan(0);
 
-    // Step 7: THE CRITICAL ASSERTION — messages should be visible in the UI
+    // Step 7: Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, sessionId!);
+
+    // Step 8: THE CRITICAL ASSERTION — messages should be visible in the overlay
     // The bug causes these to be missing even though the API has them
-    const assistantMessages = page.locator('[data-testid="message-assistant"]');
+    const assistantMessages = overlay.locator('[data-testid="message-assistant"]');
     await expect(assistantMessages.first()).toBeVisible({ timeout: 10000 });
 
     const messageContent = assistantMessages.first().locator('.message-content');
@@ -125,8 +128,8 @@ test.describe('Session Message Persistence After Response Completes', () => {
     const text = await messageContent.textContent();
     expect(text!.trim().length).toBeGreaterThan(0);
 
-    // User message should also still be visible
-    const userMessages = page.locator('[data-testid="message-user"]');
+    // User message should also still be visible (scoped to overlay)
+    const userMessages = overlay.locator('[data-testid="message-user"]');
     await expect(userMessages.first()).toBeVisible({ timeout: 5000 });
   });
 
@@ -138,9 +141,8 @@ test.describe('Session Message Persistence After Response Completes', () => {
       prompt: 'Reply with exactly: "Refresh comparison test." Nothing else.',
     });
 
-    // Step 2: Navigate to the session page
-    await page.goto(`${BASE_URL}/sessions/${session.id}`);
-    await page.waitForLoadState('networkidle');
+    // Step 2: Open conversation overlay to access messages
+    let overlay = await openConversationOverlay(page, session.id);
 
     // Step 3: Wait for the session to complete
     await waitForStatus(session.id, 'waiting', 60000);
@@ -148,20 +150,23 @@ test.describe('Session Message Persistence After Response Completes', () => {
     // Step 4: Wait for the UI to settle after the status transition
     await page.waitForTimeout(3000);
 
-    // Step 5: Record message counts BEFORE refresh
-    const assistantCountBefore = await page.locator('[data-testid="message-assistant"]').count();
-    const userCountBefore = await page.locator('[data-testid="message-user"]').count();
+    // Step 5: Record message counts BEFORE refresh (scoped to overlay)
+    const assistantCountBefore = await overlay.locator('[data-testid="message-assistant"]').count();
+    const userCountBefore = await overlay.locator('[data-testid="message-user"]').count();
 
-    // Step 6: Refresh the page
+    // Step 6: Refresh the page - this closes the overlay
     await page.reload();
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(2000);
 
-    // Step 7: Record message counts AFTER refresh
-    const assistantCountAfter = await page.locator('[data-testid="message-assistant"]').count();
-    const userCountAfter = await page.locator('[data-testid="message-user"]').count();
+    // Step 7: Re-open the overlay after refresh
+    overlay = await openConversationOverlay(page, session.id);
 
-    // Step 8: Verify API has messages (ground truth)
+    // Step 8: Record message counts AFTER refresh (scoped to overlay)
+    const assistantCountAfter = await overlay.locator('[data-testid="message-assistant"]').count();
+    const userCountAfter = await overlay.locator('[data-testid="message-user"]').count();
+
+    // Step 9: Verify API has messages (ground truth)
     const apiMessages = await getSessionMessages(session.id);
     const apiAssistant = apiMessages.filter((m: any) => m.role === 'assistant');
     const apiUser = apiMessages.filter((m: any) => m.role === 'user');
@@ -186,17 +191,16 @@ test.describe('Session Message Persistence After Response Completes', () => {
       prompt: 'Reply with exactly: "API cross-check test." Nothing else.',
     });
 
-    // Step 2: Navigate and wait for completion
-    await page.goto(`${BASE_URL}/sessions/${session.id}`);
-    await page.waitForLoadState('networkidle');
+    // Step 2: Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
     await waitForStatus(session.id, 'waiting', 60000);
 
     // Step 3: Wait for UI to process the status change
     await page.waitForTimeout(3000);
 
-    // Step 4: Count messages in the UI
-    const uiAssistantCount = await page.locator('[data-testid="message-assistant"]').count();
-    const uiUserCount = await page.locator('[data-testid="message-user"]').count();
+    // Step 4: Count messages in the overlay
+    const uiAssistantCount = await overlay.locator('[data-testid="message-assistant"]').count();
+    const uiUserCount = await overlay.locator('[data-testid="message-user"]').count();
 
     // Step 5: Get ground truth from API
     const apiMessages = await getSessionMessages(session.id);

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -6,6 +6,7 @@ import {
   getSession,
   navigateAndWait,
   waitForSessionToExist,
+  openConversationOverlay,
 } from './helpers';
 
 test.describe('New Session - Thinking Toggle', () => {
@@ -126,10 +127,11 @@ test.describe('Session Management', () => {
     // Wait for session to be available
     await waitForSessionToExist(session.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
-    // The initial user message should be visible
-    await expect(page.locator('.message-content').getByText('Hello Claude', { exact: true })).toBeVisible({ timeout: 10000 });
+    // The initial user message should be visible (scoped to overlay)
+    await expect(overlay.locator('.message-content').getByText('Hello Claude', { exact: true })).toBeVisible({ timeout: 10000 });
   });
 
   test('draft prompt is unique per session', async ({ page }) => {

--- a/tests/e2e/todo-tracking.spec.ts
+++ b/tests/e2e/todo-tracking.spec.ts
@@ -9,6 +9,7 @@ import {
   getConversations,
   navigateAndWait,
   waitForElement,
+  openConversationOverlay,
 } from './helpers';
 
 test.describe('Todo Tracking — Category 1: API Tests', () => {
@@ -134,8 +135,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
   });
 
   test('todo drawer is hidden when no todos exist', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${sessionId}`);
-    const drawer = page.locator('.todo-drawer');
+    const overlay = await openConversationOverlay(page, sessionId);
+    const drawer = overlay.locator('.todo-drawer');
     await expect(drawer).not.toBeAttached();
   });
 
@@ -144,8 +145,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
-    const drawer = page.locator('.todo-drawer');
+    const overlay = await openConversationOverlay(page, sessionId);
+    const drawer = overlay.locator('.todo-drawer');
     await expect(drawer).toBeVisible();
   });
 
@@ -154,8 +155,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
-    const label = page.locator('.todo-label');
+    const overlay = await openConversationOverlay(page, sessionId);
+    const label = overlay.locator('.todo-label');
     await expect(label).toContainText('Todos');
   });
 
@@ -171,8 +172,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Todo 6', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
-    const summary = page.locator('.todo-summary');
+    const overlay = await openConversationOverlay(page, sessionId);
+    const summary = overlay.locator('.todo-summary');
     await expect(summary).toBeVisible();
 
     const chips = summary.locator('.todo-chip');
@@ -191,8 +192,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Todo 6', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
-    const moreIndicator = page.locator('.todo-more');
+    const overlay = await openConversationOverlay(page, sessionId);
+    const moreIndicator = overlay.locator('.todo-more');
     await expect(moreIndicator).toContainText('(+2 more)');
   });
 });
@@ -221,15 +222,15 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Pending task', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoItem = page.locator('.todo-item.todo-pending');
+    const todoItem = overlay.locator('.todo-item.todo-pending');
     await expect(todoItem).toBeVisible();
 
-    const icon = page.locator('.status-icon.status-pending');
+    const icon = overlay.locator('.status-icon.status-pending');
     await expect(icon).toBeVisible();
   });
 
@@ -238,15 +239,15 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'In progress task', status: 'in_progress' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoItem = page.locator('.todo-item.todo-in_progress');
+    const todoItem = overlay.locator('.todo-item.todo-in_progress');
     await expect(todoItem).toBeVisible();
 
-    const icon = page.locator('.status-icon.status-in_progress');
+    const icon = overlay.locator('.status-icon.status-in_progress');
     await expect(icon).toBeVisible();
   });
 
@@ -257,15 +258,15 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Completed task', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoItem = page.locator('.todo-item.todo-completed');
+    const todoItem = overlay.locator('.todo-item.todo-completed');
     await expect(todoItem).toBeVisible();
 
-    const icon = page.locator('.status-icon.status-completed');
+    const icon = overlay.locator('.status-icon.status-completed');
     await expect(icon).toBeVisible();
 
     const content = todoItem.locator('.todo-content');
@@ -277,12 +278,12 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Completed task', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoItem = page.locator('.todo-item.todo-completed');
+    const todoItem = overlay.locator('.todo-item.todo-completed');
     const opacity = await todoItem.evaluate((el) => {
       return window.getComputedStyle(el).opacity;
     });
@@ -296,14 +297,14 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Completed task', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const pending = page.locator('.todo-item.todo-pending');
-    const inProgress = page.locator('.todo-item.todo-in_progress');
-    const completed = page.locator('.todo-item.todo-completed');
+    const pending = overlay.locator('.todo-item.todo-pending');
+    const inProgress = overlay.locator('.todo-item.todo-in_progress');
+    const completed = overlay.locator('.todo-item.todo-completed');
 
     await expect(pending).toBeVisible();
     await expect(inProgress).toBeVisible();
@@ -345,12 +346,12 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
-    const summary = page.locator('.todo-summary');
+    const summary = overlay.locator('.todo-summary');
     await expect(summary).toBeVisible();
 
-    const todoList = page.locator('.todo-list');
+    const todoList = overlay.locator('.todo-list');
     await expect(todoList).not.toBeVisible();
   });
 
@@ -359,15 +360,15 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Click header to expand
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoList = page.locator('.todo-list');
+    const todoList = overlay.locator('.todo-list');
     await expect(todoList).toBeVisible();
 
-    const summary = page.locator('.todo-summary');
+    const summary = overlay.locator('.todo-summary');
     await expect(summary).not.toBeVisible();
   });
 
@@ -379,18 +380,18 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Pending', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Click header to expand
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const completedCount = page.locator('.count.completed');
+    const completedCount = overlay.locator('.count.completed');
     await expect(completedCount).toContainText('2 done');
 
-    const inProgressCount = page.locator('.count.in-progress');
+    const inProgressCount = overlay.locator('.count.in-progress');
     await expect(inProgressCount).toContainText('1 active');
 
-    const pendingCount = page.locator('.count.pending');
+    const pendingCount = overlay.locator('.count.pending');
     await expect(pendingCount).toContainText('1 pending');
   });
 
@@ -399,16 +400,16 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Click to expand
-    await page.locator('.todo-header').click();
-    await expect(page.locator('.todo-list')).toBeVisible();
+    await overlay.locator('.todo-header').click();
+    await expect(overlay.locator('.todo-list')).toBeVisible();
 
     // Click to collapse
-    await page.locator('.todo-header').click();
-    await expect(page.locator('.todo-list')).not.toBeVisible();
-    await expect(page.locator('.todo-summary')).toBeVisible();
+    await overlay.locator('.todo-header').click();
+    await expect(overlay.locator('.todo-list')).not.toBeVisible();
+    await expect(overlay.locator('.todo-summary')).toBeVisible();
   });
 
   test('expanded list shows all todos with full content', async ({ page }) => {
@@ -418,12 +419,12 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Third todo item', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoItems = page.locator('.todo-item');
+    const todoItems = overlay.locator('.todo-item');
     await expect(todoItems).toHaveCount(3);
 
     await expect(todoItems.nth(0).locator('.todo-content')).toContainText(
@@ -544,9 +545,9 @@ test.describe('Todo Tracking — Category 6: Text Handling', () => {
       { content: longText, status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
-    const chipText = page.locator('.todo-chip .todo-text');
+    const chipText = overlay.locator('.todo-chip .todo-text');
     await expect(chipText).toContainText('Implement user authe...');
   });
 
@@ -555,9 +556,9 @@ test.describe('Todo Tracking — Category 6: Text Handling', () => {
       { content: 'Fix bug', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
-    const chipText = page.locator('.todo-chip .todo-text');
+    const chipText = overlay.locator('.todo-chip .todo-text');
     await expect(chipText).toContainText('Fix bug');
     await expect(chipText).not.toContainText('...');
   });
@@ -568,12 +569,12 @@ test.describe('Todo Tracking — Category 6: Text Handling', () => {
       { content: longText, status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const todoContent = page.locator('.todo-item .todo-content');
+    const todoContent = overlay.locator('.todo-item .todo-content');
     await expect(todoContent).toContainText(longText);
     await expect(todoContent).not.toContainText('...');
   });
@@ -615,8 +616,8 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
     todos = await getTodos(sessionId, conversationId);
     expect(todos).toEqual([]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
-    const drawer = page.locator('.todo-drawer');
+    const overlay = await openConversationOverlay(page, sessionId);
+    const drawer = overlay.locator('.todo-drawer');
     await expect(drawer).not.toBeAttached();
   });
 
@@ -625,12 +626,12 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
       { content: 'Only todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
-    const chips = page.locator('.todo-chip');
+    const chips = overlay.locator('.todo-chip');
     await expect(chips).toHaveCount(1);
 
-    const moreIndicator = page.locator('.todo-more');
+    const moreIndicator = overlay.locator('.todo-more');
     await expect(moreIndicator).not.toBeVisible();
   });
 
@@ -642,12 +643,12 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
       { content: 'Todo 4', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
-    const chips = page.locator('.todo-chip');
+    const chips = overlay.locator('.todo-chip');
     await expect(chips).toHaveCount(4);
 
-    const moreIndicator = page.locator('.todo-more');
+    const moreIndicator = overlay.locator('.todo-more');
     await expect(moreIndicator).not.toBeVisible();
   });
 
@@ -657,18 +658,18 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
       { content: 'Completed 2', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}`);
+    const overlay = await openConversationOverlay(page, sessionId);
 
     // Expand drawer
-    await page.locator('.todo-header').click();
+    await overlay.locator('.todo-header').click();
 
-    const completedCount = page.locator('.count.completed');
+    const completedCount = overlay.locator('.count.completed');
     await expect(completedCount).toBeVisible();
 
-    const inProgressCount = page.locator('.count.in-progress');
+    const inProgressCount = overlay.locator('.count.in-progress');
     await expect(inProgressCount).not.toBeVisible();
 
-    const pendingCount = page.locator('.count.pending');
+    const pendingCount = overlay.locator('.count.pending');
     await expect(pendingCount).not.toBeVisible();
   });
 });

--- a/tests/e2e/websocket-recovery.spec.ts
+++ b/tests/e2e/websocket-recovery.spec.ts
@@ -9,6 +9,7 @@ import {
   waitForPageReady,
   waitForSessionToExist,
   updateSessionStatus,
+  openConversationOverlay,
 } from './helpers';
 
 test.describe('WebSocket wake-from-sleep recovery', () => {
@@ -34,12 +35,11 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await seedUserMessage(session.id, 'hello');
     await seedAssistantMessage(session.id, 'hi there');
 
-    // Navigate to session detail
-    await navigateAndWait(page, `/sessions/${session.id}`);
-    await waitForPageReady(page);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
-    // Verify initial data is visible
-    await expect(page.locator('text=hello').first()).toBeVisible({ timeout: 10000 });
+    // Verify initial data is visible (scoped to overlay)
+    await expect(overlay.locator('text=hello').first()).toBeVisible({ timeout: 10000 });
 
     // Simulate sleep: kill network via CDP to create zombie socket
     const cdp = await page.context().newCDPSession(page);
@@ -74,13 +74,13 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     // because new messages will only appear if the session is properly subscribed
     await seedAssistantMessage(session.id, 'message-after-wake');
 
-    // Verify: new message appears (proves WebSocket subscription recovered)
-    await expect(page.locator('text=message-after-wake')).toBeVisible({ timeout: 15000 });
+    // Verify: new message appears (proves WebSocket subscription recovered) - scoped to overlay
+    await expect(overlay.locator('text=message-after-wake')).toBeVisible({ timeout: 15000 });
 
-    // Verify: original conversation content still visible
-    await expect(page.locator('text=hello').first()).toBeVisible({ timeout: 10000 });
+    // Verify: original conversation content still visible (scoped to overlay)
+    await expect(overlay.locator('text=hello').first()).toBeVisible({ timeout: 10000 });
 
-    // Verify: no error toast
+    // Verify: no error toast (page-scoped since toasts render at body level)
     await expect(page.locator('.toast.toast-error')).not.toBeVisible();
   });
 
@@ -91,8 +91,8 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await waitForSessionToExist(session.id);
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
-    await waitForPageReady(page);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
     // Simulate sleep
     const cdp = await page.context().newCDPSession(page);
@@ -126,8 +126,8 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     // Push a new message via API after reconnect
     await seedAssistantMessage(session.id, 'message-after-reconnect');
 
-    // Verify it appears in the UI via WebSocket
-    await expect(page.locator('text=message-after-reconnect')).toBeVisible({ timeout: 10000 });
+    // Verify it appears in the overlay via WebSocket
+    await expect(overlay.locator('text=message-after-reconnect')).toBeVisible({ timeout: 10000 });
   });
 
   test('session list recovers project subscription after sleep', async ({ page }) => {
@@ -226,8 +226,8 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await waitForSessionToExist(session.id);
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `/sessions/${session.id}`);
-    await waitForPageReady(page);
+    // Open conversation overlay to access messages
+    const overlay = await openConversationOverlay(page, session.id);
 
     const cdp = await page.context().newCDPSession(page);
 
@@ -259,13 +259,13 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
       await page.waitForTimeout(2000);
     }
 
-    // After the 3rd cycle, seed a message and verify it appears exactly once
+    // After the 3rd cycle, seed a message and verify it appears exactly once (scoped to overlay)
     await seedAssistantMessage(session.id, 'after-three-cycles');
-    await expect(page.locator('text=after-three-cycles')).toBeVisible({ timeout: 10000 });
+    await expect(overlay.locator('text=after-three-cycles')).toBeVisible({ timeout: 10000 });
     // Verify only ONE instance (no duplicates from multiple subscriptions)
-    await expect(page.locator('text=after-three-cycles')).toHaveCount(1);
+    await expect(overlay.locator('text=after-three-cycles')).toHaveCount(1);
 
-    // Also verify no error toast appeared during any cycle
+    // Also verify no error toast appeared during any cycle (page-scoped)
     await expect(page.locator('.toast.toast-error')).not.toBeVisible();
   });
 });

--- a/tests/e2e/work-log-dedup.spec.ts
+++ b/tests/e2e/work-log-dedup.spec.ts
@@ -6,10 +6,8 @@ import {
   getSessionWorkLogs,
   getSessionMessages,
   getSession,
+  openConversationOverlay,
 } from './helpers';
-
-const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
-const API_URL = process.env.API_URL || 'http://localhost:5000';
 
 // Helper to wait for session to reach a specific status
 async function waitForSessionStatus(sessionId: string, targetStatus: string, timeoutMs = 10000) {
@@ -58,16 +56,16 @@ test.describe('Work Log Deduplication', () => {
     const thinkingLogs = associatedLogs.filter((l: any) => l.type === 'thinking');
     expect(thinkingLogs.length).toBeGreaterThan(0);
 
-    // Navigate to the session detail page — this loads work logs into the Pinia store
-    await page.goto(`${BASE_URL}/sessions/${session.id}`);
+    // Open conversation overlay — this loads work logs into the Pinia store
+    const overlay = await openConversationOverlay(page, session.id);
 
-    // Wait for the conversation tab to load and messages to appear
-    await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 15000 });
+    // Wait for messages to appear (scoped to overlay)
+    await expect(overlay.locator('[data-testid="message-assistant"]').first()).toBeVisible({ timeout: 15000 });
 
     // Get the work log count from the first WorkLogPanel (shows count in parentheses)
     // The WorkLogPanel shows "(N)" where N is the number of associated work logs
-    // Use .first() because multiple assistant messages may each have their own work log panel
-    const workLogPanel = page.locator('[data-work-log-details]').first();
+    // Use .first() because multiple assistant messages may each have their own work log panel (scoped to overlay)
+    const workLogPanel = overlay.locator('[data-work-log-details]').first();
     await expect(workLogPanel).toBeVisible({ timeout: 10000 });
 
     // Get the initial count text, e.g. "(3)"
@@ -77,6 +75,7 @@ test.describe('Work Log Deduplication', () => {
 
     // Now simulate the bug: call addWorkLog in the Pinia store with a log that already exists
     // This simulates what happens when a WebSocket delivers the same log after fetchWorkLogs
+    // Store access via page.evaluate() can remain page-scoped since Pinia store is a global singleton
     const duplicateLog = thinkingLogs[0];
     const storeHadDuplicate = await page.evaluate((log) => {
       // Access the Pinia store via the global app instance
@@ -121,7 +120,7 @@ test.describe('Work Log Deduplication', () => {
     expect(storeHadDuplicate.countAfter).toBe(1);
     expect(storeHadDuplicate.duplicated).toBe(false);
 
-    // Also verify the UI count hasn't changed
+    // Also verify the UI count hasn't changed (scoped to overlay)
     const countTextAfter = await workLogPanel.locator('.work-log-count').textContent();
     const countAfterUi = parseInt(countTextAfter!.replace(/[()]/g, ''));
     expect(countAfterUi).toBe(initialCount);
@@ -136,9 +135,9 @@ test.describe('Work Log Deduplication', () => {
 
     await waitForSessionStatus(session.id, 'waiting', 60000);
 
-    // Navigate to the session detail page — loads work logs into Pinia store
-    await page.goto(`${BASE_URL}/sessions/${session.id}`);
-    await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 15000 });
+    // Open conversation overlay — loads work logs into Pinia store
+    const overlay = await openConversationOverlay(page, session.id);
+    await expect(overlay.locator('[data-testid="message-assistant"]').first()).toBeVisible({ timeout: 15000 });
 
     // Test dedup by injecting a synthetic tool_input work log into the store,
     // then trying to add it again. This directly tests the addWorkLog dedup logic
@@ -159,6 +158,7 @@ test.describe('Work Log Deduplication', () => {
       createdAt: new Date().toISOString(),
     };
 
+    // Store access via page.evaluate() can remain page-scoped since Pinia store is a global singleton
     const storeHadDuplicate = await page.evaluate((log) => {
       const app = (window as any).__vue_app__ || document.querySelector('#app')?.__vue_app__;
       if (!app) return { error: 'No Vue app found' };

--- a/tests/e2e/work-log-panels.spec.ts
+++ b/tests/e2e/work-log-panels.spec.ts
@@ -9,10 +9,19 @@ import {
   updateSessionStatus,
   cleanupAll,
   getAPIURL,
-  TEST_PREFIX
+  TEST_PREFIX,
+  openConversationOverlay,
 } from './helpers';
 
 const API_URL = getAPIURL();
+
+// Helper to open the conversation overlay after setting session to running status
+async function openRunningSessionOverlay(page: any, sessionId: string) {
+  const overlay = await openConversationOverlay(page, sessionId);
+  // Wait for the running-state branch to render inside the overlay
+  await expect(overlay.locator('.running-state')).toBeVisible({ timeout: 10000 });
+  return overlay;
+}
 
 // Helper to wait for session to reach a specific status (for non-UI tests)
 async function waitForSessionStatus(sessionId: string, targetStatus: string, timeoutMs = 10000) {
@@ -57,16 +66,13 @@ test.describe('Work Log Panels', () => {
       // Set to running so the UI shows the running-state branch
       await updateSessionStatus(session.id, 'running');
 
-      // Navigate to session detail
-      await page.goto(`${API_URL}/sessions/${session.id}`);
+      // Open conversation overlay to access conversation content
+      const overlay = await openRunningSessionOverlay(page, session.id);
 
-      // Wait for the running-state branch to render
-      await page.waitForSelector('.running-state', { timeout: 10000 });
-
-      // Assertions
-      await expect(page.locator('.running-state')).toBeVisible();
-      await expect(page.locator('.running-title')).toHaveText('Claude is working...');
-      await expect(page.locator('.running-state .live-work-log-panel')).toBeVisible();
+      // Assertions - scope to overlay
+      await expect(overlay.locator('.running-state')).toBeVisible();
+      await expect(overlay.locator('.running-title')).toHaveText('Claude is working...');
+      await expect(overlay.locator('.running-state .live-work-log-panel')).toBeVisible();
     });
 
     test('seeding a work log via API makes it appear in real-time', async ({ page }) => {
@@ -77,8 +83,7 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('.running-state', { timeout: 10000 });
+      const overlay = await openRunningSessionOverlay(page, session.id);
 
       // Seed a work log after page is loaded
       await seedWorkLog(session.id, {
@@ -86,13 +91,13 @@ test.describe('Work Log Panels', () => {
         content: 'This is test thinking content for real-time display',
       });
 
-      // Wait for the work log item to appear in the live panel
-      await page.waitForSelector('.live-log-item', { timeout: 10000 });
+      // Wait for the work log item to appear in the live panel (scoped to overlay)
+      await expect(overlay.locator('.live-log-item').first()).toBeVisible({ timeout: 10000 });
 
-      // Verify the content appears
-      await expect(page.locator('.live-work-log-panel .thinking-block')).toBeVisible();
-      await expect(page.locator('.thinking-label')).toHaveText('Thinking');
-      await expect(page.locator('.thinking-text')).toContainText('This is test thinking content for real-time display');
+      // Verify the content appears (scoped to overlay)
+      await expect(overlay.locator('.live-work-log-panel .thinking-block')).toBeVisible();
+      await expect(overlay.locator('.thinking-label')).toHaveText('Thinking');
+      await expect(overlay.locator('.thinking-text')).toContainText('This is test thinking content for real-time display');
     });
 
     test('multiple work logs appear in order', async ({ page }) => {
@@ -103,8 +108,7 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('.running-state', { timeout: 10000 });
+      const overlay = await openRunningSessionOverlay(page, session.id);
 
       // Seed 3 work logs sequentially with delays
       await seedWorkLog(session.id, {
@@ -126,11 +130,11 @@ test.describe('Work Log Panels', () => {
         toolName: 'Bash',
       });
 
-      // Wait for all 3 log items to appear
-      await page.waitForSelector('.live-log-item', { timeout: 10000 });
+      // Wait for all 3 log items to appear (scoped to overlay)
+      await expect(overlay.locator('.live-log-item').first()).toBeVisible({ timeout: 10000 });
 
-      // Verify count
-      const logItems = page.locator('.live-log-item');
+      // Verify count (scoped to overlay)
+      const logItems = overlay.locator('.live-log-item');
       await expect(logItems).toHaveCount(3);
 
       // Verify order using nth() locator
@@ -147,8 +151,7 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('.running-state', { timeout: 10000 });
+      const overlay = await openRunningSessionOverlay(page, session.id);
 
       // Seed a thinking work log
       await seedWorkLog(session.id, {
@@ -156,12 +159,12 @@ test.describe('Work Log Panels', () => {
         content: 'Analyzing the request carefully to provide accurate response',
       });
 
-      await page.waitForSelector('.live-log-item', { timeout: 10000 });
+      await expect(overlay.locator('.live-log-item').first()).toBeVisible({ timeout: 10000 });
 
-      // Verify ThinkingBlock rendering
-      await expect(page.locator('.live-work-log-panel .thinking-block')).toBeVisible();
-      await expect(page.locator('.thinking-label')).toHaveText('Thinking');
-      await expect(page.locator('.thinking-text')).toContainText('Analyzing the request carefully to provide accurate response');
+      // Verify ThinkingBlock rendering (scoped to overlay)
+      await expect(overlay.locator('.live-work-log-panel .thinking-block')).toBeVisible();
+      await expect(overlay.locator('.thinking-label')).toHaveText('Thinking');
+      await expect(overlay.locator('.thinking-text')).toContainText('Analyzing the request carefully to provide accurate response');
     });
 
     test('tool-type work log renders as CommandBlock in live panel', async ({ page }) => {
@@ -172,8 +175,7 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('.running-state', { timeout: 10000 });
+      const overlay = await openRunningSessionOverlay(page, session.id);
 
       // Seed a tool_input work log
       await seedWorkLog(session.id, {
@@ -182,12 +184,12 @@ test.describe('Work Log Panels', () => {
         toolName: 'Bash',
       });
 
-      await page.waitForSelector('.live-log-item', { timeout: 10000 });
+      await expect(overlay.locator('.live-log-item').first()).toBeVisible({ timeout: 10000 });
 
-      // Verify CommandBlock rendering
-      await expect(page.locator('.live-work-log-panel .command-block.command-tool_input')).toBeVisible();
-      await expect(page.locator('.command-tool-name')).toHaveText('Bash');
-      await expect(page.locator('.command-label')).toHaveText('Input');
+      // Verify CommandBlock rendering (scoped to overlay)
+      await expect(overlay.locator('.live-work-log-panel .command-block.command-tool_input')).toBeVisible();
+      await expect(overlay.locator('.command-tool-name')).toHaveText('Bash');
+      await expect(overlay.locator('.command-label')).toHaveText('Input');
     });
   });
 
@@ -320,12 +322,12 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      // Navigate to session detail
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      // Find the assistant message and verify work log panel exists
-      const assistantMessage = page.locator('[data-testid="message-assistant"]').first();
+      // Find the assistant message and verify work log panel exists (scoped to overlay)
+      const assistantMessage = overlay.locator('[data-testid="message-assistant"]').first();
       await expect(assistantMessage.locator('.work-log-panel')).toBeVisible();
     });
 
@@ -350,15 +352,16 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      // Verify panel is collapsed (details element does not have 'open' attribute)
-      const details = page.locator('details[data-work-log-details]').first();
+      // Verify panel is collapsed (details element does not have 'open' attribute) - scoped to overlay
+      const details = overlay.locator('details[data-work-log-details]').first();
       await expect(details).not.toHaveAttribute('open', /.+/);
 
       // Content should not be visible when collapsed
-      await expect(page.locator('.work-log-content').first()).not.toBeVisible();
+      await expect(overlay.locator('.work-log-content').first()).not.toBeVisible();
     });
 
     test('clicking work log header expands the panel', async ({ page }) => {
@@ -381,21 +384,22 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      // Click the work log header to expand
-      await page.locator('.work-log-header').first().click();
+      // Click the work log header to expand (scoped to overlay)
+      await overlay.locator('.work-log-header').first().click();
 
-      // Verify panel is expanded
-      const details = page.locator('details[data-work-log-details]').first();
+      // Verify panel is expanded (scoped to overlay)
+      const details = overlay.locator('details[data-work-log-details]').first();
       await expect(details).toHaveAttribute('open');
 
       // Content should now be visible
-      await expect(page.locator('.work-log-content').first()).toBeVisible();
+      await expect(overlay.locator('.work-log-content').first()).toBeVisible();
 
       // Chevron should have expanded class
-      await expect(page.locator('.work-log-chevron').first()).toHaveClass(/expanded/);
+      await expect(overlay.locator('.work-log-chevron').first()).toHaveClass(/expanded/);
     });
 
     test('clicking again collapses the panel', async ({ page }) => {
@@ -418,12 +422,13 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      const header = page.locator('.work-log-header').first();
-      const details = page.locator('details[data-work-log-details]').first();
-      const chevron = page.locator('.work-log-chevron').first();
+      const header = overlay.locator('.work-log-header').first();
+      const details = overlay.locator('details[data-work-log-details]').first();
+      const chevron = overlay.locator('.work-log-chevron').first();
 
       // Click to expand
       await header.click();
@@ -473,15 +478,16 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
       // Get the actual count from the API
       const updatedWorkLogs = await getSessionWorkLogs(session.id);
       const actualCount = (updatedWorkLogs[assistantMsg.id] || []).length;
 
-      // Verify count badge shows the correct number
-      await expect(page.locator('.work-log-count').first()).toHaveText(`(${actualCount})`);
+      // Verify count badge shows the correct number (scoped to overlay)
+      await expect(overlay.locator('.work-log-count').first()).toHaveText(`(${actualCount})`);
     });
 
     test('expanded panel shows thinking blocks for thinking-type logs', async ({ page }) => {
@@ -509,18 +515,19 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      // Expand the panel
-      await page.locator('.work-log-header').first().click();
+      // Expand the panel (scoped to overlay)
+      await overlay.locator('.work-log-header').first().click();
 
-      // Verify ThinkingBlock is visible
-      await expect(page.locator('.work-log-content .thinking-block').first()).toBeVisible();
-      await expect(page.locator('.thinking-label').first()).toHaveText('Thinking');
+      // Verify ThinkingBlock is visible (scoped to overlay)
+      await expect(overlay.locator('.work-log-content .thinking-block').first()).toBeVisible();
+      await expect(overlay.locator('.thinking-label').first()).toHaveText('Thinking');
 
       // Just verify that thinking text exists (don't check specific content since auto-run may create different content)
-      await expect(page.locator('.thinking-text').first()).toBeVisible();
+      await expect(overlay.locator('.thinking-text').first()).toBeVisible();
     });
 
     test('expanded panel shows command blocks for tool-type logs', async ({ page }) => {
@@ -547,16 +554,17 @@ test.describe('Work Log Panels', () => {
         messageId: assistantMsg.id,
       });
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      // Expand the panel
-      await page.locator('.work-log-header').first().click();
+      // Expand the panel (scoped to overlay)
+      await overlay.locator('.work-log-header').first().click();
 
-      // Verify CommandBlocks are visible
-      await expect(page.locator('.work-log-content .command-block').first()).toBeVisible();
-      await expect(page.locator('.command-label').first()).toHaveText(/Input|Output/);
-      await expect(page.locator('.command-tool-name').first()).toHaveText('Bash');
+      // Verify CommandBlocks are visible (scoped to overlay)
+      await expect(overlay.locator('.work-log-content .command-block').first()).toBeVisible();
+      await expect(overlay.locator('.command-label').first()).toHaveText(/Input|Output/);
+      await expect(overlay.locator('.command-tool-name').first()).toHaveText('Bash');
     });
   });
 
@@ -576,12 +584,12 @@ test.describe('Work Log Panels', () => {
       // Wait for first turn to complete
       await waitForSessionStatus(session.id, 'waiting', 60000);
 
-      // Navigate to session detail
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-assistant"]')).toBeVisible({ timeout: 10000 });
 
-      // Session is waiting, NOT running, so .running-state should NOT exist
-      await expect(page.locator('.running-state')).toHaveCount(0);
+      // Session is waiting, NOT running, so .running-state should NOT exist (scoped to overlay)
+      await expect(overlay.locator('.running-state')).toHaveCount(0);
 
       // Work logs should appear on assistant message (if they were created)
       const workLogs = await getSessionWorkLogs(session.id);
@@ -590,8 +598,8 @@ test.describe('Work Log Panels', () => {
 
       const associatedLogs = workLogs[assistantMsg.id] || [];
       if (associatedLogs.length > 0) {
-        // If auto-run created work logs, verify panel appears on message
-        await expect(page.locator('[data-testid="message-assistant"]').first().locator('.work-log-panel')).toBeVisible();
+        // If auto-run created work logs, verify panel appears on message (scoped to overlay)
+        await expect(overlay.locator('[data-testid="message-assistant"]').first().locator('.work-log-panel')).toBeVisible();
       }
       // If auto-run didn't create work logs, skip the assertion (as documented in plan)
     });
@@ -604,11 +612,12 @@ test.describe('Work Log Panels', () => {
 
       await waitForSessionStatus(session.id, 'waiting', 60000);
 
-      await page.goto(`${API_URL}/sessions/${session.id}`);
-      await page.waitForSelector('[data-testid="message-user"]', { timeout: 10000 });
+      // Open conversation overlay to access messages
+      const overlay = await openConversationOverlay(page, session.id);
+      await expect(overlay.locator('[data-testid="message-user"]')).toBeVisible({ timeout: 10000 });
 
-      // Find user message and verify work log panel does NOT appear
-      const userMessages = page.locator('[data-testid="message-user"]');
+      // Find user message and verify work log panel does NOT appear (scoped to overlay)
+      const userMessages = overlay.locator('[data-testid="message-user"]');
       const count = await userMessages.count();
 
       for (let i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary

This PR adapts E2E tests to use the new conversation overlay pattern. The conversation tab is being removed from the main `SessionDetailView` and messages will only be accessible via the `SessionTreeOverlay` (the slide-in panel triggered by the handle on the right side of the page).

## What Changed

### New Helper Function
- Added `openConversationOverlay()` to `tests/e2e/helpers.ts` - a reusable helper that opens the overlay and returns a locator scoped to it

### Test Files Adapted
This PR includes the first batch of test adaptations (5 files):

- **effort-level.spec.ts** - Effort level dropdown visibility and interaction tests
- **orchestration-panel.spec.ts** - Orchestration panel visibility, expand/collapse, schedule button state, auto-reschedule modal, and template selector tests
- **queue-prompt.spec.ts** - Queue prompt input form visibility tests
- **scheduling-reschedule.spec.ts** - Scheduling and reschedule functionality tests
- **todo-tracking.spec.ts** - Todo tracking UI tests

### Pattern Applied
All adapted tests now:
1. Use `openConversationOverlay(page, sessionId)` instead of direct navigation to `/sessions/:id`
2. Scope all message/conversation selectors to the returned overlay locator
3. Re-open the overlay after page reloads where needed

## Previous Work

This branch builds on earlier commits that adapted other test files:
- `filtering-navigation.spec.ts`
- `helpers.ts` (added `openConversationOverlay` helper)
- `messaging-chat.spec.ts`
- `scheduling-ui.spec.ts`
- `session-message-persistence.spec.ts`
- `sessions.spec.ts`
- `websocket-recovery.spec.ts`
- `work-log-dedup.spec.ts`
- `work-log-panels.spec.ts`

## Test Plan

- [ ] Run full E2E test suite with `./scripts/pw.sh test`
- [ ] Verify all adapted tests pass with the new overlay pattern
- [ ] Confirm no regressions in test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)