### PR TITLE
Fix SessionTreeHandle status display for active child sessions

### DIFF
--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -2767,6 +2767,206 @@ describe('SessionDetailView', () => {
       const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
       expect(treeHandle.isVisible()).toBe(true);
     });
+
+    it('passes isSessionActive=true when root is completed but a child session is running', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'completed',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Populate sessionChain with a running child
+      wrapper.vm.sessionChain = [
+        { session: { id: 'session-1', status: 'completed', projectId: 'proj-1' }, depth: 0 },
+        { session: { id: 'child-1', status: 'running', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+      ];
+      await nextTick();
+
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(true);
+    });
+
+    it('passes isSessionActive=true when root is waiting and a child session is starting', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Populate sessionChain with a starting child
+      wrapper.vm.sessionChain = [
+        { session: { id: 'session-1', status: 'waiting', projectId: 'proj-1' }, depth: 0 },
+        { session: { id: 'child-1', status: 'starting', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+      ];
+      await nextTick();
+
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(true);
+    });
+
+    it('passes isSessionActive=false when root and all children are completed', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'completed',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Populate sessionChain with all completed sessions
+      wrapper.vm.sessionChain = [
+        { session: { id: 'session-1', status: 'completed', projectId: 'proj-1' }, depth: 0 },
+        { session: { id: 'child-1', status: 'completed', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+        { session: { id: 'child-2', status: 'completed', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+      ];
+      await nextTick();
+
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(false);
+    });
+
+    it('passes correct sessionStatus from running child when root is completed', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'completed',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Populate sessionChain with a running child
+      wrapper.vm.sessionChain = [
+        { session: { id: 'session-1', status: 'completed', projectId: 'proj-1' }, depth: 0 },
+        { session: { id: 'child-1', status: 'running', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+      ];
+      await nextTick();
+
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('sessionStatus')).toBe('running');
+    });
+
+    it('updates isSessionActive reactively when sessionChain changes', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'completed',
+        projectId: 'proj-1',
+      };
+
+      await router.push('/sessions/session-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true,
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+            PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+
+      // Start with all completed
+      wrapper.vm.sessionChain = [
+        { session: { id: 'session-1', status: 'completed', projectId: 'proj-1' }, depth: 0 },
+        { session: { id: 'child-1', status: 'completed', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+      ];
+      await nextTick();
+
+      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      expect(treeHandle.props('isSessionActive')).toBe(false);
+
+      // Update sessionChain to include a running child
+      wrapper.vm.sessionChain = [
+        { session: { id: 'session-1', status: 'completed', projectId: 'proj-1' }, depth: 0 },
+        { session: { id: 'child-1', status: 'running', projectId: 'proj-1', parentSessionId: 'session-1' }, depth: 1 },
+      ];
+      await nextTick();
+
+      expect(treeHandle.props('isSessionActive')).toBe(true);
+    });
   });
 
   describe('Session Name Editing', () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -58,7 +58,7 @@
       <SessionTreeHandle
         v-show="!treeOverlayOpen"
         :is-session-active="isSessionActive"
-        :session-status="sessionsStore.currentSession?.status"
+        :session-status="activeSessionStatus"
         @open="treeOverlayOpen = true"
       />
 
@@ -282,6 +282,30 @@ function resolveOverlayTarget() {
 }
 
 /**
+ * Handle SESSION_UPDATED WebSocket events.
+ * When a session in our tree changes status, update the sessionChain snapshot
+ * so that isSessionActive and activeSessionStatus recompute correctly.
+ */
+function handleSessionUpdated(msg) {
+  const updatedSession = msg.session;
+  if (!updatedSession) return;
+
+  // Update the session in sessionChain if it's part of our tree
+  const idx = sessionChain.value.findIndex(
+    entry => entry.session.id === updatedSession.id
+  );
+  if (idx >= 0) {
+    // Replace the stale snapshot with the updated one, preserving depth
+    sessionChain.value[idx] = {
+      ...sessionChain.value[idx],
+      session: updatedSession,
+    };
+    // Trigger Vue reactivity by replacing the array ref
+    sessionChain.value = [...sessionChain.value];
+  }
+}
+
+/**
  * Handle SESSION_CREATED WebSocket events.
  * When the overlay is closed and a new child session is created in our tree,
  * update overlaySessionId so the next open navigates to the new child.
@@ -372,8 +396,25 @@ const buttonStatusesToDisplay = computed(() => {
 });
 
 const isSessionActive = computed(() => {
+  // Check current session first (fast path)
   const status = sessionsStore.currentSession?.status;
-  return status === 'running' || status === 'starting';
+  if (status === 'running' || status === 'starting') return true;
+
+  // Also check if any session in the chain (descendants) is running/starting
+  return sessionChain.value.some(entry =>
+    entry.session.status === 'running' || entry.session.status === 'starting'
+  );
+});
+
+const activeSessionStatus = computed(() => {
+  const currentStatus = sessionsStore.currentSession?.status;
+  if (currentStatus === 'running' || currentStatus === 'starting') return currentStatus;
+
+  // Find the first running/starting session in the chain
+  const active = sessionChain.value.find(entry =>
+    entry.session.status === 'running' || entry.session.status === 'starting'
+  );
+  return active?.session.status || currentStatus;
 });
 
 const tabs = computed(() => [
@@ -398,8 +439,9 @@ watch(
 );
 
 onMounted(async () => {
-  // Register the SESSION_CREATED handler
+  // Register the SESSION_CREATED and SESSION_UPDATED handlers
   on(WS_MESSAGE_TYPES.SESSION_CREATED, handleSessionCreated);
+  on(WS_MESSAGE_TYPES.SESSION_UPDATED, handleSessionUpdated);
 
   // Initialize the session with WebSocket subscription and data fetching
   await initializeSession(currentSessionId.value);
@@ -488,8 +530,9 @@ onUnmounted(() => {
     send(WS_MESSAGE_TYPES.UNSUBSCRIBE_PROJECT, { projectId: currentProjectSubscriptionId });
     currentProjectSubscriptionId = null;
   }
-  // Remove the SESSION_CREATED handler
+  // Remove the SESSION_CREATED and SESSION_UPDATED handlers
   off(WS_MESSAGE_TYPES.SESSION_CREATED, handleSessionCreated);
+  off(WS_MESSAGE_TYPES.SESSION_UPDATED, handleSessionUpdated);
   // Clear viewedSessionId so other views (e.g., SessionListView) can use
   // fetchSession without the guard blocking them.
   sessionsStore.viewedSessionId = null;


### PR DESCRIPTION
## Summary

Fixes the right-side session tree handle to correctly display status when a child session is active while the parent is completed. The handle now:

- Tracks `SESSION_UPDATED` WebSocket events to keep session chain status in sync
- Shows the status of running/starting child sessions
- Only shows active indicator when root or any descendant is running/starting

## Test plan

- [x] Existing tests pass
- [x] New test cases for child session scenarios:
  - Root completed with running child
  - Root waiting with starting child  
  - Root and all children completed
  - Correct status shown from running child

🤖 Generated with [Claude Code](https://claude.com/claude-code)