### PR TITLE
Fix invisible session tree overlay close handle

### DIFF
--- a/packages/web/src/components/SessionTreeOverlay.vue
+++ b/packages/web/src/components/SessionTreeOverlay.vue
@@ -695,7 +695,7 @@ defineExpose({
 
 .overlay-close-handle {
   position: absolute;
-  left: -48px;
+  left: 0;
   top: 50%;
   transform: translateY(-50%);
   width: 44px;


### PR DESCRIPTION
## Summary
- The close handle on the left side of the SessionTreeOverlay disappeared after PR #715 changed its CSS `left` position from `0` to `-48px`
- The handle was being clipped by the parent `overlay-backdrop`'s `overflow: hidden` property, making it invisible on all screen sizes
- Reverts the position to `left: 0` so the handle renders inside the panel where it's visible

## Test plan
- [ ] Open a session detail view with a child session tree
- [ ] Verify the close handle is visible on the left side of the overlay panel
- [ ] Click the handle to confirm it closes the overlay
- [ ] Verify on mobile and desktop screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)