### PR TITLE
fix: Hide 'Add to Board' icon when Kanban is disabled

### DIFF
--- a/packages/web/src/components/ArchivedTabContent.test.js
+++ b/packages/web/src/components/ArchivedTabContent.test.js
@@ -24,7 +24,7 @@ vi.mock('./SessionCard.vue', () => ({
   default: {
     name: 'SessionCard',
     template: '<div class="session-card-mock">SessionCard</div>',
-    props: ['session', 'showSummary', 'summary', 'summaryLoading', 'summaryError', 'showUnarchive', 'prUrl', 'prSummary'],
+    props: ['session', 'showSummary', 'summary', 'summaryLoading', 'summaryError', 'showUnarchive', 'prUrl', 'prSummary', 'kanbanEnabled'],
   },
 }));
 
@@ -172,6 +172,22 @@ describe('ArchivedTabContent', () => {
       expect(sessionCard.props('showUnarchive')).toBe(true);
       expect(sessionCard.props('prUrl')).toBe('https://github.com/pr/1');
       expect(sessionCard.props('prSummary')).toBe('Test summary');
+    });
+
+    it('passes kanbanEnabled=false to SessionCard components', () => {
+      mockSessionsStore.archivedSessions = [
+        { id: 'session-1', name: 'Archived Session' },
+      ];
+
+      const wrapper = mountComponent({
+        summaries: {},
+        loadingSummaries: {},
+        summaryErrors: {},
+      });
+
+      const sessionCard = wrapper.findComponent({ name: 'SessionCard' });
+      // Archived sessions should never show the Add to Board button
+      expect(sessionCard.props('kanbanEnabled')).toBe(false);
     });
   });
 

--- a/packages/web/src/components/ArchivedTabContent.vue
+++ b/packages/web/src/components/ArchivedTabContent.vue
@@ -22,6 +22,7 @@
         :summary-loading="loadingSummaries[session.id]"
         :summary-error="summaryErrors[session.id]"
         :show-unarchive="true"
+        :kanban-enabled="false"
         :pr-url="session.prUrl"
         :pr-summary="summaries[session.id]"
         @retry-summary="$emit('retrySummary', $event)"

--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -1273,4 +1273,39 @@ describe('SessionCard', () => {
       expect(scheduledTime.exists()).toBe(false);
     });
   });
+
+  describe('kanbanEnabled prop', () => {
+    it('passes kanbanEnabled=true to SessionCardHeaderActions by default', () => {
+      const wrapper = mountComponent();
+      // The Add to Board button should be visible by default (kanbanEnabled defaults to true)
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(true);
+    });
+
+    it('hides Add to Board button when kanbanEnabled=false', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: false,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+    });
+
+    it('shows Add to Board button when kanbanEnabled=true and session is not on board', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: true,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(true);
+    });
+
+    it('hides Add to Board button when session is already on board (regardless of kanbanEnabled)', async () => {
+      // Update mock to return isOnBoard=true
+      const { useKanbanStore } = await import('../stores/kanban.js');
+      vi.mocked(useKanbanStore).mockReturnValue({
+        isSessionOnBoard: vi.fn(() => true),
+      });
+
+      const wrapper = mountComponent({
+        kanbanEnabled: true,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+    });
+  });
 });

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -72,6 +72,7 @@
           :date-to-show="dateToShow"
           :is-child="isChild"
           :is-on-board="isOnBoard"
+          :kanban-enabled="kanbanEnabled"
           :show-archive="showArchive"
           :show-unarchive="showUnarchive"
           :session-status="session.status"
@@ -211,6 +212,10 @@ const props = defineProps({
   prSummary: {
     type: Object,
     default: null,
+  },
+  kanbanEnabled: {
+    type: Boolean,
+    default: true,
   },
 });
 

