### PR TITLE
Improve new session form UX: remove collapsible, auto-scroll, modernize controls

### DIFF
--- a/packages/web/src/components/GitOptionsPanel.vue
+++ b/packages/web/src/components/GitOptionsPanel.vue
@@ -1,26 +1,36 @@
 <template>
   <div v-if="gitStatus?.isGitRepo" class="form-group">
     <label class="form-label">Git Options</label>
-    <div class="quick-git-options">
-      <label class="radio-option">
-        <input type="radio" :value="'worktree'" :checked="modelValue === 'worktree'" @change="$emit('update:modelValue', 'worktree')" />
-        <span class="radio-label">Create isolated worktree</span>
-        <span class="radio-help">Separate working directory for this session</span>
-      </label>
-      <label class="radio-option">
-        <input type="radio" :value="'branch'" :checked="modelValue === 'branch'" @change="$emit('update:modelValue', 'branch')" />
-        <span class="radio-label">Create new branch</span>
-        <span class="radio-help">Work in the project directory</span>
-      </label>
-      <label class="radio-option">
-        <input type="radio" :value="''" :checked="modelValue === ''" @change="$emit('update:modelValue', '')" />
-        <span class="radio-label">Use current branch</span>
-        <span class="radio-help">{{ gitStatus.currentBranch }}</span>
-      </label>
+    <div class="segmented-control">
+      <button
+        type="button"
+        class="segment-btn"
+        :class="{ 'segment-btn--active': modelValue === 'worktree' }"
+        @click="$emit('update:modelValue', 'worktree')"
+      >
+        <span class="segment-label-full">Worktree</span>
+        <span class="segment-label-short">WT</span>
+      </button>
+      <button
+        type="button"
+        class="segment-btn"
+        :class="{ 'segment-btn--active': modelValue === 'branch' }"
+        @click="$emit('update:modelValue', 'branch')"
+      >
+        Branch
+      </button>
+      <button
+        type="button"
+        class="segment-btn"
+        :class="{ 'segment-btn--active': modelValue === '' }"
+        @click="$emit('update:modelValue', '')"
+      >
+        Current
+      </button>
     </div>
 
     <!-- Branch name input (shown for branch or worktree) -->
-    <div v-if="modelValue" class="quick-branch-section">
+    <div v-if="modelValue" class="branch-input-row">
       <label class="form-label form-label-small">Branch Name</label>
       <div class="quick-branch-input">
         <input
@@ -40,8 +50,10 @@
           Reset
         </button>
       </div>
-      <p class="form-help">Auto-generated from session name/prompt</p>
+      <p class="form-help">Auto-generated from prompt</p>
     </div>
+
+    <p v-if="modelValue === ''" class="current-branch-hint">On: {{ gitStatus.currentBranch }}</p>
   </div>
 
   <div v-if="loadingGit" class="git-loading">
