### PR TITLE
feat: add loading spinner when switching sessions in SessionTreeOverlay

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.test.js
+++ b/packages/web/src/components/SessionTreeOverlay.test.js
@@ -991,6 +991,161 @@ describe('SessionTreeOverlay', () => {
     });
   });
 
+  describe('session switch loading state', () => {
+    const childSession = {
+      id: 'child-1',
+      name: 'Child Session',
+      status: 'running',
+      parentSessionId: 'sess-root',
+      projectId: 'proj-123',
+    };
+    const chainSessions = [
+      { session: rootSession, depth: 0 },
+      { session: childSession, depth: 1 },
+    ];
+
+    it('shows loading spinner when switching sessions', async () => {
+      // Setup: make fetchSession return a pending promise so we can
+      // observe the spinner while data is loading.
+      let resolveFetch;
+      mockSessionsStore.fetchSession.mockReturnValue(
+        new Promise(resolve => { resolveFetch = resolve; })
+      );
+      mockSessionsStore.fetchConversations.mockResolvedValue(undefined);
+      mockSessionsStore.getSessionById.mockImplementation((id) => {
+        if (id === 'sess-root') return rootSession;
+        if (id === 'child-1') return childSession;
+        return null;
+      });
+
+      const wrapper = mount(SessionTreeOverlay, {
+        props: {
+          sessionId: 'sess-root',
+          sessionChain: chainSessions,
+          summariesMap: {},
+        },
+        global: { plugins: [router] },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await new Promise(r => setTimeout(r, 10));
+
+      // Trigger session switch (don't await — we want to check mid-flight)
+      wrapper.vm.handlePickerSelect('child-1');
+      await nextTick();
+
+      // Spinner should be visible
+      const spinner = document.querySelector('.session-switch-loading');
+      expect(spinner).toBeTruthy();
+      expect(spinner.textContent).toContain('Loading session...');
+
+      // ConversationTab should NOT be visible
+      const conv = document.querySelector('.conversation-tab-mock');
+      expect(conv).toBeFalsy();
+
+      // Resolve the fetch to clean up
+      resolveFetch();
+      await new Promise(r => setTimeout(r, 50));
+
+      wrapper.unmount();
+    });
+
+    it('hides loading spinner after data loads', async () => {
+      mockSessionsStore.getSessionById.mockImplementation((id) => {
+        if (id === 'sess-root') return rootSession;
+        if (id === 'child-1') return childSession;
+        return null;
+      });
+      mockSessionsStore.fetchSession.mockResolvedValue(undefined);
+      mockSessionsStore.fetchConversations.mockResolvedValue(undefined);
+
+      const wrapper = mount(SessionTreeOverlay, {
+        props: {
+          sessionId: 'sess-root',
+          sessionChain: chainSessions,
+          summariesMap: {},
+        },
+        global: { plugins: [router] },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await new Promise(r => setTimeout(r, 10));
+
+      // Trigger switch and wait for it to complete
+      wrapper.vm.handlePickerSelect('child-1');
+      await nextTick();
+      await new Promise(r => setTimeout(r, 50));
+
+      // Spinner should be gone
+      expect(document.querySelector('.session-switch-loading')).toBeFalsy();
+      // ConversationTab should be visible with new session ID
+      const conv = document.querySelector('.conversation-tab-mock');
+      expect(conv).toBeTruthy();
+      expect(conv.getAttribute('data-session-id')).toBe('child-1');
+
+      wrapper.unmount();
+    });
+
+    it('clears spinner even when fetchSession rejects (error caught in loadSessionData)', async () => {
+      // Note: loadSessionData has its own try/catch that swallows errors.
+      // So fetchSession rejection doesn't propagate to switchToSession.
+      // The spinner still clears because loadSessionData completes normally
+      // (after catching the error internally).
+      mockSessionsStore.getSessionById.mockImplementation((id) => {
+        if (id === 'sess-root') return rootSession;
+        if (id === 'child-1') return childSession;
+        return null;
+      });
+      mockSessionsStore.fetchSession.mockRejectedValue(new Error('Network error'));
+
+      const wrapper = mount(SessionTreeOverlay, {
+        props: {
+          sessionId: 'sess-root',
+          sessionChain: chainSessions,
+          summariesMap: {},
+        },
+        global: { plugins: [router] },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await new Promise(r => setTimeout(r, 10));
+
+      wrapper.vm.handlePickerSelect('child-1');
+      await nextTick();
+      await new Promise(r => setTimeout(r, 50));
+
+      // Spinner should be cleared despite the error
+      expect(wrapper.vm.switchingSession).toBe(false);
+      expect(document.querySelector('.session-switch-loading')).toBeFalsy();
+
+      wrapper.unmount();
+    });
+
+    it('does not show spinner when selecting the already-active session', async () => {
+      const wrapper = mount(SessionTreeOverlay, {
+        props: {
+          sessionId: 'sess-root',
+          sessionChain: chainSessions,
+          summariesMap: {},
+        },
+        global: { plugins: [router] },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await new Promise(r => setTimeout(r, 10));
+
+      // Select the same session that's already active
+      wrapper.vm.handlePickerSelect('sess-root');
+      await nextTick();
+
+      // No spinner should appear
+      expect(wrapper.vm.switchingSession).toBe(false);
+      expect(document.querySelector('.session-switch-loading')).toBeFalsy();
+
+      wrapper.unmount();
+    });
+  });
+
   describe('active session spinner indicator', () => {
     it('shows spinner when session is running', async () => {
       mockSessionsStore.getSessionById.mockReturnValue({ ...rootSession, status: 'running' });

--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -157,8 +157,12 @@
 
           <!-- Content wrapper (with padding) -->
           <div class="overlay-body" ref="overlayBodyRef">
-            <!-- Conversation -->
+            <div v-if="switchingSession" class="session-switch-loading">
+              <span class="session-switch-spinner"></span>
+              <span class="session-switch-text">Loading session...</span>
+            </div>
             <ConversationTab
+              v-else
               :session-id="activeSessionId"
               :key="activeSessionId"
               :scroll-container-ref="overlayBodyRef"
@@ -212,6 +216,7 @@ const closing = ref(false);
 const activeSessionId = ref(props.sessionId);
 const isMobile = ref(false);
 const isCreatingSession = ref(false);
+const switchingSession = ref(false);
 
 // Overlay body ref for scroll container override
 const overlayBodyRef = ref(null);
@@ -346,8 +351,8 @@ function afterLeave() {
   emit('close');  // Only emit after transition completes
 }
 
-function selectSession(sessionId) {
-  switchToSession(sessionId);
+async function selectSession(sessionId) {
+  await switchToSession(sessionId);
 }
 
 async function addChildSession() {
@@ -442,16 +447,19 @@ async function saveSessionName() {
 async function switchToSession(newSessionId) {
   if (newSessionId === activeSessionId.value) return;
 
-  // Cleanup old subscription
-  cleanupSubscription();
+  // Show spinner immediately
+  switchingSession.value = true;
 
-  // Switch
-  activeSessionId.value = newSessionId;
-  console.log('[switchToSession] activeSessionId SET to:', activeSessionId.value);
+  try {
+    cleanupSubscription();
+    activeSessionId.value = newSessionId;
 
-  // Load data for new session
-  await loadSessionData(newSessionId);
-  setupSubscription(newSessionId);
+    await loadSessionData(newSessionId);
+    setupSubscription(newSessionId);
+  } finally {
+    // Always hide spinner — even if something unexpected throws
+    switchingSession.value = false;
+  }
 }
 
 async function loadSessionData(sessionId) {
@@ -591,6 +599,7 @@ defineExpose({
   visible,
   afterLeave,
   isCreatingSession,
+  switchingSession,
   pickerOpen,
   handlePickerSelect,
 });
@@ -626,6 +635,38 @@ defineExpose({
   .slide-left-leave-active {
     transition: transform 0.15s ease;
   }
+}
+
+/* Session switch loading spinner */
+.session-switch-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.session-switch-spinner {
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 2px solid rgba(6, 182, 212, 0.2);
+  border-top-color: #06b6d4;
+  border-radius: 50%;
+  animation: session-switch-spin 0.8s linear infinite;
+}
+
+@keyframes session-switch-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.session-switch-text {
+  color: #9ca3af;
+  font-size: 0.8125rem;
 }
 </style>
 


### PR DESCRIPTION
## Summary

- Shows a loading spinner with "Loading session..." text while session data is being fetched during a session switch in `SessionTreeOverlay`
- Hides the `ConversationTab` while loading to prevent a flash of stale content from the previous session
- Spinner is always cleared in a `finally` block, ensuring cleanup even on unexpected errors

## Test plan

- [ ] Unit tests: 4 new tests in `SessionTreeOverlay.test.js` covering the loading state:
  - Spinner is shown while `fetchSession` is pending
  - Spinner is hidden after data loads and `ConversationTab` shows new session
  - Spinner is cleared even when `fetchSession` rejects
  - No spinner appears when selecting the already-active session
- [ ] Manual: open the `SessionTreeOverlay`, switch between sessions, and verify the loading indicator appears briefly then disappears cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)