### PR TITLE
feat: Add list icon navigation to session detail and overlay

### DIFF
--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -52,11 +52,15 @@ describe('SessionTabsPanel', () => {
       expect(text).toContain('Commands');
     });
 
-    it('renders back link to sessions list', () => {
+    it('renders back link with icon to sessions list', () => {
       const wrapper = mountPanel();
       const backLink = wrapper.find('.tab-back');
       expect(backLink.exists()).toBe(true);
       expect(backLink.attributes('href')).toBe('/projects/proj-1/sessions');
+      // Verify icon is rendered instead of text
+      expect(backLink.find('.back-icon').exists()).toBe(true);
+      expect(backLink.findAll('svg').length).toBe(2);
+      expect(backLink.attributes('title')).toBe('Back to Sessions');
     });
 
     it('renders desktop tabs', () => {

--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -3,8 +3,22 @@
     <router-link
       :to="`/projects/${projectId}/sessions`"
       class="tab tab-back"
+      title="Back to Sessions"
     >
-      &larr; Sessions
+      <span class="back-icon" title="Back to Sessions">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="19" y1="12" x2="5" y2="12"></line>
+          <polyline points="12 19 5 12 12 5"></polyline>
+        </svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="8" y1="6" x2="21" y2="6"></line>
+          <line x1="8" y1="12" x2="21" y2="12"></line>
+          <line x1="8" y1="18" x2="21" y2="18"></line>
+          <line x1="3" y1="6" x2="3.01" y2="6"></line>
+          <line x1="3" y1="12" x2="3.01" y2="12"></line>
+          <line x1="3" y1="18" x2="3.01" y2="18"></line>
+        </svg>
+      </span>
     </router-link>
     <span class="tab-separator"></span>
 
@@ -109,5 +123,16 @@ function navigateToTab(tabId) {
 .tabs-mobile {
   align-items: center;
   gap: 0.5rem;
+}
+
+.back-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.back-icon svg {
+  display: inline-block;
+  vertical-align: middle;
 }
 </style>

--- a/packages/web/src/components/SessionTreeOverlay.test.js
+++ b/packages/web/src/components/SessionTreeOverlay.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
 import { h, defineComponent, nextTick } from 'vue';
 import SessionTreeOverlay from './SessionTreeOverlay.vue';
 
@@ -104,17 +105,30 @@ vi.mock('./SessionTreePicker.vue', () => ({
 
 describe('SessionTreeOverlay', () => {
   let pinia;
+  let router;
   const rootSession = {
     id: 'sess-root',
     name: 'Root Session',
     status: 'waiting',
     parentSessionId: null,
+    projectId: 'proj-123',
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     pinia = createPinia();
     setActivePinia(pinia);
+
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: { template: '<div />' } },
+        { path: '/sessions/:id', component: { template: '<div />' } },
+        { path: '/projects/:id/sessions', component: { template: '<div />' } },
+      ],
+    });
+    await router.push('/sessions/sess-root');
+    await router.isReady();
 
     mockSessionsStore.currentSession = { ...rootSession };
     mockSessionsStore.getSessionById.mockReturnValue(null);
@@ -138,6 +152,9 @@ describe('SessionTreeOverlay', () => {
       props: {
         sessionId: 'sess-root',
         ...propsOverrides,
+      },
+      global: {
+        plugins: [router],
       },
       attachTo: document.body,
     });
@@ -173,6 +190,36 @@ describe('SessionTreeOverlay', () => {
       const wrapper = mountOverlay();
       await nextTick();
       expect(document.querySelector('[data-testid="session-tree-close"]')).toBeTruthy();
+      wrapper.unmount();
+    });
+
+    it('renders back to sessions link in header', async () => {
+      mockSessionsStore.getSessionById.mockReturnValue({
+        ...rootSession,
+        projectId: 'proj-123',
+      });
+      const wrapper = mountOverlay();
+      await nextTick();
+      const backLink = document.querySelector('.back-to-sessions-link');
+      expect(backLink).toBeTruthy();
+      expect(backLink.getAttribute('href')).toBe('/projects/proj-123/sessions');
+      expect(backLink.getAttribute('title')).toBe('Back to Sessions');
+      // Verify SVG icons are present
+      expect(backLink.querySelectorAll('svg').length).toBe(2);
+      wrapper.unmount();
+    });
+
+    it('back link defaults to home when session has no projectId', async () => {
+      mockSessionsStore.getSessionById.mockReturnValue({
+        ...rootSession,
+        projectId: null,
+      });
+      mockSessionsStore.currentSession = { ...rootSession, projectId: null };
+      const wrapper = mountOverlay();
+      await nextTick();
+      const backLink = document.querySelector('.back-to-sessions-link');
+      expect(backLink).toBeTruthy();
+      expect(backLink.getAttribute('href')).toBe('/');
       wrapper.unmount();
     });
   });

--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -11,6 +11,24 @@
           <!-- Header (no padding constraints) -->
           <div class="overlay-header">
             <div class="overlay-header-left">
+              <router-link
+                :to="backToSessionsUrl"
+                class="back-to-sessions-link"
+                title="Back to Sessions"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <line x1="19" y1="12" x2="5" y2="12"></line>
+                  <polyline points="12 19 5 12 12 5"></polyline>
+                </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <line x1="8" y1="6" x2="21" y2="6"></line>
+                  <line x1="8" y1="12" x2="21" y2="12"></line>
+                  <line x1="8" y1="18" x2="21" y2="18"></line>
+                  <line x1="3" y1="6" x2="3.01" y2="6"></line>
+                  <line x1="3" y1="12" x2="3.01" y2="12"></line>
+                  <line x1="3" y1="18" x2="3.01" y2="18"></line>
+                </svg>
+              </router-link>
               <!-- Editing mode -->
               <template v-if="isEditingName">
                 <div class="name-edit-form">
@@ -237,6 +255,14 @@ const activeSessionName = computed(() => {
 
 const activeSessionPath = computed(() => {
   return sessionsStore.getSessionPath(activeSessionId.value);
+});
+
+const backToSessionsUrl = computed(() => {
+  const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+  if (session?.projectId) {
+    return `/projects/${session.projectId}/sessions`;
+  }
+  return '/';
 });
 
 // Methods
@@ -913,5 +939,20 @@ defineExpose({
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.back-to-sessions-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--color-text-soft, #9ca3af);
+  text-decoration: none;
+  transition: color 0.15s;
+  margin-right: 0.75rem;
+  flex-shrink: 0;
+}
+
+.back-to-sessions-link:hover {
+  color: var(--color-primary, #06b6d4);
 }
 </style>

--- a/tests/e2e/session-navigation.spec.ts
+++ b/tests/e2e/session-navigation.spec.ts
@@ -130,3 +130,54 @@ test.describe('Session Navigation - Parent/Child Links', () => {
     await expect(breadcrumb.getByText('Child Session')).toBeVisible();
   });
 });
+
+test.describe('Session List Icon Navigation', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+  let session: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Test Project', '/tmp/test');
+
+    // Create a session
+    const API_URL = getAPIURL();
+    const response = await fetch(`${API_URL}/api/projects/${project.id}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: 'Test session',
+        name: 'Test Session',
+        startImmediately: false,
+      }),
+    });
+    session = await response.json();
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('session detail back icon navigates to sessions list', async ({ page }) => {
+    // Navigate to session detail
+    await navigateAndWait(page, `/sessions/${session.id}`);
+
+    // Find and verify back icon link
+    const backLink = page.locator('.tab-back');
+    await expect(backLink).toBeVisible();
+    await expect(backLink.locator('.back-icon')).toBeVisible();
+    await expect(backLink.locator('svg')).toHaveCount(2);
+
+    // Click and verify navigation
+    await backLink.click();
+    await expect(page).toHaveURL(/\/projects\/.*\/sessions/);
+  });
+
+  test('back icon has correct title attribute for accessibility', async ({ page }) => {
+    await navigateAndWait(page, `/sessions/${session.id}`);
+
+    const backLink = page.locator('.tab-back');
+    await expect(backLink).toHaveAttribute('title', 'Back to Sessions');
+  });
+});

--- a/tests/e2e/session-tree-overlay.spec.ts
+++ b/tests/e2e/session-tree-overlay.spec.ts
@@ -165,6 +165,35 @@ test.describe('Session Tree Overlay', () => {
   });
 
   // ============================================================
+  // Back to Sessions Link
+  // ============================================================
+
+  test.describe('Back to Sessions Link', () => {
+    test('back to sessions link is visible in overlay header', async ({ page }) => {
+      const overlay = await openOverlay(page, parentSession.id);
+
+      const backLink = overlay.locator('.back-to-sessions-link');
+      await expect(backLink).toBeVisible();
+      await expect(backLink).toHaveAttribute('title', 'Back to Sessions');
+      await expect(backLink.locator('svg')).toHaveCount(2);
+    });
+
+    test('back to sessions link navigates to project sessions list', async ({ page }) => {
+      const overlay = await openOverlay(page, parentSession.id);
+
+      const backLink = overlay.locator('.back-to-sessions-link');
+      await expect(backLink).toBeVisible();
+
+      // Get href and verify it points to the project sessions
+      await expect(backLink).toHaveAttribute('href', `/projects/${project.id}/sessions`);
+
+      // Click and verify navigation
+      await backLink.click();
+      await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/sessions`), { timeout: 10000 });
+    });
+  });
+
+  // ============================================================
   // Root-Only Session (No Children - Wireframe Scenario 1)
   // ============================================================
 


### PR DESCRIPTION
## Summary
Replace text-based "← Sessions" back navigation with arrow + list icons for better visual clarity and consistent iconography across the app.

## Changes
- **SessionTabsPanel**: Added SVG icons (left arrow + list) replacing text label
- **SessionTreeOverlay**: Added back-to-sessions link with icons in overlay header
- Added `title="Back to Sessions"` attribute for accessibility
- Added computed property for back-to-sessions URL in overlay
- Updated unit tests to verify icon rendering
- Added E2E tests for navigation behavior

## Test Results
- ✅ All 3673 unit tests pass
- ✅ Linting passes (no errors)
- ✅ New E2E tests added for navigation verification

## Files Modified
- `packages/web/src/components/SessionTabsPanel.vue`
- `packages/web/src/components/SessionTabsPanel.test.js`
- `packages/web/src/components/SessionTreeOverlay.vue`
- `packages/web/src/components/SessionTreeOverlay.test.js`
- `tests/e2e/session-navigation.spec.ts`
- `tests/e2e/session-tree-overlay.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)