### PR TITLE
Fix SessionTreeOverlay header scrolling out of viewport on iPad

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -631,7 +631,7 @@ defineExpose({
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .overlay-panel-wrapper {


### PR DESCRIPTION
## Summary
- Fixed a scroll-chaining bug where the SessionTreeOverlay sticky header could scroll past the top of the viewport on iPad
- Root cause: `.overlay-backdrop` had `overflow-y: auto`, creating an unintended scrollable ancestor in the touch scroll chain
- Changed to `overflow: hidden` — the backdrop should never scroll; all content scrolling belongs in `.overlay-body`

## Test plan
- [ ] Open SessionTreeOverlay on iPad with a long conversation
- [ ] Scroll from the prompt input area or below the conversation — header should remain fixed
- [ ] Scroll from within the conversation — content scrolls normally, header stays put
- [ ] Verify no regressions on iPhone or desktop
- [ ] Unit tests pass (54/54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)