### PR TITLE
Show running indicator and live output for child sessions on session list

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -31,12 +31,13 @@ vi.mock('../stores/commandButtons.js', () => ({
 }));
 
 // Mock sessions store
+const mockSessionsStoreData = {
+  sessions: [],
+  commandRunVersion: 0,
+  toggleSessionStar: vi.fn(),
+};
 vi.mock('../stores/sessions.js', () => ({
-  useSessionsStore: vi.fn(() => ({
-    sessions: [],
-    commandRunVersion: 0,
-    toggleSessionStar: vi.fn(),
-  })),
+  useSessionsStore: vi.fn(() => mockSessionsStoreData),
 }));
 
 // Mock kanban store
@@ -73,9 +74,9 @@ vi.mock('./PrIndicators.vue', () => ({
 vi.mock('./SessionLogStream.vue', () => ({
   default: defineComponent({
     name: 'SessionLogStream',
-    props: ['sessionId'],
+    props: ['sessionIds'],
     setup(props) {
-      return () => h('div', { class: 'session-log-stream-mock', 'data-session-id': props.sessionId });
+      return () => h('div', { class: 'session-log-stream-mock', 'data-session-ids': JSON.stringify(props.sessionIds) });
     },
   }),
 }));
@@ -104,6 +105,10 @@ describe('SessionCard', () => {
     // Reset and configure API mock
     mockApi.getSessionFilesCount.mockReset();
     mockApi.getSessionFilesCount.mockResolvedValue({ count: 0 });
+
+    // Reset sessions store mock data
+    mockSessionsStoreData.sessions = [];
+    mockSessionsStoreData.commandRunVersion = 0;
   });
   const baseSession = {
     id: 'session-123',
@@ -422,6 +427,28 @@ describe('SessionCard', () => {
       expect(sessionMeta.exists()).toBe(true);
       // The .status-error class should not be present
       expect(wrapper.find('.status-error').exists()).toBe(false);
+    });
+
+    it('shows running badge when child session is running but parent is not', () => {
+      mockSessionsStoreData.sessions = [
+        { id: 'child-1', parentSessionId: baseSession.id, status: 'running' },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'waiting' },
+      });
+      expect(wrapper.find('.status-running').exists()).toBe(true);
+    });
+
+    it('does NOT show running badge when all children are completed', () => {
+      mockSessionsStoreData.sessions = [
+        { id: 'child-1', parentSessionId: baseSession.id, status: 'completed' },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'completed' },
+      });
+      expect(wrapper.find('.status-running').exists()).toBe(false);
     });
   });
 
@@ -974,12 +1001,38 @@ describe('SessionCard', () => {
       expect(wrapper.find('.session-log-stream-mock').exists()).toBe(false);
     });
 
-    it('passes correct session.id as sessionId prop', () => {
+    it('passes correct session.id as sessionIds prop', () => {
       const wrapper = mountComponent({
         session: { ...baseSession, id: 'session-xyz', status: 'running' },
       });
       const logStream = wrapper.find('.session-log-stream-mock');
-      expect(logStream.attributes('data-session-id')).toBe('session-xyz');
+      expect(JSON.parse(logStream.attributes('data-session-ids'))).toEqual(['session-xyz']);
+    });
+
+    it('renders SessionLogStream when child session is running but parent is not', () => {
+      mockSessionsStoreData.sessions = [
+        { id: 'child-1', parentSessionId: baseSession.id, status: 'running' },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'waiting' },
+      });
+      expect(wrapper.find('.session-log-stream-mock').exists()).toBe(true);
+      expect(JSON.parse(wrapper.find('.session-log-stream-mock').attributes('data-session-ids'))).toEqual(['child-1']);
+    });
+
+    it('includes both parent and child IDs when both are running', () => {
+      mockSessionsStoreData.sessions = [
+        { id: 'child-1', parentSessionId: baseSession.id, status: 'running' },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+      expect(wrapper.find('.session-log-stream-mock').exists()).toBe(true);
+      const sessionIds = JSON.parse(wrapper.find('.session-log-stream-mock').attributes('data-session-ids'));
+      expect(sessionIds).toContain(baseSession.id);
+      expect(sessionIds).toContain('child-1');
     });
   });
 

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -94,10 +94,10 @@
         @retry-summary="$emit('retrySummary', session.id)"
       />
 
-      <!-- Streaming log output for running sessions -->
+      <!-- Streaming log output for running sessions (root or children) -->
       <SessionLogStream
-        v-if="isRunning"
-        :session-id="session.id"
+        v-if="hasRunningSession"
+        :session-ids="runningSessionIds"
         data-testid="session-log-stream"
       />
     </router-link>
