### PR TITLE
Fix draft session input not clearing after submission

### DIFF
--- a/packages/web/src/components/ConversationTab.model-init.test.js
+++ b/packages/web/src/components/ConversationTab.model-init.test.js
@@ -225,6 +225,18 @@ describe('ConversationTab - Model Initialization Bug', () => {
           ResizableTextarea: {
             template: '<textarea class="resizable-textarea"></textarea>',
             props: ['modelValue', 'minHeight', 'placeholder'],
+            mounted() {
+              // Expose value getter/setter like the real ResizableTextarea
+              // ConversationTab.handleFormSubmit accesses textareaRef.value to read and clear
+              const ta = this.$el;
+              Object.defineProperty(this, 'value', {
+                get() { return ta?.value || ''; },
+                set(val) { if (ta) ta.value = val; },
+              });
+              Object.defineProperty(this, 'focus', { value: () => ta?.focus() });
+              Object.defineProperty(this, 'blur', { value: () => ta?.blur() });
+              Object.defineProperty(this, 'select', { value: () => ta?.select() });
+            },
           },
           BranchEditor: { template: '<div class="branch-editor-stub"></div>' },
           ScheduleSessionModal: { template: '<div class="schedule-session-modal-stub"></div>' },

--- a/packages/web/src/components/ConversationTab.model-init.test.js
+++ b/packages/web/src/components/ConversationTab.model-init.test.js
@@ -471,4 +471,70 @@ describe('ConversationTab - Model Initialization Bug', () => {
       );
     });
   });
+
+  describe('Draft session input clearing on start', () => {
+    it('should clear textarea when draft session starts successfully', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        model: 'sonnet',
+        pendingModel: 'sonnet',
+        projectId: 'proj-1',
+        mode: 'standard',
+      };
+      mockSessionsStore.activeConversation = {
+        id: 'conv-1',
+        sessionId: 'sess-123',
+        isActive: true,
+      };
+      mockSessionsStore.activeConversationId = 'conv-1';
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(true);
+      mockSessionsStore.startSession.mockResolvedValue(undefined);
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('My initial prompt');
+      await flushAll(wrapper);
+
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      // Textarea should be cleared after successful start
+      expect(textarea.element.value).toBe('');
+    });
+
+    it('should not clear textarea when draft session fails to start', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        model: 'sonnet',
+        pendingModel: 'sonnet',
+        projectId: 'proj-1',
+        mode: 'standard',
+      };
+      mockSessionsStore.activeConversation = {
+        id: 'conv-1',
+        sessionId: 'sess-123',
+        isActive: true,
+      };
+      mockSessionsStore.activeConversationId = 'conv-1';
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(true);
+      mockSessionsStore.startSession.mockRejectedValue(new Error('Start failed'));
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('My initial prompt');
+      await flushAll(wrapper);
+
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      // Textarea should NOT be cleared when start fails - user's input is preserved
+      expect(textarea.element.value).toBe('My initial prompt');
+    });
+  });
 });

