### PR TITLE
Fix draft session model dropdown using wrong model on first message

### DIFF
--- a/packages/web/src/components/ConversationTab.model-init.test.js
+++ b/packages/web/src/components/ConversationTab.model-init.test.js
@@ -375,6 +375,67 @@ describe('ConversationTab - Model Initialization Bug', () => {
     });
   });
 
+  describe('Draft handleFormSubmit uses selectedModel.value over pendingModel', () => {
+    /**
+     * This test surfaces the bug where handleFormSubmit() for draft sessions
+     * reads from session.pendingModel instead of selectedModel.value (the UI dropdown).
+     *
+     * Scenario:
+     * 1. Session created with model 'claude-sonnet-4-20250514' (stored as both model and pendingModel)
+     * 2. User changes dropdown to 'claude-opus-4-6-20250616'
+     * 3. handleFormSubmit() should send 'claude-opus-4-6-20250616', not 'claude-sonnet-4-20250514'
+     *
+     * BUG (before fix): handleFormSubmit used session.pendingModel || session.model,
+     * ignoring the dropdown state entirely.
+     */
+    it('should use the dropdown model when user changes it, not the stale pendingModel', async () => {
+      // Setup: Draft session with sonnet as both model and pendingModel
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        model: 'sonnet',
+        pendingModel: 'sonnet',
+        projectId: 'proj-1',
+        mode: 'standard',
+      };
+      mockSessionsStore.activeConversation = {
+        id: 'conv-1',
+        sessionId: 'sess-123',
+        isActive: true,
+      };
+      mockSessionsStore.activeConversationId = 'conv-1';
+      // Mark session as draft so handleFormSubmit() takes the draft path
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(true);
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Model selector should be initialized to sonnet
+      const modelSelector = wrapper.findComponent(ModelSelector);
+      expect(modelSelector.exists()).toBe(true);
+      expect(modelSelector.props('modelValue')).toBe('sonnet');
+
+      // Simulate user changing the dropdown to opus
+      modelSelector.vm.$emit('update:modelValue', 'opus');
+      await flushAll(wrapper);
+
+      // Type a message and submit
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('Test prompt');
+      await flushAll(wrapper);
+
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      // startSession should receive the dropdown model ('opus'), not the stale pendingModel ('sonnet')
+      expect(mockSessionsStore.startSession).toHaveBeenCalledWith(
+        'sess-123',
+        'Test prompt',
+        'opus'
+      );
+    });
+  });
+
   describe('Model selection when sending messages', () => {
     it('should send message with a valid model even when activeConversation is null', async () => {
       // Setup: No active conversation

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -430,7 +430,8 @@ async function handleFormSubmit() {
   if (isDraft.value || isScheduledDraft.value) {
     const textareaRef = inputFormRef.value?.textareaRef;
     const currentValue = textareaRef?.value || input.value;
-    const sessionModel = sessionsStore.currentSession?.pendingModel
+    const sessionModel = selectedModel.value
+      || sessionsStore.currentSession?.pendingModel
       || sessionsStore.currentSession?.model;
     await handleStart(currentValue, sessionModel);
   } else {

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -196,6 +196,54 @@ describe('Sessions Store', () => {
       expect(store.error).toBe('API Error');
       expect(store.currentSession.model).toBe('claude-sonnet-4-6');
     });
+
+    it('includes pendingModel in PATCH for draft (waiting) sessions', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', model: 'claude-sonnet-4-6', status: 'waiting' };
+      store.sessions = [{ id: 'session-1', model: 'claude-sonnet-4-6', status: 'waiting' }];
+
+      api.updateSession.mockResolvedValue({ id: 'session-1', model: 'claude-opus-4-6', pendingModel: 'claude-opus-4-6' });
+
+      await store.updateSessionModel('session-1', 'claude-opus-4-6');
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
+        model: 'claude-opus-4-6',
+        pendingModel: 'claude-opus-4-6',
+      });
+    });
+
+    it('does not include pendingModel in PATCH for running sessions', async () => {
+      const store = useSessionsStore();
+
+      store.currentSession = { id: 'session-1', model: 'claude-sonnet-4-6', status: 'running' };
+      store.sessions = [{ id: 'session-1', model: 'claude-sonnet-4-6', status: 'running' }];
+
+      api.updateSession.mockResolvedValue({ id: 'session-1', model: 'claude-opus-4-6' });
+
+      await store.updateSessionModel('session-1', 'claude-opus-4-6');
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
+        model: 'claude-opus-4-6',
+      });
+    });
+
+    it('finds draft session via currentSession when not in sessions list', async () => {
+      const store = useSessionsStore();
+
+      // Session is only in currentSession, not in the sessions array
+      store.currentSession = { id: 'session-1', model: 'claude-sonnet-4-6', status: 'waiting' };
+      store.sessions = [];
+
+      api.updateSession.mockResolvedValue({ id: 'session-1', model: 'claude-opus-4-6', pendingModel: 'claude-opus-4-6' });
+
+      await store.updateSessionModel('session-1', 'claude-opus-4-6');
+
+      expect(api.updateSession).toHaveBeenCalledWith('session-1', {
+        model: 'claude-opus-4-6',
+        pendingModel: 'claude-opus-4-6',
+      });
+    });
   });
 
   describe('updateSessionStatus', () => {

--- a/packages/web/src/stores/sessions/sessionActions.js
+++ b/packages/web/src/stores/sessions/sessionActions.js
@@ -206,6 +206,15 @@ export const sessionActions = {
     try {
       const updateData = { model };
       if (providerId !== undefined) updateData.providerId = providerId;
+
+      // For draft sessions, also update pendingModel so the backend
+      // fallback chain in draftSessionService.startDraft() stays in sync
+      const session = this.sessions.find(s => s.id === sessionId)
+        || (this.currentSession?.id === sessionId ? this.currentSession : null);
+      if (session && session.status === 'waiting') {
+        updateData.pendingModel = model;
+      }
+
       const updated = await api.updateSession(sessionId, updateData);
       this._updateSessionInAllLists(sessionId, updateData);
       return updated;

--- a/tests/e2e/draft-session-model-ui.spec.ts
+++ b/tests/e2e/draft-session-model-ui.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  cleanupCreatedResources,
+  getSession,
+  API_URL,
+} from './helpers';
+
+/**
+ * E2E tests for: Draft session model dropdown → PATCH sync
+ *
+ * Bug: When a user creates a draft session (via SessionTreeOverlay or API),
+ * then changes the model dropdown before sending the first message, the session
+ * starts with the wrong model. This happens because:
+ *   1. handleFormSubmit() reads session.pendingModel instead of the UI dropdown value
+ *   2. updateSessionModel() doesn't sync pendingModel for draft sessions
+ *
+ * These tests verify the UI-level fix: changing the model dropdown on a draft
+ * session correctly updates both model and pendingModel on the server.
+ */
+test.describe('Draft session model dropdown sync', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+    project = await seedProject('Draft Model UI Test', '/tmp/test-draft-model-ui');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('changing model dropdown on draft session syncs both model and pendingModel', async ({ page }) => {
+    // Use built-in model IDs that match the provider's actual models
+    const initialModel = 'claude-sonnet-4-6';
+    const targetModel = 'claude-opus-4-6';
+
+    // Create a draft session with a known model
+    const session = await seedSession(project.id, {
+      prompt: 'Test prompt for model dropdown sync',
+      model: initialModel,
+      startImmediately: false,
+      gitMode: 'none',
+      gitBranch: 'main',
+    });
+
+    // Verify initial state
+    const initialSession = await getSession(session.id);
+    expect(initialSession.model).toBe(initialModel);
+    expect(initialSession.pendingModel).toBe(initialModel);
+    expect(initialSession.status).toBe('waiting');
+
+    // Navigate to the session's conversation tab
+    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.waitForLoadState('networkidle');
+
+    // Wait for the model selector to appear and be populated
+    const modelSelect = page.locator('#model-select');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for the dropdown to have the initial model selected
+    await page.waitForFunction(
+      (expectedModel) => {
+        const select = document.querySelector('#model-select') as HTMLSelectElement;
+        return select && select.value === expectedModel;
+      },
+      initialModel,
+      { timeout: 10000 }
+    );
+
+    // Verify the dropdown shows the creation model
+    const initialValue = await modelSelect.inputValue();
+    expect(initialValue).toBe(initialModel);
+
+    // Check that the target model is available as an option
+    const hasTarget = await page.evaluate((targetId) => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      return Array.from(select.options).some(opt => opt.value === targetId);
+    }, targetModel);
+
+    if (!hasTarget) {
+      test.skip();
+      return;
+    }
+
+    // Set up a promise to wait for the PATCH response
+    const patchPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/api/sessions/') && resp.request().method() === 'PATCH',
+      { timeout: 10000 }
+    );
+
+    // Change the model dropdown to opus
+    await modelSelect.selectOption(targetModel);
+
+    // Wait for the PATCH to complete
+    await patchPromise;
+
+    // Give a brief moment for the server to process
+    await page.waitForTimeout(500);
+
+    // Fetch the session via API and verify both fields were updated
+    const updatedSession = await getSession(session.id);
+    expect(updatedSession.model).toBe(targetModel);
+    expect(updatedSession.pendingModel).toBe(targetModel);
+  });
+
+  test('model dropdown value persists after page reload on draft session', async ({ page }) => {
+    const initialModel = 'claude-sonnet-4-6';
+    const targetModel = 'claude-opus-4-6';
+
+    // Create a draft session with a known model
+    const session = await seedSession(project.id, {
+      prompt: 'Test model persistence after reload',
+      model: initialModel,
+      startImmediately: false,
+      gitMode: 'none',
+      gitBranch: 'main',
+    });
+
+    // Navigate to the session
+    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.waitForLoadState('networkidle');
+
+    const modelSelect = page.locator('#model-select');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for model to be initialized
+    await page.waitForFunction(
+      (expectedModel) => {
+        const select = document.querySelector('#model-select') as HTMLSelectElement;
+        return select && select.value === expectedModel;
+      },
+      initialModel,
+      { timeout: 10000 }
+    );
+
+    // Check that the target model is available
+    const hasTarget = await page.evaluate((targetId) => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      return Array.from(select.options).some(opt => opt.value === targetId);
+    }, targetModel);
+
+    if (!hasTarget) {
+      test.skip();
+      return;
+    }
+
+    // Change model to opus and wait for PATCH
+    const patchPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/api/sessions/') && resp.request().method() === 'PATCH',
+      { timeout: 10000 }
+    );
+    await modelSelect.selectOption(targetModel);
+    await patchPromise;
+    await page.waitForTimeout(500);
+
+    // Reload the page
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Wait for model selector to appear again
+    const modelSelectAfterReload = page.locator('#model-select');
+    await expect(modelSelectAfterReload).toBeVisible({ timeout: 10000 });
+
+    // Wait for the dropdown to have the updated model
+    await page.waitForFunction(
+      (expectedModel) => {
+        const select = document.querySelector('#model-select') as HTMLSelectElement;
+        return select && select.value === expectedModel;
+      },
+      targetModel,
+      { timeout: 10000 }
+    );
+
+    // Verify the model persisted after reload
+    const valueAfterReload = await modelSelectAfterReload.inputValue();
+    expect(valueAfterReload).toBe(targetModel);
+  });
+});


### PR DESCRIPTION
## Summary
- **Fixed bug** where changing the model dropdown on a draft session before sending the first message would start the session with the wrong (original) model
- **Root cause**: `handleFormSubmit()` read from `session.pendingModel` instead of the UI dropdown state (`selectedModel.value`), and `updateSessionModel()` didn't sync `pendingModel` for draft sessions
- **Fix**: Prioritize `selectedModel.value` in `handleFormSubmit()` and sync `pendingModel` when updating model on waiting sessions

## Test plan
- [ ] Unit tests pass for model priority in `handleFormSubmit()` (ConversationTab.model-init.test.js)
- [ ] Unit tests pass for `pendingModel` sync in `updateSessionModel()` (sessions.test.js)
- [ ] E2E tests verify model dropdown changes sync both `model` and `pendingModel` on the server
- [ ] E2E tests verify model persists after page reload on draft sessions
- [ ] Full E2E test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)