### PR TITLE
Move spinner from status text to Stop button in RunningState

### DIFF
--- a/packages/web/src/components/RunningState.vue
+++ b/packages/web/src/components/RunningState.vue
@@ -3,13 +3,12 @@
     <!-- Header row with status, token display, and stop button -->
     <div class="running-header">
       <div class="running-status">
-        <span class="loading-spinner"></span>
         <span class="running-title">Claude is working...</span>
       </div>
       <div class="running-actions">
         <span v-if="activeModelDisplayName" class="running-model-label">{{ activeModelDisplayName }}</span>
         <button type="button" class="btn btn-danger btn-stop" @click="onStopClick" :disabled="stopping">
-          <span v-if="stopping" class="loading-spinner"></span>
+          <span class="loading-spinner"></span>
           Stop
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Relocates the loading spinner from next to "Claude is working..." status text to inside the Stop button in `RunningState.vue`
- The spinner is now always visible while a session is running, providing a clearer activity indicator next to the interactive button

## Test plan
- [ ] Start a session and verify spinner appears inside the Stop button
- [ ] Verify "Claude is working..." text still shows without the spinner
- [ ] Verify Stop button still functions correctly (disables when stopping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)