### PR TITLE
Reorder sections in session detail summary tab

### DIFF
--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -6,14 +6,6 @@
       :session-id="sessionId"
     />
 
-    <!-- Activity Log Card -->
-    <WhatJustHappenedCard
-      v-if="session"
-      :session="session"
-      :summary="summary"
-      :descendant-summaries="descendantSummaries"
-    />
-
     <!-- Session Overview Section -->
     <div v-if="hasPrInfo" class="session-overview card">
       <div class="overview-header">
@@ -50,6 +42,14 @@
         </div>
       </div>
     </div>
+
+    <!-- Activity Log Card -->
+    <WhatJustHappenedCard
+      v-if="session"
+      :session="session"
+      :summary="summary"
+      :descendant-summaries="descendantSummaries"
+    />
 
     <!-- Child Sessions Section -->
     <SessionCardWorkflowPanel


### PR DESCRIPTION
## Summary
Reordered sections in the SummaryTab component to place Session Overview above Activity Log for better information hierarchy.

## Changes
- Moved Session Overview section to appear before Activity Log (WhatJustHappenedCard)
- Final section order: Live output, Session Overview, Activity Log, Child Sessions, Session Summary

## Test plan
- [x] Verify Session Overview appears above Activity Log on summary tab
- [x] Confirm all sections render correctly in new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)