### PR TITLE
feat: Set session name from PR title

### DIFF
--- a/packages/server/src/api/sessions-patch.js
+++ b/packages/server/src/api/sessions-patch.js
@@ -3,6 +3,7 @@ import { sessions, sessionTemplates, modelProviders } from '../database.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@claudetools/shared';
 import * as summaryService from '../services/summaryService.js';
+import { setSessionNameFromPr } from '../services/prUrlService.js';
 import { requireSession } from '../middleware/sessionLookup.js';
 
 const router = Router();
@@ -205,6 +206,12 @@ router.patch('/:id', requireSession, (req, res) => {
   // Propagate PR URL to parent session if set (not when clearing)
   if (updateData.prUrl) {
     summaryService.propagatePrUrlToParent(req.params.id, updateData.prUrl);
+
+    // Set session name from PR title (fire-and-forget async)
+    // The response returns immediately; client gets name update via WebSocket
+    setSessionNameFromPr(req.params.id, updateData.prUrl).catch(err => {
+      console.error(`[Sessions API] Failed to set session name from PR:`, err);
+    });
   }
 
   broadcastSessionUpdate(req.params.id, req.session_.projectId, updated, updateData);

--- a/packages/server/src/services/ghService.js
+++ b/packages/server/src/services/ghService.js
@@ -105,7 +105,7 @@ export async function getPrInfo(prUrl) {
   try {
     // First fetch basic PR info (this should always work)
     const { stdout: basicStdout } = await execAsync(
-      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft`
+      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft,title`
     );
     const data = JSON.parse(basicStdout);
 
@@ -160,6 +160,7 @@ export async function getPrInfo(prUrl) {
       hasMergeConflicts,
       ciStatus,
       ciFailures,
+      title: data.title || null,
     };
   } catch (error) {
     console.warn('[ghService] Failed to get PR info:', error.message);

--- a/packages/server/src/services/ghService.test.js
+++ b/packages/server/src/services/ghService.test.js
@@ -65,13 +65,14 @@ describe('ghService', () => {
         }
 
         // Handle PR view commands
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'MERGEABLE',
               isDraft: false,
+              title: 'Test PR Title',
             }),
             stderr: '',
           });
@@ -107,7 +108,66 @@ describe('ghService', () => {
         hasMergeConflicts: false,
         ciStatus: 'success',
         ciFailures: [],
+        title: 'Test PR Title',
       });
+    });
+
+    it('returns PR title in the result', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+              title: 'Fix critical bug in authentication',
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, { stdout: JSON.stringify({ statusCheckRollup: [] }), stderr: '' });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.title).toBe('Fix critical bug in authentication');
+    });
+
+    it('returns null title when gh CLI returns no title', async () => {
+      let callCount = 0;
+      exec.mockImplementation((cmd, callback) => {
+        callCount++;
+        if (callCount <= 2) {
+          callback(null, { stdout: 'ok', stderr: '' });
+          return;
+        }
+
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
+          callback(null, {
+            stdout: JSON.stringify({
+              state: 'OPEN',
+              mergedAt: null,
+              mergeable: 'MERGEABLE',
+              isDraft: false,
+              // No title field
+            }),
+            stderr: '',
+          });
+        } else if (cmd.includes('--json statusCheckRollup')) {
+          callback(null, { stdout: JSON.stringify({ statusCheckRollup: [] }), stderr: '' });
+        }
+      });
+
+      const result = await getPrInfo('https://github.com/org/repo/pull/123');
+      expect(result.title).toBeNull();
     });
 
     it('returns merged state when mergedAt is set', async () => {
@@ -119,13 +179,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'MERGED',
               mergedAt: '2024-01-15T10:00:00Z',
               mergeable: 'UNKNOWN',
               isDraft: false,
+              title: 'Merged PR',
             }),
             stderr: '',
           });
@@ -148,13 +209,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'MERGEABLE',
               isDraft: true,
+              title: 'Draft PR',
             }),
             stderr: '',
           });
@@ -176,13 +238,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'CONFLICTING',
               isDraft: false,
+              title: 'Conflicting PR',
             }),
             stderr: '',
           });
@@ -204,13 +267,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'MERGEABLE',
               isDraft: false,
+              title: 'CI Failure PR',
             }),
             stderr: '',
           });
@@ -242,13 +306,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'MERGEABLE',
               isDraft: false,
+              title: 'Pending CI PR',
             }),
             stderr: '',
           });
@@ -278,13 +343,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'MERGEABLE',
               isDraft: false,
+              title: 'Permission Error PR',
             }),
             stderr: '',
           });
@@ -318,7 +384,7 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(new Error('Could not resolve to a PullRequest'), null);
         }
       });
