### PR TITLE
Update summary tab UI: add Last Action section and timestamps

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -619,6 +619,7 @@ defineExpose({
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
+  overflow-y: auto;
 }
 
 .overlay-content {

--- a/packages/web/src/components/SummaryContent.test.js
+++ b/packages/web/src/components/SummaryContent.test.js
@@ -19,36 +19,34 @@ function mountComponent(props = {}) {
 }
 
 describe('SummaryContent', () => {
-  describe('section ordering', () => {
-    it('renders Key Actions section before Overview section', () => {
+  describe('Key Actions section', () => {
+    it('does not render Key Actions section', () => {
       const wrapper = mountComponent();
 
-      const sections = wrapper.findAll('.summary-section');
-      const headings = sections.map((s) => s.find('h3').text());
-
-      const keyActionsIndex = headings.indexOf('Key Actions');
-      const overviewIndex = headings.indexOf('Overview');
-
-      expect(keyActionsIndex).toBeGreaterThanOrEqual(0);
-      expect(overviewIndex).toBeGreaterThanOrEqual(0);
-      expect(keyActionsIndex).toBeLessThan(overviewIndex);
+      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
+      expect(headings).not.toContain('Key Actions');
     });
 
-    it('does not render Key Actions section when keyActions is empty', () => {
+    it('does not render Key Actions section even when keyActions is present', () => {
       const wrapper = mountComponent({
-        summary: { ...baseSummary, keyActions: [] },
+        summary: { ...baseSummary, keyActions: ['Action 1', 'Action 2'] },
       });
 
       const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
       expect(headings).not.toContain('Key Actions');
     });
+  });
 
-    it('does not render Key Actions section when keyActions is absent', () => {
-      const { keyActions: _, ...summaryWithoutActions } = baseSummary;
-      const wrapper = mountComponent({ summary: summaryWithoutActions });
+  describe('Overview section', () => {
+    it('renders Overview section with full summary', () => {
+      const wrapper = mountComponent();
 
-      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
-      expect(headings).not.toContain('Key Actions');
+      const overviewSection = wrapper.findAll('.summary-section').find((s) => {
+        return s.find('h3').text() === 'Overview';
+      });
+
+      expect(overviewSection).toBeDefined();
+      expect(overviewSection.find('.full-summary').text()).toBe(baseSummary.fullSummary);
     });
   });
 

--- a/packages/web/src/components/SummaryContent.test.js
+++ b/packages/web/src/components/SummaryContent.test.js
@@ -20,17 +20,32 @@ function mountComponent(props = {}) {
 
 describe('SummaryContent', () => {
   describe('Key Actions section', () => {
-    it('does not render Key Actions section', () => {
+    it('renders Key Actions section before Overview section', () => {
       const wrapper = mountComponent();
+
+      const sections = wrapper.findAll('.summary-section');
+      const headings = sections.map((s) => s.find('h3').text());
+
+      const keyActionsIndex = headings.indexOf('Key Actions');
+      const overviewIndex = headings.indexOf('Overview');
+
+      expect(keyActionsIndex).toBeGreaterThanOrEqual(0);
+      expect(overviewIndex).toBeGreaterThanOrEqual(0);
+      expect(keyActionsIndex).toBeLessThan(overviewIndex);
+    });
+
+    it('does not render Key Actions section when keyActions is empty', () => {
+      const wrapper = mountComponent({
+        summary: { ...baseSummary, keyActions: [] },
+      });
 
       const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
       expect(headings).not.toContain('Key Actions');
     });
 
-    it('does not render Key Actions section even when keyActions is present', () => {
-      const wrapper = mountComponent({
-        summary: { ...baseSummary, keyActions: ['Action 1', 'Action 2'] },
-      });
+    it('does not render Key Actions section when keyActions is absent', () => {
+      const { keyActions: _, ...summaryWithoutActions } = baseSummary;
+      const wrapper = mountComponent({ summary: summaryWithoutActions });
 
       const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
       expect(headings).not.toContain('Key Actions');

--- a/packages/web/src/components/SummaryContent.test.js
+++ b/packages/web/src/components/SummaryContent.test.js
@@ -100,13 +100,13 @@ describe('SummaryContent', () => {
       expect(headings).toContain('Key Actions');
     });
 
-    it('does not render Key Actions section when keyActions has only one item', () => {
+    it('renders Key Actions section when keyActions has only one item', () => {
       const wrapper = mountComponent({
         summary: { ...baseSummary, keyActions: ['Single action'] },
       });
 
       const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
-      expect(headings).not.toContain('Key Actions');
+      expect(headings).toContain('Key Actions');
     });
 
     it('does not render Key Actions section when keyActions is empty', () => {
@@ -126,7 +126,7 @@ describe('SummaryContent', () => {
       expect(headings).not.toContain('Key Actions');
     });
 
-    it('displays remaining actions excluding the first one', () => {
+    it('displays all actions including the first one', () => {
       const wrapper = mountComponent();
 
       const keyActionsSection = wrapper.findAll('.summary-section').find((s) => {
@@ -135,8 +135,8 @@ describe('SummaryContent', () => {
 
       expect(keyActionsSection).toBeDefined();
       const actionItems = keyActionsSection.findAll('.key-actions-list li');
-      expect(actionItems.length).toBe(baseSummary.keyActions.length - 1);
-      expect(actionItems[0].text()).toContain(baseSummary.keyActions[1]);
+      expect(actionItems.length).toBe(baseSummary.keyActions.length);
+      expect(actionItems[0].text()).toContain(baseSummary.keyActions[0]);
     });
 
     it('displays timestamps under each Key Action', () => {

--- a/packages/web/src/components/SummaryContent.test.js
+++ b/packages/web/src/components/SummaryContent.test.js
@@ -19,19 +19,94 @@ function mountComponent(props = {}) {
 }
 
 describe('SummaryContent', () => {
-  describe('Key Actions section', () => {
-    it('renders Key Actions section before Overview section', () => {
+  describe('Last Action section', () => {
+    it('renders Last Action section when keyActions has items', () => {
+      const wrapper = mountComponent();
+
+      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
+      expect(headings).toContain('Last Action');
+    });
+
+    it('displays the first item from keyActions as Last Action', () => {
+      const wrapper = mountComponent();
+
+      const lastActionSection = wrapper.findAll('.summary-section').find((s) => {
+        return s.find('h3').text() === 'Last Action';
+      });
+
+      expect(lastActionSection).toBeDefined();
+      expect(lastActionSection.find('.last-action-text').text()).toBe(baseSummary.keyActions[0]);
+    });
+
+    it('displays timestamp under Last Action', () => {
+      const wrapper = mountComponent();
+
+      const lastActionSection = wrapper.findAll('.summary-section').find((s) => {
+        return s.find('h3').text() === 'Last Action';
+      });
+
+      expect(lastActionSection).toBeDefined();
+      const timestamp = lastActionSection.find('.action-timestamp');
+      expect(timestamp.exists()).toBe(true);
+      expect(timestamp.text()).toBeTruthy();
+    });
+
+    it('renders Last Action before Key Actions and Overview sections', () => {
       const wrapper = mountComponent();
 
       const sections = wrapper.findAll('.summary-section');
       const headings = sections.map((s) => s.find('h3').text());
 
+      const lastActionIndex = headings.indexOf('Last Action');
       const keyActionsIndex = headings.indexOf('Key Actions');
       const overviewIndex = headings.indexOf('Overview');
 
-      expect(keyActionsIndex).toBeGreaterThanOrEqual(0);
-      expect(overviewIndex).toBeGreaterThanOrEqual(0);
-      expect(keyActionsIndex).toBeLessThan(overviewIndex);
+      expect(lastActionIndex).toBe(0);
+      expect(keyActionsIndex).toBeGreaterThan(lastActionIndex);
+      expect(overviewIndex).toBeGreaterThan(keyActionsIndex);
+    });
+
+    it('does not render Last Action when keyActions is empty', () => {
+      const wrapper = mountComponent({
+        summary: { ...baseSummary, keyActions: [] },
+      });
+
+      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
+      expect(headings).not.toContain('Last Action');
+    });
+
+    it('does not render Last Action when keyActions is absent', () => {
+      const { keyActions: _, ...summaryWithoutActions } = baseSummary;
+      const wrapper = mountComponent({ summary: summaryWithoutActions });
+
+      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
+      expect(headings).not.toContain('Last Action');
+    });
+
+    it('renders Last Action icon', () => {
+      const wrapper = mountComponent();
+
+      const lastActionIcon = wrapper.find('.last-action-icon');
+      expect(lastActionIcon.exists()).toBe(true);
+      expect(lastActionIcon.text()).toBe('→');
+    });
+  });
+
+  describe('Key Actions section', () => {
+    it('renders Key Actions section when keyActions has more than one item', () => {
+      const wrapper = mountComponent();
+
+      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
+      expect(headings).toContain('Key Actions');
+    });
+
+    it('does not render Key Actions section when keyActions has only one item', () => {
+      const wrapper = mountComponent({
+        summary: { ...baseSummary, keyActions: ['Single action'] },
+      });
+
+      const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
+      expect(headings).not.toContain('Key Actions');
     });
 
     it('does not render Key Actions section when keyActions is empty', () => {
@@ -49,6 +124,36 @@ describe('SummaryContent', () => {
 
       const headings = wrapper.findAll('.summary-section h3').map((h) => h.text());
       expect(headings).not.toContain('Key Actions');
+    });
+
+    it('displays remaining actions excluding the first one', () => {
+      const wrapper = mountComponent();
+
+      const keyActionsSection = wrapper.findAll('.summary-section').find((s) => {
+        return s.find('h3').text() === 'Key Actions';
+      });
+
+      expect(keyActionsSection).toBeDefined();
+      const actionItems = keyActionsSection.findAll('.key-actions-list li');
+      expect(actionItems.length).toBe(baseSummary.keyActions.length - 1);
+      expect(actionItems[0].text()).toContain(baseSummary.keyActions[1]);
+    });
+
+    it('displays timestamps under each Key Action', () => {
+      const wrapper = mountComponent();
+
+      const keyActionsSection = wrapper.findAll('.summary-section').find((s) => {
+        return s.find('h3').text() === 'Key Actions';
+      });
+
+      expect(keyActionsSection).toBeDefined();
+      const actionItems = keyActionsSection.findAll('.key-actions-list li');
+
+      actionItems.forEach((item) => {
+        const timestamp = item.find('.action-timestamp');
+        expect(timestamp.exists()).toBe(true);
+        expect(timestamp.text()).toBeTruthy();
+      });
     });
   });
 

--- a/packages/web/src/components/SummaryContent.vue
+++ b/packages/web/src/components/SummaryContent.vue
@@ -5,12 +5,26 @@
       Updating summary...
     </div>
 
-    <section v-if="summary.keyActions && summary.keyActions.length > 0" class="summary-section">
+    <section v-if="summary.keyActions && summary.keyActions.length > 0" class="summary-section last-action-section">
+      <h3>Last Action</h3>
+      <div class="last-action-content">
+        <span class="last-action-icon">&#8594;</span>
+        <div class="last-action-details">
+          <span class="last-action-text">{{ summary.keyActions[0] }}</span>
+          <span class="action-timestamp">{{ formatActionTimestamp(summary.generatedAt) }}</span>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="summary.keyActions && summary.keyActions.length > 1" class="summary-section">
       <h3>Key Actions</h3>
       <ul class="key-actions-list">
-        <li v-for="(action, index) in summary.keyActions" :key="index">
+        <li v-for="(action, index) in summary.keyActions.slice(1)" :key="index">
           <span class="action-icon">&#10003;</span>
-          {{ action }}
+          <div class="action-details">
+            {{ action }}
+            <span class="action-timestamp">{{ formatActionTimestamp(summary.generatedAt) }}</span>
+          </div>
         </li>
       </ul>
     </section>
@@ -50,6 +64,25 @@ function formatDate(timestamp) {
     minute: '2-digit',
   });
 }
+
+function formatActionTimestamp(timestamp) {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
 </script>
 
 <style scoped>
@@ -85,6 +118,35 @@ function formatDate(timestamp) {
   letter-spacing: 0.05em;
 }
 
+.last-action-section {
+  background: rgba(0, 188, 212, 0.08);
+  border-left: 3px solid var(--color-primary);
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.last-action-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.last-action-icon {
+  color: var(--color-primary);
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+.last-action-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.last-action-text {
+  line-height: 1.5;
+}
+
 .full-summary {
   margin: 0;
   line-height: 1.6;
@@ -106,6 +168,18 @@ function formatDate(timestamp) {
 .action-icon {
   color: var(--color-success);
   flex-shrink: 0;
+}
+
+.action-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.action-timestamp {
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+  font-weight: 400;
 }
 
 .summary-footer {

--- a/packages/web/src/components/SummaryContent.vue
+++ b/packages/web/src/components/SummaryContent.vue
@@ -5,6 +5,16 @@
       Updating summary...
     </div>
 
+    <section v-if="summary.keyActions && summary.keyActions.length > 0" class="summary-section">
+      <h3>Key Actions</h3>
+      <ul class="key-actions-list">
+        <li v-for="(action, index) in summary.keyActions" :key="index">
+          <span class="action-icon">&#10003;</span>
+          {{ action }}
+        </li>
+      </ul>
+    </section>
+
     <section class="summary-section">
       <h3>Overview</h3>
       <p class="full-summary">{{ summary.fullSummary }}</p>
@@ -78,6 +88,24 @@ function formatDate(timestamp) {
 .full-summary {
   margin: 0;
   line-height: 1.6;
+}
+
+.key-actions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.key-actions-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.action-icon {
+  color: var(--color-success);
+  flex-shrink: 0;
 }
 
 .summary-footer {

--- a/packages/web/src/components/SummaryContent.vue
+++ b/packages/web/src/components/SummaryContent.vue
@@ -16,10 +16,10 @@
       </div>
     </section>
 
-    <section v-if="summary.keyActions && summary.keyActions.length > 1" class="summary-section">
+    <section v-if="summary.keyActions && summary.keyActions.length > 0" class="summary-section">
       <h3>Key Actions</h3>
       <ul class="key-actions-list">
-        <li v-for="(action, index) in summary.keyActions.slice(1)" :key="index">
+        <li v-for="(action, index) in summary.keyActions" :key="index">
           <span class="action-icon">&#10003;</span>
           <div class="action-details">
             {{ action }}

--- a/packages/web/src/components/SummaryContent.vue
+++ b/packages/web/src/components/SummaryContent.vue
@@ -5,16 +5,6 @@
       Updating summary...
     </div>
 
-    <section v-if="summary.keyActions && summary.keyActions.length > 0" class="summary-section">
-      <h3>Key Actions</h3>
-      <ul class="key-actions-list">
-        <li v-for="(action, index) in summary.keyActions" :key="index">
-          <span class="action-icon">&#10003;</span>
-          {{ action }}
-        </li>
-      </ul>
-    </section>
-
     <section class="summary-section">
       <h3>Overview</h3>
       <p class="full-summary">{{ summary.fullSummary }}</p>
@@ -88,24 +78,6 @@ function formatDate(timestamp) {
 .full-summary {
   margin: 0;
   line-height: 1.6;
-}
-
-.key-actions-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.key-actions-list li {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.action-icon {
-  color: var(--color-success);
-  flex-shrink: 0;
 }
 
 .summary-footer {

--- a/packages/web/src/components/WhatJustHappenedCard.test.js
+++ b/packages/web/src/components/WhatJustHappenedCard.test.js
@@ -93,13 +93,14 @@ describe('WhatJustHappenedCard', () => {
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      // Verify first step has completed icon
-      const firstIcon = wrapper.find('[data-testid="chain-step-icon-0"]');
-      expect(firstIcon.classes()).toContain('completed');
+      // Verify numbered badges are displayed
+      const firstBadge = wrapper.find('[data-testid="chain-step-number-0"]');
+      expect(firstBadge.exists()).toBe(true);
+      expect(firstBadge.text()).toBe('1');
 
-      // Verify second step has error icon
-      const secondIcon = wrapper.find('[data-testid="chain-step-icon-1"]');
-      expect(secondIcon.classes()).toContain('error');
+      const secondBadge = wrapper.find('[data-testid="chain-step-number-1"]');
+      expect(secondBadge.exists()).toBe(true);
+      expect(secondBadge.text()).toBe('2');
 
       // Verify error message is displayed
       const errorText = wrapper.find('.chain-step-error');
@@ -270,6 +271,104 @@ describe('WhatJustHappenedCard', () => {
       const lastActivity = wrapper.find('.last-activity');
       expect(lastActivity.exists()).toBe(true);
       expect(lastActivity.text()).toContain('2 minutes ago');
+    });
+  });
+
+  describe('Step numbering', () => {
+    it('displays sequential numbers for chain steps', async () => {
+      sessionsStore.sessions = [
+        { id: 'root-123', name: 'Root Session', status: 'waiting', updatedAt: '2024-01-01T00:00:00Z' },
+        { id: 'child-1', name: 'Task 1', status: 'completed', parentSessionId: 'root-123', updatedAt: '2024-01-01T01:00:00Z', lastActivityAt: '2024-01-01T01:00:00Z' },
+        { id: 'child-2', name: 'Task 2', status: 'completed', parentSessionId: 'child-1', updatedAt: '2024-01-01T02:00:00Z', lastActivityAt: '2024-01-01T02:00:00Z' },
+        { id: 'child-3', name: 'Task 3', status: 'completed', parentSessionId: 'child-2', updatedAt: '2024-01-01T03:00:00Z', lastActivityAt: '2024-01-01T03:00:00Z' },
+      ];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const stepNumbers = wrapper.findAll('[data-testid^="chain-step-number-"]');
+      expect(stepNumbers.length).toBe(3);
+      expect(stepNumbers[0].text()).toBe('1');
+      expect(stepNumbers[1].text()).toBe('2');
+      expect(stepNumbers[2].text()).toBe('3');
+    });
+
+    it('shows sequential numbering for truncated chains', async () => {
+      const sessions = [
+        { id: 'root-123', name: 'Root Session', status: 'waiting', updatedAt: '2024-01-01T00:00:00Z' },
+      ];
+
+      // Create 8 descendant sessions (chain of 8)
+      for (let i = 1; i <= 8; i++) {
+        sessions.push({
+          id: `child-${i}`,
+          name: `Task ${i}`,
+          status: 'completed',
+          parentSessionId: i === 1 ? 'root-123' : `child-${i - 1}`,
+          updatedAt: `2024-01-01T${i.toString().padStart(2, '0')}:00:00Z`,
+          lastActivityAt: `2024-01-01T${i.toString().padStart(2, '0')}:00:00Z`,
+        });
+      }
+
+      sessionsStore.sessions = sessions;
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Should show first 2 + last 3 = 5 steps with numbers 1-5
+      const stepNumbers = wrapper.findAll('[data-testid^="chain-step-number-"]');
+      expect(stepNumbers.length).toBe(5);
+      expect(stepNumbers[0].text()).toBe('1');
+      expect(stepNumbers[1].text()).toBe('2');
+      expect(stepNumbers[2].text()).toBe('3');
+      expect(stepNumbers[3].text()).toBe('4');
+      expect(stepNumbers[4].text()).toBe('5');
+    });
+  });
+
+  describe('Step timestamps', () => {
+    it('displays timestamps for each chain step', async () => {
+      sessionsStore.sessions = [
+        { id: 'root-123', name: 'Root Session', status: 'waiting', updatedAt: '2024-01-01T00:00:00Z' },
+        { id: 'child-1', name: 'Task 1', status: 'completed', parentSessionId: 'root-123', updatedAt: '2024-01-15T10:30:00Z', lastActivityAt: '2024-01-15T10:30:00Z' },
+        { id: 'child-2', name: 'Task 2', status: 'completed', parentSessionId: 'child-1', updatedAt: '2024-01-15T14:45:00Z', lastActivityAt: '2024-01-15T14:45:00Z' },
+      ];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const timestamps = wrapper.findAll('[data-testid^="chain-step-timestamp-"]');
+      expect(timestamps.length).toBe(2);
+      // Verify the timestamps contain date, month, and time (format may vary by locale)
+      expect(timestamps[0].text()).toMatch(/Jan.*15.*2024/);
+      expect(timestamps[1].text()).toMatch(/Jan.*15.*2024/);
+    });
+
+    it('uses updatedAt as fallback when lastActivityAt is absent', async () => {
+      sessionsStore.sessions = [
+        { id: 'root-123', name: 'Root Session', status: 'waiting', updatedAt: '2024-01-01T00:00:00Z' },
+        { id: 'child-1', name: 'Task 1', status: 'completed', parentSessionId: 'root-123', updatedAt: '2024-03-20T08:15:00Z' },
+      ];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const timestamp = wrapper.find('[data-testid="chain-step-timestamp-0"]');
+      expect(timestamp.exists()).toBe(true);
+      expect(timestamp.text()).toMatch(/Mar.*20.*2024/);
+    });
+
+    it('does not display timestamp when both lastActivityAt and updatedAt are absent', async () => {
+      sessionsStore.sessions = [
+        { id: 'root-123', name: 'Root Session', status: 'waiting', updatedAt: '2024-01-01T00:00:00Z' },
+        { id: 'child-1', name: 'Task 1', status: 'completed', parentSessionId: 'root-123' },
+      ];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const timestamp = wrapper.find('[data-testid="chain-step-timestamp-0"]');
+      expect(timestamp.exists()).toBe(false);
     });
   });
 });

--- a/packages/web/src/components/WhatJustHappenedCard.vue
+++ b/packages/web/src/components/WhatJustHappenedCard.vue
@@ -10,26 +10,10 @@
         <!-- Chain step -->
         <div class="chain-step" :data-testid="`chain-step-${index}`">
           <div
-            class="chain-step-icon"
-            :class="{
-              'completed': step.status === 'completed' || step.status === 'stopped',
-              'error': step.status === 'error',
-              'running': step.status === 'running' || step.status === 'starting'
-            }"
-            :data-testid="`chain-step-icon-${index}`"
+            class="chain-step-number"
+            :data-testid="`chain-step-number-${index}`"
           >
-            <svg v-if="step.status === 'completed' || step.status === 'stopped'" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="20 6 9 17 4 12"></polyline>
-            </svg>
-            <svg v-else-if="step.status === 'error'" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="10"></circle>
-              <line x1="15" y1="9" x2="9" y2="15"></line>
-              <line x1="9" y1="9" x2="15" y2="15"></line>
-            </svg>
-            <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="10"></circle>
-              <polyline points="12 6 12 12 16 14"></polyline>
-            </svg>
+            {{ index + 1 }}
           </div>
 
           <div class="chain-step-content">
@@ -45,6 +29,13 @@
             </div>
             <div v-else-if="step.status === 'error'" class="chain-step-error">
               Errored: {{ step.errorMessage || 'An error occurred' }}
+            </div>
+            <div
+              v-if="formatStepTimestamp(step)"
+              class="chain-step-timestamp"
+              :data-testid="`chain-step-timestamp-${index}`"
+            >
+              {{ formatStepTimestamp(step) }}
             </div>
           </div>
         </div>
@@ -176,6 +167,21 @@ function getStepSummary(sessionId) {
 }
 
 /**
+ * Format the timestamp for a step
+ */
+function formatStepTimestamp(step) {
+  const timestamp = step.lastActivityAt || step.updatedAt;
+  if (!timestamp) return null;
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
  * Generate workflow tally text
  */
 const workflowTally = computed(() => {
@@ -252,7 +258,7 @@ const lastActivityTime = computed(() => {
   align-items: flex-start;
 }
 
-.chain-step-icon {
+.chain-step-number {
   flex-shrink: 0;
   width: 24px;
   height: 24px;
@@ -262,27 +268,8 @@ const lastActivityTime = computed(() => {
   border-radius: 50%;
   background: var(--color-bg-secondary);
   color: var(--color-text-secondary);
-}
-
-.chain-step-icon.completed {
-  background: rgba(46, 160, 67, 0.15);
-  color: var(--color-success);
-}
-
-.chain-step-icon.error {
-  background: rgba(248, 81, 73, 0.15);
-  color: var(--color-error);
-}
-
-.chain-step-icon.running {
-  background: rgba(210, 153, 34, 0.15);
-  color: var(--color-warning);
-  animation: pulse 2s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
+  font-weight: 500;
+  font-size: 0.875rem;
 }
 
 .chain-step-content {
@@ -305,6 +292,12 @@ const lastActivityTime = computed(() => {
 .chain-step-error {
   font-size: 0.875rem;
   color: var(--color-error);
+}
+
+.chain-step-timestamp {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  margin-top: 0.25rem;
 }
 
 .chain-connector {

--- a/tests/e2e/session-summaries.spec.ts
+++ b/tests/e2e/session-summaries.spec.ts
@@ -120,10 +120,10 @@ test.describe('Session Summaries', () => {
       );
     });
 
-    test('displays key actions as a checklist', async ({ page }) => {
+    test('does not display key actions section even when keyActions data is present', async ({ page }) => {
       const session = await seedSession(project.id, {
-        prompt: 'Test key actions display',
-        name: 'Key Actions Test',
+        prompt: 'Test key actions not displayed',
+        name: 'Key Actions Not Displayed Test',
         startImmediately: false,
       });
       await waitForSessionToExist(session.id);
@@ -137,14 +137,13 @@ test.describe('Session Summaries', () => {
 
       await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
+      // Key Actions list should NOT be visible (removed from UI)
       const keyActionsList = page.locator('.key-actions-list');
-      await expect(keyActionsList).toBeVisible();
+      await expect(keyActionsList).toHaveCount(0);
 
-      const items = keyActionsList.locator('li');
-      await expect(items).toHaveCount(3);
-      await expect(items.nth(0)).toContainText('Added login endpoint');
-      await expect(items.nth(1)).toContainText('Created user model');
-      await expect(items.nth(2)).toContainText('Set up JWT tokens');
+      // The full summary should still be visible
+      const fullSummary = page.locator('.full-summary');
+      await expect(fullSummary).toBeVisible();
     });
 
     test('files modified section is no longer rendered (removed)', async ({ page }) => {

--- a/tests/e2e/session-summaries.spec.ts
+++ b/tests/e2e/session-summaries.spec.ts
@@ -120,10 +120,10 @@ test.describe('Session Summaries', () => {
       );
     });
 
-    test('does not display key actions section even when keyActions data is present', async ({ page }) => {
+    test('displays key actions as a checklist', async ({ page }) => {
       const session = await seedSession(project.id, {
-        prompt: 'Test key actions not displayed',
-        name: 'Key Actions Not Displayed Test',
+        prompt: 'Test key actions display',
+        name: 'Key Actions Test',
         startImmediately: false,
       });
       await waitForSessionToExist(session.id);
@@ -137,13 +137,14 @@ test.describe('Session Summaries', () => {
 
       await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
-      // Key Actions list should NOT be visible (removed from UI)
       const keyActionsList = page.locator('.key-actions-list');
-      await expect(keyActionsList).toHaveCount(0);
+      await expect(keyActionsList).toBeVisible();
 
-      // The full summary should still be visible
-      const fullSummary = page.locator('.full-summary');
-      await expect(fullSummary).toBeVisible();
+      const items = keyActionsList.locator('li');
+      await expect(items).toHaveCount(3);
+      await expect(items.nth(0)).toContainText('Added login endpoint');
+      await expect(items.nth(1)).toContainText('Created user model');
+      await expect(items.nth(2)).toContainText('Set up JWT tokens');
     });
 
     test('files modified section is no longer rendered (removed)', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Implemented numbered badges replacing activity log icons, with date/time stamps for all activity logs
- Restored and enhanced the Key Actions section in the Summary tab — now displays **all** key actions (including the first, which is also shown in the Last Action section)
- Added a new **Last Action** section above Key Actions, highlighting the most recent action with smart timestamp formatting
- Added timestamps under each action in both the Last Action and Key Actions sections
- Fixed two failing E2E tests:
  - `session-summaries.spec.ts`: Key Actions list now includes all items (not `slice(1)`)
  - `session-tree-overlay.spec.ts`: Added `overflow-y: auto` to `.overlay-backdrop` so vertical scroll works when content exceeds the viewport

## Files Modified

- `packages/web/src/components/SummaryContent.vue` — Last Action section, Key Actions fix, timestamps
- `packages/web/src/components/SummaryContent.test.js` — Updated tests to match new rendering behavior
- `packages/web/src/components/SessionTreeOverlay.vue` — Added `overflow-y: auto` to overlay backdrop
- `packages/web/src/components/WhatJustHappenedCard.vue` — Numbered badges and timestamp display

## Test plan

- [x] Unit tests: `yarn workspace @claudetools/web test` — all 3689 pass, 0 failures
- [x] E2E: `session-summaries.spec.ts` "displays key actions as a checklist" — passes
- [x] E2E: `session-tree-overlay.spec.ts` "vertical scroll works when content exceeds viewport" — passes
- [x] Full E2E suite — 975 passed, 11 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)