@@ -83,7 +95,7 @@ defineEmits(['update:modelValue', 'update:branchName', 'branchEdit', 'resetBranc
 
 <style scoped>
 .form-help {
-  margin: 0.5rem 0 0;
+  margin: 0.25rem 0 0;
   font-size: 0.75rem;
   color: var(--color-text-soft);
 }
@@ -97,54 +109,50 @@ defineEmits(['update:modelValue', 'update:branchName', 'branchEdit', 'resetBranc
   margin-bottom: 1rem;
 }
 
-.quick-git-options {
+/* Segmented control (pill selector) */
+.segmented-control {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  background: var(--color-background-mute, var(--color-bg-soft, #2a2a3e));
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 0.1875rem;
+  gap: 0.125rem;
 }
 
-.radio-option {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.75rem;
-  border: 1px solid var(--color-border);
+.segment-btn {
+  flex: 1;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text-soft);
+  background: transparent;
+  border: none;
   border-radius: 0.375rem;
   cursor: pointer;
-  transition: border-color 0.15s, background-color 0.15s;
+  transition: background-color 0.15s, color 0.15s;
+  white-space: nowrap;
 }
 
-.radio-option:hover {
-  border-color: var(--color-border-hover);
-  background-color: var(--color-bg-hover);
-}
-
-.radio-option:has(input:checked) {
-  border-color: var(--color-accent);
-  background-color: var(--color-accent-bg);
-}
-
-.radio-option input[type="radio"] {
-  margin-top: 0.125rem;
-}
-
-.radio-label {
-  font-weight: 500;
+.segment-btn:hover {
   color: var(--color-text);
 }
 
-.radio-help {
-  margin-left: auto;
-  font-size: 0.75rem;
-  color: var(--color-text-soft);
+.segment-btn--active {
+  background-color: var(--color-primary, var(--color-accent, #22c55e));
+  color: #fff;
 }
 
-.quick-branch-section {
-  margin-top: 1rem;
-  padding: 1rem;
-  background-color: var(--color-bg-soft);
-  border-radius: 0.375rem;
+.segment-btn--active:hover {
+  color: #fff;
+}
+
+/* Show full label by default, hide short label */
+.segment-label-short {
+  display: none;
+}
+
+.branch-input-row {
+  margin-top: 0.5rem;
 }
 
 .form-label-small {
@@ -167,20 +175,24 @@ defineEmits(['update:modelValue', 'update:branchName', 'branchEdit', 'resetBranc
   font-size: 0.75rem;
 }
 
+.current-branch-hint {
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
 @media (max-width: 480px) {
-  .radio-option {
-    flex-wrap: wrap;
-    padding: 0.5rem;
+  .segment-btn {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.75rem;
   }
 
-  .radio-help {
-    width: 100%;
-    margin-left: 1.5rem;
-    margin-top: 0.25rem;
+  /* On small screens, show abbreviated "WT" instead of "Worktree" */
+  .segment-label-full {
+    display: none;
   }
-
-  .quick-branch-section {
-    padding: 0.75rem;
+  .segment-label-short {
+    display: inline;
   }
 }
 </style>

--- a/packages/web/src/components/SchedulingOptions.vue
+++ b/packages/web/src/components/SchedulingOptions.vue
@@ -330,4 +330,11 @@ watch(
   padding-top: 1rem;
   border-top: 1px solid var(--color-border);
 }
+
+/* Rec 10: Tighten spacing on mobile */
+@media (max-width: 480px) {
+  .form-group {
+    margin-bottom: 0.5rem;
+  }
+}
 </style>

--- a/packages/web/src/components/SessionFormOptions.vue
+++ b/packages/web/src/components/SessionFormOptions.vue
@@ -181,9 +181,13 @@ defineEmits([
 
 @media (max-width: 480px) {
   .options-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+  }
+  /* Let the last item span full width */
+  .options-row > :last-child {
+    grid-column: 1 / -1;
   }
 }
 </style>

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -6,11 +6,11 @@
     <h1>New Session</h1>
 
     <form @submit.prevent="handleSubmit" class="form card">
-      <!-- NEW: Start From Template selector - populates all fields -->
-      <div v-if="allTemplates.length > 0" class="form-group template-prefill-section">
-        <label class="form-label" for="start-from-template">Start From Template (optional)</label>
-        <select id="start-from-template" v-model="startFromTemplateId" class="form-input" @change="handleStartFromTemplateChange">
-          <option :value="null">Select a template to pre-fill the form...</option>
+      <!-- Start From Template selector (Rec 7: slimmed down) -->
+      <div v-if="allTemplates.length > 0" class="form-group">
+        <label class="form-label" for="start-from-template">Start From Template</label>
+        <select id="start-from-template" v-model="startFromTemplateId" class="form-input" @change="handleStartFromTemplateChange" title="Selecting a template will populate all form fields below. You can still edit before starting.">
+          <option :value="null">Select a template to pre-fill...</option>
           <optgroup v-if="projectTemplates.length" label="Project Templates">
             <option v-for="template in projectTemplates" :key="template.id" :value="template.id">
               {{ template.name }}
@@ -22,9 +22,6 @@
             </option>
           </optgroup>
         </select>
-        <p class="form-help">
-          Selecting a template will populate all form fields below. You can still edit before starting.
-        </p>
       </div>
 
       <div class="form-group">
@@ -33,7 +30,7 @@
           ref="textareaRef"
           class="form-input form-textarea"
           placeholder="What would you like Claude to help you with?"
-          :min-height="120"
+          :min-height="textareaMinHeight"
           required
           @input="handleInput"
           @keydown="handleKeydown"
@@ -46,13 +43,6 @@
           />
         </div>
       </div>
-
-      <!-- Quick Responses Panel - shows quick response templates below the prompt -->
-      <QuickResponsesPanel
-        :show-empty="true"
-        @insert="handleQuickResponseInsert"
-        @openSettings="quickResponseSettingsOpen = true"
-      />
 
       <SessionFormOptions
         :mode="mode"
@@ -70,16 +60,6 @@
 
       <div v-if="error" class="error-message">{{ error }}</div>
 
-      <!-- Scheduling Options -->
-      <SchedulingOptions v-model="schedulingData" />
-
-      <div class="form-actions">
-        <button type="submit" class="btn btn-primary btn-full-width" :disabled="loading">
-          <span v-if="loading" class="loading-spinner"></span>
-          {{ startImmediately ? 'Start Session' : 'Create Draft' }}
-        </button>
-      </div>
-
       <!-- Git Options -->
       <GitOptionsPanel
         :gitStatus="gitStatus"
@@ -94,48 +74,56 @@
         @resetBranch="resetBranchName"
       />
 
-      <!-- Next Template (optional) -->
-      <div v-if="allTemplates.length > 0" class="form-group">
-        <label class="form-label" for="template">Next Template (optional)</label>
-        <select id="template" v-model="selectedTemplateId" class="form-input">
-          <option :value="null">None - single session</option>
-          <optgroup v-if="projectTemplates.length" label="Project Templates">
-            <option v-for="template in projectTemplates" :key="template.id" :value="template.id">
-              {{ template.name }}
+      <!-- Advanced Options — shown inline (no collapsible) when relevant -->
+      <div v-if="showAdvancedOptions" ref="advancedOptionsRef" class="advanced-options">
+        <!-- Scheduling Options (hidden when starting immediately) -->
+        <SchedulingOptions v-if="!startImmediately" v-model="schedulingData" />
+
+        <!-- Next Template (optional) -->
+        <div v-if="allTemplates.length > 0" class="form-group">
+          <label class="form-label" for="template">Next Template (optional)</label>
+          <select id="template" v-model="selectedTemplateId" class="form-input">
+            <option :value="null">None - single session</option>
+            <optgroup v-if="projectTemplates.length" label="Project Templates">
+              <option v-for="template in projectTemplates" :key="template.id" :value="template.id">
+                {{ template.name }}
+              </option>
+            </optgroup>
+            <optgroup v-if="globalTemplates.length" label="Global Templates">
+              <option v-for="template in globalTemplates" :key="template.id" :value="template.id">
+                {{ template.name }}
+              </option>
+            </optgroup>
+          </select>
+          <p class="form-help">
+            After this session completes, the selected template will automatically start a new session.
+          </p>
+        </div>
+
+        <!-- Parent Session (optional) -->
+        <div v-if="availableSessions.length > 0" class="form-group">
+          <label class="form-label" for="parent-session">Parent Session (optional)</label>
+          <select id="parent-session" v-model="parentSessionId" class="form-input">
+            <option :value="null">None - create standalone session</option>
+            <option v-for="session in availableSessions" :key="session.id" :value="session.id">
+              {{ session.name }}
             </option>
-          </optgroup>
-          <optgroup v-if="globalTemplates.length" label="Global Templates">
-            <option v-for="template in globalTemplates" :key="template.id" :value="template.id">
-              {{ template.name }}
-            </option>
-          </optgroup>
-        </select>
-        <p class="form-help">
-          After this session completes, the selected template will automatically start a new session.
-        </p>
+          </select>
+          <p class="form-help">
+            Choose a parent session to link this as a child session. Child sessions help organize related work.
+          </p>
+        </div>
       </div>
 
-      <!-- Parent Session (optional) -->
-      <div v-if="availableSessions.length > 0" class="form-group">
-        <label class="form-label" for="parent-session">Parent Session (optional)</label>
-        <select id="parent-session" v-model="parentSessionId" class="form-input">
-          <option :value="null">None - create standalone session</option>
-          <option v-for="session in availableSessions" :key="session.id" :value="session.id">
-            {{ session.name }}
-          </option>
-        </select>
-        <p class="form-help">
-          Choose a parent session to link this as a child session. Child sessions help organize related work.
-        </p>
+      <!-- Submit + Cancel (Rec 1: moved to bottom, sticky on mobile) -->
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" @click="goBack">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-submit" :disabled="loading">
+          <span v-if="loading" class="loading-spinner"></span>
+          {{ startImmediately ? 'Start Session' : 'Create Draft' }}
+        </button>
       </div>
     </form>
-
-    <!-- Quick Response Settings Modal -->
-    <QuickResponseSettings
-      :isOpen="quickResponseSettingsOpen"
-      :projectId="route.params.id"
-      @close="quickResponseSettingsOpen = false"
-    />
 
     <!-- Slash Command Wizard Modal -->
     <SlashCommandWizard
@@ -155,15 +143,12 @@ import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 import { useTemplatesStore } from '../stores/templates.js';
 import { useProjectDefaultsStore } from '../stores/projectDefaults.js';
-import { useQuickResponsesStore } from '../stores/quickResponses.js';
 import { api } from '../composables/useApi.js';
 import { useSubmitShortcut } from '../composables/useSubmitShortcut.js';
 import { generateWorktreeBranch } from '@claudetools/shared';
 import FileAttachment from '../components/FileAttachment.vue';
 import SessionFormOptions from '../components/SessionFormOptions.vue';
 import GitOptionsPanel from '../components/GitOptionsPanel.vue';
-import QuickResponsesPanel from '../components/QuickResponsesPanel.vue';
-import QuickResponseSettings from '../components/QuickResponseSettings.vue';
 import SchedulingOptions from '../components/SchedulingOptions.vue';
 import ResizableTextarea from '../components/ResizableTextarea.vue';
 import SlashCommandButton from '../components/SlashCommandButton.vue';
@@ -176,7 +161,6 @@ const sessionsStore = useSessionsStore();
 const uiStore = useUiStore();
 const templatesStore = useTemplatesStore();
 const defaultsStore = useProjectDefaultsStore();
-const quickResponsesStore = useQuickResponsesStore();
 const projectsStore = useProjectsStore();
 
 const prompt = ref('');
@@ -188,8 +172,11 @@ const mode = ref('yolo');
 const model = ref(null);
 const providerId = ref(null);
 const loading = ref(false);
-const quickResponseSettingsOpen = ref(false);
 const showSlashCommandWizard = ref(false);
+
+// Rec 9: Responsive textarea min height
+const textareaMinHeight = computed(() => window.innerWidth <= 480 ? 80 : 120);
+
 
 // Track which fields are using project defaults
 const usingDefaults = ref({
@@ -212,6 +199,7 @@ const handleKeydown = useSubmitShortcut(() => {
 const gitStatus = ref(null);
 const attachedFiles = ref([]);
 const fileAttachment = ref(null);
+const advancedOptionsRef = ref(null);
 const selectedTemplateId = ref(null);
 const startFromTemplateId = ref(null);
 const parentSessionId = ref(null);
@@ -244,6 +232,11 @@ const availableSessions = computed(() => {
   return sessionsStore.sessions
     .filter((s) => s.status === 'completed')
     .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+});
+
+// Rec 4: Show advanced options only when there's content to show
+const showAdvancedOptions = computed(() => {
+  return !startImmediately.value || allTemplates.value.length > 0 || availableSessions.value.length > 0;
 });
 
 const loadingGit = ref(false);
@@ -322,8 +315,28 @@ watch(thinkingEnabled, () => {
   usingDefaults.value.thinkingEnabled = false;
 });
 
-watch(startImmediately, () => {
+// Rec 3: Reset scheduling data when startImmediately is toggled on
+// Also auto-scroll to the advanced options section when toggled off
+watch(startImmediately, (newVal) => {
   usingDefaults.value.startImmediately = false;
+  if (newVal) {
+    // Clear any scheduling data when switching to start immediately
+    schedulingData.value = {
+      scheduledAt: null,
+      autoRescheduleEnabled: false,
+      rescheduleDelayMinutes: 15,
+      rescheduleOnTokenLimit: true,
+      rescheduleOnServiceError: true,
+      maxRescheduleCount: null,
+      maxTotalTokens: null,
+      rescheduleAtTokenCount: null,
+    };
+  } else {
+    // Scroll the advanced options into view after Vue renders the section
+    nextTick(() => {
+      advancedOptionsRef.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+  }
 });
 
 watch(quickGitMode, () => {
@@ -435,14 +448,16 @@ onMounted(async () => {
   // Fetch templates for this project
   templatesStore.fetchProjectTemplates(projectId);
 
-  // Fetch quick responses for this project
-  quickResponsesStore.fetchForProject(projectId);
-
   // Pre-populate parent session ID if provided in route query
   if (route.query.parentSessionId) {
     parentSessionId.value = route.query.parentSessionId;
   }
 });
+
+// Rec 1: Navigate back to sessions list
+function goBack() {
+  router.push(`/projects/${route.params.id}/sessions`);
+}
 
 function handleBranchEdit() {
   editingBranch.value = true;
@@ -466,31 +481,6 @@ function handleSlashCommandInsert({ text }) {
 
     // Trigger input event to update prompt ref and UI
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
-    textarea.focus();
-  }
-}
-
-function handleQuickResponseInsert({ content, autoSubmit }) {
-  const textarea = textareaRef.value;
-  if (!textarea) return;
-
-  // Combine existing message with quick response content
-  const existingText = textarea.value.trim();
-  const newContent = existingText
-    ? `${existingText}\n\n${content}`
-    : content;
-
-  textarea.value = newContent;
-  textarea.dispatchEvent(new Event('input', { bubbles: true }));
-
-  if (autoSubmit) {
-    // Auto-submit: submit the form
-    setTimeout(() => {
-      handleSubmit();
-    }, 0);
-  } else {
-    // Non-auto-submit: focus textarea for further editing
-    textarea.selectionStart = textarea.selectionEnd = newContent.length;
     textarea.focus();
   }
 }
@@ -597,22 +587,13 @@ h1 {
   margin-top: 0;
 }
 
-.form {
-  width: 100%;
-}
+/* Rec 8: Constrain form width */
+.form { width: 100%; max-width: 640px; margin: 0 auto; }
 
 .form-help {
   margin: 0.5rem 0 0;
   font-size: 0.75rem;
   color: var(--color-text-soft);
-}
-
-.template-prefill-section {
-  background-color: var(--color-bg-soft);
-  padding: 1rem;
-  border-radius: 0.5rem;
-  border: 1px dashed var(--color-border);
-  margin-bottom: 1rem;
 }
 
 .attachment-row {
@@ -622,15 +603,35 @@ h1 {
   align-items: center;
 }
 
+/* Rec 1: Form actions as flex row with Cancel + Submit */
 .form-actions {
-  margin-bottom: 1.5rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 1rem;
 }
 
-.btn-full-width {
-  width: 100%;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-  font-size: 1.1rem;
+.btn-submit {
+  flex: 1;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  font-size: 1.05rem;
+}
+
+.btn-secondary {
+  padding: 0.75rem 1.25rem;
+  font-size: 1.05rem;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-soft);
+  border-radius: var(--border-radius, 4px);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-secondary:hover {
+  border-color: var(--color-border-hover);
+  color: var(--color-text);
 }
 
 .error-message {
@@ -638,10 +639,35 @@ h1 {
   margin-bottom: 1rem;
 }
 
+/* Advanced Options section */
+.advanced-options {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 @media (max-width: 480px) {
   h1 {
     margin-bottom: 0.5rem;
     font-size: 1.5rem;
+  }
+
+  /* Rec 10: Tighten card padding on mobile */
+  .form.card {
+    padding: 0.75rem;
+  }
+}
+
+/* Rec 1: Sticky form actions on mobile */
+@media (max-width: 640px) {
+  .form-actions {
+    position: sticky;
+    bottom: 0;
+    background: var(--color-background-soft, var(--color-bg-soft, #1a1a2e));
+    border-top: 1px solid var(--color-border);
+    padding: 0.75rem 1rem;
+    margin: 0 -1rem -1rem;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+    z-index: 10;
   }
 }
 </style>

--- a/tests/e2e/commandButtons.spec.ts
+++ b/tests/e2e/commandButtons.spec.ts
@@ -62,8 +62,9 @@ test.describe('Command Buttons', () => {
     // Wait for command to finish
     await expect(page.locator('.status-running')).toBeHidden({ timeout: 15000 });
 
-    // Expand output
+    // Expand output and wait for actual command output to render
     await page.click('.output-header');
+    await expect(page.locator('.output-text')).toContainText('Persist output', { timeout: 5000 });
     const initialOutput = await page.textContent('.output-text');
     expect(initialOutput).toBeTruthy();
 

--- a/tests/e2e/quick-responses.spec.ts
+++ b/tests/e2e/quick-responses.spec.ts
@@ -418,109 +418,28 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
 });
 
 // ============================================================
-// Category 3: Quick Response Panel in New Session View (3 tests)
+// Category 3: Quick Response Panel NOT in New Session View
+// (Panel was intentionally removed — quick responses are only
+//  available in the conversation reply flow, not on the initial
+//  session creation form.)
 // ============================================================
 
 test.describe('Category 3: Quick Response Panel in New Session View', () => {
-  test('panel displays responses in new session view', async ({ page }) => {
-    const project = await seedProject('QR NewSession Display', '/tmp/qr-new-1');
-    await seedQuickResponse(project.id, { label: 'New Session QR', content: 'New session content' });
+  test('quick responses panel is not present in new session view', async ({ page }) => {
+    const project = await seedProject('QR NewSession Removed', '/tmp/qr-new-removed');
+    await seedQuickResponse(project.id, { label: 'Should Not Appear', content: 'Not here' });
 
     await page.goto(`/projects/${project.id}/sessions/new`);
     await waitForPageReady(page);
 
-    // Expand the panel
+    // QuickResponsesPanel was removed from the new session view (Rec 2).
+    // Verify it is NOT rendered even when the project has quick responses.
     const panel = page.locator('.quick-responses-panel');
-    await expect(panel).toBeVisible({ timeout: 10000 });
-    await panel.click();
-    await page.waitForTimeout(300);
+    await expect(panel).not.toBeVisible({ timeout: 3000 });
 
-    // Verify response chip is visible with correct label
-    const responseBtn = page.locator('.response-button', { hasText: 'New Session QR' });
-    await expect(responseBtn).toBeVisible({ timeout: 5000 });
-  });
-
-  test('clicking response inserts content into prompt textarea', async ({ page }) => {
-    const project = await seedProject('QR NewSession Insert', '/tmp/qr-new-2');
-    await seedQuickResponse(project.id, { label: 'Insert Prompt', content: 'Prompt content here' });
-
-    await page.goto(`/projects/${project.id}/sessions/new`);
-    await waitForPageReady(page);
-
-    // Expand and click response
-    const panel = page.locator('.quick-responses-panel');
-    await expect(panel).toBeVisible({ timeout: 10000 });
-    await panel.click();
-    await page.waitForTimeout(300);
-
-    await page.locator('.response-button', { hasText: 'Insert Prompt' }).click();
-
-    // Verify prompt textarea contains the content
+    // The prompt textarea should still be present and functional
     const textarea = page.locator('textarea#prompt');
-    await expect(textarea).toHaveValue('Prompt content here', { timeout: 5000 });
-  });
-
-  test('auto-submit response triggers form submission in new session', async ({ page }) => {
-    const project = await seedProject('QR NewSession AutoSubmit', '/tmp/qr-new-3');
-    await seedQuickResponse(project.id, {
-      label: 'Auto Create',
-      content: 'Auto-create this session',
-      autoSubmit: true,
-    });
-
-    await page.goto(`/projects/${project.id}/sessions/new`);
-    await waitForPageReady(page);
-
-    // Expand and click auto-submit response
-    const panel = page.locator('.quick-responses-panel');
-    await expect(panel).toBeVisible({ timeout: 10000 });
-    await panel.click();
-    await page.waitForTimeout(300);
-
-    await page.locator('.response-button', { hasText: 'Auto Create' }).click();
-
-    // Auto-submit should trigger form submission, which navigates away from the new session view.
-    // Verify we navigate away (URL changes to session detail)
-    await expect(page).not.toHaveURL(/\/sessions\/new/, { timeout: 10000 });
-  });
-
-  test('settings gear opens settings modal from new session view', async ({ page }) => {
-    const project = await seedProject('QR NewSession Settings', '/tmp/qr-new-settings');
-    await seedQuickResponse(project.id, { label: 'Settings Test', content: 'Settings content' });
-
-    // Wait for the quick-responses API call to complete before interacting.
-    // The store fetch fires without await in onMounted, so we need to catch it.
-    const apiDone = page.waitForResponse(
-      (resp) => resp.url().includes('/quick-responses') && resp.status() === 200,
-      { timeout: 30000 }
-    );
-
-    await page.goto(`/projects/${project.id}/sessions/new`);
-    await apiDone;
-
-    // Expand the panel
-    const panel = page.locator('.quick-responses-panel');
-    await expect(panel).toBeVisible({ timeout: 10000 });
-    await panel.click();
-
-    // Wait for responses content or empty state to appear
-    await expect(
-      page.locator('.responses-content, .empty-state')
-    ).toBeVisible({ timeout: 5000 });
-
-    // Click the settings gear button (only visible when panel is expanded)
-    const settingsBtn = page.locator('button[aria-label="Manage quick responses"]');
-    await expect(settingsBtn).toBeVisible({ timeout: 5000 });
-    await settingsBtn.click();
-
-    // Verify settings modal opens with correct title
-    const settingsModal = page.locator('.settings-panel[role="dialog"]');
-    await expect(settingsModal).toBeVisible({ timeout: 5000 });
-    await expect(settingsModal.locator('.settings-title')).toContainText('Quick Responses');
-
-    // Verify modal can be closed
-    await page.locator('.close-button').click();
-    await expect(settingsModal).not.toBeVisible({ timeout: 3000 });
+    await expect(textarea).toBeVisible({ timeout: 5000 });
   });
 });
 

--- a/tests/e2e/session-tree-overlay.spec.ts
+++ b/tests/e2e/session-tree-overlay.spec.ts
@@ -722,10 +722,13 @@ test.describe('Session Tree Overlay', () => {
       await expect(overlay).toBeVisible({ timeout: 5000 });
 
       // Wait for slide-in animation to complete (300ms + buffer)
-      await page.waitForTimeout(400);
+      await page.waitForTimeout(500);
+
+      // Re-assert visibility before measuring (guards against re-render during animation)
+      await expect(overlay).toBeVisible({ timeout: 5000 });
 
       // Verify it's positioned on the right side
-      const overlayBox = await overlay.boundingBox();
+      const overlayBox = await overlay.boundingBox({ timeout: 5000 });
       const viewportSize = page.viewportSize();
       if (overlayBox && viewportSize) {
         // Overlay should start from the right side (with some margin for padding)


### PR DESCRIPTION
## Summary
- **Removed collapsible `<details>` wrapper** from advanced options — the section now shows inline when relevant (e.g. when "Start Immediately" is toggled off), eliminating an unnecessary extra click
- **Added auto-scroll** so when the user toggles "Start Immediately" off, the scheduling options smoothly scroll into view — solving the below-the-fold problem on small screens
- **Modernized Git Options** from radio buttons to a compact segmented control (pill selector) that abbreviates "Worktree" to "WT" on mobile
- **Improved mobile layout**: session form options use a 2-column grid, form actions are sticky at the bottom, form width is constrained to 640px with a Cancel button alongside Submit
- **Removed QuickResponsesPanel** from the new session view (it's only available in the conversation reply flow now)
- **Updated E2E tests** to match the new UI behavior

## Test plan
- [ ] Toggle "Start Immediately" off and verify scheduling options appear inline without needing to expand anything
- [ ] On a small screen, verify the scheduling section auto-scrolls into view when toggling the switch
- [ ] Verify Git Options segmented control works (Worktree / Branch / Current)
- [ ] Verify form submits correctly with both "Start Session" and "Create Draft" flows
- [ ] Run unit tests: `yarn workspace @claudetools/web test`
- [ ] Run E2E tests: `./scripts/pw.sh test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)