### PR TITLE
Add empty state display to SummaryTab when no content available

### DIFF
--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -82,6 +82,10 @@ describe('SummaryTab', () => {
             props: ['content'],
           },
           SessionLogStream: { template: '<div class="session-log-stream-stub"></div>' },
+          SummaryContent: {
+            name: 'SummaryContent',
+            template: '<div class="summary-content-stub"></div>',
+          },
         },
       },
     });
@@ -435,6 +439,69 @@ describe('SummaryTab', () => {
       await flushAll(wrapper);
 
       expect(wrapper.find('.expand-toggle').exists()).toBe(false);
+    });
+  });
+
+  describe('Empty State', () => {
+    it('shows empty state when session has no summary, no latest response, and is not running', async () => {
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.empty-state').exists()).toBe(true);
+      expect(wrapper.text()).toContain("This session hasn't started yet.");
+      expect(wrapper.text()).toContain('Start the session or send a message to see a summary here.');
+    });
+
+    it('does not show empty state while loading', async () => {
+      api.getSessionSummary.mockReturnValue(new Promise(() => {}));
+
+      const wrapper = mountComponent();
+      await nextTick();
+
+      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.loading-state').exists()).toBe(true);
+    });
+
+    it('does not show empty state when summary exists', async () => {
+      api.getSessionSummary.mockResolvedValue({ shortSummary: 'A summary', fullSummary: 'Details' });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.findComponent({ name: 'SummaryContent' }).exists()).toBe(true);
+    });
+
+    it('does not show empty state when latest response exists', async () => {
+      api.getWorkflowLatestResponse.mockResolvedValue({
+        message: { content: 'A response', timestamp: Date.now(), role: 'assistant' },
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.latest-response').exists()).toBe(true);
+    });
+
+    it('does not show empty state when session is running', async () => {
+      sessionsStore.currentSession = { id: 'sess-123', status: 'running' };
+      sessionsStore.sessions = [sessionsStore.currentSession];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.empty-state').exists()).toBe(false);
+    });
+
+    it('does not show empty state when session is starting', async () => {
+      sessionsStore.currentSession = { id: 'sess-123', status: 'starting' };
+      sessionsStore.sessions = [sessionsStore.currentSession];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.empty-state').exists()).toBe(false);
     });
   });
 

--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -780,7 +780,7 @@ describe('SummaryTab', () => {
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      expect(wrapper.find('.empty-state').exists()).toBe(true);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(true);
       expect(wrapper.text()).toContain("This session hasn't started yet.");
       expect(wrapper.text()).toContain('Start the session or send a message to see a summary here.');
     });
@@ -791,7 +791,7 @@ describe('SummaryTab', () => {
       const wrapper = mountComponent();
       await nextTick();
 
-      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(false);
       expect(wrapper.find('.loading-state').exists()).toBe(true);
     });
 
@@ -801,7 +801,7 @@ describe('SummaryTab', () => {
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(false);
       expect(wrapper.findComponent({ name: 'SummaryContent' }).exists()).toBe(true);
     });
 
@@ -813,7 +813,7 @@ describe('SummaryTab', () => {
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(false);
       expect(wrapper.find('.latest-response').exists()).toBe(true);
     });
 
@@ -824,7 +824,7 @@ describe('SummaryTab', () => {
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(false);
     });
 
     it('does not show empty state when session is starting', async () => {
@@ -834,7 +834,7 @@ describe('SummaryTab', () => {
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      expect(wrapper.find('.empty-state').exists()).toBe(false);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(false);
     });
   });
 

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -100,6 +100,14 @@
       :regenerating="generatingManual"
       @regenerate="handleRegenerate"
     />
+
+    <!-- Empty state for sessions with no content -->
+    <div v-else-if="!latestResponse && !isRunning" class="empty-state">
+      <div class="empty-state-content">
+        <p class="empty-state-text">This session hasn't started yet.</p>
+        <p class="empty-state-hint">Start the session or send a message to see a summary here.</p>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -525,6 +533,33 @@ async function handleRegenerate() {
 
 .expand-toggle:hover {
   text-decoration: underline;
+}
+
+/* Empty State Styles */
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  text-align: center;
+}
+
+.empty-state-content {
+  max-width: 320px;
+}
+
+.empty-state-text {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--color-text);
+  margin: 0 0 0.5rem;
+}
+
+.empty-state-hint {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+  margin: 0;
+  line-height: 1.4;
 }
 
 </style>

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -105,10 +105,10 @@
     />
 
     <!-- Empty state for sessions with no content -->
-    <div v-else-if="!latestResponse && !isRunning" class="empty-state">
-      <div class="empty-state-content">
-        <p class="empty-state-text">This session hasn't started yet.</p>
-        <p class="empty-state-hint">Start the session or send a message to see a summary here.</p>
+    <div v-else-if="!latestResponse && !isRunning" class="summary-empty-state">
+      <div class="summary-empty-state-content">
+        <p class="summary-empty-state-text">This session hasn't started yet.</p>
+        <p class="summary-empty-state-hint">Start the session or send a message to see a summary here.</p>
       </div>
     </div>
   </div>
@@ -646,7 +646,7 @@ async function handleRegenerate() {
 }
 
 /* Empty State Styles */
-.empty-state {
+.summary-empty-state {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -654,18 +654,18 @@ async function handleRegenerate() {
   text-align: center;
 }
 
-.empty-state-content {
+.summary-empty-state-content {
   max-width: 320px;
 }
 
-.empty-state-text {
+.summary-empty-state-text {
   font-size: 1rem;
   font-weight: 500;
   color: var(--color-text);
   margin: 0 0 0.5rem;
 }
 
-.empty-state-hint {
+.summary-empty-state-hint {
   font-size: 0.875rem;
   color: var(--color-text-soft);
   margin: 0;


### PR DESCRIPTION
## Summary

Added an empty state UI to the SummaryTab component that displays when a session hasn't started yet and has no summary or latest response content. This improves the user experience by providing helpful guidance on how to get started.

## Changes

- Added `SummaryContent` component stub to tests
- Added comprehensive Empty State test suite (5 test cases covering various session states)
- Implemented empty state UI with centered layout and helpful messaging
- Styled empty state with appropriate colors and typography

## Test Plan

- ✅ Empty state displays when session has no summary, no latest response, and is not running
- ✅ Empty state does not display while loading
- ✅ Empty state does not display when summary exists
- ✅ Empty state does not display when latest response exists
- ✅ Empty state does not display when session is running or starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)