### PR TITLE
refactor: Use store getter for workflow session tree traversal

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -33,8 +33,35 @@ vi.mock('../stores/commandButtons.js', () => ({
 // Mock sessions store
 const mockSessionsStoreData = {
   sessions: [],
+  activeSessions: [],
   commandRunVersion: 0,
   toggleSessionStar: vi.fn(),
+  getWorkflowSessions: vi.fn((sessionId) => {
+    // Default implementation: search both sessions and activeSessions
+    const root = mockSessionsStoreData.sessions.find(s => s.id === sessionId)
+      || mockSessionsStoreData.activeSessions.find(s => s.id === sessionId)
+      || mockSessionsStoreData._currentSession;
+    if (!root) return [{ id: sessionId }];
+    const all = [root];
+    const stack = [sessionId];
+    const visited = new Set();
+    while (stack.length > 0) {
+      const currentId = stack.pop();
+      if (visited.has(currentId)) continue;
+      visited.add(currentId);
+      const children = [
+        ...mockSessionsStoreData.sessions.filter(s => s.parentSessionId === currentId),
+        ...mockSessionsStoreData.activeSessions.filter(s => s.parentSessionId === currentId),
+      ];
+      const seen = new Set(all.map(s => s.id));
+      for (const child of children) {
+        if (!seen.has(child.id)) { all.push(child); seen.add(child.id); }
+        stack.push(child.id);
+      }
+    }
+    return all;
+  }),
+  _currentSession: null,
 };
 vi.mock('../stores/sessions.js', () => ({
   useSessionsStore: vi.fn(() => mockSessionsStoreData),
@@ -108,7 +135,9 @@ describe('SessionCard', () => {
 
     // Reset sessions store mock data
     mockSessionsStoreData.sessions = [];
+    mockSessionsStoreData.activeSessions = [];
     mockSessionsStoreData.commandRunVersion = 0;
+    mockSessionsStoreData._currentSession = null;
   });
   const baseSession = {
     id: 'session-123',
@@ -122,6 +151,10 @@ describe('SessionCard', () => {
   function mountComponent(props = {}) {
     const pinia = createPinia();
     setActivePinia(pinia);
+    const sessionToMount = { ...baseSession, ...props.session };
+    // Set _currentSession so the mock getWorkflowSessions can find the root
+    // when the session is only passed as a prop (not in sessions/activeSessions arrays)
+    mockSessionsStoreData._currentSession = sessionToMount;
     return mount(SessionCard, {
       props: {
         session: baseSession,
@@ -449,6 +482,43 @@ describe('SessionCard', () => {
         session: { ...baseSession, status: 'completed' },
       });
       expect(wrapper.find('.status-running').exists()).toBe(false);
+    });
+
+    it('shows running badge when child is in activeSessions but not sessions', () => {
+      mockSessionsStoreData.sessions = [];
+      mockSessionsStoreData.activeSessions = [
+        { id: 'child-1', parentSessionId: baseSession.id, status: 'running' },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'waiting' },
+      });
+      expect(wrapper.find('.status-running').exists()).toBe(true);
+    });
+
+    it('shows running badge when both parent and child are in activeSessions', () => {
+      mockSessionsStoreData.sessions = [];
+      mockSessionsStoreData.activeSessions = [
+        { id: baseSession.id, status: 'waiting', parentSessionId: null },
+        { id: 'child-1', parentSessionId: baseSession.id, status: 'running' },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'waiting' },
+      });
+      expect(wrapper.find('.status-running').exists()).toBe(true);
+    });
+
+    it('does not double-count when child is in both sessions and activeSessions', () => {
+      const childSession = { id: 'child-1', parentSessionId: baseSession.id, status: 'running' };
+      mockSessionsStoreData.sessions = [childSession];
+      mockSessionsStoreData.activeSessions = [childSession];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'waiting' },
+      });
+      // Badge should still show (running), but should not double-count the child
+      expect(wrapper.find('.status-running').exists()).toBe(true);
     });
   });
 

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -199,23 +199,10 @@ const dateToShow = computed(() => {
 
 /**
  * Get all sessions in the workflow tree (root + all descendants at any depth).
- * Uses iterative DFS to find children, grandchildren, etc.
+ * Delegates to the store getter which searches both sessions and activeSessions arrays.
  */
 function getWorkflowSessions() {
-  const all = [props.session];
-  const stack = [props.session.id];
-  const visited = new Set();
-  while (stack.length > 0) {
-    const currentId = stack.pop();
-    if (visited.has(currentId)) continue;
-    visited.add(currentId);
-    const children = sessionsStore.sessions.filter(s => s.parentSessionId === currentId);
-    for (const child of children) {
-      all.push(child);
-      stack.push(child.id);
-    }
-  }
-  return all;
+  return sessionsStore.getWorkflowSessions(props.session.id);
 }
 
 // Get workflow status including all descendant sessions (full tree traversal)

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -43,118 +43,157 @@ export const useSessionsStore = defineStore('sessions', {
   getters: {
     // ==================== SESSION GETTERS ====================
 
+    // Helper: find a session by ID across both arrays (sessions first, then activeSessions)
+    _findSessionById: (state) => (id) => {
+      return state.sessions.find((s) => s.id === id) || state.activeSessions.find((s) => s.id === id);
+    },
+
+    // Helper: find children across both store arrays (deduplicated)
+    _findChildren: (state) => (parentId) => {
+      const fromSessions = state.sessions.filter(s => s.parentSessionId === parentId);
+      const fromActive = state.activeSessions.filter(s => s.parentSessionId === parentId);
+      const seen = new Set(fromSessions.map(s => s.id));
+      const merged = [...fromSessions];
+      for (const s of fromActive) {
+        if (!seen.has(s.id)) { merged.push(s); seen.add(s.id); }
+      }
+      return merged;
+    },
+
     getSessionById: (state) => (id) => {
       return state.sessions.find((s) => s.id === id);
     },
 
-    getChildSessions: (state) => (parentId) => {
-      return state.sessions.filter((s) => s.parentSessionId === parentId);
-    },
+    getChildSessions() { return (parentId) => this._findChildren(parentId); },
 
-    hasChildren: (state) => (sessionId) => {
-      return state.sessions.some((s) => s.parentSessionId === sessionId);
-    },
+    hasChildren() { return (sessionId) => this._findChildren(sessionId).length > 0; },
 
-    getChildCount: (state) => (sessionId) => {
-      return state.sessions.filter((s) => s.parentSessionId === sessionId).length;
-    },
+    getChildCount() { return (sessionId) => this._findChildren(sessionId).length; },
 
-    getAllDescendants: (state) => (sessionId) => {
-      const descendants = [];
-      const stack = [sessionId];
-      const visited = new Set();
-      while (stack.length > 0) {
-        const currentId = stack.pop();
-        if (visited.has(currentId)) continue;
-        visited.add(currentId);
-        const children = state.sessions.filter((s) => s.parentSessionId === currentId);
-        for (const child of children) {
-          descendants.push(child);
-          stack.push(child.id);
+    getAllDescendants() {
+      return (sessionId) => {
+        const descendants = [];
+        const stack = [sessionId];
+        const visited = new Set();
+        while (stack.length > 0) {
+          const currentId = stack.pop();
+          if (visited.has(currentId)) continue;
+          visited.add(currentId);
+          const children = this._findChildren(currentId);
+          for (const child of children) {
+            descendants.push(child);
+            stack.push(child.id);
+          }
         }
-      }
-      return descendants;
-    },
-
-    getWorkflowEffectiveStatus: (state) => (rootSessionId) => {
-      const root = state.sessions.find((s) => s.id === rootSessionId);
-      if (!root) return 'idle';
-      const allSessions = [root];
-      const stack = [rootSessionId];
-      const visited = new Set();
-      while (stack.length > 0) {
-        const currentId = stack.pop();
-        if (visited.has(currentId)) continue;
-        visited.add(currentId);
-        const children = state.sessions.filter((s) => s.parentSessionId === currentId);
-        for (const child of children) {
-          allSessions.push(child);
-          stack.push(child.id);
-        }
-      }
-      const runningStatuses = ['running', 'starting'];
-      return allSessions.some((s) => runningStatuses.includes(s.status)) ? 'running' : 'idle';
-    },
-
-    getSessionPath: (state) => (sessionId) => {
-      const path = [];
-      const findSession = (id) => {
-        if (state.currentSession?.id === id) return state.currentSession;
-        return state.sessions.find((s) => s.id === id);
+        return descendants;
       };
-      let current = findSession(sessionId);
-      while (current) {
-        path.unshift(current);
-        if (!current.parentSessionId) break;
-        current = findSession(current.parentSessionId);
-      }
-      return path;
     },
 
-    getRootSession: (state) => (sessionId) => {
-      let current = state.sessions.find((s) => s.id === sessionId);
-      while (current?.parentSessionId) {
-        current = state.sessions.find((s) => s.id === current.parentSessionId);
-      }
-      return current || null;
+    getWorkflowEffectiveStatus() {
+      return (rootSessionId) => {
+        const root = this._findSessionById(rootSessionId);
+        if (!root) return 'idle';
+        const allSessions = [root];
+        const stack = [rootSessionId];
+        const visited = new Set();
+        while (stack.length > 0) {
+          const currentId = stack.pop();
+          if (visited.has(currentId)) continue;
+          visited.add(currentId);
+          const children = this._findChildren(currentId);
+          for (const child of children) {
+            allSessions.push(child);
+            stack.push(child.id);
+          }
+        }
+        const runningStatuses = ['running', 'starting'];
+        return allSessions.some((s) => runningStatuses.includes(s.status)) ? 'running' : 'idle';
+      };
     },
 
-    getWorkflowAggregatedStatus: (state) => (rootSessionId) => {
-      const root = state.sessions.find((s) => s.id === rootSessionId);
-      if (!root) {
-        return {
-          effectiveStatus: 'idle', runningCount: 0, scheduledCount: 0,
-          waitingCount: 0, completedCount: 0, totalCount: 0,
-          hasScheduledDescendant: false, rootIsScheduled: false,
+    getSessionPath() {
+      return (sessionId) => {
+        const path = [];
+        const findSession = (id) => {
+          if (this.currentSession?.id === id) return this.currentSession;
+          return this._findSessionById(id);
         };
-      }
-      const allSessions = [root];
-      const stack = [rootSessionId];
-      const visited = new Set();
-      while (stack.length > 0) {
-        const currentId = stack.pop();
-        if (visited.has(currentId)) continue;
-        visited.add(currentId);
-        const children = state.sessions.filter((s) => s.parentSessionId === currentId);
-        for (const child of children) { allSessions.push(child); stack.push(child.id); }
-      }
-      const runningStatuses = ['running', 'starting'];
-      let runningCount = 0, scheduledCount = 0, waitingCount = 0, completedCount = 0;
-      for (const session of allSessions) {
-        if (runningStatuses.includes(session.status)) runningCount++;
-        else if (session.status === 'scheduled') scheduledCount++;
-        else if (session.status === 'waiting') waitingCount++;
-        else if (session.status === 'completed' || session.status === 'stopped') completedCount++;
-      }
-      return {
-        effectiveStatus: runningCount > 0 ? 'running' : 'idle',
-        runningCount,
-        scheduledCount,
-        waitingCount,
-        completedCount,
-        totalCount: allSessions.length - 1,
-        hasScheduledDescendant: allSessions.slice(1).some((s) => s.status === 'scheduled'),
-        rootIsScheduled: root.status === 'scheduled',
+        let current = findSession(sessionId);
+        while (current) {
+          path.unshift(current);
+          if (!current.parentSessionId) break;
+          current = findSession(current.parentSessionId);
+        }
+        return path;
+      };
+    },
+
+    getRootSession() {
+      return (sessionId) => {
+        let current = this._findSessionById(sessionId);
+        while (current?.parentSessionId) {
+          current = this._findSessionById(current.parentSessionId);
+        }
+        return current || null;
+      };
+    },
+
+    getWorkflowAggregatedStatus() {
+      return (rootSessionId) => {
+        const root = this._findSessionById(rootSessionId);
+        if (!root) {
+          return {
+            effectiveStatus: 'idle', runningCount: 0, scheduledCount: 0,
+            waitingCount: 0, completedCount: 0, totalCount: 0,
+            hasScheduledDescendant: false, rootIsScheduled: false,
+          };
+        }
+        const allSessions = [root];
+        const stack = [rootSessionId];
+        const visited = new Set();
+        while (stack.length > 0) {
+          const currentId = stack.pop();
+          if (visited.has(currentId)) continue;
+          visited.add(currentId);
+          const children = this._findChildren(currentId);
+          for (const child of children) { allSessions.push(child); stack.push(child.id); }
+        }
+        const runningStatuses = ['running', 'starting'];
+        let runningCount = 0, scheduledCount = 0, waitingCount = 0, completedCount = 0;
+        for (const session of allSessions) {
+          if (runningStatuses.includes(session.status)) runningCount++;
+          else if (session.status === 'scheduled') scheduledCount++;
+          else if (session.status === 'waiting') waitingCount++;
+          else if (session.status === 'completed' || session.status === 'stopped') completedCount++;
+        }
+        return {
+          effectiveStatus: runningCount > 0 ? 'running' : 'idle',
+          runningCount,
+          scheduledCount,
+          waitingCount,
+          completedCount,
+          totalCount: allSessions.length - 1,
+          hasScheduledDescendant: allSessions.slice(1).some((s) => s.status === 'scheduled'),
+          rootIsScheduled: root.status === 'scheduled',
+        };
+      };
+    },
+
+    getWorkflowSessions() {
+      return (rootSessionId) => {
+        const root = this._findSessionById(rootSessionId);
+        if (!root) return [];
+        const all = [root];
+        const stack = [rootSessionId];
+        const visited = new Set();
+        while (stack.length > 0) {
+          const currentId = stack.pop();
+          if (visited.has(currentId)) continue;
+          visited.add(currentId);
+          const children = this._findChildren(currentId);
+          for (const child of children) { all.push(child); stack.push(child.id); }
+        }
+        return all;
       };
     },
 

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -4863,6 +4863,79 @@ describe('Sessions Store', () => {
         expect(result.scheduledCount).toBe(1); // the child
         expect(result.totalCount).toBe(1); // only the child (descendants only)
       });
+
+      it('finds child in activeSessions when parent is in sessions', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'waiting', parentSessionId: null },
+        ];
+        store.activeSessions = [
+          { id: 'child-1', status: 'running', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.runningCount).toBe(1);
+      });
+
+      it('finds root in activeSessions', () => {
+        const store = useSessionsStore();
+        store.sessions = [];
+        store.activeSessions = [
+          { id: 'root', status: 'waiting', parentSessionId: null },
+          { id: 'child-1', status: 'running', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.effectiveStatus).toBe('running');
+        expect(result.runningCount).toBe(1);
+      });
+
+      it('deduplicates when session exists in both arrays', () => {
+        const store = useSessionsStore();
+        const child = { id: 'child-1', status: 'running', parentSessionId: 'root' };
+        store.sessions = [
+          { id: 'root', status: 'waiting', parentSessionId: null },
+          child,
+        ];
+        store.activeSessions = [child];
+
+        const result = store.getWorkflowAggregatedStatus('root');
+
+        expect(result.runningCount).toBe(1);
+        expect(result.totalCount).toBe(1);
+      });
+    });
+
+    describe('getWorkflowEffectiveStatus', () => {
+      it('returns running when child is only in activeSessions', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'waiting', parentSessionId: null },
+        ];
+        store.activeSessions = [
+          { id: 'child-1', status: 'running', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowEffectiveStatus('root');
+
+        expect(result).toBe('running');
+      });
+
+      it('returns idle when no running sessions exist in either array', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'completed', parentSessionId: null },
+        ];
+        store.activeSessions = [
+          { id: 'child-1', status: 'completed', parentSessionId: 'root' },
+        ];
+
+        const result = store.getWorkflowEffectiveStatus('root');
+
+        expect(result).toBe('idle');
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Refactored the workflow session tree traversal logic from `SessionCard.vue` into a new store getter `getWorkflowSessions()`. The store getters now search both `sessions` and `activeSessions` arrays to ensure child sessions are found even during initial sync.

This fixes the issue where the running indicator doesn't appear for parent sessions when children are only present in the `activeSessions` array (before being fully loaded into the main `sessions` array).

## Changes

- **SessionCard.vue**: Replaced inline DFS logic in `getWorkflowSessions()` with a call to the store getter
- **sessions.js store**: 
  - Added helper getter `_findSessionById()` to search both arrays
  - Added helper getter `_findChildren()` to find children across both arrays with deduplication
  - Added new getter `getWorkflowSessions()` for complete workflow tree traversal
  - Updated existing getters to use the new helpers for consistency
- **SessionCard.test.js**: Enhanced test mocks and added new test cases for activeSessions scenarios
- **sessions.test.js**: Added test cases verifying correct behavior when sessions are in activeSessions

## Test Plan

- [x] SessionCard tests pass (including new activeSessions tests)
- [x] Sessions store tests pass (including new multi-array search tests)
- [x] Running indicator appears for parent sessions with running children in activeSessions
- [x] No duplicate counting when same session exists in both arrays
- [x] Workflow status calculation works correctly with sessions split across arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)