### PR TITLE
Hide "New Conversation" button in SessionTreeOverlay

### DIFF
--- a/packages/web/src/components/ConversationPanel.vue
+++ b/packages/web/src/components/ConversationPanel.vue
@@ -36,6 +36,7 @@
 
         <!-- New conversation button -->
         <button
+          v-if="!hideNewConversation"
           type="button"
           class="btn btn-new"
           @click="handleCreate"
@@ -56,6 +57,7 @@ import ConversationTreeItem from './ConversationTreeItem.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
+  hideNewConversation: { type: Boolean, default: false },
 });
 
 const sessionsStore = useSessionsStore();

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="conversation-tab">
     <!-- Unified Conversation Panel - selector + BTE cost display -->
-    <ConversationPanel v-if="!isScheduledForFuture" :session-id="sessionId" />
+    <ConversationPanel v-if="!isScheduledForFuture" :session-id="sessionId" :hide-new-conversation="hideNewConversation" />
 
     <ConversationMessages
       ref="conversationMessagesRef"
@@ -131,6 +131,7 @@ import { useProjectsStore } from '../stores/projects.js';
 const props = defineProps({
   sessionId: { type: String, required: true },
   scrollContainerRef: { type: Object, default: null },
+  hideNewConversation: { type: Boolean, default: false },
 });
 
 const sessionsStore = useSessionsStore();

--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -195,6 +195,7 @@
               :session-id="activeSessionId"
               :key="activeSessionId"
               :scroll-container-ref="overlayBodyRef"
+              :hide-new-conversation="true"
             />
           </div>
           </div><!-- end overlay-content -->


### PR DESCRIPTION
## Summary
- Hides the "New Conversation" button when the conversation panel renders inside the SessionTreeOverlay
- The button remains visible in the main SessionDetailView
- Implements a `hideNewConversation` prop threaded through `ConversationTab` → `ConversationPanel`

## Test plan
- [x] All 3,795 web unit tests pass
- [ ] Verify "New Conversation" button is **not visible** in the session tree overlay
- [ ] Verify "New Conversation" button **is still visible** on the main session detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)