### PR TITLE
Fix: Hide Session Overview section when no PR info exists

### DIFF
--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -44,6 +44,9 @@ describe('SummaryTab', () => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
 
+    // Reset API mock implementations to defaults
+    api.getSessionSummary.mockResolvedValue(null);
+
     // Get actual store instances
     sessionsStore = useSessionsStore();
     uiStore = useUiStore();
@@ -90,7 +93,28 @@ describe('SummaryTab', () => {
   }
 
   describe('Session Overview', () => {
-    it('renders session overview section', async () => {
+    it('does not render session overview when no PR info', async () => {
+      // Default session has no prUrl, so no PR info
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.session-overview').exists()).toBe(false);
+      expect(wrapper.text()).not.toContain('Session Overview');
+    });
+
+    it('renders session overview when PR info exists', async () => {
+      // Setup session with PR URL and summary with prState
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        prUrl: 'https://github.com/example/repo/pull/123',
+      };
+      sessionsStore.sessions = [sessionsStore.currentSession];
+      api.getSessionSummary.mockResolvedValue({
+        prState: 'open',
+        ciStatus: 'success',
+      });
+
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
@@ -106,6 +130,18 @@ describe('SummaryTab', () => {
     });
 
     it('does not have regenerate button in overview header', async () => {
+      // Setup session with PR info so the header is actually rendered
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        prUrl: 'https://github.com/example/repo/pull/123',
+      };
+      sessionsStore.sessions = [sessionsStore.currentSession];
+      api.getSessionSummary.mockResolvedValue({
+        prState: 'open',
+        ciStatus: 'success',
+      });
+
       const wrapper = mountComponent();
       await flushAll(wrapper);
 

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -9,13 +9,13 @@
     />
 
     <!-- Session Overview Section -->
-    <div class="session-overview card">
+    <div v-if="hasPrInfo" class="session-overview card">
       <div class="overview-header">
         <h3>Session Overview</h3>
       </div>
 
       <!-- PR Info in Overview -->
-      <div v-if="hasPrInfo" class="overview-pr" data-testid="pr-overview-badge">
+      <div class="overview-pr" data-testid="pr-overview-badge">
         <a :href="prUrl" target="_blank" class="pr-link">
           {{ extractPrNumber(prUrl) }}
         </a>

--- a/tests/e2e/session-summaries.spec.ts
+++ b/tests/e2e/session-summaries.spec.ts
@@ -55,10 +55,11 @@ test.describe('Session Summaries', () => {
   // Category 1: Summary Tab — Overview Card (1 test)
   // The overview-stats section (conversations, messages, status) was removed
   // during the summary tab refactoring. Only the overview card itself remains.
+  // The overview card is now only visible when there's PR info (prUrl AND prState).
   // ============================================================
 
   test.describe('Category 1: Summary Tab — Overview Card', () => {
-    test('displays session overview card without stats', async ({ page }) => {
+    test('displays session overview card when PR info exists', async ({ page }) => {
       const session = await seedSession(project.id, {
         prompt: 'Test overview card',
         name: 'Overview Card Test',
@@ -66,16 +67,22 @@ test.describe('Session Summaries', () => {
       });
       await waitForSessionToExist(session.id);
 
-      // Seed a summary so the page loads properly
-      seedSessionSummaryDirect(session.id, {
+      // Add PR info to the session (required for overview to be visible)
+      await updateSessionWithPR(session.id, {
+        prUrl: 'https://github.com/org/repo/pull/100',
+      });
+
+      // Seed a summary with PR state so the overview card shows
+      seedSessionSummaryWithPR(session.id, {
         shortSummary: 'Overview test',
         fullSummary: 'Testing the overview card display',
         outcome: 'completed',
+        prState: 'open',
       });
 
       await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
-      // Verify the session overview card exists
+      // Verify the session overview card exists (only shows with PR info)
       const overviewCard = page.locator('.session-overview.card');
       await expect(overviewCard).toBeVisible();
 
@@ -329,6 +336,7 @@ test.describe('Session Summaries', () => {
   test.describe('Category 4: Manual Regenerate Button', () => {
     // The regenerate button was removed from the overview-header during the summary tab
     // refactoring. It now only exists in the summary footer (SummaryContent component).
+    // Note: The overview header is only visible when there's PR info (prUrl AND prState).
 
     test('regenerate button is NOT visible in overview header', async ({ page }) => {
       const session = await seedSession(project.id, {
@@ -338,10 +346,16 @@ test.describe('Session Summaries', () => {
       });
       await waitForSessionToExist(session.id);
 
-      seedSessionSummaryDirect(session.id, {
+      // Add PR info to the session (required for overview header to be visible)
+      await updateSessionWithPR(session.id, {
+        prUrl: 'https://github.com/org/repo/pull/200',
+      });
+
+      seedSessionSummaryWithPR(session.id, {
         shortSummary: 'Regen header test',
         fullSummary: 'Testing regenerate button removed from header',
         outcome: 'completed',
+        prState: 'open',
       });
 
       await navigateAndWait(page, `/sessions/${session.id}/summary`);
@@ -778,7 +792,7 @@ test.describe('Session Summaries', () => {
   // ============================================================
 
   test.describe('Category 9: Edge Cases & Empty States', () => {
-    test('shows no summary content when session has no summary', async ({ page }) => {
+    test('shows no summary content and no overview when session has no summary', async ({ page }) => {
       const session = await seedSession(project.id, {
         prompt: 'Test no summary content',
         name: 'No Summary Content Test',
@@ -790,9 +804,9 @@ test.describe('Session Summaries', () => {
 
       await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
-      // The overview card should still be visible
+      // The overview card should NOT be visible (requires PR info: prUrl AND prState)
       const overviewCard = page.locator('.session-overview');
-      await expect(overviewCard).toBeVisible();
+      await expect(overviewCard).toHaveCount(0);
 
       // The summary-content card should NOT be in the DOM (v-else-if="summary")
       const summaryContent = page.locator('.summary-content');


### PR DESCRIPTION
## Summary
Fixes a UX issue where the Session Overview section in the Summary tab was displaying an empty card with just a heading when no PR information was available.

## Problem
The `.session-overview` div was always rendered regardless of whether it had content, resulting in a blank section with only the heading "Session Overview" when there was no PR information.

## Solution
Added `v-if="hasPrInfo"` to the outer `.session-overview` div to conditionally render the entire section only when PR information is available (both `prUrl` on the session AND `prState` in the summary).

## Changes
- **SummaryTab.vue**: Added `v-if="hasPrInfo"` to `.session-overview` div and removed redundant inner `v-if`
- **SummaryTab.test.js**: Updated tests to verify conditional rendering behavior
- **session-summaries.spec.ts**: Updated E2E tests to reflect new behavior

## Test Plan
- [x] Unit tests updated and passing
- [x] E2E tests updated to verify overview only shows with PR info
- [x] Manual verification: Sessions without PR info don't show overview
- [x] Manual verification: Sessions with PR info show overview correctly

## Screenshots
**Before:** Empty overview card shown even without PR info
**After:** Overview card only appears when PR information exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)