@@ -193,23 +193,52 @@ const onAddToBoardClick = () => {
   emit('addToBoard', props.session);
 };
 
-const isRunning = computed(() => ['running', 'starting'].includes(props.session.status));
-
 const dateToShow = computed(() => {
   return props.session.lastActivityAt || props.session.updatedAt || props.session.createdAt;
 });
 
-// Get individual session status for display
+// Get workflow status including child sessions
 const workflowStatus = computed(() => {
-  const status = props.session.status;
+  const rootStatus = props.session.status;
   const runningStatuses = ['running', 'starting'];
+
+  // Find child sessions from the store
+  const children = sessionsStore.sessions.filter(
+    s => s.parentSessionId === props.session.id,
+  );
+
+  // Count running sessions (root + children)
+  let runningCount = runningStatuses.includes(rootStatus) ? 1 : 0;
+  runningCount += children.filter(c => runningStatuses.includes(c.status)).length;
+
+  // Count scheduled sessions (root + children)
+  let scheduledCount = rootStatus === 'scheduled' ? 1 : 0;
+  scheduledCount += children.filter(c => c.status === 'scheduled').length;
+
   return {
-    runningCount: runningStatuses.includes(status) ? 1 : 0,
-    scheduledCount: status === 'scheduled' ? 1 : 0,
-    totalCount: 1,
-    effectiveStatus: status,
+    runningCount,
+    scheduledCount,
+    totalCount: 1 + children.length,
+    effectiveStatus: rootStatus,
   };
 });
