### PR TITLE
Rename 'What Just Happened' to 'Activity Log' in session summary view

### DIFF
--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="summary-tab">
-    <!-- What Just Happened Card -->
+    <!-- Activity Log Card -->
     <WhatJustHappenedCard
       v-if="session"
       :session="session"

--- a/packages/web/src/components/WhatJustHappenedCard.vue
+++ b/packages/web/src/components/WhatJustHappenedCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="shouldShowCard" class="what-just-happened-card card" data-testid="what-just-happened-card">
     <div class="card-header">
-      <h3>What Just Happened</h3>
+      <h3>Activity Log</h3>
     </div>
 
     <!-- Chain Trail -->


### PR DESCRIPTION
## Summary
- Changed heading text from "What Just Happened" to "Activity Log" in the session summary view
- Updated `WhatJustHappenedCard.vue` component header text
- Updated comment in `SummaryTab.vue` for consistency

## Test plan
- [ ] Verify the heading displays correctly in the session summary view
- [ ] Confirm the comment is consistent in `SummaryTab.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)