### PR TITLE
Remove breadcrumb navigation from SessionTreeOverlay

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.test.js
+++ b/packages/web/src/components/SessionTreeOverlay.test.js
@@ -708,63 +708,6 @@ describe('SessionTreeOverlay', () => {
     });
   });
 
-  describe('breadcrumb', () => {
-    it('shows breadcrumb when viewing child session', async () => {
-      const child = { id: 'child-1', name: 'Child', status: 'waiting', parentSessionId: 'sess-root' };
-      mockSessionsStore.getSessionPath.mockReturnValue([rootSession, child]);
-      const wrapper = mountOverlay();
-      await nextTick();
-      wrapper.vm.activeSessionId = 'child-1';
-      await nextTick();
-      expect(document.querySelector('[data-testid="session-tree-breadcrumb"]')).toBeTruthy();
-      wrapper.unmount();
-    });
-
-    it('hides breadcrumb at root level', async () => {
-      const wrapper = mountOverlay();
-      await nextTick();
-      expect(document.querySelector('[data-testid="session-tree-breadcrumb"]')).toBeFalsy();
-      wrapper.unmount();
-    });
-
-    it('breadcrumb click calls selectSession without router navigation', async () => {
-      const child = { id: 'child-1', name: 'Child', status: 'waiting', parentSessionId: 'sess-root' };
-      mockSessionsStore.getSessionPath.mockReturnValue([rootSession, child]);
-      mockSessionsStore.getSessionById.mockImplementation((id) => {
-        if (id === 'sess-root') return rootSession;
-        if (id === 'child-1') return child;
-        return null;
-      });
-
-      const wrapper = mount(SessionTreeOverlay, {
-        props: {
-          sessionId: 'sess-root',
-          sessionChain: [{ session: rootSession, depth: 0 }, { session: child, depth: 1 }],
-          summariesMap: {},
-        },
-        global: { plugins: [router] },
-        attachTo: document.body,
-      });
-      await nextTick();
-      // Set active to child so breadcrumb shows
-      wrapper.vm.activeSessionId = 'child-1';
-      await nextTick();
-
-      // Find the breadcrumb link for the root session (non-active, rendered as button)
-      const breadcrumbLinks = document.querySelectorAll('.breadcrumb-link');
-      expect(breadcrumbLinks.length).toBeGreaterThan(0);
-
-      // Click the root breadcrumb link
-      breadcrumbLinks[0].click();
-      await nextTick();
-      await new Promise(r => setTimeout(r, 10));
-
-      // activeSessionId should switch to root
-      expect(wrapper.vm.activeSessionId).toBe('sess-root');
-      wrapper.unmount();
-    });
-  });
-
   describe('data loading', () => {
     it('calls fetchConversations on mount', async () => {
       const wrapper = mountOverlay();

--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -157,39 +157,6 @@
 
           <!-- Content wrapper (with padding) -->
           <div class="overlay-body" ref="overlayBodyRef">
-            <!-- Breadcrumb (inline) -->
-            <nav
-              v-if="activeSessionPath.length > 1"
-              class="overlay-breadcrumb"
-              aria-label="Session hierarchy"
-              data-testid="session-tree-breadcrumb"
-            >
-              <ol class="breadcrumb-list">
-                <li
-                  v-for="(session, index) in activeSessionPath"
-                  :key="session.id"
-                  class="breadcrumb-item"
-                >
-                  <button
-                    v-if="session.id !== activeSessionId"
-                    class="breadcrumb-link"
-                    :title="session.name"
-                    @click="selectSession(session.id)"
-                  >
-                    {{ truncateName(session.name) }}
-                  </button>
-                  <span
-                    v-else
-                    class="breadcrumb-current"
-                    :title="session.name"
-                  >
-                    {{ truncateName(session.name) }}
-                  </span>
-                  <span v-if="index < activeSessionPath.length - 1" class="breadcrumb-separator">/</span>
-                </li>
-              </ol>
-            </nav>
-
             <!-- Conversation -->
             <ConversationTab
               :session-id="activeSessionId"
@@ -332,10 +299,6 @@ const activeSessionName = computed(() => {
   return session?.name || 'Session';
 });
 
-const activeSessionPath = computed(() => {
-  return sessionsStore.getSessionPath(activeSessionId.value);
-});
-
 const overlaySessionStatus = computed(() => {
   const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
   return session?.status || '';
@@ -354,12 +317,6 @@ const backToSessionsUrl = computed(() => {
 });
 
 // Methods
-function truncateName(name, maxLength = 30) {
-  if (!name) return 'Unnamed';
-  if (name.length <= maxLength) return name;
-  return name.substring(0, maxLength - 3) + '...';
-}
-
 function close() {
   // Guard: don't re-trigger if already closing
   if (closing.value) {
@@ -823,58 +780,6 @@ defineExpose({
   color: var(--color-text-soft, #9ca3af);
   margin-left: 0.5rem;
   flex-shrink: 0;
-}
-
-/* Breadcrumb (inline) */
-.overlay-breadcrumb {
-  padding: 0.5rem;
-  margin-top: 0.5rem;
-  background: var(--color-background-secondary, rgba(0, 0, 0, 0.1));
-  border-radius: var(--border-radius, 6px);
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
-}
-
-.breadcrumb-list {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  flex-wrap: wrap;
-}
-
-.breadcrumb-item {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.8rem;
-}
-
-.breadcrumb-link {
-  background: none;
-  border: none;
-  color: var(--color-text-soft, #9ca3af);
-  cursor: pointer;
-  font-size: 0.8rem;
-  padding: 0;
-  text-decoration: none;
-  transition: color 0.15s;
-}
-
-.breadcrumb-link:hover {
-  color: var(--color-primary, #06b6d4);
-  text-decoration: underline;
-}
-
-.breadcrumb-current {
-  color: var(--color-text, #e5e7eb);
-  font-weight: 500;
-}
-
-.breadcrumb-separator {
-  color: var(--color-text-soft, #9ca3af);
-  margin: 0 0.25rem;
 }
 
 /* Ensure messages container scrolls within the overlay */

--- a/tests/e2e/session-tree-overlay.spec.ts
+++ b/tests/e2e/session-tree-overlay.spec.ts
@@ -1039,7 +1039,7 @@ test.describe('Session Tree Overlay', () => {
       await expect(overlay.locator('.overlay-content')).toBeVisible();
     });
 
-    test('breadcrumb updates to show parent > new session path', async ({ page }) => {
+    test('picker shows both parent and new child session after creation', async ({ page }) => {
       const overlay = await openOverlay(page, parentSession.id);
 
       const addBtn = overlay.locator('[data-testid="overlay-add-session-btn"]');
@@ -1049,11 +1049,13 @@ test.describe('Session Tree Overlay', () => {
       const rootName = overlay.locator('.overlay-root-name');
       await expect(rootName).toHaveText('New Session', { timeout: 10000 });
 
-      // Breadcrumb should show the parent and the new session
-      const breadcrumb = overlay.locator('[data-testid="session-tree-breadcrumb"]');
-      await expect(breadcrumb).toBeVisible({ timeout: 5000 });
-      await expect(breadcrumb).toContainText('Parent Session');
-      await expect(breadcrumb).toContainText('New Session');
+      // Open picker and verify both parent and new session are listed
+      const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
+      await dropdown.locator('.dropdown-trigger').click();
+      const picker = page.locator('[data-testid="session-tree-picker"]');
+      await expect(picker).toBeVisible({ timeout: 5000 });
+      await expect(picker).toContainText('Parent Session');
+      await expect(picker).toContainText('New Session');
     });
 
     test('can create multiple child sessions in sequence', async ({ page }) => {
@@ -1066,9 +1068,22 @@ test.describe('Session Tree Overlay', () => {
       const rootName = overlay.locator('.overlay-root-name');
       await expect(rootName).toHaveText('New Session', { timeout: 10000 });
 
-      // Navigate back to parent via breadcrumb
-      const breadcrumbLink = overlay.locator('.breadcrumb-link').first();
-      await breadcrumbLink.click();
+      // Navigate back to parent via session picker
+      const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
+      await dropdown.locator('.dropdown-trigger').click();
+      const picker = page.locator('[data-testid="session-tree-picker"]');
+      await expect(picker).toBeVisible({ timeout: 5000 });
+
+      // Click the parent session item (first item in picker)
+      const items = picker.locator('[role="option"]');
+      const count = await items.count();
+      for (let i = 0; i < count; i++) {
+        const text = await items.nth(i).textContent();
+        if (text?.includes('Parent Session')) {
+          await items.nth(i).click();
+          break;
+        }
+      }
       await expect(rootName).toContainText('Parent Session', { timeout: 5000 });
 
       // Create second child


### PR DESCRIPTION
## Summary
- Removed the breadcrumb navigation from the top of the SessionTreeOverlay component, which was redundant with the session selector dropdown already in the header
- Cleaned up the associated computed property (`activeSessionPath`), helper function (`truncateName`), CSS styles, and test suite
- Net deletion of 152 lines across 2 files; all 54 remaining tests pass

## Test plan
- [x] All 54 unit tests pass after changes
- [ ] Verify the overlay still renders correctly without the breadcrumb
- [ ] Verify session switching still works via the dropdown picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)