### PR TITLE
Remove timestamps from Key Actions list

### DIFF
--- a/packages/web/src/components/SummaryContent.test.js
+++ b/packages/web/src/components/SummaryContent.test.js
@@ -139,7 +139,7 @@ describe('SummaryContent', () => {
       expect(actionItems[0].text()).toContain(baseSummary.keyActions[0]);
     });
 
-    it('displays timestamps under each Key Action', () => {
+    it('does not display timestamps under Key Actions', () => {
       const wrapper = mountComponent();
 
       const keyActionsSection = wrapper.findAll('.summary-section').find((s) => {
@@ -151,8 +151,7 @@ describe('SummaryContent', () => {
 
       actionItems.forEach((item) => {
         const timestamp = item.find('.action-timestamp');
-        expect(timestamp.exists()).toBe(true);
-        expect(timestamp.text()).toBeTruthy();
+        expect(timestamp.exists()).toBe(false);
       });
     });
   });

--- a/packages/web/src/components/SummaryContent.vue
+++ b/packages/web/src/components/SummaryContent.vue
@@ -23,7 +23,6 @@
           <span class="action-icon">&#10003;</span>
           <div class="action-details">
             {{ action }}
-            <span class="action-timestamp">{{ formatActionTimestamp(summary.generatedAt) }}</span>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
Remove timestamps from the Key Actions list on the session detail view's summary tab, while keeping the timestamp in the "Last Action" section and footer. This creates a cleaner, less cluttered UI.

## Changes
- **Removed** timestamp display from individual items in the Key Actions list
- **Preserved** timestamp in the "Last Action" section
- **Preserved** "Last updated" timestamp in the footer

## Files Modified
- `packages/web/src/components/SummaryContent.vue` - Removed timestamp span from Key Actions list
- `packages/web/src/components/SummaryContent.test.js` - Updated test to verify timestamps are NOT displayed

## Testing
✅ All 20 SummaryContent unit tests passing
✅ All 3,696 web package tests passing
✅ E2E tests passing (2 summary-regenerate tests)

## Test plan
- [x] Unit tests verify timestamps are NOT in Key Actions list
- [x] Unit tests verify timestamp IS in Last Action section
- [x] All existing tests continue to pass
- [x] E2E tests verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)