@@ -336,13 +402,14 @@ describe('ghService', () => {
           return;
         }
 
-        if (cmd.includes('--json state,mergedAt,mergeable,isDraft')) {
+        if (cmd.includes('--json state,mergedAt,mergeable,isDraft,title')) {
           callback(null, {
             stdout: JSON.stringify({
               state: 'OPEN',
               mergedAt: null,
               mergeable: 'MERGEABLE',
               isDraft: false,
+              title: 'Empty CI PR',
             }),
             stderr: '',
           });

--- a/packages/server/src/services/prUrlService.js
+++ b/packages/server/src/services/prUrlService.js
@@ -135,6 +135,9 @@ export async function extractPrUrlIfNeeded(sessionId) {
     sessions.update(sessionId, { prUrl });
     console.log(`[PrUrlService] Extracted PR URL for session ${sessionId}: ${prUrl}`);
 
+    // Set session name from PR title (async, fire-and-forget)
+    await setSessionNameFromPr(sessionId, prUrl);
+
     // Broadcast session update so UI shows PR URL immediately
     broadcastSessionUpdate(sessionId, session.projectId, sessions.getById(sessionId));
 
@@ -181,9 +184,40 @@ export async function enrichPrData(summaryData, prUrl, projectRepoUrl, sessionId
       if (prInfo.ciFailures !== undefined) {
         summaryData.ciFailures = prInfo.ciFailures;
       }
+      // Add PR title to summary data
+      if (prInfo.title) {
+        summaryData.prTitle = prInfo.title;
+      }
     }
   } catch (error) {
     console.warn(`[PrUrlService] Failed to get PR info for ${prUrl}:`, error.message);
+  }
+}
+
+/**
+ * Set session name from PR title when PR URL is associated.
+ * @param {string} sessionId - The session ID
+ * @param {string} prUrl - The PR URL
+ */
+export async function setSessionNameFromPr(sessionId, prUrl) {
+  const session = sessions.getById(sessionId);
+  if (!session || session.manuallyNamed) return; // Don't overwrite if manually named
+
+  try {
+    const prInfo = await ghService.getPrInfo(prUrl);
+    if (prInfo?.title) {
+      sessions.update(sessionId, {
+        name: prInfo.title,
+        manuallyNamed: true, // Protect from summary overwrites
+      });
+      console.log(`[PrUrlService] Set session ${sessionId} name from PR title: "${prInfo.title}"`);
+
+      // Broadcast the update
+      const updated = sessions.getById(sessionId);
+      broadcastSessionUpdate(sessionId, session.projectId, updated);
+    }
+  } catch (error) {
+    console.warn(`[PrUrlService] Failed to set session name from PR ${prUrl}:`, error.message);
   }
 }
 

--- a/packages/server/src/services/prUrlService.test.js
+++ b/packages/server/src/services/prUrlService.test.js
@@ -29,6 +29,7 @@ import {
   extractPrUrlFromMessages,
   extractPrUrlIfNeeded,
   enrichPrData,
+  setSessionNameFromPr,
 } from './prUrlService.js';
 import { broadcastSessionUpdate } from './summaryBroadcast.js';
 import * as ghService from './ghService.js';
@@ -313,6 +314,177 @@ describe('prUrlService', () => {
 
       expect(summaryData.prUrl).toBe('https://github.com/user/repo/pull/123');
       expect(summaryData.prState).toBeUndefined();
+    });
+
+    it('adds PR title to summary data when available', async () => {
+      const summaryData = { prUrl: 'https://github.com/user/repo/pull/123' };
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'OPEN',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'passing',
+        title: 'Fix critical bug',
+      });
+
+      await enrichPrData(summaryData, 'https://github.com/user/repo/pull/123', 'https://github.com/user/repo', 'sess-1');
+
+      expect(summaryData.prTitle).toBe('Fix critical bug');
+    });
+
+    it('does not add prTitle when title is not present', async () => {
+      const summaryData = { prUrl: 'https://github.com/user/repo/pull/123' };
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'OPEN',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'passing',
+        // No title field
+      });
+
+      await enrichPrData(summaryData, 'https://github.com/user/repo/pull/123', 'https://github.com/user/repo', 'sess-1');
+
+      expect(summaryData.prTitle).toBeUndefined();
+    });
+  });
+
+  describe('setSessionNameFromPr', () => {
+    let projectId, sessionId;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      const project = projects.create('Test Project', '/tmp/test');
+      projectId = project.id;
+      const session = sessions.create(projectId, 'Original Name', 'Test prompt', 'standard');
+      sessionId = session.id;
+    });
+
+    it('sets session name to PR title when PR URL is provided', async () => {
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'Add new feature',
+        state: 'OPEN',
+        merged: false,
+      });
+
+      await setSessionNameFromPr(sessionId, 'https://github.com/org/repo/pull/123');
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.name).toBe('Add new feature');
+      expect(updated.manuallyNamed).toBe(true);
+    });
+
+    it('does not overwrite name if manuallyNamed is already true', async () => {
+      sessions.update(sessionId, { name: 'Custom Name', manuallyNamed: true });
+
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'Different Title',
+        state: 'OPEN',
+        merged: false,
+      });
+
+      await setSessionNameFromPr(sessionId, 'https://github.com/org/repo/pull/123');
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.name).toBe('Custom Name'); // Should NOT change
+    });
+
+    it('handles gh CLI errors gracefully without setting name', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      ghService.getPrInfo.mockRejectedValue(new Error('gh not available'));
+
+      await setSessionNameFromPr(sessionId, 'https://github.com/org/repo/pull/123');
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.name).toBe('Original Name'); // Should NOT change
+      expect(updated.manuallyNamed).toBe(false);
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('handles missing PR title gracefully without setting name', async () => {
+      ghService.getPrInfo.mockResolvedValue({ state: 'OPEN', merged: false }); // No title
+
+      await setSessionNameFromPr(sessionId, 'https://github.com/org/repo/pull/123');
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.name).toBe('Original Name'); // Should NOT change
+      expect(updated.manuallyNamed).toBe(false);
+    });
+
+    it('broadcasts session update after setting name', async () => {
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'New Title',
+        state: 'OPEN',
+        merged: false,
+      });
+
+      await setSessionNameFromPr(sessionId, 'https://github.com/org/repo/pull/123');
+
+      expect(broadcastSessionUpdate).toHaveBeenCalledWith(
+        sessionId,
+        projectId,
+        expect.objectContaining({ name: 'New Title' })
+      );
+    });
+
+    it('does nothing for non-existent session', async () => {
+      await setSessionNameFromPr('non-existent', 'https://github.com/org/repo/pull/123');
+      expect(ghService.getPrInfo).not.toHaveBeenCalled();
+      expect(broadcastSessionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('handles null session gracefully', async () => {
+      await setSessionNameFromPr(null, 'https://github.com/org/repo/pull/123');
+      expect(ghService.getPrInfo).not.toHaveBeenCalled();
+      expect(broadcastSessionUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('extractPrUrlIfNeeded with name setting', () => {
+    let projectId, sessionId;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      const project = projects.create('Test Project', '/tmp/test');
+      projectId = project.id;
+      const session = sessions.create(projectId, 'Original Name', 'Test prompt', 'standard');
+      sessionId = session.id;
+    });
+
+    it('sets session name from PR title when extracting PR URL', async () => {
+      const prUrl = 'https://github.com/org/repo/pull/123';
+      messages.create(sessionId, 'assistant', `I've created a PR: ${prUrl}`);
+
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'Extracted PR Title',
+        state: 'OPEN',
+        merged: false,
+      });
+
+      await extractPrUrlIfNeeded(sessionId);
+
+      const session = sessions.getById(sessionId);
+      expect(session.prUrl).toBe(prUrl);
+      expect(session.name).toBe('Extracted PR Title');
+      expect(session.manuallyNamed).toBe(true);
+    });
+
+    it('does not set name if manuallyNamed is true', async () => {
+      sessions.update(sessionId, { name: 'My Custom Session', manuallyNamed: true });
+      const prUrl = 'https://github.com/org/repo/pull/123';
+      messages.create(sessionId, 'assistant', `I've created a PR: ${prUrl}`);
+
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'Different PR Title',
+        state: 'OPEN',
+        merged: false,
+      });
+
+      await extractPrUrlIfNeeded(sessionId);
+
+      const session = sessions.getById(sessionId);
+      expect(session.prUrl).toBe(prUrl);
+      expect(session.name).toBe('My Custom Session'); // Should NOT change
     });
   });
 });


