### PR TITLE
Fix: Always show 'Back to list' button in canvas detail view

### DIFF
--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -99,7 +99,7 @@ describe('CanvasFileViewer', () => {
 
       expect(wrapper.find('.breadcrumb-back').exists()).toBe(true);
       expect(wrapper.find('.breadcrumb-separator').exists()).toBe(true);
-      expect(wrapper.find('.breadcrumb-back').text()).toBe('← Canvas');
+      expect(wrapper.find('.breadcrumb-back').text()).toBe('← Back to list');
     });
   });
 

--- a/packages/web/src/components/CanvasFileViewerHeader.vue
+++ b/packages/web/src/components/CanvasFileViewerHeader.vue
@@ -7,7 +7,7 @@
         class="breadcrumb-back"
         @click="$emit('back')"
       >
-        ← Canvas
+        ← Back to list
       </button>
       <span v-if="showBackButton" class="breadcrumb-separator">/</span>
       <div class="viewer-filename-wrapper">

--- a/packages/web/src/components/CanvasTab.test.js
+++ b/packages/web/src/components/CanvasTab.test.js
@@ -70,7 +70,7 @@ describe('CanvasTab', () => {
     props: ['item', 'sessionId', 'versions', 'showBackButton'],
     emits: ['back', 'selectVersion', 'delete', 'deleteAll'],
     template: `<div class="canvas-file-viewer">
-      <button v-if="showBackButton" class="breadcrumb-back">← Canvas</button>
+      <button v-if="showBackButton" class="breadcrumb-back">← Back to list</button>
       Viewing {{ item?.filename }}
     </div>`,
   });
@@ -489,8 +489,8 @@ describe('CanvasTab', () => {
       // Viewer should be shown with explicit selection
       expect(wrapper.find('.canvas-file-viewer').exists()).toBe(true);
       expect(wrapper.text()).toContain('doc.txt');
-      // Back button should NOT be visible with only one item (nowhere to go back to)
-      expect(wrapper.find('.breadcrumb-back').exists()).toBe(false);
+      // Back button should always be visible (even with one item)
+      expect(wrapper.find('.breadcrumb-back').exists()).toBe(true);
     });
 
     it('shows back button when item is explicitly selected from multiple items', async () => {
@@ -507,7 +507,7 @@ describe('CanvasTab', () => {
       expect(canvasStore.items).toHaveLength(2);
       // Back button should be present when viewing an item
       expect(wrapper.find('.breadcrumb-back').exists()).toBe(true);
-      expect(wrapper.text()).toContain('← Canvas');
+      expect(wrapper.text()).toContain('← Back to list');
       expect(wrapper.text()).toContain('doc2.txt');
     });
   });

--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -164,7 +164,7 @@ const shouldShowViewer = computed(() => {
 });
 
 const showBackButton = computed(() => {
-  return groupedItems.value.length > 1;
+  return true; // Always show back button
 });
 
 // Auto-navigate to the latest version when a new version of the viewed file arrives


### PR DESCRIPTION
## Summary
Fixed canvas detail view navigation by ensuring the back button always displays, even with a single canvas item.

## The Problem
The back button in the canvas file detail view was conditionally hidden when only one canvas item existed in the session. This left users with no way to navigate back to the list view, effectively trapping them in the detail view.

## The Solution
- **Always show back button**: Removed conditional logic that only showed the button when `groupedItems.value.length > 1`
- **Improved clarity**: Changed button text from "← Canvas" to "← Back to list"
- **Updated tests**: Fixed all test assertions to match the new behavior

## Changes
- `CanvasTab.vue` - Changed `showBackButton` to always return `true`
- `CanvasFileViewerHeader.vue` - Updated button text to "← Back to list"
- `CanvasFileViewer.test.js` - Updated test to expect new button text
- `CanvasTab.test.js` - Updated tests for always-visible back button

## Testing
✅ All 3,673 tests passing  
✅ 0 failures  
✅ Verified back button appears with both single and multiple canvas items

## Impact
- Minimal risk: Simple logic and text changes
- No API or database changes
- Improves UX by preventing users from getting stuck in detail view
- Follows common UI patterns for navigation

Fixes #5418

🤖 Generated with [Claude Code](https://claude.com/claude-code)