### PR TITLE
Remove indentation from SessionTreePicker dropdown options

### DIFF
--- a/packages/web/src/components/SessionTreePicker.test.js
+++ b/packages/web/src/components/SessionTreePicker.test.js
@@ -86,14 +86,13 @@ describe('SessionTreePicker', () => {
       });
     });
 
-    it('items have depth-based padding', () => {
+    it('items have no depth-based padding (uniform alignment)', () => {
       const wrapper = mountComponent();
       const items = wrapper.findAll('.picker-item');
-      // Root (depth 0) should have 0.5rem padding
-      expect(items[0].attributes('style')).toContain('padding-left: 0.5rem');
-      // Children (depth 1) should have 1.5rem padding
-      expect(items[1].attributes('style')).toContain('padding-left: 1.5rem');
-      expect(items[2].attributes('style')).toContain('padding-left: 1.5rem');
+      // All items should have no inline padding-left style — uniform CSS padding applies
+      items.forEach(item => {
+        expect(item.attributes('style')).toBeUndefined();
+      });
     });
 
     it('renders correctly with single session (no children)', () => {
@@ -119,7 +118,7 @@ describe('SessionTreePicker', () => {
       expect(items).toHaveLength(1);
       expect(items[0].find('.picker-item-role').exists()).toBe(true);
       expect(items[0].find('.picker-item-role').text()).toBe('');
-      expect(items[0].attributes('style')).toContain('padding-left: 0.5rem');
+      expect(items[0].attributes('style')).toBeUndefined();
     });
 
     it('status badges display correctly without hierarchy labels', () => {
@@ -166,9 +165,9 @@ describe('SessionTreePicker', () => {
 
       const items = wrapper.findAll('.picker-item');
       expect(items).toHaveLength(10);
-      // All items at depth 1 should have the same padding-left
+      // All items should have no inline padding style — uniform CSS padding applies
       items.forEach(item => {
-        expect(item.attributes('style')).toContain('padding-left: 1.5rem');
+        expect(item.attributes('style')).toBeUndefined();
       });
     });
 
@@ -191,7 +190,7 @@ describe('SessionTreePicker', () => {
       expect(nameEl.classes()).toContain('picker-item-name');
     });
 
-    it('deeper items have more indentation', () => {
+    it('items at all depths have uniform alignment (no indentation)', () => {
       const deepSessions = [
         { session: { id: 'd0', name: 'Root', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 0 },
         { session: { id: 'd1', name: 'Child', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
@@ -206,9 +205,10 @@ describe('SessionTreePicker', () => {
       });
 
       const items = wrapper.findAll('.picker-item');
-      expect(items[0].attributes('style')).toContain('padding-left: 0.5rem');
-      expect(items[1].attributes('style')).toContain('padding-left: 1.5rem');
-      expect(items[2].attributes('style')).toContain('padding-left: 2.5rem');
+      // No inline style — uniform CSS padding applies to all depths
+      items.forEach(item => {
+        expect(item.attributes('style')).toBeUndefined();
+      });
     });
   });
 

--- a/packages/web/src/components/SessionTreePicker.vue
+++ b/packages/web/src/components/SessionTreePicker.vue
@@ -13,7 +13,6 @@
       :class="{
         'picker-item--active': entry.session.id === activeSessionId,
       }"
-      :style="{ paddingLeft: `${0.5 + entry.depth * 1}rem` }"
       role="option"
       :aria-selected="entry.session.id === activeSessionId ? 'true' : 'false'"
       :tabindex="index === focusedIndex ? 0 : -1"


### PR DESCRIPTION
## Summary
- Removes depth-based `paddingLeft` inline style from `SessionTreePicker.vue` so all dropdown items have uniform padding
- Updates 4 test assertion blocks in `SessionTreePicker.test.js` to verify no inline padding style is applied

## Test plan
- [x] All 31 existing unit tests pass (`yarn workspace @claudetools/web test src/components/SessionTreePicker.test.js`)
- [ ] Visual verification: dropdown items should appear flat/uniform when opened in the SessionTreeOverlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)