+
+// Collect all running/starting session IDs in the workflow (root + children)
+const runningSessionIds = computed(() => {
+  const ids = [];
+  if (['running', 'starting'].includes(props.session.status)) {
+    ids.push(props.session.id);
+  }
+  // Find running child sessions from the store
+  const children = sessionsStore.sessions.filter(
+    s => s.parentSessionId === props.session.id
+      && ['running', 'starting'].includes(s.status),
+  );
+  children.forEach(c => ids.push(c.id));
+  return ids;
+});
+
+const hasRunningSession = computed(() => runningSessionIds.value.length > 0);
 
 // Scheduled time display (for this specific session when it's scheduled)
 const scheduledTimeDisplay = computed(() => {

--- a/packages/web/src/components/SessionLogStream.test.js
+++ b/packages/web/src/components/SessionLogStream.test.js
@@ -31,7 +31,7 @@ describe('SessionLogStream', () => {
 
   function mountComponent(props = {}) {
     return mount(SessionLogStream, {
-      props: { sessionId: 'session-1', ...props },
+      props: { sessionIds: ['session-1'], ...props },
       global: {
         plugins: [createPinia()],
       },
@@ -136,12 +136,12 @@ describe('SessionLogStream', () => {
   });
 
   describe('interaction', () => {
-    it('clicking collapse toggle calls toggleSessionLogCollapsed with correct sessionId', async () => {
+    it('clicking collapse toggle calls toggleSessionLogCollapsed with first sessionId', async () => {
       mockStreamingStore.getSessionWorkLogs.mockReturnValue([
         { id: '1', type: 'tool_use', tool: 'Read', summary: 'test' },
       ]);
 
-      const wrapper = mountComponent({ sessionId: 'session-42' });
+      const wrapper = mountComponent({ sessionIds: ['session-42'] });
       await wrapper.find('.log-header').trigger('click');
 
       expect(mockStreamingStore.toggleSessionLogCollapsed).toHaveBeenCalledWith('session-42');
@@ -153,10 +153,72 @@ describe('SessionLogStream', () => {
       ]);
       mockStreamingStore.isSessionLogCollapsed.mockReturnValue(true);
 
-      const wrapper = mountComponent({ sessionId: 'session-42' });
+      const wrapper = mountComponent({ sessionIds: ['session-42'] });
       await wrapper.find('.log-collapsed').trigger('click');
 
       expect(mockStreamingStore.toggleSessionLogCollapsed).toHaveBeenCalledWith('session-42');
+    });
+  });
+
+  describe('multiple sessionIds', () => {
+    it('merges work logs from multiple sessions', () => {
+      mockStreamingStore.getSessionWorkLogs.mockImplementation((id) => {
+        if (id === 'session-a') return [{ id: 'a1', type: 'tool_use', tool: 'Read', summary: 'From A' }];
+        if (id === 'session-b') return [{ id: 'b1', type: 'tool_use', tool: 'Write', summary: 'From B' }];
+        return [];
+      });
+
+      const wrapper = mountComponent({ sessionIds: ['session-a', 'session-b'] });
+      const entries = wrapper.findAll('.log-entry');
+      expect(entries).toHaveLength(2);
+    });
+
+    it('caps merged logs at 15 entries', () => {
+      const logsA = Array.from({ length: 10 }, (_, i) => ({ id: `a${i}`, type: 'tool_use', tool: 'Read', summary: `A${i}` }));
+      const logsB = Array.from({ length: 10 }, (_, i) => ({ id: `b${i}`, type: 'tool_use', tool: 'Write', summary: `B${i}` }));
+
+      mockStreamingStore.getSessionWorkLogs.mockImplementation((id) => {
+        if (id === 'session-a') return logsA;
+        if (id === 'session-b') return logsB;
+        return [];
+      });
+
+      const wrapper = mountComponent({ sessionIds: ['session-a', 'session-b'] });
+      const entries = wrapper.findAll('.log-entry');
+      expect(entries).toHaveLength(15);
+    });
+
+    it('shows partial text from the first session that has it', () => {
+      mockStreamingStore.getSessionPartialText.mockImplementation((id) => {
+        if (id === 'session-a') return '';
+        if (id === 'session-b') return 'Partial from B';
+        return '';
+      });
+
+      const wrapper = mountComponent({ sessionIds: ['session-a', 'session-b'] });
+      expect(wrapper.find('.log-partial').text()).toBe('Partial from B');
+    });
+
+    it('shows thinking from the first session that has it', () => {
+      mockStreamingStore.getPartialThinking.mockImplementation((id) => {
+        if (id === 'session-a') return null;
+        if (id === 'session-b') return 'Thinking from B';
+        return null;
+      });
+
+      const wrapper = mountComponent({ sessionIds: ['session-a', 'session-b'] });
+      expect(wrapper.find('.log-thinking').text()).toBe('Thinking from B');
+    });
+
+    it('uses first sessionId for collapse state', () => {
+      mockStreamingStore.getSessionWorkLogs.mockReturnValue([
+        { id: '1', type: 'tool_use', tool: 'Read', summary: 'test' },
+      ]);
+      mockStreamingStore.isSessionLogCollapsed.mockImplementation((id) => id === 'root-session');
+
+      const wrapper = mountComponent({ sessionIds: ['root-session', 'child-session'] });
+      expect(wrapper.find('.session-log-stream').exists()).toBe(false);
+      expect(wrapper.find('.log-collapsed').exists()).toBe(true);
     });
   });
 });

--- a/packages/web/src/components/SessionLogStream.vue
+++ b/packages/web/src/components/SessionLogStream.vue
@@ -58,15 +58,41 @@ import { computed } from 'vue';
 import { useSessionStreamingStore } from '../stores/sessionStreaming.js';
 
 const props = defineProps({
-  sessionId: { type: String, required: true },
+  sessionIds: { type: Array, required: true },
 });
 
 const streamingStore = useSessionStreamingStore();
 
-const recentLogs = computed(() => streamingStore.getSessionWorkLogs(props.sessionId));
-const partialText = computed(() => streamingStore.getSessionPartialText(props.sessionId));
-const thinking = computed(() => streamingStore.getPartialThinking(props.sessionId));
-const isCollapsed = computed(() => streamingStore.isSessionLogCollapsed(props.sessionId));
+// Merge work logs from all running sessions
+const recentLogs = computed(() => {
+  const allLogs = props.sessionIds.flatMap(
+    id => streamingStore.getSessionWorkLogs(id),
+  );
+  return allLogs.slice(-15);
+});
+
+// Show partial text from the first session that has it
+const partialText = computed(() => {
+  for (const id of props.sessionIds) {
+    const text = streamingStore.getSessionPartialText(id);
+    if (text) return text;
+  }
+  return '';
+});
+
+// Show thinking from the first session that has it
+const thinking = computed(() => {
+  for (const id of props.sessionIds) {
+    const t = streamingStore.getPartialThinking(id);
+    if (t) return t;
+  }
+  return '';
+});
+
+// Collapsed state uses the root session ID (first in array)
+const isCollapsed = computed(() =>
+  streamingStore.isSessionLogCollapsed(props.sessionIds[0]),
+);
 
 const hasContent = computed(() => recentLogs.value.length > 0 || partialText.value || thinking.value);
 
@@ -81,7 +107,7 @@ const partialTextPreview = computed(() => {
 });
 
 function toggleCollapse() {
-  streamingStore.toggleSessionLogCollapsed(props.sessionId);
+  streamingStore.toggleSessionLogCollapsed(props.sessionIds[0]);
 }
 </script>
 

--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -397,8 +397,8 @@ describe('SummaryTab', () => {
             WhatJustHappenedCard: { template: '<div class="what-just-happened-card-stub"></div>' },
             SessionLogStream: {
               name: 'SessionLogStream',
-              props: ['sessionId'],
-              template: '<div class="session-log-stream-stub">{{ sessionId }}</div>',
+              props: ['sessionIds'],
+              template: '<div class="session-log-stream-stub">{{ sessionIds }}</div>',
             },
           },
         },
@@ -407,7 +407,7 @@ describe('SummaryTab', () => {
 
       const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
       expect(logStream.exists()).toBe(true);
-      expect(logStream.props('sessionId')).toBe('sess-456');
+      expect(logStream.props('sessionIds')).toEqual(['sess-456']);
     });
 
     it('unmounts SessionLogStream when session status changes from running to completed', async () => {

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -3,7 +3,7 @@
     <!-- Live output for running sessions -->
     <SessionLogStream
       v-if="isRunning"
-      :session-id="sessionId"
+      :session-ids="[sessionId]"
     />
 
     <!-- Session Overview Section -->

--- a/packages/web/src/components/WorkflowSessionItem.test.js
+++ b/packages/web/src/components/WorkflowSessionItem.test.js
@@ -17,9 +17,9 @@ vi.mock('../stores/templates.js', () => ({
 vi.mock('./SessionLogStream.vue', () => ({
   default: defineComponent({
     name: 'SessionLogStream',
-    props: ['sessionId'],
+    props: ['sessionIds'],
     setup(props) {
-      return () => h('div', { class: 'session-log-stream-mock', 'data-session-id': props.sessionId });
+      return () => h('div', { class: 'session-log-stream-mock', 'data-session-ids': JSON.stringify(props.sessionIds) });
     },
   }),
 }));
@@ -400,10 +400,10 @@ describe('WorkflowSessionItem', () => {
       expect(wrapper.find('.session-log-stream-mock').exists()).toBe(false);
     });
 
-    it('passes correct session.id as sessionId prop', () => {
+    it('passes correct session.id as sessionIds prop', () => {
       const wrapper = mountComponent({ id: 'child-session-42', status: 'running' });
       const logStream = wrapper.find('.session-log-stream-mock');
-      expect(logStream.attributes('data-session-id')).toBe('child-session-42');
+      expect(JSON.parse(logStream.attributes('data-session-ids'))).toEqual(['child-session-42']);
     });
   });
 });

--- a/packages/web/src/components/WorkflowSessionItem.vue
+++ b/packages/web/src/components/WorkflowSessionItem.vue
@@ -35,7 +35,7 @@
     <!-- Streaming log output for running child sessions -->
     <SessionLogStream
       v-if="isRunning"
-      :session-id="session.id"
+      :session-ids="[session.id]"
     />
   </div>
 

--- a/tests/e2e/child-session-live-output.spec.ts
+++ b/tests/e2e/child-session-live-output.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  seedChildSession,
+  seedWorkLog,
+  cleanupCreatedResources,
+  navigateAndWait,
+  updateSessionStatus,
+  waitForSessionToExist,
+} from './helpers';
+
+test.describe('Child Session Live Output on Session List', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+    project = await seedProject('Child Live Output', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('running badge appears on parent card when child session is running', async ({ page }) => {
+    // Create parent session
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent task',
+      name: 'Parent Session',
+    });
+    await waitForSessionToExist(parent.id);
+    await updateSessionStatus(parent.id, 'waiting');
+
+    // Create a child session and set it to running
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child task',
+      name: 'Child Session',
+    });
+    await waitForSessionToExist(child.id);
+    await updateSessionStatus(child.id, 'running');
+
+    // Navigate to session list
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.session-card',
+    });
+
+    // The parent card should display a "running" status badge
+    // because its child is running
+    const runningBadge = page.locator('.status-running');
+    await expect(runningBadge).toBeVisible({ timeout: 15000 });
+    await expect(runningBadge).toContainText('running');
+  });
+
+  test('live output appears on parent card when child session emits work logs', async ({ page }) => {
+    // Create parent session (NOT running)
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent task',
+      name: 'Parent Session',
+    });
+    await waitForSessionToExist(parent.id);
+    await updateSessionStatus(parent.id, 'waiting');
+
+    // Create a running child session
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child task',
+      name: 'Child Session',
+    });
+    await waitForSessionToExist(child.id);
+    await updateSessionStatus(child.id, 'running');
+
+    // Navigate to session list
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.session-card',
+    });
+
+    // Seed a work log on the child session
+    await seedWorkLog(child.id, {
+      type: 'tool_input',
+      content: JSON.stringify({ command: 'git status' }),
+      toolName: 'Bash',
+    });
+
+    // The live output pane should be visible on the parent card
+    const logStream = page.locator('.session-log-stream');
+    await expect(logStream).toBeVisible({ timeout: 15000 });
+
+    // Verify the "Live Output" header
+    const headerLabel = page.locator('.log-header-label');
+    await expect(headerLabel).toHaveText('Live Output');
+
+    // Verify at least one log entry rendered
+    const logEntry = page.locator('.log-entry');
+    await expect(async () => {
+      const count = await logEntry.count();
+      expect(count).toBeGreaterThanOrEqual(1);
+    }).toPass({ timeout: 10000 });
+  });
+
+  test('no running badge or live output when parent and children are all stopped', async ({ page }) => {
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent task',
+      name: 'Parent Session',
+    });
+    await waitForSessionToExist(parent.id);
+    await updateSessionStatus(parent.id, 'stopped');
+
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child task',
+      name: 'Child Session',
+    });
+    await waitForSessionToExist(child.id);
+    await updateSessionStatus(child.id, 'stopped');
+
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.session-card',
+    });
+
+    // No running badge should appear
+    const runningBadge = page.locator('.status-running');
+    await expect(runningBadge).toHaveCount(0);
+
+    // No live output pane should appear
+    const logStream = page.locator('.session-log-stream');
+    await expect(logStream).toHaveCount(0);
+  });
+
+  test('running badge and live output still work for a running parent session', async ({ page }) => {
+    const parent = await seedSession(project.id, {
+      prompt: 'Running parent',
+      name: 'Running Parent',
+    });
+    await waitForSessionToExist(parent.id);
+    await updateSessionStatus(parent.id, 'running');
+
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.session-card',
+    });
+
+    // Running badge should appear
+    const runningBadge = page.locator('.status-running');
+    await expect(runningBadge).toBeVisible({ timeout: 15000 });
+
+    // Seed work log on parent
+    await seedWorkLog(parent.id, {
+      type: 'tool_input',
+      content: JSON.stringify({ command: 'echo hello' }),
+      toolName: 'Bash',
+    });
+
+    // Live output should appear
+    const logStream = page.locator('.session-log-stream');
+    await expect(logStream).toBeVisible({ timeout: 15000 });
+  });
+
+  test('work logs from multiple running children appear in live output', async ({ page }) => {
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent task',
+      name: 'Parent Session',
+    });
+    await waitForSessionToExist(parent.id);
+    await updateSessionStatus(parent.id, 'waiting');
+
+    // Create two running child sessions
+    const child1 = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child 1',
+      name: 'Child 1',
+    });
+    await waitForSessionToExist(child1.id);
+    await updateSessionStatus(child1.id, 'running');
+
+    const child2 = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child 2',
+      name: 'Child 2',
+    });
+    await waitForSessionToExist(child2.id);
+    await updateSessionStatus(child2.id, 'running');
+
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.session-card',
+    });
+
+    // Seed work logs on both children
+    await seedWorkLog(child1.id, {
+      type: 'tool_input',
+      content: JSON.stringify({ command: 'ls' }),
+      toolName: 'Bash',
+    });
+    await new Promise(r => setTimeout(r, 100));
+    await seedWorkLog(child2.id, {
+      type: 'tool_input',
+      content: JSON.stringify({ file: 'README.md' }),
+      toolName: 'Read',
+    });
+
+    // Live output should appear
+    const logStream = page.locator('.session-log-stream');
+    await expect(logStream).toBeVisible({ timeout: 15000 });
+
+    // Should have at least 2 log entries (one from each child)
+    const logEntries = page.locator('.log-entry');
+    await expect(async () => {
+      const count = await logEntries.count();
+      expect(count).toBeGreaterThanOrEqual(2);
+    }).toPass({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary
- **SessionCard** now checks child session statuses from the sessions store, so the running badge and `SessionLogStream` pane appear on a parent card whenever any child is running/starting
- **SessionLogStream** accepts a `sessionIds` array prop and merges work logs, partial text, and thinking from all running sessions in the workflow
- Updated all consumers (`SummaryTab`, `WorkflowSessionItem`) to pass the new array prop

## Test plan
- [x] All 3800 unit tests pass (132 test files)
- [x] 5 new E2E tests covering: running badge for child, live output for child, no false positives, parent regression, merged multi-child logs
- [x] Existing live output persistence E2E tests pass (5/5)
- [x] Existing summary tab + hierarchy E2E tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)