### PR TITLE
Remove Conversations tab from session detail view

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -646,10 +646,10 @@ defineExpose({
 
 .overlay-close-handle {
   position: absolute;
-  left: 0;
+  left: -48px;
   top: 50%;
   transform: translateY(-50%);
-  width: 40px;
+  width: 44px;
   height: 100px;
   display: flex;
   flex-direction: column;

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -11,9 +11,6 @@ import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useUiStore } from '../stores/ui.js';
 
 // Mock components
-vi.mock('../components/ConversationTab.vue', () => ({
-  default: { name: 'ConversationTab', template: '<div>Conversation Tab</div>' }
-}));
 vi.mock('../components/ChangesTab.vue', () => ({
   default: { name: 'ChangesTab', template: '<div>Changes Tab</div>' }
 }));
@@ -206,7 +203,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -228,7 +224,7 @@ describe('SessionDetailView', () => {
       expect(notesTab).toBeUndefined();
     });
 
-    it('includes Summary, Conversation, Changes, Canvas, Commands tabs', async () => {
+    it('includes Summary, Changes, Canvas, Commands tabs', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -242,7 +238,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -275,7 +270,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -309,7 +303,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -341,7 +334,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -373,7 +365,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -408,7 +399,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -441,7 +431,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -475,7 +464,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -507,7 +495,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -543,7 +530,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -578,7 +564,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -656,7 +641,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -691,7 +675,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -719,7 +702,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -756,7 +738,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -790,7 +771,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -860,7 +840,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -899,7 +878,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -971,7 +949,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1029,7 +1006,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1064,7 +1040,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1101,7 +1076,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1135,7 +1109,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1168,7 +1141,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1215,7 +1187,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1248,7 +1219,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1287,7 +1257,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1326,7 +1295,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1362,7 +1330,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1402,7 +1369,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1443,7 +1409,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1480,7 +1445,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1528,7 +1492,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1593,7 +1556,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1634,7 +1596,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1677,7 +1638,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1725,7 +1685,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1758,7 +1717,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1791,7 +1749,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1824,7 +1781,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1856,7 +1812,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1889,7 +1844,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1922,7 +1876,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1954,7 +1907,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -1987,7 +1939,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2021,7 +1972,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2055,7 +2005,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2099,7 +2048,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2134,7 +2082,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2175,7 +2122,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2212,7 +2158,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2247,7 +2192,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2289,7 +2233,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2323,7 +2266,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2379,7 +2321,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2422,7 +2363,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2456,7 +2396,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2490,7 +2429,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2522,7 +2460,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2554,7 +2491,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2585,7 +2521,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2616,7 +2551,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2647,7 +2581,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2678,7 +2611,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2709,7 +2641,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2743,7 +2674,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -2782,7 +2712,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2808,7 +2737,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2833,7 +2761,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2855,7 +2782,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2877,7 +2803,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2900,7 +2825,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2922,7 +2846,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2944,7 +2867,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2966,7 +2888,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -2988,7 +2909,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, SummaryTab: true, ChangesTab: true,
+            SummaryTab: true, ChangesTab: true,
             CanvasTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3004,7 +2925,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, SummaryTab: true, ChangesTab: true,
+            SummaryTab: true, ChangesTab: true,
             CanvasTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3021,7 +2942,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, SummaryTab: true, ChangesTab: true,
+            SummaryTab: true, ChangesTab: true,
             CanvasTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3038,7 +2959,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, SummaryTab: true, ChangesTab: true,
+            SummaryTab: true, ChangesTab: true,
             CanvasTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3072,7 +2993,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -3105,7 +3025,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -3140,7 +3059,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -3172,7 +3090,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -3205,7 +3122,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -3238,7 +3154,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             SummaryTab: true,
             ChangesTab: true,
             CanvasTab: true,
@@ -3301,7 +3216,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            ChangesTab: true, CanvasTab: true,
             SummaryTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3353,7 +3268,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            ChangesTab: true, CanvasTab: true,
             SummaryTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3396,7 +3311,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            ChangesTab: true, CanvasTab: true,
             SummaryTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3467,7 +3382,7 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            ChangesTab: true, CanvasTab: true,
             SummaryTab: true, CommandsTab: true, PrIndicators: true,
           },
         },
@@ -3503,7 +3418,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -3558,7 +3472,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,
@@ -3602,7 +3515,6 @@ describe('SessionDetailView', () => {
         global: {
           plugins: [pinia, router],
           stubs: {
-            ConversationTab: true,
             ChangesTab: true,
             CanvasTab: true,
             SummaryTab: true,

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -48,7 +48,6 @@
         <!-- CRITICAL: :key ensures components remount when navigating between sessions,
              preventing stale WebSocket handlers from capturing the wrong sessionId -->
         <SummaryTab v-if="activeTab === 'summary'" :key="route.params.id" :session-id="route.params.id" />
-        <ConversationTab v-else-if="activeTab === 'conversation'" :key="route.params.id" :session-id="route.params.id" />
         <ChangesTab v-else-if="activeTab === 'changes'" :key="route.params.id" :session-id="route.params.id" @update:file-count="changesFileCount = $event" />
         <CanvasTab v-else-if="activeTab === 'canvas'" :key="route.params.id" :session-id="route.params.id" />
         <CommandsTab v-else-if="activeTab === 'commands'" :key="route.params.id" :session-id="route.params.id" :project-id="sessionsStore.currentSession?.projectId" />
@@ -85,7 +84,6 @@ import { useUiStore } from '../stores/ui.js';
 import { useKanbanStore } from '../stores/kanban.js';
 import { useSessionPolling } from '../composables/useSessionPolling.js';
 import { useSessionInitializer } from '../composables/useSessionInitializer.js';
-import ConversationTab from '../components/ConversationTab.vue';
 import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
@@ -302,7 +300,6 @@ const isSessionActive = computed(() => {
 
 const tabs = computed(() => [
   { id: 'summary', label: 'Summary' },
-  { id: 'conversation', label: 'Conversations' },
   { id: 'changes', label: changesFileCount.value > 0 ? `Changes (${changesFileCount.value})` : 'Changes' },
   { id: 'canvas', label: canvasStore.groupedItems.length > 0 ? `Canvas (${canvasStore.groupedItems.length})` : 'Canvas' },
   { id: 'commands', label: 'Commands' }
@@ -393,7 +390,7 @@ async function handleDuplicate() {
   try {
     const newSession = await sessionsStore.duplicateSession(currentSessionId.value);
     uiStore.success('Session duplicated');
-    router.push(`/sessions/${newSession.id}/conversation`);
+    router.push(`/sessions/${newSession.id}/summary`);
   } catch (err) {
     uiStore.error(err.message);
   }

--- a/tests/e2e/commandButtons.spec.ts
+++ b/tests/e2e/commandButtons.spec.ts
@@ -67,8 +67,8 @@ test.describe('Command Buttons', () => {
     const initialOutput = await page.textContent('.output-text');
     expect(initialOutput).toBeTruthy();
 
-    // Switch to conversation tab and back
-    await page.click('text=Conversation');
+    // Switch to summary tab and back
+    await page.click('text=Summary');
     await expect(page.locator('.commands-tab')).toBeHidden();
     await page.click('text=Commands');
     // Wait for component to fully remount and restore state from store

--- a/tests/e2e/conversation-management.spec.ts
+++ b/tests/e2e/conversation-management.spec.ts
@@ -16,6 +16,7 @@ import {
   getConversationMessages,
   generateConversationSummary,
   getAPIURL,
+  openSessionOverlay,
 } from './helpers';
 
 /**
@@ -128,7 +129,8 @@ test.describe('Multiple Conversations', () => {
   });
 
   test('new conversation button visible in UI', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // The "New Conversation" button should be visible
     const newBtn = page.locator('.btn-new');
@@ -137,7 +139,8 @@ test.describe('Multiple Conversations', () => {
   });
 
   test('clicking new conversation creates conversation and updates UI', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Click "New Conversation" button
     const newBtn = page.locator('.btn-new');
@@ -183,7 +186,8 @@ test.describe('Active Conversation Tracking and Switching', () => {
   });
 
   test('conversation selector hidden when only one conversation', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Dropdown container should NOT be visible with only 1 conversation
     const dropdownContainer = page.locator('.dropdown-container');
@@ -198,7 +202,8 @@ test.describe('Active Conversation Tracking and Switching', () => {
     // Create a second conversation
     await seedConversation(session.id, 'Second Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Dropdown trigger should now be visible
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -209,7 +214,8 @@ test.describe('Active Conversation Tracking and Switching', () => {
     // Create a second conversation
     await seedConversation(session.id, 'Second Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Click the dropdown trigger
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -229,7 +235,8 @@ test.describe('Active Conversation Tracking and Switching', () => {
     // Create second conversation (becomes active, has no messages)
     await seedConversation(session.id, 'Second Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Second conv is active and empty - no user messages should be visible
     const userMessages = page.locator('[data-testid="message-user"]');
@@ -256,7 +263,8 @@ test.describe('Active Conversation Tracking and Switching', () => {
   test('active conversation highlighted in dropdown', async ({ page }) => {
     await seedConversation(session.id, 'Second Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -273,7 +281,8 @@ test.describe('Active Conversation Tracking and Switching', () => {
     await seedConversation(session.id, 'Second Conv');
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // The entire conversation panel should be hidden when running
     const conversationPanel = page.locator('.conversation-panel');
@@ -301,7 +310,8 @@ test.describe('Conversation Branching', () => {
   });
 
   test('branch button visible on user messages', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Wait for the user message to appear
     const userMessage = page.locator('[data-testid="message-user"]');
@@ -316,7 +326,8 @@ test.describe('Conversation Branching', () => {
   });
 
   test('branch button not visible on assistant messages', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Wait for at least one message to appear
     const userMessage = page.locator('[data-testid="message-user"]');
@@ -334,7 +345,8 @@ test.describe('Conversation Branching', () => {
   });
 
   test('clicking branch button opens branch editor', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     const userMessage = page.locator('[data-testid="message-user"]');
     await expect(userMessage.first()).toBeVisible({ timeout: 10000 });
@@ -428,7 +440,8 @@ test.describe('Conversation Branching', () => {
     await new Promise((r) => setTimeout(r, 3000));
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -444,7 +457,8 @@ test.describe('Conversation Branching', () => {
   test('cannot branch while session is running', async ({ page }) => {
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // The conversation panel is hidden when running
     const conversationPanel = page.locator('.conversation-panel');
@@ -475,7 +489,8 @@ test.describe('Conversation Tree Visualization', () => {
     // Create a second root conversation
     await seedConversation(session.id, 'Second Root');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -505,7 +520,8 @@ test.describe('Conversation Tree Visualization', () => {
     await new Promise((r) => setTimeout(r, 3000));
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -534,7 +550,8 @@ test.describe('Conversation Tree Visualization', () => {
     await new Promise((r) => setTimeout(r, 3000));
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -562,7 +579,8 @@ test.describe('Conversation Tree Visualization', () => {
     await new Promise((r) => setTimeout(r, 3000));
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -579,7 +597,8 @@ test.describe('Conversation Tree Visualization', () => {
   test('conversation name displayed in tree', async ({ page }) => {
     await seedConversation(session.id, 'My Custom Name');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -595,7 +614,8 @@ test.describe('Conversation Tree Visualization', () => {
   test('message count shown in tree metadata', async ({ page }) => {
     await seedConversation(session.id, 'Second Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -666,7 +686,8 @@ test.describe('Per-Conversation Token Tracking', () => {
     // Create a second conversation so the dropdown appears
     await seedConversation(session.id, 'Second Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -805,7 +826,8 @@ test.describe('Conversation Deletion', () => {
   test('delete button visible on non-active conversations in dropdown', async ({ page }) => {
     await seedConversation(session.id, 'Deletable Conv');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');
@@ -826,7 +848,8 @@ test.describe('Conversation Deletion', () => {
   test('delete button not visible on active conversation', async ({ page }) => {
     await seedConversation(session.id, 'Keep Active');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Open dropdown
     const selectorBtn = page.locator('[data-testid="conversation-selector"]');

--- a/tests/e2e/draft-session-model-ui.spec.ts
+++ b/tests/e2e/draft-session-model-ui.spec.ts
@@ -4,6 +4,7 @@ import {
   seedSession,
   cleanupCreatedResources,
   getSession,
+  openSessionOverlay,
   API_URL,
 } from './helpers';
 
@@ -52,8 +53,9 @@ test.describe('Draft session model dropdown sync', () => {
     expect(initialSession.status).toBe('waiting');
 
     // Navigate to the session's conversation tab
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Wait for the model selector to appear and be populated
     const modelSelect = page.locator('#model-select');
@@ -119,8 +121,9 @@ test.describe('Draft session model dropdown sync', () => {
     });
 
     // Navigate to the session
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     const modelSelect = page.locator('#model-select');
     await expect(modelSelect).toBeVisible({ timeout: 10000 });
@@ -158,6 +161,7 @@ test.describe('Draft session model dropdown sync', () => {
     // Reload the page
     await page.reload();
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Wait for model selector to appear again
     const modelSelectAfterReload = page.locator('#model-select');

--- a/tests/e2e/effort-level.spec.ts
+++ b/tests/e2e/effort-level.spec.ts
@@ -13,6 +13,7 @@ import {
   getAgentCallLogs,
   seedAgentCallLog,
   navigateAndWait,
+  openSessionOverlay,
   API_URL,
   waitForSessionToExist,
 } from './helpers';
@@ -425,13 +426,14 @@ test.describe('Effort Level Feature - E2E Tests', () => {
     test.use({ viewport: { width: 1280, height: 720 } });
 
     test('effort level dropdown is visible in conversation input area', async ({ page }) => {
-      const project = await seedProject('Conversation Dropdown Test', '/tmp/conversation-dropdown');
+      const project = await seedProject('Conversation Dropdown Test', '/tmp/summary-dropdown');
       const session = await seedSession(project.id, {
         prompt: 'Test prompt',
         effortLevel: 'high',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Check that effort level dropdown is visible in input form
       const dropdown = page.locator('.input-form #effort-select');
@@ -439,13 +441,14 @@ test.describe('Effort Level Feature - E2E Tests', () => {
     });
 
     test('dropdown reflects current session effortLevel', async ({ page }) => {
-      const project = await seedProject('Conversation Reflect Test', '/tmp/conversation-reflect');
+      const project = await seedProject('Conversation Reflect Test', '/tmp/summary-reflect');
       const session = await seedSession(project.id, {
         prompt: 'Test prompt',
         effortLevel: 'medium',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Check that dropdown shows "medium"
       const dropdown = page.locator('.input-form #effort-select');
@@ -454,13 +457,14 @@ test.describe('Effort Level Feature - E2E Tests', () => {
     });
 
     test('dropdown shows "auto" for null effortLevel', async ({ page }) => {
-      const project = await seedProject('Conversation Auto Test', '/tmp/conversation-auto');
+      const project = await seedProject('Conversation Auto Test', '/tmp/summary-auto');
       const session = await seedSession(project.id, {
         prompt: 'Test prompt',
         // effortLevel defaults to null (auto)
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Check that dropdown shows "auto"
       const dropdown = page.locator('.input-form #effort-select');
@@ -469,13 +473,14 @@ test.describe('Effort Level Feature - E2E Tests', () => {
     });
 
     test('changing dropdown to "max" updates session via API', async ({ page }) => {
-      const project = await seedProject('Conversation Change Max Test', '/tmp/conversation-change-max');
+      const project = await seedProject('Conversation Change Max Test', '/tmp/summary-change-max');
       const session = await seedSession(project.id, {
         prompt: 'Test prompt',
         effortLevel: 'low',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Change dropdown to "max"
       await page.locator('.input-form #effort-select').selectOption('max');
@@ -497,13 +502,14 @@ test.describe('Effort Level Feature - E2E Tests', () => {
     });
 
     test('changing dropdown to "low" updates session via API', async ({ page }) => {
-      const project = await seedProject('Conversation Change Low Test', '/tmp/conversation-change-low');
+      const project = await seedProject('Conversation Change Low Test', '/tmp/summary-change-low');
       const session = await seedSession(project.id, {
         prompt: 'Test prompt',
         effortLevel: 'high',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Change dropdown to "low"
       await page.locator('.input-form #effort-select').selectOption('low');
@@ -524,13 +530,14 @@ test.describe('Effort Level Feature - E2E Tests', () => {
     });
 
     test('changes persist across page refresh', async ({ page }) => {
-      const project = await seedProject('Conversation Persist Test', '/tmp/conversation-persist');
+      const project = await seedProject('Conversation Persist Test', '/tmp/summary-persist');
       const session = await seedSession(project.id, {
         prompt: 'Test prompt',
         effortLevel: 'medium',
       });
 
-      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${process.env.BASE_URL || 'http://localhost:5000'}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Change dropdown to "high"
       await page.locator('.input-form #effort-select').selectOption('high');
@@ -547,6 +554,7 @@ test.describe('Effort Level Feature - E2E Tests', () => {
 
       // Reload page
       await page.reload();
+      await openSessionOverlay(page);
 
       // Wait for page to be ready
       await page.waitForSelector('.input-form #effort-select');
@@ -877,7 +885,8 @@ test.describe('Effort Level Feature - E2E Tests', () => {
         startImmediately: false,
       });
 
-      await navigateAndWait(page, `${API_URL}/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       const dropdown = page.locator('.input-form #effort-select');
 

--- a/tests/e2e/file-attachments.spec.ts
+++ b/tests/e2e/file-attachments.spec.ts
@@ -9,6 +9,7 @@ import {
   getSessionAttachments,
   updateSessionStatus,
   navigateAndWait,
+  openSessionOverlay,
   waitForSessionToExist,
   waitForPageReady,
   getAPIURL,
@@ -57,7 +58,7 @@ test.describe('File Attachments - Session Creation', () => {
     expect(session.name).toBe('Text File Test');
 
     // Navigate and prepare session for testing
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Verify attachments are stored and returned in messages
@@ -81,7 +82,7 @@ test.describe('File Attachments - Session Creation', () => {
     expect(session.id).toBeTruthy();
 
     // Navigate and prepare session for testing
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Verify all attachments are stored
@@ -105,7 +106,7 @@ test.describe('File Attachments - Session Creation', () => {
     expect(session.id).toBeTruthy();
 
     // Navigate and prepare session for testing
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Get messages and verify the user message exists with the file
@@ -130,7 +131,7 @@ test.describe('File Attachments - Session Creation', () => {
       [{ name: 'code.js', content: 'const x = 1;', type: 'application/javascript' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Get messages with attachments
@@ -165,7 +166,7 @@ test.describe('File Attachments - Follow-up Messages', () => {
     );
 
     // Navigate and prepare session for testing
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Send follow-up message with attachment - this should succeed
@@ -197,7 +198,7 @@ test.describe('File Attachments - Follow-up Messages', () => {
       [{ name: 'initial.txt', content: 'Initial content', type: 'text/plain' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Verify the initial message has the attachment
@@ -232,7 +233,7 @@ test.describe('File Attachments - UI Display', () => {
       [{ name: 'display-test.txt', content: 'Test content for display', type: 'text/plain' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Poll for attachment linkage before asserting (attachments are linked asynchronously
@@ -255,6 +256,7 @@ test.describe('File Attachments - UI Display', () => {
     for (let attempt = 0; attempt < 3 && !visible; attempt++) {
       await page.reload();
       await page.waitForLoadState('networkidle');
+      await openSessionOverlay(page);
       try {
         await expect(attachmentLocator).toBeVisible({ timeout: 5000 });
         visible = true;
@@ -277,7 +279,7 @@ test.describe('File Attachments - UI Display', () => {
       ]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     // Poll for attachment linkage before asserting (attachments are linked asynchronously
@@ -294,6 +296,7 @@ test.describe('File Attachments - UI Display', () => {
 
     await page.reload();
     await waitForPageReady(page);
+    await openSessionOverlay(page);
 
     // Wait for attachment chips to appear in DOM
     await page.waitForSelector('.attachment-chip', { timeout: 10000 });
@@ -324,7 +327,7 @@ test.describe('File Attachments - Different File Types', () => {
       [{ name: 'data.json', content: jsonContent, type: 'application/json' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     const attachments = await getSessionAttachments(session.id);
@@ -340,7 +343,7 @@ test.describe('File Attachments - Different File Types', () => {
       [{ name: 'script.js', content: jsContent, type: 'application/javascript' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     const attachments = await getSessionAttachments(session.id);
@@ -356,7 +359,7 @@ test.describe('File Attachments - Different File Types', () => {
       [{ name: 'readme.md', content: mdContent, type: 'text/markdown' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     const attachments = await getSessionAttachments(session.id);
@@ -372,7 +375,7 @@ test.describe('File Attachments - Different File Types', () => {
       [{ name: 'styles.css', content: cssContent, type: 'text/css' }]
     );
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     const attachments = await getSessionAttachments(session.id);
@@ -403,7 +406,7 @@ test.describe('File Attachments - Error Handling', () => {
 
     expect(session.id).toBeTruthy();
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     const attachments = await getSessionAttachments(session.id);
@@ -423,7 +426,7 @@ test.describe('File Attachments - Error Handling', () => {
 
     expect(session.id).toBeTruthy();
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await prepareSessionForTest(page, session.id);
 
     const attachments = await getSessionAttachments(session.id);

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -574,7 +574,7 @@ test.describe('Session Detail Tab Navigation', () => {
     await cleanupCreatedResources();
   });
 
-  test('session detail defaults to conversation tab', async ({ page }) => {
+  test('session detail defaults to summary tab', async ({ page }) => {
     await navigateAndWait(page, `/sessions/${session.id}`);
 
     // The route uses optional :tab? param, so URL stays at /sessions/:id

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -123,6 +123,34 @@ export async function navigateAndWait(
 }
 
 /**
+ * Open the session tree overlay on the session detail page.
+ * Clicks the tree handle and waits for the overlay to appear.
+ * Returns a Locator scoped to the overlay container.
+ */
+export async function openSessionOverlay(page: Page, timeout = 10000) {
+  const handle = page.locator('[data-testid="session-tree-handle"]');
+  await handle.waitFor({ state: 'visible', timeout });
+  await handle.click();
+  const overlay = page.locator('.session-tree-overlay');
+  await overlay.waitFor({ state: 'visible', timeout });
+  return overlay;
+}
+
+/**
+ * Navigate to a session detail page and open the session tree overlay.
+ * Combines navigateAndWait + openSessionOverlay for convenience.
+ * Returns the overlay Locator.
+ */
+export async function navigateAndOpenOverlay(
+  page: Page,
+  url: string,
+  options: { timeout?: number; waitFor?: string } = {},
+) {
+  await navigateAndWait(page, url, options);
+  return openSessionOverlay(page, options.timeout || 10000);
+}
+
+/**
  * Wait for a session to exist in the API
  */
 export async function waitForSessionToExist(sessionId: string, timeout = 5000): Promise<any> {

--- a/tests/e2e/messaging-chat.spec.ts
+++ b/tests/e2e/messaging-chat.spec.ts
@@ -11,6 +11,7 @@ import {
   seedConversationHistory,
   seedWorkLog,
   getSessionMessages,
+  openSessionOverlay,
 } from './helpers';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
@@ -36,7 +37,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     // Wait for message content to render before checking specific elements
     await page.locator('.message-assistant .message-content').first().waitFor({ timeout: 10000 });
 
@@ -55,7 +57,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const messageContent = page.locator('.message-assistant .message-content').first();
@@ -72,7 +75,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const messageContent = page.locator('.message-assistant .message-content').first();
@@ -90,7 +94,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     // Wait for message content to render before checking specific elements
     await page.locator('.message-assistant .message-content').first().waitFor({ timeout: 10000 });
 
@@ -110,7 +115,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const messageContent = page.locator('.message-assistant .message-content').first();
@@ -128,7 +134,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const messageContent = page.locator('.message-assistant .message-content').first();
@@ -146,7 +153,8 @@ test.describe('Markdown Rendering', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const messageContent = page.locator('.message-assistant .message-content').first();
@@ -177,7 +185,8 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const toolsSection = page.locator('.message-assistant .message-tools').first();
@@ -194,7 +203,8 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const toolDetails = page.locator('.message-assistant .message-tools details').first();
@@ -219,7 +229,8 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const toolsSection = page.locator('.message-assistant .message-tools').first();
@@ -236,7 +247,8 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const toolDetails = page.locator('.message-assistant .message-tools details').first();
@@ -261,7 +273,8 @@ test.describe('Tool Usage Display', () => {
     );
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const toolBlocks = page.locator('.message-assistant .message-tools details');
@@ -298,7 +311,8 @@ test.describe('Work Log UI Panels', () => {
     });
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const workLogPanel = page.locator('.message-assistant .work-log-panel').first();
@@ -315,7 +329,8 @@ test.describe('Work Log UI Panels', () => {
     });
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const workLogHeader = page.locator('.message-assistant .work-log-panel summary').first();
@@ -338,7 +353,8 @@ test.describe('Work Log UI Panels', () => {
     });
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const workLogHeader = page.locator('.message-assistant .work-log-panel summary').first();
@@ -372,7 +388,8 @@ test.describe('Jump Navigation Buttons', () => {
     seedAssistantMessage(session.id, 'Hello! How can I help you?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     // Button should not be visible when at bottom (hasNewMessages starts false)
@@ -385,7 +402,8 @@ test.describe('Jump Navigation Buttons', () => {
     seedConversationHistory(session.id, 30);
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(800);
 
     // On initial load, page auto-scrolls to bottom; hasNewMessages is false
@@ -399,7 +417,8 @@ test.describe('Jump Navigation Buttons', () => {
     seedAssistantMessage(session.id, 'Sure, I can help you with that!', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     // hasAssistantMessages=true, isNearBottom=true (loaded at bottom), isUsersTurn=true (waiting)
@@ -412,7 +431,8 @@ test.describe('Jump Navigation Buttons', () => {
     seedAssistantMessage(session.id, 'I am currently working...', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     // isUsersTurn = false when running
@@ -424,7 +444,8 @@ test.describe('Jump Navigation Buttons', () => {
     // Draft session = waiting status with no assistant messages
     const session = await seedSession(project.id, { prompt: 'Hello there, draft session', name: 'No Assistant Test' , startImmediately: false });
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const scrollToClaudeBtn = page.locator('.scroll-to-claude-btn');
@@ -450,7 +471,8 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'Hello! How can I help?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const textarea = page.locator('.input-form textarea');
@@ -462,7 +484,8 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'How can I help?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const textarea = page.locator('.input-form textarea');
@@ -476,7 +499,8 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'How can I help?', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const textarea = page.locator('.input-form textarea');
@@ -500,7 +524,8 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'I am here.', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     // Clear the textarea (pendingPrompt is pre-filled for startImmediately=false sessions)
@@ -516,7 +541,8 @@ test.describe('Resizable Textarea', () => {
     seedAssistantMessage(session.id, 'I am here.', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const textarea = page.locator('.input-form textarea');
@@ -544,7 +570,8 @@ test.describe('Model Name Display', () => {
     seedAssistantMessage(session.id, 'I am Claude Sonnet.', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const assistantMsg = page.locator('[data-testid="message-assistant"]').first();
@@ -558,7 +585,8 @@ test.describe('Model Name Display', () => {
     seedAssistantMessage(session.id, 'Got it!', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const userMsg = page.locator('[data-testid="message-user"]').first();
@@ -572,7 +600,8 @@ test.describe('Model Name Display', () => {
     seedAssistantMessage(session.id, 'I am Haiku.', 'claude-haiku-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const assistantMessages = page.locator('[data-testid="message-assistant"]');
@@ -609,7 +638,8 @@ test.describe('Message States & Error Handling', () => {
       name: 'Draft Session Test',
     });
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const textarea = page.locator('.input-form textarea');
@@ -623,7 +653,8 @@ test.describe('Message States & Error Handling', () => {
       startImmediately: false, // Don't auto-start - keeps it as a true draft
     });
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     // Draft sessions hide messages in the template (v-if="!isDraft && !isScheduledDraft")
@@ -637,7 +668,8 @@ test.describe('Message States & Error Handling', () => {
     seedAssistantMessage(session.id, 'Yes, I can help you!', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const inputForm = page.locator('.input-form');
@@ -649,7 +681,8 @@ test.describe('Message States & Error Handling', () => {
     seedAssistantMessage(session.id, 'Processing...', 'claude-sonnet-4-20250514');
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForTimeout(500);
 
     const runningState = page.locator('.running-state');

--- a/tests/e2e/model-selector-default.spec.ts
+++ b/tests/e2e/model-selector-default.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { openSessionOverlay } from './helpers';
 
 /**
  * E2E tests for model selector default behavior
@@ -93,8 +94,9 @@ test.describe('Model Selector Default Value', () => {
     console.log('Created test session:', sessionId);
 
     // Navigate to the session's conversation tab
-    await page.goto(`/sessions/${sessionId}/conversation`);
+    await page.goto(`/sessions/${sessionId}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Wait for the page to fully load
     await page.waitForTimeout(1500);
@@ -152,8 +154,9 @@ test.describe('Model Selector Default Value', () => {
     const sessionId = session.id;
 
     // Navigate to the session's conversation tab
-    await page.goto(`/sessions/${sessionId}/conversation`);
+    await page.goto(`/sessions/${sessionId}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
     await page.waitForTimeout(2000);
 
     // Take screenshot

--- a/tests/e2e/orchestration-panel.spec.ts
+++ b/tests/e2e/orchestration-panel.spec.ts
@@ -9,6 +9,7 @@ import {
   cleanupAll,
   cleanupTemplates,
   navigateAndWait,
+  openSessionOverlay,
 } from './helpers';
 
 // ============================================================
@@ -36,7 +37,8 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     const panel = page.locator('.orchestration-panel');
     await expect(panel).toBeVisible();
@@ -53,7 +55,8 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Panel content should NOT be visible (collapsed by default)
     const content = page.locator('.orchestration-content');
@@ -81,7 +84,8 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
     // Enable auto-reschedule via API
     await updateSessionScheduling(session.id, { autoRescheduleEnabled: true });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Content should be visible without clicking (auto-expanded)
     const content = page.locator('.orchestration-content');
@@ -106,7 +110,8 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
     // Set next template via API
     await setNextTemplate(session.id, template.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Content should be visible without clicking (auto-expanded)
     const content = page.locator('.orchestration-content');
@@ -143,7 +148,8 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -166,7 +172,8 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -193,7 +200,8 @@ test.describe('Orchestration Panel - Schedule Button State', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -244,7 +252,8 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -267,7 +276,8 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -301,7 +311,8 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand panel → click configure
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -332,7 +343,8 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand panel → click configure
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -380,7 +392,8 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
     // Enable auto-reschedule via API first
     await updateSessionScheduling(session.id, { autoRescheduleEnabled: true });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Panel should be expanded (auto-expanded because autoRescheduleEnabled)
     const content = page.locator('.orchestration-content');
@@ -453,7 +466,8 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -483,7 +497,8 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -510,7 +525,8 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -542,7 +558,8 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -592,7 +609,8 @@ test.describe('Orchestration Panel - Template Selector', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -620,7 +638,8 @@ test.describe('Orchestration Panel - Template Selector', () => {
     // Set next template via API before navigating
     await setNextTemplate(session.id, template1.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Panel should be auto-expanded (because template is set)
     const content = page.locator('.orchestration-content');
@@ -664,7 +683,8 @@ test.describe('Orchestration Panel - Integration', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -699,7 +719,8 @@ test.describe('Orchestration Panel - Integration', () => {
       startImmediately: false,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand the panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -763,7 +784,8 @@ test.describe('Orchestration Panel - Integration', () => {
       rescheduleDelayMinutes: 15,
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Panel should be auto-expanded (template + auto-reschedule set)
     const content = page.locator('.orchestration-content');

--- a/tests/e2e/provider-model-sync.spec.ts
+++ b/tests/e2e/provider-model-sync.spec.ts
@@ -8,6 +8,7 @@ import {
   seedProject,
   seedSession,
   getProvider,
+  openSessionOverlay,
 } from './helpers';
 
 /**
@@ -60,8 +61,9 @@ test.describe('Provider Model Sync in Model Selector', () => {
     expect(providerCheck.models?.some((m: any) => m.modelId === 'test-model-v1')).toBe(true);
 
     // Navigate to the session conversation tab
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // 5. Wait for the model selector to load with providers
     const modelSelect = page.locator('#model-select');
@@ -92,8 +94,9 @@ test.describe('Provider Model Sync in Model Selector', () => {
     await page.waitForLoadState('networkidle');
 
     // 8. Navigate back to the session conversation tab
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // 9. Assert the model selector now contains test-model-v2 and NOT test-model-v1
     const modelSelectAfter = page.locator('#model-select');
@@ -126,8 +129,9 @@ test.describe('Provider Model Sync in Model Selector', () => {
     expect(providerCheck.models?.some((m: any) => m.modelId === 'test-model-v1')).toBe(true);
 
     // Navigate to the session conversation tab
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // 5. Wait for the model selector to load with providers
     const modelSelect = page.locator('#model-select');
@@ -157,8 +161,9 @@ test.describe('Provider Model Sync in Model Selector', () => {
     await page.waitForLoadState('networkidle');
 
     // 8. Navigate back to the session conversation tab
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // 9. Assert the model selector now contains test-model-v2-updated and NOT test-model-v1
     const modelSelectAfter = page.locator('#model-select');

--- a/tests/e2e/queue-prompt.spec.ts
+++ b/tests/e2e/queue-prompt.spec.ts
@@ -13,6 +13,7 @@ import {
   updateSessionStatus,
   updateSessionFields,
   updatePendingPrompt,
+  openSessionOverlay,
 } from './helpers';
 
 // ============================================================
@@ -40,7 +41,8 @@ test.describe('Queue Prompt - Input Form Visibility During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     const textarea = page.locator('textarea');
     await expect(textarea).toBeVisible();
@@ -56,7 +58,8 @@ test.describe('Queue Prompt - Input Form Visibility During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await expect(page.locator('.send-button-row')).not.toBeVisible();
     await expect(page.locator('.input-controls')).not.toBeVisible();
@@ -69,7 +72,8 @@ test.describe('Queue Prompt - Input Form Visibility During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'starting');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // The input form should not be visible when starting
     await expect(page.locator('.input-form')).not.toBeVisible();
@@ -101,7 +105,8 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await page.locator('textarea').fill('My prompt');
 
@@ -118,7 +123,8 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
     // Clear the pending prompt so the textarea starts empty
     await updatePendingPrompt(session.id, '');
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Ensure textarea is empty
     await page.locator('textarea').fill('');
@@ -133,7 +139,8 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
       startImmediately: false,
     });
     // Session stays in waiting state (startImmediately: false sets to waiting by default)
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await page.locator('textarea').fill('Some content');
 
@@ -147,7 +154,8 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await page.locator('textarea').fill('Prompt');
 
@@ -181,7 +189,8 @@ test.describe('Queue Prompt - Auto-Send Toggle Persistence', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await page.locator('textarea').fill('My prompt');
     await page.locator('.auto-send-checkbox').check();
@@ -202,7 +211,8 @@ test.describe('Queue Prompt - Auto-Send Toggle Persistence', () => {
     await updatePendingPrompt(session.id, 'test');
     await updateSessionFields(session.id, { autoSendPendingPrompt: true });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // The textarea should show the pendingPrompt, and checkbox should be checked
     await expect(page.locator('.auto-send-checkbox')).toBeChecked();
@@ -242,7 +252,8 @@ test.describe('Queue Prompt - OrchestrationPanel During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await expect(page.locator('.orchestration-panel')).toBeVisible();
   });
@@ -258,7 +269,8 @@ test.describe('Queue Prompt - OrchestrationPanel During Running', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Expand orchestration panel
     const panelHeader = page.locator('.orchestration-panel .panel-header');
@@ -300,7 +312,8 @@ test.describe('Queue Prompt - Auto-Send Reset on Transitions', () => {
     await updatePendingPrompt(session.id, 'test');
     await updateSessionFields(session.id, { autoSendPendingPrompt: true });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Verify checkbox is checked
     await expect(page.locator('.auto-send-checkbox')).toBeChecked();
@@ -321,7 +334,8 @@ test.describe('Queue Prompt - Auto-Send Reset on Transitions', () => {
       startImmediately: false,
     });
     await updateSessionStatus(session.id, 'running');
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Type a prompt and enable auto-send
     await page.locator('textarea').fill('My important prompt');
@@ -373,7 +387,8 @@ test.describe('Queue Prompt - Auto-Send End-to-End', () => {
     await updateSessionFields(session.id, { autoSendPendingPrompt: true });
 
     // 3. Navigate to the session page
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // 4. Now start the first turn by sending the initial prompt via the message API.
     //    This calls continueSession on the server, triggering a real agent turn (VCR replayed).

--- a/tests/e2e/quick-responses.spec.ts
+++ b/tests/e2e/quick-responses.spec.ts
@@ -10,6 +10,7 @@ import {
   navigateAndWait,
   waitForPageReady,
   getAPIURL,
+  openSessionOverlay,
 } from './helpers';
 
 const API_URL = getAPIURL();
@@ -91,7 +92,8 @@ async function navigateToSessionAndExpandPanel(page, sessionId: string) {
     { timeout: 30000 }
   );
 
-  await page.goto(`/sessions/${sessionId}/conversation`);
+  await page.goto(`/sessions/${sessionId}/summary`);
+  await openSessionOverlay(page);
 
   // Wait for the quick-responses API call to complete.
   await apiDone;
@@ -380,8 +382,9 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
 
     const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
 
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
     await waitForPageReady(page);
+    await openSessionOverlay(page);
 
     const panel = page.locator('.quick-responses-panel');
     await expect(panel).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/scheduled-session-prompt-visible.spec.ts
+++ b/tests/e2e/scheduled-session-prompt-visible.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { seedProject, cleanupCreatedResources, navigateAndWait, getSessionMessages, getSession, getAPIURL, getProject } from './helpers';
+import { seedProject, cleanupCreatedResources, navigateAndWait, getSessionMessages, getSession, getAPIURL, getProject, openSessionOverlay } from './helpers';
 
 /**
  * Test for Bug: Scheduled session prompt is not visible in conversation
@@ -125,7 +125,8 @@ test.describe('Scheduled Session Prompt Visibility Bug', () => {
       expect(userMessagesAfter[0].content).toBe(testPrompt);
 
       // Navigate to verify the UI also shows the user message
-      await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       const userMessageLocator = page.locator('[data-testid="message-user"]');
       const userMessageCount = await userMessageLocator.count();
 
@@ -168,7 +169,8 @@ test.describe('Scheduled Session Prompt Visibility Bug', () => {
       expect(userMessagesAfter.length).toBe(0);
 
       // Navigate to verify the UI also shows no user message
-      await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       const userMessageLocator = page.locator('[data-testid="message-user"]');
       const userMessageCount = await userMessageLocator.count();
 
@@ -190,7 +192,8 @@ test.describe('Scheduled Session Prompt Visibility Bug', () => {
     expect(messagesBefore.filter((m: any) => m.role === 'user').length).toBe(0);
 
     // Navigate to session
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Manually trigger the session start by calling the start API
     // First, change status to 'waiting' so we can use the /start endpoint
@@ -215,6 +218,7 @@ test.describe('Scheduled Session Prompt Visibility Bug', () => {
     // Reload page to see updated messages
     await page.reload();
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // BUG VERIFICATION: Check if user message was created
     const messagesAfter = await getSessionMessages(session.id);

--- a/tests/e2e/scheduled-session-prompt.spec.ts
+++ b/tests/e2e/scheduled-session-prompt.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { seedProject, cleanupAll, navigateAndWait, getSessionMessages } from './helpers';
+import { seedProject, cleanupAll, navigateAndWait, openSessionOverlay, getSessionMessages } from './helpers';
 
 /**
  * Test for Issue #435: Scheduled session prompt should appear in text input, not as message
@@ -32,7 +32,8 @@ test.describe('Scheduled Session Prompt Location (#435)', () => {
     const session = await createScheduledSession(project.id, testPrompt, futureTime);
 
     // Navigate to the session detail page (conversation tab)
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // VERIFY 1: Prompt should be in the text input field
     const textarea = page.locator('textarea');
@@ -60,7 +61,8 @@ test.describe('Scheduled Session Prompt Location (#435)', () => {
     const session = await createScheduledSession(project.id, testPrompt, futureTime);
 
     // Navigate to the session (conversation tab)
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Verify prompt is in textarea initially
     const textarea = page.locator('textarea');

--- a/tests/e2e/scheduling-reschedule.spec.ts
+++ b/tests/e2e/scheduling-reschedule.spec.ts
@@ -10,6 +10,7 @@ import {
   cleanupCreatedResources,
   cleanupAll,
   navigateAndWait,
+  openSessionOverlay,
   waitForPageReady,
   updatePendingPrompt,
   updateSessionStatus,
@@ -538,7 +539,8 @@ test.describe('Category 5: Scheduling UI Components', () => {
     });
 
     // Navigate to session detail conversation tab (Edit Schedule button is in ConversationTab)
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Click "Edit Schedule" button
     const editButton = page.getByRole('button', { name: 'Edit Schedule' });

--- a/tests/e2e/scheduling-ui.spec.ts
+++ b/tests/e2e/scheduling-ui.spec.ts
@@ -159,6 +159,7 @@ test.describe('Scheduling UI', () => {
       // Verify via page reload that the time is still correct
       await page.reload();
       await page.waitForLoadState('networkidle');
+      await openSessionOverlay(page);
 
       const countdownTextAfterReload = page.locator('.countdown-text strong');
       await expect(countdownTextAfterReload).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/scheduling-ui.spec.ts
+++ b/tests/e2e/scheduling-ui.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { seedProject, seedSession, cleanupAll, navigateAndWait } from './helpers';
+import { seedProject, seedSession, cleanupAll, navigateAndWait, openSessionOverlay } from './helpers';
 
 test.describe('Scheduling UI', () => {
   test.describe.configure({ timeout: 60000 });
@@ -21,7 +21,8 @@ test.describe('Scheduling UI', () => {
       const session = await seedSession(project.id, { prompt: 'Initial content', startImmediately: false });
 
       // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Expand the Orchestration panel
       const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
@@ -43,7 +44,8 @@ test.describe('Scheduling UI', () => {
       const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
 
       // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Expand the Orchestration panel
       const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
@@ -71,7 +73,8 @@ test.describe('Scheduling UI', () => {
       const session = await seedSession(project.id, { prompt: 'Scheduled task: do something', startImmediately: false });
 
       // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Expand the Orchestration panel
       const orchestrationPanel = page.locator('.orchestration-panel .panel-header');
@@ -104,7 +107,8 @@ test.describe('Scheduling UI', () => {
       const session = await seedSession(project.id, { prompt: 'Test scheduled time display', startImmediately: false });
 
       // Navigate to the session
-      await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+      await navigateAndWait(page, `/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Expand the Orchestration panel
       const orchestrationPanel = page.locator('.orchestration-panel .panel-header');

--- a/tests/e2e/session-actions.spec.ts
+++ b/tests/e2e/session-actions.spec.ts
@@ -64,13 +64,13 @@ test.describe('Duplicate Session', () => {
     await page.locator('.menu-items button.menu-item').filter({ hasText: 'Duplicate' }).click();
 
     // After a successful duplicate, handleDuplicate() navigates to the new session:
-    //   router.push(`/sessions/${newSessionId}/conversation`)
+    //   router.push(`/sessions/${newSessionId}/summary`)
     // Waiting for that URL change confirms the duplicate API call succeeded.
-    await page.waitForURL(/\/sessions\/[^/]+\/conversation/, { timeout: 15000 });
+    await page.waitForURL(/\/sessions\/[^/]+\/summary/, { timeout: 15000 });
 
     // Extract the new session ID from the current URL
     const newUrl = page.url();
-    const newSessionIdMatch = newUrl.match(/\/sessions\/([^/]+)\/conversation/);
+    const newSessionIdMatch = newUrl.match(/\/sessions\/([^/]+)\/summary/);
     expect(newSessionIdMatch).toBeTruthy();
     const newSessionId = newSessionIdMatch![1];
 

--- a/tests/e2e/session-detail-scroll.spec.ts
+++ b/tests/e2e/session-detail-scroll.spec.ts
@@ -75,33 +75,36 @@ test.describe('Session Detail Scroll Behavior', () => {
     await openSessionOverlay(page);
     await expect(page.locator('[data-testid="message-user"]')).toBeVisible({ timeout: 10000 });
 
-    // The messages container uses max-height (viewport-relative) with overflow-y: auto.
-    // This is intentional for layout stability. The key check is that the container
-    // itself is scrollable and not trapped in a tiny fixed-pixel container.
+    // In the overlay, .overlay-body is the scroll container (ConversationTab passes
+    // overlayBodyRef as scrollContainerRef). The .messages div still has max-height
+    // but the effective scrollable area is the overlay-body.
+    // The key check is that the scroll container is tall enough and scrollable,
+    // not trapped in a tiny fixed-pixel container.
     const containerInfo = await page.evaluate(() => {
-      const container = document.querySelector('.messages');
-      if (!container) return null;
-      const style = window.getComputedStyle(container);
+      // Check overlay-body (the actual scroll container in overlay context)
+      const overlayBody = document.querySelector('.overlay-body');
+      if (!overlayBody) return null;
+      const style = window.getComputedStyle(overlayBody);
       return {
-        scrollHeight: container.scrollHeight,
-        clientHeight: container.clientHeight,
-        isScrollable: container.scrollHeight > container.clientHeight + 100,
-        maxHeight: style.maxHeight,
+        scrollHeight: overlayBody.scrollHeight,
+        clientHeight: overlayBody.clientHeight,
+        isScrollable: overlayBody.scrollHeight > overlayBody.clientHeight + 100,
+        overflowY: style.overflowY,
         // Verify it's not a tiny fixed-pixel container (old bug was 500px)
-        clientHeightPx: container.clientHeight,
+        clientHeightPx: overlayBody.clientHeight,
       };
     });
 
     expect(containerInfo).not.toBeNull();
-    // With 80 paragraphs, the messages container should be scrollable
+    // With 80 paragraphs, the scroll container should be scrollable
     expect(containerInfo!.isScrollable).toBe(true);
     // Container should be at least 300px tall (not trapped in a tiny box)
     expect(containerInfo!.clientHeightPx).toBeGreaterThan(300);
 
-    // Scroll to the very bottom of the messages container.
+    // Scroll to the very bottom of the overlay-body scroll container.
     // Override scroll-behavior to 'auto' so scrollTo lands instantly.
     await page.evaluate(() => {
-      const container = document.querySelector('.messages') as HTMLElement | null;
+      const container = document.querySelector('.overlay-body') as HTMLElement | null;
       if (container) {
         container.style.scrollBehavior = 'auto';
         container.scrollTop = container.scrollHeight;
@@ -111,7 +114,7 @@ test.describe('Session Detail Scroll Behavior', () => {
 
     // Verify we reached the bottom (allow small tolerance for sub-pixel rounding)
     const afterScroll = await page.evaluate(() => {
-      const container = document.querySelector('.messages');
+      const container = document.querySelector('.overlay-body');
       if (!container) return { distanceFromBottom: 999 };
       return { distanceFromBottom: container.scrollHeight - container.scrollTop - container.clientHeight };
     });
@@ -120,7 +123,7 @@ test.describe('Session Detail Scroll Behavior', () => {
     // Wait and verify no bounce-back
     await page.waitForTimeout(500);
     const afterWait = await page.evaluate(() => {
-      const container = document.querySelector('.messages');
+      const container = document.querySelector('.overlay-body');
       if (!container) return { distanceFromBottom: 999 };
       return { distanceFromBottom: container.scrollHeight - container.scrollTop - container.clientHeight };
     });

--- a/tests/e2e/session-detail-scroll.spec.ts
+++ b/tests/e2e/session-detail-scroll.spec.ts
@@ -4,6 +4,7 @@ import {
   seedSession,
   cleanupAll,
   navigateAndWait,
+  openSessionOverlay,
 } from './helpers';
 
 /**
@@ -47,7 +48,7 @@ test.describe('Session Detail Scroll Behavior', () => {
     // Mobile viewport (below 768px, uses top: 51px)
     await page.setViewportSize({ width: 375, height: 812 });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await expect(page.locator('.tabs')).toBeVisible({ timeout: 10000 });
 
     const layout = await page.evaluate(() => {
@@ -70,7 +71,8 @@ test.describe('Session Detail Scroll Behavior', () => {
   });
 
   test('page-level scroll reaches bottom of conversation', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await expect(page.locator('[data-testid="message-user"]')).toBeVisible({ timeout: 10000 });
 
     // The messages container uses max-height (viewport-relative) with overflow-y: auto.

--- a/tests/e2e/session-message-persistence.spec.ts
+++ b/tests/e2e/session-message-persistence.spec.ts
@@ -26,6 +26,7 @@ import {
   getSession,
   BASE_URL,
   API_URL,
+  openSessionOverlay,
 } from './helpers';
 
 test.describe('Session Message Persistence After Response Completes', () => {
@@ -50,8 +51,9 @@ test.describe('Session Message Persistence After Response Completes', () => {
     });
 
     // Step 2: Navigate to the session page while it's running
-    await page.goto(`${BASE_URL}/sessions/${session.id}/conversation`);
+    await page.goto(`${BASE_URL}/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Step 3: Wait for streaming content to appear in the UI
     // Either the streaming indicator or a committed assistant message should appear
@@ -102,8 +104,9 @@ test.describe('Session Message Persistence After Response Completes', () => {
     trackSession(sessionId!);
 
     // Navigate to conversation tab (default is now summary tab)
-    await page.goto(`${BASE_URL}/sessions/${sessionId}/conversation`);
+    await page.goto(`${BASE_URL}/sessions/${sessionId}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Step 4: Wait for the session to complete
     // The session runs via the real Claude API
@@ -143,8 +146,9 @@ test.describe('Session Message Persistence After Response Completes', () => {
     });
 
     // Step 2: Navigate to the session page
-    await page.goto(`${BASE_URL}/sessions/${session.id}/conversation`);
+    await page.goto(`${BASE_URL}/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Step 3: Wait for the session to complete
     await waitForStatus(session.id, 'waiting', 60000);
@@ -159,6 +163,7 @@ test.describe('Session Message Persistence After Response Completes', () => {
     // Step 6: Refresh the page
     await page.reload();
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
     await page.waitForTimeout(2000);
 
     // Step 7: Record message counts AFTER refresh
@@ -191,8 +196,9 @@ test.describe('Session Message Persistence After Response Completes', () => {
     });
 
     // Step 2: Navigate and wait for completion
-    await page.goto(`${BASE_URL}/sessions/${session.id}/conversation`);
+    await page.goto(`${BASE_URL}/sessions/${session.id}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
     await waitForStatus(session.id, 'waiting', 60000);
 
     // Step 3: Wait for UI to process the status change

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -6,6 +6,7 @@ import {
   getSession,
   navigateAndWait,
   waitForSessionToExist,
+  openSessionOverlay,
 } from './helpers';
 
 test.describe('New Session - Thinking Toggle', () => {
@@ -126,7 +127,8 @@ test.describe('Session Management', () => {
     // Wait for session to be available
     await waitForSessionToExist(session.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // The initial user message should be visible
     await expect(page.locator('.message-content').getByText('Hello Claude', { exact: true })).toBeVisible({ timeout: 10000 });
@@ -146,7 +148,7 @@ test.describe('Session Management', () => {
     const storageKey2 = `session-draft-${session2.id}`;
 
     // Navigate to first session
-    await page.goto(`/sessions/${session1.id}/conversation`);
+    await page.goto(`/sessions/${session1.id}/summary`);
 
     // Set different drafts for each session in localStorage
     await page.evaluate(
@@ -166,7 +168,7 @@ test.describe('Session Management', () => {
     expect(storedValue).toBe('Draft for session 2');
 
     // Navigate to session 2
-    await page.goto(`/sessions/${session2.id}/conversation`);
+    await page.goto(`/sessions/${session2.id}/summary`);
 
     // Verify session 1's draft is still intact after navigating away
     storedValue = await page.evaluate((key) => localStorage.getItem(key), storageKey1);

--- a/tests/e2e/slash-commands.spec.ts
+++ b/tests/e2e/slash-commands.spec.ts
@@ -5,6 +5,7 @@ import {
   cleanupAll,
   waitForSessionStatus,
   navigateAndWait,
+  openSessionOverlay,
   waitForSessionToExist,
 } from './helpers';
 
@@ -33,8 +34,9 @@ test.describe('Slash Commands', () => {
     await waitForSessionStatus(page, sessionId, 'waiting', 30000);
 
     // Navigate directly to the session conversation
-    await page.goto(`/sessions/${sessionId}/conversation`);
+    await page.goto(`/sessions/${sessionId}/summary`);
     await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
 
     // Wait for the input form to be visible (indicates session loaded and in sendable state)
     const inputForm = page.locator('.input-form');

--- a/tests/e2e/todo-tracking.spec.ts
+++ b/tests/e2e/todo-tracking.spec.ts
@@ -9,6 +9,7 @@ import {
   getConversations,
   navigateAndWait,
   waitForElement,
+  openSessionOverlay,
 } from './helpers';
 
 test.describe('Todo Tracking — Category 1: API Tests', () => {
@@ -134,7 +135,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
   });
 
   test('todo drawer is hidden when no todos exist', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     const drawer = page.locator('.todo-drawer');
     await expect(drawer).not.toBeAttached();
   });
@@ -144,7 +146,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     const drawer = page.locator('.todo-drawer');
     await expect(drawer).toBeVisible();
   });
@@ -154,7 +157,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     const label = page.locator('.todo-label');
     await expect(label).toContainText('Todos');
   });
@@ -171,7 +175,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Todo 6', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     const summary = page.locator('.todo-summary');
     await expect(summary).toBeVisible();
 
@@ -191,7 +196,8 @@ test.describe('Todo Tracking — Category 2: Drawer Visibility', () => {
       { content: 'Todo 6', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     const moreIndicator = page.locator('.todo-more');
     await expect(moreIndicator).toContainText('(+2 more)');
   });
@@ -221,7 +227,8 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Pending task', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -238,7 +245,8 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'In progress task', status: 'in_progress' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -257,7 +265,8 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Completed task', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -277,7 +286,8 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Completed task', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -296,7 +306,8 @@ test.describe('Todo Tracking — Category 3: Todo Statuses Display', () => {
       { content: 'Completed task', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -345,7 +356,8 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     const summary = page.locator('.todo-summary');
     await expect(summary).toBeVisible();
@@ -359,7 +371,8 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Click header to expand
     await page.locator('.todo-header').click();
@@ -379,7 +392,8 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Pending', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Click header to expand
     await page.locator('.todo-header').click();
@@ -399,7 +413,8 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Test todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Click to expand
     await page.locator('.todo-header').click();
@@ -418,7 +433,8 @@ test.describe('Todo Tracking — Category 4: Expand/Collapse Behavior', () => {
       { content: 'Third todo item', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -544,7 +560,8 @@ test.describe('Todo Tracking — Category 6: Text Handling', () => {
       { content: longText, status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     const chipText = page.locator('.todo-chip .todo-text');
     await expect(chipText).toContainText('Implement user authe...');
@@ -555,7 +572,8 @@ test.describe('Todo Tracking — Category 6: Text Handling', () => {
       { content: 'Fix bug', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     const chipText = page.locator('.todo-chip .todo-text');
     await expect(chipText).toContainText('Fix bug');
@@ -568,7 +586,8 @@ test.describe('Todo Tracking — Category 6: Text Handling', () => {
       { content: longText, status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();
@@ -615,7 +634,8 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
     todos = await getTodos(sessionId, conversationId);
     expect(todos).toEqual([]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     const drawer = page.locator('.todo-drawer');
     await expect(drawer).not.toBeAttached();
   });
@@ -625,7 +645,8 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
       { content: 'Only todo', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     const chips = page.locator('.todo-chip');
     await expect(chips).toHaveCount(1);
@@ -642,7 +663,8 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
       { content: 'Todo 4', status: 'pending' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     const chips = page.locator('.todo-chip');
     await expect(chips).toHaveCount(4);
@@ -657,7 +679,8 @@ test.describe('Todo Tracking — Category 7: Edge Cases & Empty States', () => {
       { content: 'Completed 2', status: 'completed' },
     ]);
 
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
 
     // Expand drawer
     await page.locator('.todo-header').click();

--- a/tests/e2e/token-usage-cost.spec.ts
+++ b/tests/e2e/token-usage-cost.spec.ts
@@ -22,6 +22,7 @@ import {
   getTokenWeights,
   seedConversationTokens,
   getAPIURL,
+  openSessionOverlay,
 } from './helpers';
 
 const DEFAULT_WEIGHTS = { input: 1.0, output: 5.0, cacheRead: 0.1, cacheCreation: 1.25 };
@@ -117,27 +118,31 @@ test.describe('Token Cost Panel — BTE Display', () => {
 
   test('cost panel is visible when tokens have non-zero cost', async ({ page }) => {
     seedConversationTokens(sessionId, null, { inputTokens: 5000, outputTokens: 2000 });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     await expect(page.locator('.token-cost-panel')).toBeVisible({ timeout: 10000 });
   });
 
   test('cost panel is hidden when cost is zero', async ({ page }) => {
     // Seed all-zero tokens → BTE = 0 → v-if="hasNonZeroCost" is false → panel hidden
     seedConversationTokens(sessionId, null, { inputTokens: 0, outputTokens: 0 });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     await expect(page.locator('.token-cost-panel')).not.toBeVisible({ timeout: 10000 });
   });
 
   test('displays BTE value in collapsed view', async ({ page }) => {
     // input=10000, output=2000 → BTE = 10000×1.0 + 2000×5.0 = 20000 → "20.0K"
     seedConversationTokens(sessionId, null, { inputTokens: 10000, outputTokens: 2000 });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     await expect(page.locator('.token-cost-panel .cost-value')).toHaveText('20.0K', { timeout: 10000 });
   });
 
   test('clicking cost display expands breakdown', async ({ page }) => {
     seedConversationTokens(sessionId, null, { inputTokens: 10000, outputTokens: 2000 });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     await page.locator('.token-cost-panel .cost-display').click();
     await expect(page.locator('.token-breakdown')).toBeVisible({ timeout: 10000 });
   });
@@ -150,7 +155,8 @@ test.describe('Token Cost Panel — BTE Display', () => {
       cacheReadInputTokens: 5000,
       cacheCreationInputTokens: 1000,
     });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     await page.locator('.token-cost-panel .cost-display').click();
     await expect(page.locator('.token-breakdown')).toBeVisible({ timeout: 10000 });
 
@@ -192,7 +198,8 @@ test.describe('Token Weights Modal', () => {
     await resetTokenWeights();
     // Seed tokens so the cost panel is visible (BTE > 0)
     seedConversationTokens(sessionId, null, { inputTokens: 10000, outputTokens: 2000 });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     // Expand cost panel to reveal the gear/settings button
     await page.locator('.token-cost-panel .cost-display').click();
     await expect(page.locator('.token-breakdown')).toBeVisible({ timeout: 10000 });
@@ -329,7 +336,8 @@ test.describe('Per-Conversation Token Tracking', () => {
     // input=5000, output=1000 → BTE = 5000×1.0 + 1000×5.0 = 10000 → "10.0K" (with default weights)
     seedConversationTokens(sessionId, convA.id, { inputTokens: 5000, outputTokens: 1000 });
     // Full page load ensures Pinia store initializes fresh and fetches current (default) weights from API
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     // Wait for settings to be fetched before asserting BTE (TokenCostPanel fetches on mount)
     await page.waitForTimeout(500);
     await expect(page.locator('.token-cost-panel .cost-value')).toHaveText('10.0K', { timeout: 10000 });
@@ -346,7 +354,8 @@ test.describe('Per-Conversation Token Tracking', () => {
 
     // input=5000, output=1000 → BTE = 5000×1.0 + 1000×10.0 = 15000 → "15.0K"
     seedConversationTokens(sessionId, convA.id, { inputTokens: 5000, outputTokens: 1000 });
-    await navigateAndWait(page, `/sessions/${sessionId}/conversation`);
+    await navigateAndWait(page, `/sessions/${sessionId}/summary`);
+    await openSessionOverlay(page);
     // Wait for the settings store to fetch custom weights from API before asserting
     await page.waitForTimeout(500);
     await expect(page.locator('.token-cost-panel .cost-value')).toHaveText('15.0K', { timeout: 10000 });

--- a/tests/e2e/ui-ux.spec.ts
+++ b/tests/e2e/ui-ux.spec.ts
@@ -16,6 +16,7 @@ import {
   seedConversation,
   getConversations,
   updateSessionStatus,
+  openSessionOverlay,
   API_URL,
   BASE_URL,
 } from './helpers';
@@ -79,7 +80,7 @@ test.describe('Dark Mode Styling', () => {
   });
 
   test('text uses light colors for readability', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await page.waitForSelector('.session-name', { timeout: 8000 });
 
@@ -103,7 +104,7 @@ test.describe('Dark Mode Styling', () => {
     // Star the session first
     await toggleSessionStar(session.id);
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await page.waitForSelector('.btn-star.is-starred', { timeout: 8000 });
 
@@ -146,7 +147,7 @@ test.describe('Toast Notifications', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open overflow menu and click Archive
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -165,7 +166,7 @@ test.describe('Toast Notifications', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open overflow menu and click Duplicate
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -180,9 +181,9 @@ test.describe('Toast Notifications', () => {
     await expect(toast.locator('.toast-message')).toContainText('duplicated', { ignoreCase: true });
 
     // Track the new session for cleanup
-    await page.waitForURL(/\/sessions\/[^/]+\/conversation/, { timeout: 15000 });
+    await page.waitForURL(/\/sessions\/[^/]+\/summary/, { timeout: 15000 });
     const newUrl = page.url();
-    const newSessionIdMatch = newUrl.match(/\/sessions\/([^/]+)\/conversation/);
+    const newSessionIdMatch = newUrl.match(/\/sessions\/([^/]+)\/summary/);
     if (newSessionIdMatch) {
       trackSession(newSessionIdMatch[1]);
     }
@@ -194,7 +195,7 @@ test.describe('Toast Notifications', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Trigger archive to produce a toast
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -215,7 +216,7 @@ test.describe('Toast Notifications', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Trigger archive to produce a toast
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -239,7 +240,7 @@ test.describe('Toast Notifications', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Trigger archive to produce a success toast
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -271,7 +272,7 @@ test.describe('Toast Notifications', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Trigger archive (will fail due to intercepted route)
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -295,7 +296,7 @@ test.describe('Toast Notifications', () => {
     // Accept all dialogs
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Star the session (produces a toast in some implementations) — actually, star doesn't produce a toast
     // Instead, archive via overflow menu and then check if the "Deleting..." info toast + "Session archived" success toast both appear
@@ -356,7 +357,7 @@ test.describe('Loading States & Spinners', () => {
     });
 
     // Navigate (don't wait for networkidle since we're delaying the response)
-    await page.goto(`/sessions/${session.id}/conversation`);
+    await page.goto(`/sessions/${session.id}/summary`);
 
     // Loading state should be visible while waiting
     await expect(page.locator('.loading-state')).toBeVisible({ timeout: 3000 });
@@ -394,7 +395,7 @@ test.describe('Loading States & Spinners', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Intercept delete API and delay it
     await page.route(`**/api/sessions/${session.id}`, async (route) => {
@@ -421,7 +422,7 @@ test.describe('Loading States & Spinners', () => {
   test('loading spinner disappears after data loads', async ({ page }) => {
     const session = await seedSession(project.id, { prompt: 'test', name: 'Loading Done Test', startImmediately: false });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // After page is ready, loading state should not be visible
     await expect(page.locator('.loading-state')).not.toBeVisible();
@@ -449,7 +450,7 @@ test.describe('Responsive / Mobile Design', () => {
 
   test('desktop viewport shows tab links', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await expect(page.locator('.tabs-desktop')).toBeVisible({ timeout: 8000 });
     await expect(page.locator('.tabs-mobile')).not.toBeVisible();
@@ -458,7 +459,7 @@ test.describe('Responsive / Mobile Design', () => {
   test('mobile viewport shows tab dropdown on session detail', async ({ page }) => {
     // Set viewport BEFORE navigation (below 640px tab breakpoint)
     await page.setViewportSize({ width: 375, height: 812 });
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await expect(page.locator('.tabs-mobile')).toBeVisible({ timeout: 8000 });
     await expect(page.locator('.tabs-desktop')).not.toBeVisible();
@@ -466,7 +467,7 @@ test.describe('Responsive / Mobile Design', () => {
 
   test('mobile tab dropdown navigates to correct tab', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await page.waitForSelector('.tabs-mobile .tab-select', { timeout: 8000 });
 
@@ -481,7 +482,7 @@ test.describe('Responsive / Mobile Design', () => {
   test('session name font size adjusts for mobile', async ({ page }) => {
     // Set viewport below 768px header breakpoint
     await page.setViewportSize({ width: 375, height: 812 });
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await page.waitForSelector('.session-name', { timeout: 8000 });
 
@@ -499,7 +500,7 @@ test.describe('Responsive / Mobile Design', () => {
 
   test('session header layout adjusts for mobile', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     await page.waitForSelector('.session-header-row', { timeout: 8000 });
 
@@ -533,7 +534,7 @@ test.describe('Overflow Menu', () => {
   });
 
   test('overflow menu opens on kebab click and shows all items', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Click kebab button
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -552,7 +553,7 @@ test.describe('Overflow Menu', () => {
   });
 
   test('overflow menu closes on overlay click', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open menu
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -567,7 +568,7 @@ test.describe('Overflow Menu', () => {
   });
 
   test('overflow menu closes on Escape key', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open menu
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -583,7 +584,7 @@ test.describe('Overflow Menu', () => {
   });
 
   test('overflow menu keyboard navigation with ArrowDown/Up', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open menu
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -609,7 +610,7 @@ test.describe('Overflow Menu', () => {
     // Accept confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open menu
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -630,18 +631,18 @@ test.describe('Overflow Menu', () => {
     await secondItem.dispatchEvent('keydown', { key: 'Enter', bubbles: true });
 
     // Should navigate to new session (duplicate successful)
-    await page.waitForURL(/\/sessions\/[^/]+\/conversation/, { timeout: 15000 });
+    await page.waitForURL(/\/sessions\/[^/]+\/summary/, { timeout: 15000 });
 
     // Track the new session for cleanup
     const newUrl = page.url();
-    const newSessionIdMatch = newUrl.match(/\/sessions\/([^/]+)\/conversation/);
+    const newSessionIdMatch = newUrl.match(/\/sessions\/([^/]+)\/summary/);
     if (newSessionIdMatch) {
       trackSession(newSessionIdMatch[1]);
     }
   });
 
   test('overflow menu has correct ARIA attributes', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     const kebab = page.locator('button.btn-kebab[aria-label="Session actions"]');
     await expect(kebab).toBeVisible({ timeout: 8000 });
@@ -665,7 +666,7 @@ test.describe('Overflow Menu', () => {
   });
 
   test('overflow menu delete item shows danger styling', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open menu
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -712,7 +713,7 @@ test.describe('Modal Dialogs', () => {
       await dialog.dismiss(); // Don't actually delete
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open overflow menu and click Delete
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -730,7 +731,7 @@ test.describe('Modal Dialogs', () => {
     // Dismiss the confirm dialog (cancel)
     page.on('dialog', dialog => dialog.dismiss());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open overflow menu and click Delete
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -755,7 +756,7 @@ test.describe('Modal Dialogs', () => {
     // Accept the confirm dialog
     page.on('dialog', dialog => dialog.accept());
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open overflow menu and click Delete
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -779,7 +780,7 @@ test.describe('Modal Dialogs', () => {
       await dialog.dismiss(); // Don't actually duplicate
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Open overflow menu and click Duplicate
     await page.waitForSelector('button.btn-kebab[aria-label="Session actions"]', { timeout: 8000 });
@@ -796,7 +797,7 @@ test.describe('Modal Dialogs', () => {
   test('custom modal closes on Escape key', async ({ page }) => {
     // Need to trigger ScheduleSessionModal
     // The schedule button is inside the OrchestrationPanel, accessible from ConversationTab
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Look for schedule button in the orchestration panel
     const scheduleBtn = page.locator('button').filter({ hasText: /schedule/i }).first();
@@ -820,7 +821,7 @@ test.describe('Modal Dialogs', () => {
   });
 
   test('custom modal closes on overlay click', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Look for schedule button
     const scheduleBtn = page.locator('button').filter({ hasText: /schedule/i }).first();
@@ -882,7 +883,8 @@ test.describe('Collapsible Sections', () => {
   test('tool details section is collapsed by default', async ({ page }) => {
     const session = await seedSessionWithToolMessage();
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Wait for messages to render
     await page.waitForSelector('.message-tools details', { timeout: 10000 });
@@ -898,7 +900,8 @@ test.describe('Collapsible Sections', () => {
   test('clicking tool details summary expands the section', async ({ page }) => {
     const session = await seedSessionWithToolMessage();
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await page.waitForSelector('.message-tools details', { timeout: 10000 });
 
@@ -913,7 +916,8 @@ test.describe('Collapsible Sections', () => {
   test('clicking expanded tool details collapses it', async ({ page }) => {
     const session = await seedSessionWithToolMessage();
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     await page.waitForSelector('.message-tools details', { timeout: 10000 });
 
@@ -1130,7 +1134,7 @@ test.describe('Tab Indicators', () => {
       filename: 'indicator-test.md',
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Canvas indicator dot should be visible
     await expect(page.locator('.canvas-indicator')).toBeVisible({ timeout: 8000 });
@@ -1149,7 +1153,7 @@ test.describe('Tab Indicators', () => {
       filename: 'item2.txt',
     });
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // Canvas tab label should contain "(2)"
     const canvasTab = page.locator('.tabs-desktop .tab').filter({ hasText: 'Canvas' });
@@ -1159,7 +1163,7 @@ test.describe('Tab Indicators', () => {
 
   test('tabs without indicators show clean labels', async ({ page }) => {
     // No canvas items, no changes seeded
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
 
     // No indicator dots should be visible
     await expect(page.locator('.canvas-indicator')).not.toBeVisible();

--- a/tests/e2e/websocket-recovery.spec.ts
+++ b/tests/e2e/websocket-recovery.spec.ts
@@ -9,6 +9,7 @@ import {
   waitForPageReady,
   waitForSessionToExist,
   updateSessionStatus,
+  openSessionOverlay,
 } from './helpers';
 
 test.describe('WebSocket wake-from-sleep recovery', () => {
@@ -35,8 +36,9 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await seedAssistantMessage(session.id, 'hi there');
 
     // Navigate to session detail (conversation tab for messages)
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await waitForPageReady(page);
+    await openSessionOverlay(page);
 
     // Verify initial data is visible
     await expect(page.locator('text=hello').first()).toBeVisible({ timeout: 10000 });
@@ -91,8 +93,9 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await waitForSessionToExist(session.id);
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await waitForPageReady(page);
+    await openSessionOverlay(page);
 
     // Simulate sleep
     const cdp = await page.context().newCDPSession(page);
@@ -188,8 +191,9 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await waitForSessionToExist(session.id);
     await updateSessionStatus(session.id, 'waiting');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await waitForPageReady(page);
+    await openSessionOverlay(page);
 
     // Wait for everything to settle
     await page.waitForTimeout(2000);
@@ -226,8 +230,9 @@ test.describe('WebSocket wake-from-sleep recovery', () => {
     await waitForSessionToExist(session.id);
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, `/sessions/${session.id}/conversation`);
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await waitForPageReady(page);
+    await openSessionOverlay(page);
 
     const cdp = await page.context().newCDPSession(page);
 

--- a/tests/e2e/work-log-dedup.spec.ts
+++ b/tests/e2e/work-log-dedup.spec.ts
@@ -6,6 +6,7 @@ import {
   getSessionWorkLogs,
   getSessionMessages,
   getSession,
+  openSessionOverlay,
 } from './helpers';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5000';
@@ -59,7 +60,8 @@ test.describe('Work Log Deduplication', () => {
     expect(thinkingLogs.length).toBeGreaterThan(0);
 
     // Navigate to the session detail page — this loads work logs into the Pinia store
-    await page.goto(`${BASE_URL}/sessions/${session.id}/conversation`);
+    await page.goto(`${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
 
     // Wait for the conversation tab to load and messages to appear
     await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 15000 });
@@ -137,7 +139,8 @@ test.describe('Work Log Deduplication', () => {
     await waitForSessionStatus(session.id, 'waiting', 60000);
 
     // Navigate to the session detail page — loads work logs into Pinia store
-    await page.goto(`${BASE_URL}/sessions/${session.id}/conversation`);
+    await page.goto(`${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
     await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 15000 });
 
     // Test dedup by injecting a synthetic tool_input work log into the store,

--- a/tests/e2e/work-log-panels.spec.ts
+++ b/tests/e2e/work-log-panels.spec.ts
@@ -9,7 +9,8 @@ import {
   updateSessionStatus,
   cleanupAll,
   getAPIURL,
-  TEST_PREFIX
+  TEST_PREFIX,
+  openSessionOverlay,
 } from './helpers';
 
 const API_URL = getAPIURL();
@@ -58,7 +59,8 @@ test.describe('Work Log Panels', () => {
       await updateSessionStatus(session.id, 'running');
 
       // Navigate to session detail
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
 
       // Wait for the running-state branch to render
       await page.waitForSelector('.running-state', { timeout: 10000 });
@@ -77,7 +79,8 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('.running-state', { timeout: 10000 });
 
       // Seed a work log after page is loaded
@@ -103,7 +106,8 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('.running-state', { timeout: 10000 });
 
       // Seed 3 work logs sequentially with delays
@@ -147,7 +151,8 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('.running-state', { timeout: 10000 });
 
       // Seed a thinking work log
@@ -172,7 +177,8 @@ test.describe('Work Log Panels', () => {
       });
 
       await updateSessionStatus(session.id, 'running');
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('.running-state', { timeout: 10000 });
 
       // Seed a tool_input work log
@@ -321,7 +327,8 @@ test.describe('Work Log Panels', () => {
       }
 
       // Navigate to session detail
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Find the assistant message and verify work log panel exists
@@ -350,7 +357,8 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Verify panel is collapsed (details element does not have 'open' attribute)
@@ -381,7 +389,8 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Click the work log header to expand
@@ -418,7 +427,8 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       const header = page.locator('.work-log-header').first();
@@ -473,7 +483,8 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Get the actual count from the API
@@ -509,7 +520,8 @@ test.describe('Work Log Panels', () => {
         });
       }
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Expand the panel
@@ -547,7 +559,8 @@ test.describe('Work Log Panels', () => {
         messageId: assistantMsg.id,
       });
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Expand the panel
@@ -577,7 +590,8 @@ test.describe('Work Log Panels', () => {
       await waitForSessionStatus(session.id, 'waiting', 60000);
 
       // Navigate to session detail
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-assistant"]', { timeout: 10000 });
 
       // Session is waiting, NOT running, so .running-state should NOT exist
@@ -604,7 +618,8 @@ test.describe('Work Log Panels', () => {
 
       await waitForSessionStatus(session.id, 'waiting', 60000);
 
-      await page.goto(`${API_URL}/sessions/${session.id}/conversation`);
+      await page.goto(`${API_URL}/sessions/${session.id}/summary`);
+      await openSessionOverlay(page);
       await page.waitForSelector('[data-testid="message-user"]', { timeout: 10000 });
 
       // Find user message and verify work log panel does NOT appear


### PR DESCRIPTION
## Summary
- Removes the "Conversations" tab from the session detail view tab bar (remaining tabs: Summary, Changes, Canvas, Commands)
- Keeps `ConversationTab.vue` intact since `SessionTreeOverlay.vue` still depends on it
- Fixes `handleDuplicate` to navigate to `/summary` instead of the removed `/conversation` route
- Updates unit tests (`SessionDetailView.test.js`) to remove ConversationTab mocks/stubs and update tab assertions
- Updates ~28 E2E test files to use session overlay for conversation-dependent tests instead of the removed tab route

## Test plan
- [ ] Run `yarn workspace @claudetools/web test` — unit tests pass
- [ ] Run `./scripts/pw.sh test` — E2E tests pass
- [ ] Verify session detail view shows only Summary, Changes, Canvas, Commands tabs
- [ ] Verify session tree overlay still renders ConversationTab correctly
- [ ] Verify duplicating a session navigates to the summary tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)