### PR TITLE
Fix SessionTreeOverlay conversation scrolling jitter during streaming

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -783,10 +783,13 @@ defineExpose({
   flex-shrink: 0;
 }
 
-/* Ensure messages container scrolls within the overlay */
+/* Ensure messages container does NOT independently scroll within the overlay.
+   The .overlay-body is the sole scroll container; .messages just flows inside it.
+   This prevents two nested scroll containers from fighting each other during
+   streaming auto-scroll (useMessageScroll targets .overlay-body via scrollContainerRef). */
 .session-tree-overlay :deep(.messages) {
   max-height: none !important;
-  overflow-y: auto;
+  overflow-y: visible;
   flex: 1;
 }
 

--- a/packages/web/src/composables/useMessageScroll.js
+++ b/packages/web/src/composables/useMessageScroll.js
@@ -64,7 +64,13 @@ export function useMessageScroll({ messages, partialText, activeConversationId, 
       const el = getScrollEl();
       if (el) {
         programmaticScroll = true;
-        el.scrollTop = el.scrollHeight;
+        // Use instant behavior to avoid smooth-scroll CSS animations fighting
+        // with rapid programmatic scroll updates during streaming.
+        if (typeof el.scrollTo === 'function') {
+          el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+        } else {
+          el.scrollTop = el.scrollHeight;
+        }
         isNearBottom.value = true;
         hasNewMessages.value = false;
       }


### PR DESCRIPTION
## Summary
- **Fix dual scroll containers in overlay**: Changed `.messages` deep override from `overflow-y: auto` → `overflow-y: visible` so `.overlay-body` is the sole scroll container in the overlay context, preventing two nested scrollable elements from fighting during auto-scroll
- **Fix smooth-scroll jitter**: Changed programmatic `scrollToBottom()` to use `el.scrollTo({ behavior: 'instant' })` instead of direct `scrollTop` assignment, bypassing CSS `scroll-behavior: smooth` that caused animations to fight with rapid (~150ms) scroll updates during streaming

## Test plan
- [x] All unit tests pass (3801 web tests, 3565 server tests)
- [ ] Manual test: Open SessionTreeOverlay on an actively streaming session and verify conversation no longer jitters/jumps
- [ ] Manual test: Verify normal SessionDetailView conversation scrolling still works independently
- [ ] Manual test: Verify user can scroll away from bottom in overlay to pause auto-scroll (userScrolledAway still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)