### PR TITLE
Fix session tree picker showing only 2 sessions instead of full tree

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.test.js
+++ b/packages/web/src/components/SessionTreeOverlay.test.js
@@ -123,10 +123,10 @@ vi.mock('./SessionTreePicker.vue', () => ({
         'data-testid': 'session-tree-picker',
       }, this.sessions?.map(s =>
         h('div', {
-          key: s.id,
+          key: s.session.id,
           role: 'option',
-          onClick: () => this.$emit('select', s.id),
-        }, s.name)
+          onClick: () => this.$emit('select', s.session.id),
+        }, s.session.name)
       ));
     },
   }),
@@ -526,7 +526,7 @@ describe('SessionTreeOverlay', () => {
       projectId: 'proj-123',
     };
 
-    const chainSessions = [rootSession, childSession];
+    const chainSessions = [{ session: rootSession, depth: 0 }, { session: childSession, depth: 1 }];
     const chainSummaries = {
       'sess-root': { shortSummary: 'Root summary' },
       'child-1': { shortSummary: 'Child summary' },
@@ -551,7 +551,7 @@ describe('SessionTreeOverlay', () => {
       const wrapper = mount(SessionTreeOverlay, {
         props: {
           sessionId: 'sess-root',
-          sessionChain: [rootSession],
+          sessionChain: [{ session: rootSession, depth: 0 }],
           summariesMap: {},
         },
         global: { plugins: [router] },
@@ -739,7 +739,7 @@ describe('SessionTreeOverlay', () => {
       const wrapper = mount(SessionTreeOverlay, {
         props: {
           sessionId: 'sess-root',
-          sessionChain: [rootSession, child],
+          sessionChain: [{ session: rootSession, depth: 0 }, { session: child, depth: 1 }],
           summariesMap: {},
         },
         global: { plugins: [router] },

--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -319,7 +319,7 @@ const rootSession = computed(() => {
 
 const rootSessionName = computed(() => {
   // Use sessionChain root if available (most reliable after buildSessionChain)
-  if (props.sessionChain.length > 0) return props.sessionChain[0].name || 'Session';
+  if (props.sessionChain.length > 0) return props.sessionChain[0].session?.name || 'Session';
   return rootSession.value?.name || sessionsStore.currentSession?.name || 'Session';
 });
 

--- a/packages/web/src/components/SessionTreePicker.test.js
+++ b/packages/web/src/components/SessionTreePicker.test.js
@@ -11,25 +11,34 @@ describe('SessionTreePicker', () => {
 
     sessions = [
       {
-        id: 'root-1',
-        name: 'Root Session',
-        status: 'completed',
-        createdAt: Date.now() - 7200000,
-        lastActivityAt: Date.now() - 3600000,
+        session: {
+          id: 'root-1',
+          name: 'Root Session',
+          status: 'completed',
+          createdAt: Date.now() - 7200000,
+          lastActivityAt: Date.now() - 3600000,
+        },
+        depth: 0,
       },
       {
-        id: 'child-1',
-        name: 'Child Session 1',
-        status: 'running',
-        createdAt: Date.now() - 3600000,
-        lastActivityAt: Date.now() - 1800000,
+        session: {
+          id: 'child-1',
+          name: 'Child Session 1',
+          status: 'running',
+          createdAt: Date.now() - 3600000,
+          lastActivityAt: Date.now() - 1800000,
+        },
+        depth: 1,
       },
       {
-        id: 'child-2',
-        name: 'Child Session 2',
-        status: 'waiting',
-        createdAt: Date.now() - 1800000,
-        lastActivityAt: Date.now() - 900000,
+        session: {
+          id: 'child-2',
+          name: 'Child Session 2',
+          status: 'waiting',
+          createdAt: Date.now() - 1800000,
+          lastActivityAt: Date.now() - 900000,
+        },
+        depth: 1,
       },
     ];
 
@@ -77,22 +86,26 @@ describe('SessionTreePicker', () => {
       });
     });
 
-    it('all items have consistent padding', () => {
+    it('items have depth-based padding', () => {
       const wrapper = mountComponent();
       const items = wrapper.findAll('.picker-item');
-      // All items should have the same padding-left
-      items.forEach(item => {
-        expect(item.attributes('style')).toContain('padding-left: 0.5rem');
-      });
+      // Root (depth 0) should have 0.5rem padding
+      expect(items[0].attributes('style')).toContain('padding-left: 0.5rem');
+      // Children (depth 1) should have 1.5rem padding
+      expect(items[1].attributes('style')).toContain('padding-left: 1.5rem');
+      expect(items[2].attributes('style')).toContain('padding-left: 1.5rem');
     });
 
     it('renders correctly with single session (no children)', () => {
       const singleSession = [{
-        id: 'single-1',
-        name: 'Only Session',
-        status: 'completed',
-        createdAt: Date.now(),
-        lastActivityAt: Date.now(),
+        session: {
+          id: 'single-1',
+          name: 'Only Session',
+          status: 'completed',
+          createdAt: Date.now(),
+          lastActivityAt: Date.now(),
+        },
+        depth: 0,
       }];
       const wrapper = mount(SessionTreePicker, {
         props: {
@@ -111,9 +124,9 @@ describe('SessionTreePicker', () => {
 
     it('status badges display correctly without hierarchy labels', () => {
       const sessionsWithStatuses = [
-        { id: 's1', name: 'Session 1', status: 'running', createdAt: Date.now(), lastActivityAt: Date.now() },
-        { id: 's2', name: 'Session 2', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() },
-        { id: 's3', name: 'Session 3', status: 'error', createdAt: Date.now(), lastActivityAt: Date.now() },
+        { session: { id: 's1', name: 'Session 1', status: 'running', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 0 },
+        { session: { id: 's2', name: 'Session 2', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
+        { session: { id: 's3', name: 'Session 3', status: 'error', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
       ];
       const wrapper = mount(SessionTreePicker, {
         props: {
@@ -132,13 +145,16 @@ describe('SessionTreePicker', () => {
       expect(items[2].find('.picker-item-status').exists()).toBe(false);
     });
 
-    it('all items have consistent alignment regardless of count', () => {
+    it('all items at the same depth have consistent alignment', () => {
       const manySessions = Array.from({ length: 10 }, (_, i) => ({
-        id: `s-${i}`,
-        name: `Session ${i}`,
-        status: 'completed',
-        createdAt: Date.now() - (i * 1000000),
-        lastActivityAt: Date.now() - (i * 500000),
+        session: {
+          id: `s-${i}`,
+          name: `Session ${i}`,
+          status: 'completed',
+          createdAt: Date.now() - (i * 1000000),
+          lastActivityAt: Date.now() - (i * 500000),
+        },
+        depth: 1,
       }));
       const wrapper = mount(SessionTreePicker, {
         props: {
@@ -150,9 +166,9 @@ describe('SessionTreePicker', () => {
 
       const items = wrapper.findAll('.picker-item');
       expect(items).toHaveLength(10);
-      // All items should have the same padding-left regardless of position
+      // All items at depth 1 should have the same padding-left
       items.forEach(item => {
-        expect(item.attributes('style')).toContain('padding-left: 0.5rem');
+        expect(item.attributes('style')).toContain('padding-left: 1.5rem');
       });
     });
 
@@ -167,12 +183,32 @@ describe('SessionTreePicker', () => {
     it('truncates long session names with CSS', () => {
       const longName = 'A'.repeat(100);
       const wrapper = mountComponent({
-        sessions: [{ ...sessions[0], name: longName }],
+        sessions: [{ session: { ...sessions[0].session, name: longName }, depth: 0 }],
       });
       const nameEl = wrapper.find('.picker-item-name');
       expect(nameEl.text()).toBe(longName);
       // The CSS class should apply text-overflow: ellipsis
       expect(nameEl.classes()).toContain('picker-item-name');
+    });
+
+    it('deeper items have more indentation', () => {
+      const deepSessions = [
+        { session: { id: 'd0', name: 'Root', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 0 },
+        { session: { id: 'd1', name: 'Child', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
+        { session: { id: 'd2', name: 'Grandchild', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 2 },
+      ];
+      const wrapper = mount(SessionTreePicker, {
+        props: {
+          sessions: deepSessions,
+          activeSessionId: 'd0',
+          summaries: {},
+        },
+      });
+
+      const items = wrapper.findAll('.picker-item');
+      expect(items[0].attributes('style')).toContain('padding-left: 0.5rem');
+      expect(items[1].attributes('style')).toContain('padding-left: 1.5rem');
+      expect(items[2].attributes('style')).toContain('padding-left: 2.5rem');
     });
   });
 
@@ -227,7 +263,7 @@ describe('SessionTreePicker', () => {
 
     it('shows ● Running for starting status', () => {
       const wrapper = mountComponent({
-        sessions: [{ ...sessions[0], status: 'starting' }],
+        sessions: [{ session: { ...sessions[0].session, status: 'starting' }, depth: 0 }],
       });
       const status = wrapper.find('.picker-item-status');
       expect(status.text()).toBe('● Running');
@@ -235,7 +271,7 @@ describe('SessionTreePicker', () => {
 
     it('shows ⏰ Scheduled for scheduled status', () => {
       const wrapper = mountComponent({
-        sessions: [{ ...sessions[0], status: 'scheduled' }],
+        sessions: [{ session: { ...sessions[0].session, status: 'scheduled' }, depth: 0 }],
       });
       const status = wrapper.find('.picker-item-status');
       expect(status.text()).toBe('⏰ Scheduled');
@@ -244,21 +280,21 @@ describe('SessionTreePicker', () => {
 
     it('shows no status badge for error status', () => {
       const wrapper = mountComponent({
-        sessions: [{ ...sessions[0], status: 'error' }],
+        sessions: [{ session: { ...sessions[0].session, status: 'error' }, depth: 0 }],
       });
       expect(wrapper.find('.picker-item-status').exists()).toBe(false);
     });
 
     it('shows no status badge for completed status', () => {
       const wrapper = mountComponent({
-        sessions: [{ ...sessions[0], status: 'completed' }],
+        sessions: [{ session: { ...sessions[0].session, status: 'completed' }, depth: 0 }],
       });
       expect(wrapper.find('.picker-item-status').exists()).toBe(false);
     });
 
     it('shows no status badge for waiting status', () => {
       const wrapper = mountComponent({
-        sessions: [{ ...sessions[0], status: 'waiting' }],
+        sessions: [{ session: { ...sessions[0].session, status: 'waiting' }, depth: 0 }],
       });
       expect(wrapper.find('.picker-item-status').exists()).toBe(false);
     });

--- a/packages/web/src/components/SessionTreePicker.vue
+++ b/packages/web/src/components/SessionTreePicker.vue
@@ -7,38 +7,38 @@
     @keydown="handleKeydown"
   >
     <div
-      v-for="(session, index) in sessions"
-      :key="session.id"
+      v-for="(entry, index) in sessions"
+      :key="entry.session.id"
       class="picker-item"
       :class="{
-        'picker-item--active': session.id === activeSessionId,
+        'picker-item--active': entry.session.id === activeSessionId,
       }"
-      :style="{ paddingLeft: '0.5rem' }"
+      :style="{ paddingLeft: `${0.5 + entry.depth * 1}rem` }"
       role="option"
-      :aria-selected="session.id === activeSessionId ? 'true' : 'false'"
+      :aria-selected="entry.session.id === activeSessionId ? 'true' : 'false'"
       :tabindex="index === focusedIndex ? 0 : -1"
       :ref="el => { if (el) itemRefs[index] = el }"
       :data-index="index"
-      @click="emit('select', session.id)"
-      @keydown.enter.prevent="emit('select', session.id)"
+      @click="emit('select', entry.session.id)"
+      @keydown.enter.prevent="emit('select', entry.session.id)"
     >
       <div class="picker-item-label">
         <span class="picker-item-role">
           {{ getRoleLabel(index) }}
         </span>
         <span
-          v-if="statusLabel(session)"
-          :class="['picker-item-status', `status-${session.status}`]"
+          v-if="statusLabel(entry.session)"
+          :class="['picker-item-status', `status-${entry.session.status}`]"
         >
-          {{ statusLabel(session) }}
+          {{ statusLabel(entry.session) }}
         </span>
       </div>
-      <div class="picker-item-name" :title="session.name">
-        {{ session.name }}
+      <div class="picker-item-name" :title="entry.session.name">
+        {{ entry.session.name }}
       </div>
       <div class="picker-item-meta">
-        <span class="picker-item-summary">{{ getSummaryText(session.id) }}</span>
-        <span class="picker-item-date">{{ formatDate(session.lastActivityAt || session.updatedAt || session.createdAt) }}</span>
+        <span class="picker-item-summary">{{ getSummaryText(entry.session.id) }}</span>
+        <span class="picker-item-date">{{ formatDate(entry.session.lastActivityAt || entry.session.updatedAt || entry.session.createdAt) }}</span>
       </div>
     </div>
   </div>
@@ -69,7 +69,7 @@ const itemRefs = ref({});
 
 onMounted(() => {
   // Focus the active session item initially
-  const activeIndex = props.sessions.findIndex(s => s.id === props.activeSessionId);
+  const activeIndex = props.sessions.findIndex(e => e.session.id === props.activeSessionId);
   if (activeIndex >= 0) {
     focusedIndex.value = activeIndex;
     nextTick(() => {

--- a/packages/web/src/stores/sessions/sessionActions.js
+++ b/packages/web/src/stores/sessions/sessionActions.js
@@ -73,6 +73,14 @@ export const sessionActions = {
         return;
       }
       this.currentSession = fetchedSession;
+      // Add the fetched session to the sessions array if not already present
+      // This ensures getSessionById() can find it for computed properties like activeSessionName
+      const existingIndex = this.sessions.findIndex((s) => s.id === id);
+      if (existingIndex !== -1) {
+        this.sessions[existingIndex] = fetchedSession;
+      } else {
+        this.sessions.push(fetchedSession);
+      }
       if (this.currentSession?.parentSessionId) {
         let parentId = this.currentSession.parentSessionId;
         while (parentId) {

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -3374,10 +3374,12 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      // sessionChain should be built with root and child
+      // sessionChain should be built with root and child as {session, depth} entries
       expect(wrapper.vm.sessionChain.length).toBe(2);
-      expect(wrapper.vm.sessionChain[0].id).toBe('parent-1');
-      expect(wrapper.vm.sessionChain[1].id).toBe('child-1');
+      expect(wrapper.vm.sessionChain[0].session.id).toBe('parent-1');
+      expect(wrapper.vm.sessionChain[0].depth).toBe(0);
+      expect(wrapper.vm.sessionChain[1].session.id).toBe('child-1');
+      expect(wrapper.vm.sessionChain[1].depth).toBe(1);
     });
 
     it('passes sessionChain and summariesMap to SessionTreeOverlay', async () => {
@@ -3495,9 +3497,10 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      // Session chain should now include the new child
+      // Session chain should now include the new child as {session, depth} entries
       expect(wrapper.vm.sessionChain.length).toBe(2);
-      expect(wrapper.vm.sessionChain[1].id).toBe('new-child');
+      expect(wrapper.vm.sessionChain[1].session.id).toBe('new-child');
+      expect(wrapper.vm.sessionChain[1].depth).toBe(1);
     });
 
     it('fetches summaries for sessions in the chain', async () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -142,8 +142,8 @@ const summariesMap = ref({});
 const hasDescendants = computed(() => sessionChain.value.length > 1);
 
 /**
- * Build the linear session chain from root to leaf.
- * Fetches project sessions and summaries for each session in the chain.
+ * Build the full session tree from root, flattened depth-first with depth info.
+ * Fetches project sessions and summaries for each session in the tree.
  */
 async function buildSessionChain() {
   const sessionId = currentSessionId.value;
@@ -184,37 +184,33 @@ async function buildSessionChain() {
     if (current && !current.parentSessionId) {
       root = current;
     } else if (current) {
-      sessionChain.value = [current];
+      sessionChain.value = [{ session: current, depth: 0 }];
       return;
     } else {
       return;
     }
   }
 
-  // Walk the chain from root through descendants
-  const chain = [root];
-  let currentId = root.id;
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const children = sessionsStore.getChildSessions(currentId);
-    if (children.length === 0) break;
-
-    // Follow the first child (linear chain)
-    const child = children[0];
-    chain.push(child);
-    currentId = child.id;
+  // Walk the full tree depth-first from root, collecting {session, depth} entries
+  const tree = [];
+  function walkTree(session, depth) {
+    tree.push({ session, depth });
+    const children = sessionsStore.getChildSessions(session.id);
+    for (const child of children) {
+      walkTree(child, depth + 1);
+    }
   }
+  walkTree(root, 0);
 
-  sessionChain.value = chain;
+  sessionChain.value = tree;
 
-  // Fetch summaries for all sessions in the chain (non-blocking)
-  for (const sess of chain) {
-    if (!summariesMap.value[sess.id]) {
-      api.getSessionSummary(sess.id)
+  // Fetch summaries for all sessions in the tree (non-blocking)
+  for (const entry of tree) {
+    if (!summariesMap.value[entry.session.id]) {
+      api.getSessionSummary(entry.session.id)
         .then(summary => {
           if (summary) {
-            summariesMap.value = { ...summariesMap.value, [sess.id]: summary };
+            summariesMap.value = { ...summariesMap.value, [entry.session.id]: summary };
           }
         })
         .catch(() => { /* Summaries are not critical */ });

--- a/tests/e2e/session-tree-overlay.spec.ts
+++ b/tests/e2e/session-tree-overlay.spec.ts
@@ -290,20 +290,13 @@ test.describe('Session Tree Overlay', () => {
       // Session names should still be displayed
       await expect(picker).toContainText('Parent Session');
 
-      // Verify all items are visible and have consistent alignment
+      // Verify all items are visible
       const items = picker.locator('[role="option"]');
       const count = await items.count();
       expect(count).toBeGreaterThanOrEqual(2);
-
-      // Check that all items have the same padding (no indentation)
-      const firstItemStyle = await items.nth(0).getAttribute('style');
-      for (let i = 1; i < count; i++) {
-        const itemStyle = await items.nth(i).getAttribute('style');
-        expect(itemStyle).toBe(firstItemStyle);
-      }
     });
 
-    test('all picker items have consistent left alignment', async ({ page }) => {
+    test('child picker items are indented more than parent', async ({ page }) => {
       const overlay = await openOverlay(page, parentSession.id);
 
       const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
@@ -318,17 +311,17 @@ test.describe('Session Tree Overlay', () => {
       const count = await items.count();
       expect(count).toBeGreaterThanOrEqual(2);
 
-      // Get the padding-left value from the first item
-      const firstItemPadding = await items.nth(0).evaluate(el => {
-        return window.getComputedStyle(el).paddingLeft;
+      // Get the padding-left value from the first item (root/parent at depth 0)
+      const parentPadding = await items.nth(0).evaluate(el => {
+        return parseFloat(window.getComputedStyle(el).paddingLeft);
       });
 
-      // Verify all items have the same padding-left
+      // Child items (depth 1+) should have more padding than the parent
       for (let i = 1; i < count; i++) {
-        const itemPadding = await items.nth(i).evaluate(el => {
-          return window.getComputedStyle(el).paddingLeft;
+        const childPadding = await items.nth(i).evaluate(el => {
+          return parseFloat(window.getComputedStyle(el).paddingLeft);
         });
-        expect(itemPadding).toBe(firstItemPadding);
+        expect(childPadding).toBeGreaterThan(parentPadding);
       }
     });
 

--- a/tests/e2e/session-tree-picker-all-children.spec.ts
+++ b/tests/e2e/session-tree-picker-all-children.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  seedChildSession,
+  cleanupCreatedResources,
+  navigateAndWait,
+  waitForSessionToExist,
+} from './helpers';
+
+test.describe('Session Tree Picker Shows All Children', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+  let parentSession: any;
+  let children: any[] = [];
+
+  test.beforeEach(async () => {
+    children = [];
+    project = await seedProject('Picker All Children Test', '/tmp/picker-all-children-test');
+    parentSession = await seedSession(project.id, {
+      prompt: 'Parent session prompt',
+      name: 'Parent Session',
+    });
+    await waitForSessionToExist(parentSession.id);
+
+    // Create 4 child sessions under the same parent
+    for (let i = 1; i <= 4; i++) {
+      const child = await seedChildSession(project.id, parentSession.id, {
+        prompt: `Child ${i} prompt`,
+        name: `Child Session ${i}`,
+      });
+      await waitForSessionToExist(child.id);
+      children.push(child);
+    }
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  async function openOverlayAndPicker(page: any, sessionId: string) {
+    await navigateAndWait(page, `/sessions/${sessionId}`, {
+      waitFor: '.session-detail',
+      timeout: 15000,
+    });
+    const handle = page.locator('[data-testid="session-tree-handle"]');
+    await expect(handle).toBeVisible({ timeout: 10000 });
+    await handle.click();
+    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    await expect(overlay).toBeVisible({ timeout: 5000 });
+    await page.waitForTimeout(400);
+
+    // Open the picker dropdown
+    const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
+    await expect(dropdown).toBeVisible({ timeout: 10000 });
+    await dropdown.locator('.dropdown-trigger').click();
+    const picker = page.locator('[data-testid="session-tree-picker"]');
+    await expect(picker).toBeVisible({ timeout: 5000 });
+
+    return { overlay, picker };
+  }
+
+  test('picker shows all 4 child sessions plus parent (5 total)', async ({ page }) => {
+    const { picker } = await openOverlayAndPicker(page, parentSession.id);
+
+    const items = picker.locator('[role="option"]');
+    // Should show parent + 4 children = 5 items
+    await expect(items).toHaveCount(5, { timeout: 10000 });
+  });
+
+  test('picker displays all child session names', async ({ page }) => {
+    const { picker } = await openOverlayAndPicker(page, parentSession.id);
+
+    await expect(picker).toContainText('Parent Session');
+    await expect(picker).toContainText('Child Session 1');
+    await expect(picker).toContainText('Child Session 2');
+    await expect(picker).toContainText('Child Session 3');
+    await expect(picker).toContainText('Child Session 4');
+  });
+
+  test('child sessions are indented more than the parent', async ({ page }) => {
+    const { picker } = await openOverlayAndPicker(page, parentSession.id);
+
+    const items = picker.locator('[role="option"]');
+    const count = await items.count();
+    expect(count).toBe(5);
+
+    // Get the padding of the parent (first item at depth 0)
+    const parentPadding = await items.nth(0).evaluate(el => {
+      return parseFloat(window.getComputedStyle(el).paddingLeft);
+    });
+
+    // All child items (indices 1-4) should have more padding than the parent
+    for (let i = 1; i < count; i++) {
+      const childPadding = await items.nth(i).evaluate(el => {
+        return parseFloat(window.getComputedStyle(el).paddingLeft);
+      });
+      expect(childPadding).toBeGreaterThan(parentPadding);
+    }
+  });
+
+  test('selecting a sibling session switches the overlay conversation', async ({ page }) => {
+    const { overlay, picker } = await openOverlayAndPicker(page, parentSession.id);
+
+    const items = picker.locator('[role="option"]');
+    const count = await items.count();
+    expect(count).toBe(5);
+
+    // Find which index has Child Session 4
+    let child4Index = -1;
+    for (let i = 0; i < count; i++) {
+      const itemName = await items.nth(i).locator('.picker-item-name').textContent();
+      if (itemName?.trim() === 'Child Session 4') {
+        child4Index = i;
+        break;
+      }
+    }
+    expect(child4Index).not.toBe(-1); // Child Session 4 should exist
+    expect(child4Index).toBeGreaterThanOrEqual(1); // Should not be at index 0 (parent)
+
+    // Click the Child Session 4 item
+    await items.nth(child4Index).click();
+
+    // Picker should close
+    await expect(picker).not.toBeVisible({ timeout: 5000 });
+
+    // Overlay should now show the selected child session name
+    const rootName = overlay.locator('.overlay-root-name');
+    await expect(rootName).toContainText('Child Session 4', { timeout: 5000 });
+  });
+
+  test('opening picker from a child session still shows all siblings', async ({ page }) => {
+    // Navigate to child session 2 instead of the parent
+    const { picker } = await openOverlayAndPicker(page, children[1].id);
+
+    // Should still show all sessions in the tree (parent + 4 children)
+    const items = picker.locator('[role="option"]');
+    await expect(items).toHaveCount(5, { timeout: 10000 });
+
+    await expect(picker).toContainText('Parent Session');
+    await expect(picker).toContainText('Child Session 1');
+    await expect(picker).toContainText('Child Session 2');
+    await expect(picker).toContainText('Child Session 3');
+    await expect(picker).toContainText('Child Session 4');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed `buildSessionChain()` which followed only `children[0]` at each level, creating a linear chain instead of showing all sessions in the tree
- Replaced linear walk with depth-first tree traversal that produces `{session, depth}` entries, enabling the picker to display all siblings with depth-based indentation
- Ensured fetched sessions are synced to the `sessions` array so `getSessionById()` works reliably in the overlay

## Test plan
- [x] All 3828 unit tests pass (132 test files)
- [x] 59 E2E tests pass (existing overlay tests + new picker-all-children tests)
- [ ] Manual: Navigate to root session `59e294a9`, open tree overlay, verify all 4+ child sessions appear with indentation
- [ ] Manual: Open picker from a child session and verify full tree is still visible
- [ ] Manual: Select different siblings in the picker and verify conversation switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)