--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -3798,7 +3798,7 @@ describe('ConversationTab - Input clearing on submit', () => {
       global: {
         stubs: {
           ConversationPanel: { template: '<div class="conversation-panel-stub"></div>' },
-          ConversationMessages: { template: '<div class="conversation-messages-stub"></div>' },
+          ConversationMessages: { template: '<div class="conversation-messages-stub"></div>', methods: { scrollToBottom: vi.fn() } },
           TodoDrawer: { template: '<div class="todo-drawer-stub"></div>' },
           RunningState: { template: '<div class="running-state-stub"></div>' },
           WorkLogPanel: { template: '<div class="work-log-panel-stub"></div>' },

--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -3715,3 +3715,223 @@ describe('ConversationTab - Watcher session-scoping guards', () => {
     // (The guard returns before reaching the auto-send reset block)
   });
 });
+
+/**
+ * Draft session input clearing tests
+ *
+ * These tests validate that when a draft session is started via handleFormSubmit,
+ * the input fields are only cleared on success (handleStart returns true).
+ * If handleStart fails (returns false), the input should be preserved so the user
+ * doesn't lose their work.
+ *
+ * This also tests the same behavior for follow-up messages (handleSend).
+ */
+describe('ConversationTab - Input clearing on submit', () => {
+  let mockSessionsStore;
+  let mockUiStore;
+  let consoleError;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+
+    mockSessionsStore = {
+      messages: [],
+      currentSession: { id: 'sess-123', status: 'waiting', thinkingEnabled: false, mode: 'standard', projectId: 'proj-1' },
+      activeConversation: { id: 'conv-1', name: 'Test Conv' },
+      activeConversationId: 'conv-1',
+      conversations: [{ id: 'conv-1', name: 'Test Conv', isActive: true }],
+      getWorkLogsForMessage: vi.fn().mockReturnValue([]),
+      getUnassociatedWorkLogs: [],
+      partialThinking: null,
+      isDraftSession: vi.fn().mockReturnValue(false),
+      isScheduledDraft: vi.fn().mockReturnValue(false),
+      fetchConversations: vi.fn().mockResolvedValue([]),
+      fetchWorkLogs: vi.fn().mockResolvedValue([]),
+      fetchMessages: vi.fn().mockResolvedValue([]),
+      sendMessage: vi.fn().mockResolvedValue(),
+      stopSession: vi.fn().mockResolvedValue(),
+      restartSession: vi.fn().mockResolvedValue(),
+      startSession: vi.fn().mockResolvedValue(),
+      updateSessionThinking: vi.fn().mockResolvedValue(),
+      updateSessionMode: vi.fn().mockResolvedValue(),
+      updateNextTemplate: vi.fn().mockResolvedValue(),
+      addWorkLog: vi.fn(),
+      associateWorkLogs: vi.fn(),
+      clearWorkLogs: vi.fn(),
+      clearConversations: vi.fn(),
+      addConversation: vi.fn(),
+      updateConversation: vi.fn(),
+      removeConversation: vi.fn(),
+      setPartialThinking: vi.fn(),
+      clearPartialThinking: vi.fn(),
+      finalizeUsage: vi.fn(),
+      updateRunningUsage: vi.fn(),
+    };
+
+    mockUiStore = {
+      error: vi.fn(),
+      success: vi.fn(),
+    };
+
+    vi.mocked(useSessionsStore).mockReturnValue(mockSessionsStore);
+    vi.mocked(useUiStore).mockReturnValue(mockUiStore);
+
+    consoleError = console.error;
+    console.error = vi.fn();
+
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    console.error = consoleError;
+    vi.unstubAllGlobals();
+  });
+
+  function mountComponent(props = { sessionId: 'sess-123' }) {
+    return mount(ConversationTab, {
+      props,
+      global: {
+        stubs: {
+          ConversationPanel: { template: '<div class="conversation-panel-stub"></div>' },
+          ConversationMessages: { template: '<div class="conversation-messages-stub"></div>' },
+          TodoDrawer: { template: '<div class="todo-drawer-stub"></div>' },
+          RunningState: { template: '<div class="running-state-stub"></div>' },
+          WorkLogPanel: { template: '<div class="work-log-panel-stub"></div>' },
+          LiveWorkLogPanel: { template: '<div class="live-work-log-panel-stub"></div>' },
+          MarkdownViewer: { template: '<div class="markdown-stub"><slot /></div>' },
+          FileAttachment: { template: '<div class="file-attachment-stub"></div>', methods: { clear: vi.fn() } },
+          QuickResponsesPanel: { template: '<div class="quick-responses-panel-stub"></div>' },
+          QuickResponseSettings: { template: '<div class="quick-response-settings-stub"></div>' },
+          ModelSelector: { template: '<div class="model-selector-stub"></div>' },
+          TokenCostPanel: { template: '<div class="token-cost-panel-stub"></div>' },
+          TemplateSelector: { template: '<div class="template-selector-stub"></div>' },
+          SchedulingInfo: { template: '<div class="scheduling-info-stub"></div>' },
+          ScheduleSessionModal: { template: '<div class="schedule-session-modal-stub"></div>' },
+          AutoRescheduleModal: { template: '<div class="auto-reschedule-modal-stub"></div>' },
+          SlashCommandButton: { template: '<div class="slash-command-button-stub"></div>' },
+          SlashCommandWizard: { template: '<div class="slash-command-wizard-stub"></div>' },
+          OrchestrationPanel: { template: '<div class="orchestration-panel-stub"></div>' },
+          BranchEditor: { template: '<div class="branch-editor-stub"></div>' },
+        },
+      },
+    });
+  }
+
+  async function flushAll(wrapper) {
+    await flushPromises();
+    await nextTick();
+    await wrapper.vm.$nextTick?.();
+  }
+
+  describe('Draft session - input clearing on successful start', () => {
+    it('clears textarea after successful draft session start', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        thinkingEnabled: false,
+        mode: 'standard',
+        pendingModel: 'sonnet',
+      };
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(true);
+      mockSessionsStore.startSession.mockResolvedValue();
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('My draft prompt');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.startSession).toHaveBeenCalledWith(
+        'sess-123',
+        'My draft prompt',
+        'sonnet'
+      );
+      // After successful start, textarea should be cleared
+      expect(textarea.element.value).toBe('');
+    });
+
+    it('preserves textarea content when draft session start fails', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        thinkingEnabled: false,
+        mode: 'standard',
+        pendingModel: 'sonnet',
+      };
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(true);
+      mockSessionsStore.startSession.mockRejectedValue(new Error('Start failed'));
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('My draft prompt');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.startSession).toHaveBeenCalled();
+      // After failed start, textarea should still have the user's text
+      expect(textarea.element.value).toBe('My draft prompt');
+    });
+  });
+
+  describe('Follow-up message - input clearing on successful send', () => {
+    it('clears textarea after successful message send', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        thinkingEnabled: false,
+        mode: 'standard',
+      };
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(false);
+      mockSessionsStore.sendMessage.mockResolvedValue();
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('Follow-up message');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.sendMessage).toHaveBeenCalledWith(
+        'sess-123',
+        'Follow-up message',
+        [],
+        'sonnet'
+      );
+      // After successful send, textarea should be cleared
+      expect(textarea.element.value).toBe('');
+    });
+
+    it('preserves textarea content when message send fails', async () => {
+      mockSessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        thinkingEnabled: false,
+        mode: 'standard',
+      };
+      mockSessionsStore.isDraftSession = vi.fn().mockReturnValue(false);
+      mockSessionsStore.sendMessage.mockRejectedValue(new Error('Send failed'));
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const textarea = wrapper.find('textarea');
+      await textarea.setValue('Follow-up message');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushAll(wrapper);
+
+      expect(mockSessionsStore.sendMessage).toHaveBeenCalled();
+      // After failed send, textarea should still have the user's text
+      expect(textarea.element.value).toBe('Follow-up message');
+    });
+  });
+});

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -443,7 +443,13 @@ async function handleFormSubmit() {
     const sessionModel = selectedModel.value
       || sessionsStore.currentSession?.pendingModel
       || sessionsStore.currentSession?.model;
-    await handleStart(currentValue, sessionModel);
+    const success = await handleStart(currentValue, sessionModel);
+    if (success) {
+      input.value = '';
+      if (textareaRef) textareaRef.value = '';
+      attachedFiles.value = [];
+      inputFormRef.value?.clearFiles();
+    }
   } else {
     const textareaRef = inputFormRef.value?.textareaRef;
     const currentValue = textareaRef?.value || input.value;

--- a/packages/web/src/components/RunningState.test.js
+++ b/packages/web/src/components/RunningState.test.js
@@ -32,9 +32,16 @@ describe('RunningState', () => {
       expect(wrapper.find('.running-title').text()).toBe('Claude is working...');
     });
 
-    it('should render loading spinner', () => {
+    it('should render loading spinner inside stop button', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('.loading-spinner').exists()).toBe(true);
+      const btn = wrapper.find('.btn-stop');
+      expect(btn.find('.loading-spinner').exists()).toBe(true);
+    });
+
+    it('should not render loading spinner in the status area', () => {
+      const wrapper = mountComponent();
+      const status = wrapper.find('.running-status');
+      expect(status.find('.loading-spinner').exists()).toBe(false);
     });
 
     it('should render stop button', () => {
@@ -75,10 +82,13 @@ describe('RunningState', () => {
       expect(wrapper.find('.btn-stop').attributes('disabled')).toBeDefined();
     });
 
-    it('should show spinner when stopping', () => {
-      const wrapper = mountComponent({ stopping: true });
-      const btn = wrapper.find('.btn-stop');
-      expect(btn.find('.loading-spinner').exists()).toBe(true);
+    it('should always show spinner in stop button regardless of stopping state', () => {
+      // Spinner is always visible in the stop button (not conditionally shown only when stopping)
+      const wrapperNotStopping = mountComponent({ stopping: false });
+      expect(wrapperNotStopping.find('.btn-stop').find('.loading-spinner').exists()).toBe(true);
+
+      const wrapperStopping = mountComponent({ stopping: true });
+      expect(wrapperStopping.find('.btn-stop').find('.loading-spinner').exists()).toBe(true);
     });
   });
 

--- a/packages/web/src/composables/useSessionControl.js
+++ b/packages/web/src/composables/useSessionControl.js
@@ -61,13 +61,15 @@ export function useSessionControl({ getSessionId }) {
    * @param {string} model - The model to use
    */
   async function handleStart(prompt, model) {
-    if (restarting.value || !prompt?.trim()) return;
+    if (restarting.value || !prompt?.trim()) return false;
 
     restarting.value = true;
     try {
       await sessionsStore.startSession(getSessionId(), prompt, model);
+      return true;
     } catch (err) {
       uiStore.error(err.message);
+      return false;
     } finally {
       restarting.value = false;
     }

--- a/packages/web/src/composables/useSessionControl.test.js
+++ b/packages/web/src/composables/useSessionControl.test.js
@@ -199,6 +199,41 @@ describe('useSessionControl', () => {
       expect(mockUiStore.error).toHaveBeenCalledWith('Start failed');
     });
 
+    it('should return true on successful start', async () => {
+      mockSessionsStore.startSession.mockResolvedValue();
+      const { handleStart } = createControl();
+
+      const result = await handleStart('test prompt', 'sonnet');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false on start failure', async () => {
+      mockSessionsStore.startSession.mockRejectedValue(new Error('Start failed'));
+      const { handleStart } = createControl();
+
+      const result = await handleStart('test prompt', 'sonnet');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when prompt is empty', async () => {
+      const { handleStart } = createControl();
+
+      const result = await handleStart('', 'sonnet');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when restarting is already true', async () => {
+      const { handleStart, restarting } = createControl();
+      restarting.value = true;
+
+      const result = await handleStart('test prompt', 'sonnet');
+
+      expect(result).toBe(false);
+    });
+
     it('should set restarting to false after completion', async () => {
       mockSessionsStore.startSession.mockResolvedValue();
       const { handleStart, restarting } = createControl();

--- a/scripts/pw.sh
+++ b/scripts/pw.sh
@@ -124,8 +124,10 @@ detect_or_start_server() {
     local server_pid=$!
 
     # Wait for .server-port file to be created
+    # Timeout must cover the full build step (yarn build) which runs before
+    # .server-port is written. Builds typically take 15-30s, so 120s gives margin.
     local elapsed=0
-    local timeout=60
+    local timeout=120
     while [ $elapsed -lt $timeout ]; do
         if [ -f "$port_file" ]; then
             detected_port=$(cat "$port_file")

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -111,21 +111,24 @@ if lsof -i:${SELECTED_PORT} >/dev/null 2>&1; then
 fi
 
 # -----------------------------------------------------------------------------
-# Write port to file for tool discovery
-#
-# Other tools (like playwright.config.ts) read this file to know which
-# port the server is running on.
-# -----------------------------------------------------------------------------
-echo "$SELECTED_PORT" > "$PORT_FILE"
-
-# Write VCR mode for pw.sh to detect mismatches
-echo "${VCR_MODE:-}" > ".vcr-mode"
-
-# -----------------------------------------------------------------------------
 # Start the server
 #
 # Use VCR mode if VCR_MODE is set (for E2E tests)
 # VCR_MODE can be: auto (default), record, or replay
 # -----------------------------------------------------------------------------
 echo "Starting server on port ${SELECTED_PORT}..."
-VCR_MODE="${VCR_MODE:-}" yarn build && NODE_ENV=production VCR_MODE="${VCR_MODE}" node packages/server/src/index.js -p ${SELECTED_PORT}
+
+# Build first, then write port file AFTER build completes.
+# This prevents pw.sh from detecting the port and starting health checks
+# while the build is still running (which can cause 30s timeout failures).
+VCR_MODE="${VCR_MODE:-}" yarn build
+
+# Write port to file for tool discovery (after build, before server start)
+# Other tools (like playwright.config.ts) read this file to know which
+# port the server is running on.
+echo "$SELECTED_PORT" > "$PORT_FILE"
+
+# Write VCR mode for pw.sh to detect mismatches
+echo "${VCR_MODE:-}" > ".vcr-mode"
+
+NODE_ENV=production VCR_MODE="${VCR_MODE}" node packages/server/src/index.js -p ${SELECTED_PORT}

--- a/tests/e2e/canvas-editor.spec.ts
+++ b/tests/e2e/canvas-editor.spec.ts
@@ -20,7 +20,7 @@ test.describe('Canvas Markdown Editor', () => {
   test.beforeEach(async () => {
     await cleanupAll();
     project = await seedProject('Editor Test Project', '/tmp/test');
-    session = await seedSession(project.id, { prompt: 'Test', name: 'Editor Test' });
+    session = await seedSession(project.id, { prompt: 'Test', name: 'Editor Test', startImmediately: false });
   });
 
   test.afterEach(async () => {

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -21,7 +21,7 @@ test.describe('Canvas Management', () => {
   test.beforeEach(async () => {
     await cleanupAll();
     project = await seedProject('Test Project', '/tmp/test');
-    session = await seedSession(project.id, { prompt: 'Test', name: 'Canvas Test' });
+    session = await seedSession(project.id, { prompt: 'Test', name: 'Canvas Test', startImmediately: false });
   });
 
   test.afterEach(async () => {
@@ -54,7 +54,7 @@ test.describe('Canvas Trash & Soft Delete', () => {
   test.beforeEach(async () => {
     await cleanupAll();
     project = await seedProject('Trash Test Project', '/tmp/test');
-    session = await seedSession(project.id, { prompt: 'Test', name: 'Trash Test' });
+    session = await seedSession(project.id, { prompt: 'Test', name: 'Trash Test', startImmediately: false });
   });
 
   test.afterEach(async () => {


### PR DESCRIPTION
## Summary
- Fixed a bug where the prompt input text persisted after submitting in draft sessions (e.g. from SessionTreeOverlay)
- Root cause: `handleFormSubmit()` in `ConversationTab.vue` only cleared the input in the follow-up message path, not the draft session path
- Made `handleStart()` return a success boolean and added matching input-clearing logic to the draft branch
- Added comprehensive test coverage for input clearing behavior on both successful and failed operations
- Fixed server startup race condition in `start-server.sh` where `.server-port` file was written before build completed, causing pw.sh health check timeouts

## Changes
- Modified `handleStart()` composable to return success boolean
- Updated draft session path in `ConversationTab.vue` to conditionally clear input based on success
- Added test coverage for:
  - Draft session input clearing on successful start
  - Draft session input preservation on failed start
  - Follow-up message input clearing on successful send
  - Follow-up message input preservation on failed send
  - RunningState spinner positioning
- Fixed `start-server.sh` build order:
  - Build completes before `.server-port` is written
  - Prevents pw.sh from detecting port during build
- Increased pw.sh server detection timeout from 60s to 120s
- Updated E2E tests to use `startImmediately: false` for better isolation

## Test plan
- [x] Open a session tree overlay and start a new draft/child session
- [x] Verify the input field clears after the prompt is submitted successfully
- [x] Verify the input is NOT cleared if the session fails to start
- [x] Verify follow-up messages on running sessions still clear the input correctly
- [x] Run unit tests for ConversationTab, RunningState, and useSessionControl
- [x] Run E2E tests with pw.sh to verify server startup reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)