### PR TITLE
Change "When enabled" to "When checked" in analytics settings text

### DIFF
--- a/packages/web/src/views/GeneralSettingsView.test.js
+++ b/packages/web/src/views/GeneralSettingsView.test.js
@@ -76,7 +76,7 @@ describe('GeneralSettingsView', () => {
     });
 
     it('renders help text', () => {
-      expect(wrapper.text()).toContain('When enabled, no usage analytics will be collected.');
+      expect(wrapper.text()).toContain('When checked, no usage analytics will be collected.');
     });
 
     it('renders Save Settings button', () => {

--- a/packages/web/src/views/GeneralSettingsView.vue
+++ b/packages/web/src/views/GeneralSettingsView.vue
@@ -14,7 +14,7 @@
         Disable analytics tracking
       </label>
       <p class="form-help">
-        When enabled, no usage analytics will be collected. Changes take effect on next page load.
+        When checked, no usage analytics will be collected. Changes take effect on next page load.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

- Changed "When enabled" to "When checked" in `GeneralSettingsView.vue` help text to better match the checkbox UI element
- Updated the corresponding test in `GeneralSettingsView.test.js` to reflect the new wording

## Test plan

- [ ] Verify the General Settings page displays "When checked, no usage analytics will be collected. Changes take effect on next page load."
- [ ] Run `yarn workspace @claudetools/web test src/views/GeneralSettingsView.test.js` and confirm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)