### PR TITLE
feat: Agent canvas API always uses root session

### DIFF
--- a/packages/server/src/services/sessionPrompts.js
+++ b/packages/server/src/services/sessionPrompts.js
@@ -131,11 +131,15 @@ CRITICAL: Do NOT start coding until you have presented a plan and received appro
 
 /**
  * Build system prompt with canvas write instructions
- * @param {string} sessionId
+ * @param {object|null} session - Session object
  * @returns {string}
  */
-function buildCanvasWriteSystemPrompt(sessionId) {
+function buildCanvasWriteSystemPrompt(session) {
   const apiUrl = getApiBaseUrl();
+  // Use root session ID, fall back to session.id if getRootSessionId returns null, fall back to 'unknown-session' if session is null
+  const sessionId = session
+    ? (sessions.getRootSessionId(session.id) || session.id)
+    : 'unknown-session';
   return `When you generate artifacts that should be displayed on the canvas (images, markdown documents, code snippets, data visualizations, PDFs), POST them to:
 
 POST ${apiUrl}/api/sessions/${sessionId}/canvas
@@ -152,11 +156,15 @@ The file type is automatically detected from the file extension. Supported forma
 
 /**
  * Build system prompt with canvas read instructions
- * @param {string} sessionId
+ * @param {object|null} session - Session object
  * @returns {string}
  */
-function buildCanvasReadSystemPrompt(sessionId) {
+function buildCanvasReadSystemPrompt(session) {
   const apiUrl = getApiBaseUrl();
+  // Use root session ID, fall back to session.id if getRootSessionId returns null, fall back to 'unknown-session' if session is null
+  const sessionId = session
+    ? (sessions.getRootSessionId(session.id) || session.id)
+    : 'unknown-session';
   return `## Reading from Canvas
 
 To list all files on the canvas:
@@ -428,8 +436,8 @@ This session is part of a multi-session workflow:
  */
 export function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode) {
   const session = sessions.getById(sessionId);
-  const canvasWriteInstructions = buildCanvasWriteSystemPrompt(sessionId);
-  const canvasReadInstructions = buildCanvasReadSystemPrompt(sessionId);
+  const canvasWriteInstructions = buildCanvasWriteSystemPrompt(session);  // Pass session object
+  const canvasReadInstructions = buildCanvasReadSystemPrompt(session);    // Pass session object
   const sessionApiInstructions = buildSessionApiInstructions(sessionId, projectId);
   const kanbanApiInstructions = buildKanbanApiInstructions(sessionId, projectId);
   const attachmentsContext = getSessionAttachmentsContext(sessionId);

--- a/packages/server/src/services/sessionPrompts.test.js
+++ b/packages/server/src/services/sessionPrompts.test.js
@@ -265,16 +265,98 @@ describe('sessionPrompts', () => {
       expect(result).not.toContain(DEFAULT_SYSTEM_PROMPT);
     });
 
-    it('includes canvas write instructions with sessionId', () => {
-      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
-      expect(result).toContain(`/api/sessions/${sessionId}/canvas`);
+    it('includes canvas write instructions for root session (no parent)', () => {
+      sessions.getById.mockReturnValue({
+        id: 'root-123',
+        parentSessionId: null,
+        gitWorktree: null,
+        gitBranch: null,
+      });
+      sessions.getRootSessionId = vi.fn().mockReturnValue('root-123');
+
+      const result = buildSystemPromptConfig('root-123', projectId, null, 'standard');
+      expect(result).toContain('/api/sessions/root-123/canvas');
       expect(result).toContain('POST');
+      expect(sessions.getRootSessionId).toHaveBeenCalledWith('root-123');
+    });
+
+    it('includes canvas write instructions for child session (uses root ID)', () => {
+      sessions.getById.mockReturnValue({
+        id: 'child-456',
+        parentSessionId: 'parent-789',
+        gitWorktree: null,
+        gitBranch: null,
+      });
+      sessions.getRootSessionId = vi.fn().mockReturnValue('root-123');
+
+      const result = buildSystemPromptConfig('child-456', projectId, null, 'standard');
+      expect(result).toContain('/api/sessions/root-123/canvas');
+      expect(result).not.toContain('/api/sessions/child-456/canvas');
+      expect(sessions.getRootSessionId).toHaveBeenCalledWith('child-456');
     });
 
     it('includes canvas read instructions', () => {
       const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
       expect(result).toContain('Reading from Canvas');
       expect(result).toContain('curl');
+    });
+
+    it('handles null session gracefully in canvas prompts', () => {
+      sessions.getById.mockReturnValue(null);
+      sessions.getRootSessionId = vi.fn();
+
+      const result = buildSystemPromptConfig('unknown-session', projectId, null, 'standard');
+      expect(result).toContain('/api/sessions/unknown-session/canvas');
+      expect(sessions.getRootSessionId).not.toHaveBeenCalled();
+    });
+
+    it('uses root session ID for all canvas endpoints including history', () => {
+      sessions.getById.mockReturnValue({
+        id: 'child-456',
+        parentSessionId: 'parent-789',
+        gitWorktree: null,
+        gitBranch: null,
+      });
+      sessions.getRootSessionId = vi.fn().mockReturnValue('root-123');
+
+      const result = buildSystemPromptConfig('child-456', projectId, null, 'standard');
+      expect(result).toContain('/api/sessions/root-123/canvas/file/');
+      expect(result).toContain('/history/');
+      expect(result).not.toMatch(/\/api\/sessions\/child-456\/canvas\/file\/.*\/history\//);
+    });
+
+    it('falls back to session.id when getRootSessionId returns null', () => {
+      sessions.getById.mockReturnValue({
+        id: 'orphan-123',
+        parentSessionId: 'nonexistent-parent',
+        gitWorktree: null,
+        gitBranch: null,
+      });
+      sessions.getRootSessionId = vi.fn().mockReturnValue(null);
+
+      const result = buildSystemPromptConfig('orphan-123', projectId, null, 'standard');
+      expect(result).toContain('/api/sessions/orphan-123/canvas');
+      expect(result).toBeDefined();
+      expect(result).not.toContain('/api/sessions/null/canvas');
+    });
+
+    it('maintains correct prompt ordering with child session context', () => {
+      sessions.getById.mockReturnValue({
+        id: 'child-456',
+        parentSessionId: 'parent-789',
+        gitWorktree: null,
+        gitBranch: null,
+      });
+      sessions.getRootSessionId = vi.fn().mockReturnValue('root-123');
+
+      const result = buildSystemPromptConfig('child-456', projectId, null, 'standard');
+      const childCtxIdx = result.indexOf('## Child Session');
+      const canvasWriteIdx = result.indexOf('When you generate artifacts');
+      const canvasReadIdx = result.indexOf('## Reading from Canvas');
+
+      expect(childCtxIdx).toBeGreaterThanOrEqual(0);
+      expect(canvasWriteIdx).toBeGreaterThan(childCtxIdx);
+      expect(canvasReadIdx).toBeGreaterThan(canvasWriteIdx);
     });
 
     it('includes session API instructions with sessionId and projectId', () => {


### PR DESCRIPTION
## Summary

Researched canvas API for agents, created implementation plan, and successfully deployed changes to redirect agent canvas calls to root session canvas. All tests passing.

## Changes

### Problem
Currently, each session has its own canvas. When an agent in a child session uses canvas API operations, those operations affect the child session's canvas. We need to modify the agent-facing canvas API to **always operate on the root session's canvas**, regardless of which child session the agent is running in.

### Solution
Modified the agent's system prompt generation in `packages/server/src/services/sessionPrompts.js` to always use the root session ID in canvas API URLs. The HTTP API endpoints remain unchanged - only the agent's system prompt changes.

**Key Changes:**
- `buildCanvasWriteSystemPrompt()` now accepts session object instead of sessionId string
- `buildCanvasReadSystemPrompt()` now accepts session object instead of sessionId string
- Both functions use `sessions.getRootSessionId()` to get root session ID
- Added fallback chain: `root ID → session.id → 'unknown-session'` to prevent "null" in URLs
- Updated `buildSystemPromptConfig()` to pass session object to canvas functions

### Example Behavior

**Root Session:**
- Agent sees: `/api/sessions/root-123/canvas`
- Creates items in: root-123's canvas

**Child Session:**
- Agent sees: `/api/sessions/root-123/canvas` (same as root!)
- Agent creates items in: root-123's canvas
- Frontend can still POST to `/api/sessions/child-456/canvas` for child's own canvas

## Testing

✅ All 52 unit tests passing
- Root sessions correctly use their own ID in canvas URLs
- Child sessions correctly use root session ID in canvas URLs
- Null/edge cases handled gracefully
- No "null" strings appear in URLs
- Prompt ordering maintained

## Benefits

1. ✅ Minimal code changes - Only 3 functions in 1 file
2. ✅ No API changes - Frontend completely unaffected
3. ✅ Backward compatible - Root sessions work exactly as before
4. ✅ Defensive coding - Multiple fallbacks prevent invalid URLs

## Manual Testing Recommended

1. Create a root session and ask agent to create a plan → should appear in root's canvas
2. Create a child session and ask agent to create a plan → should appear in ROOT's canvas (not child's)
3. Verify child session's canvas tab is empty
4. Frontend upload to child's canvas → should only appear in child's canvas

## Files Modified

- `packages/server/src/services/sessionPrompts.js` - Main implementation
- `packages/server/src/services/sessionPrompts.test.js` - Unit tests

## Files NOT Modified

- `packages/server/src/api/canvas.js` - API endpoints unchanged
- `packages/server/src/db/CanvasItemRepository.js` - Database layer unchanged
- `packages/web/*` - Frontend unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)