### PR TITLE
Fix: Add type validation for key_actions and files_modified in summary parsing

### DIFF
--- a/packages/server/src/services/summaryPrompts.js
+++ b/packages/server/src/services/summaryPrompts.js
@@ -186,8 +186,10 @@ export function parseSummaryResponse(responseText) {
     return {
       shortSummary: parsed.short_summary || 'Summary generation failed',
       fullSummary: parsed.full_summary || 'Unable to generate summary',
-      keyActions: parsed.key_actions || [],
-      filesModified: parsed.files_modified || [],
+      keyActions: Array.isArray(parsed.key_actions) ? parsed.key_actions :
+        (typeof parsed.key_actions === 'string' ? [parsed.key_actions] : []),
+      filesModified: Array.isArray(parsed.files_modified) ? parsed.files_modified :
+        (typeof parsed.files_modified === 'string' ? [parsed.files_modified] : []),
       outcome: parsed.outcome || 'ongoing',
       prUrl: parsed.pr_url || null,
       sessionTitle: parsed.session_title || null,

--- a/packages/server/src/services/summaryPrompts.test.js
+++ b/packages/server/src/services/summaryPrompts.test.js
@@ -383,6 +383,157 @@ describe('summaryPrompts', () => {
       const result = parseSummaryResponse('A'.repeat(600));
       expect(result.fullSummary.length).toBe(500);
     });
+
+    describe('type coercion for key_actions and files_modified', () => {
+      it('handles string value for key_actions (converts to array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: 'Fixed bug', // String instead of array
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual(['Fixed bug']);
+      });
+
+      it('handles string value for files_modified (converts to array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+          files_modified: 'src/app.js', // String instead of array
+        }));
+        expect(result.filesModified).toEqual(['src/app.js']);
+      });
+
+      it('handles array value for key_actions (passes through)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: ['action1', 'action2'],
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual(['action1', 'action2']);
+      });
+
+      it('handles array value for files_modified (passes through)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+          files_modified: ['file1.js', 'file2.js'],
+        }));
+        expect(result.filesModified).toEqual(['file1.js', 'file2.js']);
+      });
+
+      it('handles null value for key_actions (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: null,
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual([]);
+      });
+
+      it('handles null value for files_modified (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+          files_modified: null,
+        }));
+        expect(result.filesModified).toEqual([]);
+      });
+
+      it('handles undefined value for key_actions (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual([]);
+      });
+
+      it('handles undefined value for files_modified (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+        }));
+        expect(result.filesModified).toEqual([]);
+      });
+
+      it('handles number value for key_actions (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: 42, // Invalid type
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual([]);
+      });
+
+      it('handles number value for files_modified (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+          files_modified: 42, // Invalid type
+        }));
+        expect(result.filesModified).toEqual([]);
+      });
+
+      it('handles object value for key_actions (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: { invalid: 'object' }, // Invalid type
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual([]);
+      });
+
+      it('handles object value for files_modified (converts to empty array)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+          files_modified: { invalid: 'object' }, // Invalid type
+        }));
+        expect(result.filesModified).toEqual([]);
+      });
+
+      it('handles empty string for key_actions (converts to array with empty string)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: '',
+          files_modified: [],
+        }));
+        expect(result.keyActions).toEqual(['']);
+      });
+
+      it('handles empty string for files_modified (converts to array with empty string)', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: [],
+          files_modified: '',
+        }));
+        expect(result.filesModified).toEqual(['']);
+      });
+
+      it('handles both key_actions and files_modified as strings simultaneously', () => {
+        const result = parseSummaryResponse(JSON.stringify({
+          short_summary: 'Test',
+          full_summary: 'Full',
+          key_actions: 'Fixed authentication bug',
+          files_modified: 'src/auth/login.js',
+        }));
+        expect(result.keyActions).toEqual(['Fixed authentication bug']);
+        expect(result.filesModified).toEqual(['src/auth/login.js']);
+      });
+    });
   });
 
   describe('parseConversationSummaryResponse', () => {


### PR DESCRIPTION
## Summary

Fixed a critical bug where `key_actions` and `files_modified` in session summaries were displaying as individual characters instead of complete action items (e.g., "✓ F", "✓ i", "✓ x" instead of "✓ Fixed bug").

## Root Cause

Claude AI occasionally returns `key_actions` and `files_modified` as **strings** instead of **arrays** in the JSON response. The code lacked type validation, causing:
1. String values to pass through unchanged
2. Vue's `v-for` to iterate over strings character-by-character
3. Each character to be rendered as a separate list item

**Location:** `packages/server/src/services/summaryPrompts.js`, lines 189-190

## Changes

### 1. Fixed Type Validation in `parseSummaryResponse()`

**File:** `packages/server/src/services/summaryPrompts.js`

Added type checking for both `keyActions` and `filesModified` fields:
- If array → use as-is
- If string → wrap in array (preserves the data)
- If anything else → fall back to empty array

```javascript
keyActions: Array.isArray(parsed.key_actions) ? parsed.key_actions :
  (typeof parsed.key_actions === 'string' ? [parsed.key_actions] : []),
filesModified: Array.isArray(parsed.files_modified) ? parsed.files_modified :
  (typeof parsed.files_modified === 'string' ? [parsed.files_modified] : []),
```

### 2. Added Comprehensive Unit Tests

**File:** `packages/server/src/services/summaryPrompts.test.js`

Added 15 test cases covering:
- String values converted to arrays
- Array values pass through unchanged
- Null/undefined values convert to empty arrays
- Invalid types (numbers, objects) convert to empty arrays
- Empty strings handled correctly
- Both fields can be strings simultaneously

## Test Results

✅ All 67 tests in `summaryPrompts.test.js` pass  
✅ All 746 tests in the entire server package pass  
✅ No regressions detected

## Impact

- **Risk:** Low - only affects parsing layer, adds defensive validation
- **Breaking changes:** None - backwards compatible with existing data
- **Performance:** Negligible - simple type checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)