--- a/packages/web/src/components/SessionCardHeaderActions.test.js
+++ b/packages/web/src/components/SessionCardHeaderActions.test.js
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import SessionCardHeaderActions from './SessionCardHeaderActions.vue';
+
+describe('SessionCardHeaderActions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  function mountComponent(props = {}) {
+    return mount(SessionCardHeaderActions, {
+      props: {
+        dateToShow: '2024-01-15T10:30:00Z',
+        isChild: false,
+        isOnBoard: false,
+        kanbanEnabled: true,
+        showArchive: false,
+        showUnarchive: false,
+        sessionStatus: 'completed',
+        starred: false,
+        ...props,
+      },
+    });
+  }
+
+  describe('Add to Board button', () => {
+    it('shows Add to Board button when kanbanEnabled=true and isOnBoard=false', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: false,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(true);
+    });
+
+    it('hides Add to Board button when kanbanEnabled=false', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: false,
+        isOnBoard: false,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+    });
+
+    it('hides Add to Board button when isOnBoard=true (even if kanbanEnabled=true)', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: true,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+    });
+
+    it('defaults kanbanEnabled to true for backward compatibility', () => {
+      // Mount without passing kanbanEnabled prop explicitly
+      const wrapper = mount(SessionCardHeaderActions, {
+        props: {
+          dateToShow: '2024-01-15T10:30:00Z',
+          isChild: false,
+          isOnBoard: false,
+          showArchive: false,
+          showUnarchive: false,
+          sessionStatus: 'completed',
+          starred: false,
+        },
+      });
+      // Should show button since kanbanEnabled defaults to true
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(true);
+    });
+
+    it('Add to Board button is interactive', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: false,
+      });
+      const btn = wrapper.find('.add-to-board-btn');
+      expect(btn.exists()).toBe(true);
+      // Button is clickable (not disabled)
+      expect(btn.attributes('disabled')).toBeUndefined();
+    });
+
+    it('has correct title attribute', () => {
+      const wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: false,
+      });
+      const btn = wrapper.find('.add-to-board-btn');
+      expect(btn.attributes('title')).toBe('Add to kanban board');
+    });
+  });
+
+  describe('isChild behavior', () => {
+    it('hides all action buttons (including Add to Board) when isChild=true', () => {
+      const wrapper = mountComponent({
+        isChild: true,
+        kanbanEnabled: true,
+        isOnBoard: false,
+        showArchive: true,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+      expect(wrapper.find('.archive-btn').exists()).toBe(false);
+      expect(wrapper.find('.archive-actions').exists()).toBe(false);
+    });
+  });
+
+  describe('archive button', () => {
+    let confirmSpy;
+
+    beforeEach(() => {
+      confirmSpy = vi.spyOn(window, 'confirm');
+    });
+
+    afterEach(() => {
+      if (confirmSpy) {
+        confirmSpy.mockRestore();
+      }
+    });
+
+    it('shows archive button when showArchive is true and canArchive is true', () => {
+      const wrapper = mountComponent({
+        showArchive: true,
+        sessionStatus: 'completed',
+      });
+      const archiveBtn = wrapper.find('.archive-btn');
+      expect(archiveBtn.exists()).toBe(true);
+      expect(archiveBtn.attributes('title')).toBe('Archive session');
+    });
+
+    it('hides archive button when sessionStatus is running', () => {
+      const wrapper = mountComponent({
+        showArchive: true,
+        sessionStatus: 'running',
+      });
+      expect(wrapper.find('.archive-btn[title="Archive session"]').exists()).toBe(false);
+    });
+
+    it('hides archive button when sessionStatus is starting', () => {
+      const wrapper = mountComponent({
+        showArchive: true,
+        sessionStatus: 'starting',
+      });
+      expect(wrapper.find('.archive-btn[title="Archive session"]').exists()).toBe(false);
+    });
+
+    it('shows confirm dialog when archive button is clicked', async () => {
+      confirmSpy.mockReturnValue(true);
+      const wrapper = mountComponent({
+        showArchive: true,
+        sessionStatus: 'completed',
+      });
+      const btn = wrapper.find('.archive-btn');
+      await btn.trigger('click');
+      expect(confirmSpy).toHaveBeenCalledWith('Archive this session?');
+    });
+
+    it('does not emit archive event when user cancels', async () => {
+      confirmSpy.mockReturnValue(false);
+      const wrapper = mountComponent({
+        showArchive: true,
+        sessionStatus: 'completed',
+      });
+      const btn = wrapper.find('.archive-btn');
+      await btn.trigger('click');
+      expect(wrapper.emitted('archive')).toBeFalsy();
+    });
+  });
+
+  describe('unarchive button', () => {
+    let confirmSpy;
+
+    beforeEach(() => {
+      confirmSpy = vi.spyOn(window, 'confirm');
+    });
+
+    afterEach(() => {
+      if (confirmSpy) {
+        confirmSpy.mockRestore();
+      }
+    });
+
+    it('shows unarchive button when showUnarchive is true', () => {
+      const wrapper = mountComponent({
+        showUnarchive: true,
+      });
+      const unarchiveBtn = wrapper.find('.archive-btn');
+      expect(unarchiveBtn.exists()).toBe(true);
+      expect(unarchiveBtn.attributes('title')).toBe('Unarchive session');
+    });
+
+    it('shows confirm dialog when unarchive button is clicked', async () => {
+      confirmSpy.mockReturnValue(true);
+      const wrapper = mountComponent({
+        showUnarchive: true,
+      });
+      const btn = wrapper.find('.archive-btn');
+      await btn.trigger('click');
+      expect(confirmSpy).toHaveBeenCalledWith('Restore this session to active?');
+    });
+
+    it('does not emit unarchive event when user cancels', async () => {
+      confirmSpy.mockReturnValue(false);
+      const wrapper = mountComponent({
+        showUnarchive: true,
+      });
+      const btn = wrapper.find('.archive-btn');
+      await btn.trigger('click');
+      expect(wrapper.emitted('unarchive')).toBeFalsy();
+    });
+  });
+
+  describe('star button', () => {
+    it('shows star button in archive-actions', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.star-btn-mobile').exists()).toBe(true);
+    });
+
+    it('star button is interactive', () => {
+      const wrapper = mountComponent();
+      const btn = wrapper.find('.star-btn-mobile');
+      expect(btn.exists()).toBe(true);
+      // Button is clickable (not disabled)
+      expect(btn.attributes('disabled')).toBeUndefined();
+    });
+
+    it('shows filled star when starred is true', () => {
+      const wrapper = mountComponent({ starred: true });
+      const btn = wrapper.find('.star-btn-mobile');
+      // When starred=true, SVG should have fill="currentColor"
+      const svg = btn.find('svg');
+      expect(svg.attributes('fill')).toBe('currentColor');
+    });
+
+    it('shows outline star when starred is false', () => {
+      const wrapper = mountComponent({ starred: false });
+      const btn = wrapper.find('.star-btn-mobile');
+      // When starred=false, SVG should have fill="none"
+      const svg = btn.find('svg');
+      expect(svg.attributes('fill')).toBe('none');
+    });
+  });
+
+  describe('date display', () => {
+    it('displays formatted date', () => {
+      const wrapper = mountComponent({
+        dateToShow: '2024-01-15T10:30:00Z',
+      });
+      const dateEl = wrapper.find('.session-date');
+      expect(dateEl.exists()).toBe(true);
+      expect(dateEl.text()).toMatch(/Jan.*15.*2024/);
+    });
+  });
+
+  describe('combined visibility scenarios', () => {
+    it('shows Add to Board button only when kanbanEnabled=true AND isOnBoard=false AND isChild=false', () => {
+      // All conditions met
+      let wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: false,
+        isChild: false,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(true);
+
+      // kanbanEnabled=false
+      wrapper = mountComponent({
+        kanbanEnabled: false,
+        isOnBoard: false,
+        isChild: false,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+
+      // isOnBoard=true
+      wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: true,
+        isChild: false,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+
+      // isChild=true
+      wrapper = mountComponent({
+        kanbanEnabled: true,
+        isOnBoard: false,
+        isChild: true,
+      });
+      expect(wrapper.find('.add-to-board-btn').exists()).toBe(false);
+    });
+  });
+});

--- a/packages/web/src/components/SessionCardHeaderActions.vue
+++ b/packages/web/src/components/SessionCardHeaderActions.vue
@@ -5,9 +5,9 @@
     </div>
     <!-- Action buttons (always visible on root sessions, not on child sessions) -->
     <div v-if="!isChild" class="archive-actions">
-      <!-- Add to Board button (only show if session is not already on board) -->
+      <!-- Add to Board button (only show if kanban is enabled and session is not already on board) -->
       <button
-        v-if="!isOnBoard"
+        v-if="kanbanEnabled && !isOnBoard"
         class="add-to-board-btn"
         title="Add to kanban board"
         @click.stop.prevent="$emit('addToBoard')"
@@ -76,6 +76,10 @@ const props = defineProps({
   isOnBoard: {
     type: Boolean,
     default: false,
+  },
+  kanbanEnabled: {
+    type: Boolean,
+    default: true,
   },
   showArchive: {
     type: Boolean,

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -132,6 +132,7 @@
             :children="group.children"
             :summaries="summaries"
             :show-archive="true"
+            :kanban-enabled="projectsStore.currentProject?.kanbanEnabled ?? true"
             :pr-url="group.parent.prUrl"
             :pr-summary="summaries[group.parent.id]"
             @retry-summary="retryFetchSummary"


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency where the "Add to Board" icon was appearing on session cards even when the Kanban feature was disabled at the project level.

## Problem

The UI had inconsistent behavior regarding Kanban feature visibility:
- ✅ The "Kanban" tab button properly checked `kanbanEnabled` before showing
- ✅ The "Kanban" dropdown option properly checked `kanbanEnabled` before showing
- ❌ The "Add to Board" icon on session cards did NOT check `kanbanEnabled`

This resulted in users seeing the "Add to Board" icon even when Kanban was disabled, which was confusing since clicking it wouldn't make sense.

## Solution

Added a `kanbanEnabled` prop to the component hierarchy:
- `SessionCardHeaderActions.vue`: Accepts `kanbanEnabled` prop and conditionally renders the "Add to Board" button
- `SessionCard.vue`: Passes `kanbanEnabled` prop through to `SessionCardHeaderActions`
- `SessionListView.vue`: Passes the project's `kanbanEnabled` setting to `SessionCard` components
- `ArchivedTabContent.vue`: Explicitly sets `kanbanEnabled=false` (archived sessions should never show the icon)

## Changes

- **SessionCardHeaderActions.vue**: Added `kanbanEnabled` prop (defaults to `true` for backward compatibility) and updated the "Add to Board" button condition from `v-if="!isOnBoard"` to `v-if="kanbanEnabled && !isOnBoard"`
- **SessionCard.vue**: Added `kanbanEnabled` prop and passes it to `SessionCardHeaderActions`
- **SessionListView.vue**: Passes `projectsStore.currentProject?.kanbanEnabled ?? true` to `SessionCard` components
- **ArchivedTabContent.vue**: Sets `kanbanEnabled=false` for archived sessions
- **Tests**: Added comprehensive test coverage for the new `kanbanEnabled` prop behavior in both `SessionCard.test.js` and a new `SessionCardHeaderActions.test.js` file

## Testing

- All existing tests pass (3655 passed)
- Added new tests to verify:
  - "Add to Board" button shows when `kanbanEnabled=true` and session is not on board
  - "Add to Board" button hides when `kanbanEnabled=false`
  - "Add to Board" button hides when session is already on board (regardless of `kanbanEnabled`)
  - Backward compatibility (defaults to `true` when prop is not provided)
  - Archived sessions never show the icon

## Test Plan

Manual testing checklist:
- [ ] Create a project with Kanban **enabled** → verify "Add to Board" icon appears on session cards
- [ ] Disable Kanban on the same project → verify "Add to Board" icon disappears from session cards
- [ ] Re-enable Kanban → verify "Add to Board" icon reappears
- [ ] Verify existing functionality (archive, star, etc.) still works correctly
- [ ] Test with sessions already on the board → icon should not appear (regardless of `kanbanEnabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)