### PR DESCRIPTION
## Summary
Automatically set session names to PR titles when PR URLs are associated with sessions. This provides more meaningful session names and protects them from being overwritten by summary generation.

## Changes
- **Extended `ghService.getPrInfo()`** to include PR title in response
- **Added `setSessionNameFromPr()`** function in `prUrlService.js` to manage session naming from PR titles
- **Integrated name setting** in two places:
  - `extractPrUrlIfNeeded()` - when PR URL is automatically extracted from conversation
  - `sessions-patch.js` API - when PR URL is manually set via PATCH endpoint
- **Added comprehensive test coverage** including:
  - Tests for PR title extraction in ghService
  - Tests for setSessionNameFromPr() function covering all edge cases
  - Tests for PR title in summary data enrichment
  - Tests for name preservation during PR URL extraction

## Implementation Details

The solution uses the existing `manuallyNamed` flag to protect PR-based names from being overwritten by summary generation. This ensures:
- ✅ PR titles are used as session names when PR URLs are associated
- ✅ PR-based names are protected from summary overwrites
- ✅ User-manually named sessions are never overwritten
- ✅ Graceful degradation when gh CLI is unavailable
- ✅ Fire-and-forget pattern prevents blocking API responses on gh CLI calls

## Edge Cases Handled
- Session already has a custom name → Not overwritten
- gh CLI not available → Gracefully degrades, PR URL still saved
- PR title missing from response → Name not set
- Multiple PR URLs in conversation → Name only set on first extraction
- PR URL cleared → Name remains (user can manually rename)
- Session already manually named → PR title does not override

## Test Plan
✅ All unit tests passing
- `ghService.test.js` - PR title extraction
- `prUrlService.test.js` - setSessionNameFromPr(), enrichPrData(), extractPrUrlIfNeeded()
✅ Manual testing recommended
- Set PR URL manually and verify name updates
- Create PR in session and verify name auto-updates
- Trigger summary generation and verify name preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)