### PR TITLE
Fix SessionTreeOverlay title to always show root session name

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -88,7 +88,7 @@
               <!-- Display mode -->
               <template v-else>
                 <div class="session-name-wrapper">
-                  <span class="overlay-root-name">{{ activeSessionName }}</span>
+                  <span class="overlay-root-name">{{ rootSessionName }}</span>
                   <button class="btn-link name-edit-trigger" @click="startEditName" title="Edit session name">
                     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                       <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>


### PR DESCRIPTION
## Summary
- Fixed a bug where the SessionTreeOverlay title changed to the selected session's name when navigating the session tree
- Replaced `activeSessionName` with the existing `rootSessionName` computed property on line 91 so the title always reflects the root session

## Test plan
- [x] All 57 existing unit tests pass
- [ ] Open a session with child sessions, open the tree overlay, and select a child session — verify the title at the top remains the root session's name

🤖 Generated with [Claude Code](https://claude.com/claude-code)