### PR TITLE
Show live output panel for running descendant sessions on summary tab

### DIFF
--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -17,14 +17,30 @@ vi.mock('../composables/useApi.js', () => ({
 // Note: Not mocking sessions and UI stores - will use actual Pinia instances
 
 // Mock WebSocket composable
-vi.mock('../composables/useWebSocket.js', () => ({
-  useSessionSubscription: vi.fn(() => ({
+// Factory that creates a fresh subscription mock, tracking calls per sessionId
+const subscriptionsBySessionId = {};
+function createMockSubscription() {
+  return {
     onSummaryUpdate: vi.fn(() => vi.fn()),
     onSummaryGenerating: vi.fn(() => vi.fn()),
     onWorkLog: vi.fn(() => vi.fn()),
     onPartial: vi.fn(() => vi.fn()),
     onThinkingPartial: vi.fn(() => vi.fn()),
-  })),
+    onChangesUpdate: vi.fn(() => vi.fn()),
+    onStatus: vi.fn(() => vi.fn()),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  };
+}
+vi.mock('../composables/useWebSocket.js', () => ({
+  useSessionSubscription: vi.fn((sessionId) => {
+    const sub = createMockSubscription();
+    if (!subscriptionsBySessionId[sessionId]) {
+      subscriptionsBySessionId[sessionId] = [];
+    }
+    subscriptionsBySessionId[sessionId].push(sub);
+    return sub;
+  }),
 }));
 
 // Mock router
@@ -36,6 +52,7 @@ vi.mock('vue-router', () => ({
 
 import SummaryTab from './SummaryTab.vue';
 import { api } from '../composables/useApi.js';
+import { useSessionSubscription } from '../composables/useWebSocket.js';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
 
@@ -47,6 +64,9 @@ describe('SummaryTab', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+
+    // Clear subscription tracking
+    Object.keys(subscriptionsBySessionId).forEach(k => delete subscriptionsBySessionId[k]);
 
     // Reset API mock implementations to defaults
     api.getSessionSummary.mockResolvedValue(null);
@@ -338,6 +358,278 @@ describe('SummaryTab', () => {
       await flushAll(wrapper);
 
       expect(wrapper.findComponent({ name: 'SessionLogStream' }).exists()).toBe(false);
+    });
+  });
+
+  describe('Descendant Session Live Output', () => {
+    function mountWithLogStream(props = { sessionId: 'sess-123' }) {
+      return mount(SummaryTab, {
+        props,
+        global: {
+          stubs: {
+            MarkdownViewer: {
+              template: '<div class="markdown-stub">{{ content }}</div>',
+              props: ['content'],
+            },
+            SessionLogStream: {
+              name: 'SessionLogStream',
+              props: ['sessionIds'],
+              template: '<div class="session-log-stream-stub">{{ sessionIds }}</div>',
+            },
+          },
+        },
+      });
+    }
+
+    it('renders SessionLogStream when parent is waiting but a child session is running', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.exists()).toBe(true);
+    });
+
+    it('includes running child session IDs in sessionIds prop', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.props('sessionIds')).toEqual(['child-1']);
+    });
+
+    it('includes both parent and child IDs when both are running', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'running',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.props('sessionIds')).toEqual(['sess-123', 'child-1']);
+    });
+
+    it('includes deeply nested running descendants (grandchild)', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'waiting', parentSessionId: 'sess-123', projectId: 'proj-1' },
+        { id: 'grandchild-1', status: 'running', parentSessionId: 'child-1', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.exists()).toBe(true);
+      expect(logStream.props('sessionIds')).toEqual(['grandchild-1']);
+    });
+
+    it('excludes non-running child sessions from sessionIds', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'completed', parentSessionId: 'sess-123', projectId: 'proj-1' },
+        { id: 'child-2', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+        { id: 'child-3', status: 'error', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.exists()).toBe(true);
+      // Only child-2 is running
+      expect(logStream.props('sessionIds')).toEqual(['child-2']);
+    });
+
+    it('does not render SessionLogStream when parent is waiting and no children are running', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'completed', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      expect(wrapper.findComponent({ name: 'SessionLogStream' }).exists()).toBe(false);
+    });
+
+    it('subscribes to WebSocket events for running descendant sessions', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      // useSessionSubscription should have been called for the child session
+      expect(useSessionSubscription).toHaveBeenCalledWith('child-1');
+
+      // The descendant subscription should have called subscribe()
+      const childSubs = subscriptionsBySessionId['child-1'];
+      expect(childSubs).toBeDefined();
+      expect(childSubs.length).toBeGreaterThanOrEqual(1);
+      // The descendant subscription (not the initial parent one) calls subscribe()
+      const descendantSub = childSubs.find(s => s.subscribe.mock.calls.length > 0);
+      expect(descendantSub).toBeDefined();
+      expect(descendantSub.subscribe).toHaveBeenCalled();
+    });
+
+    it('unsubscribes from descendant when child session stops running', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      // Confirm it was subscribed
+      const childSubs = subscriptionsBySessionId['child-1'];
+      const descendantSub = childSubs.find(s => s.subscribe.mock.calls.length > 0);
+      expect(descendantSub).toBeDefined();
+      expect(descendantSub.unsubscribe).not.toHaveBeenCalled();
+
+      // Change child status to completed — replace sessions array to trigger reactivity
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'completed', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+      await flushAll(wrapper);
+
+      // SessionLogStream should be gone (no running sessions)
+      expect(wrapper.findComponent({ name: 'SessionLogStream' }).exists()).toBe(false);
+      // unsubscribe should have been called
+      expect(descendantSub.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('cleans up all descendant subscriptions on unmount', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+        { id: 'child-2', status: 'starting', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      // Both children should be subscribed
+      const child1Sub = subscriptionsBySessionId['child-1']?.find(s => s.subscribe.mock.calls.length > 0);
+      const child2Sub = subscriptionsBySessionId['child-2']?.find(s => s.subscribe.mock.calls.length > 0);
+      expect(child1Sub).toBeDefined();
+      expect(child2Sub).toBeDefined();
+
+      // Unmount
+      wrapper.unmount();
+
+      // Both should be unsubscribed
+      expect(child1Sub.unsubscribe).toHaveBeenCalled();
+      expect(child2Sub.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('subscribes to new running descendant when added dynamically', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [sessionsStore.currentSession];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      // Initially no SessionLogStream
+      expect(wrapper.findComponent({ name: 'SessionLogStream' }).exists()).toBe(false);
+
+      // Add a running child session
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-new', status: 'running', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+      await flushAll(wrapper);
+
+      // SessionLogStream should now appear
+      expect(wrapper.findComponent({ name: 'SessionLogStream' }).exists()).toBe(true);
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.props('sessionIds')).toEqual(['child-new']);
+
+      // Should have subscribed to the new child
+      expect(useSessionSubscription).toHaveBeenCalledWith('child-new');
+    });
+
+    it('includes starting child sessions in live output', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        projectId: 'proj-1',
+      };
+      sessionsStore.sessions = [
+        sessionsStore.currentSession,
+        { id: 'child-1', status: 'starting', parentSessionId: 'sess-123', projectId: 'proj-1' },
+      ];
+
+      const wrapper = mountWithLogStream();
+      await flushAll(wrapper);
+
+      const logStream = wrapper.findComponent({ name: 'SessionLogStream' });
+      expect(logStream.exists()).toBe(true);
+      expect(logStream.props('sessionIds')).toEqual(['child-1']);
     });
   });
 

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="summary-tab">
-    <!-- Live output for running sessions -->
+    <!-- Live output for running sessions (includes child sessions) -->
     <SessionLogStream
-      v-if="isRunning"
-      :session-ids="[sessionId]"
+      v-if="runningSessionIds.length > 0"
+      :session-ids="runningSessionIds"
     />
 
     <!-- Most Recent Agent Response -->
@@ -104,7 +104,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { api } from '../composables/useApi.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useWebSocket.js';
@@ -148,6 +148,83 @@ onThinkingPartial((thinking) => {
   }
 });
 
+// --- Descendant session streaming subscriptions ---
+// Track active descendant subscriptions so we can clean them up
+const descendantSubscriptions = {};
+
+function subscribeToDescendant(sessionId) {
+  if (descendantSubscriptions[sessionId]) return;
+
+  const sub = useSessionSubscription(sessionId);
+  const cleanups = [];
+
+  cleanups.push(sub.onWorkLog((log) => {
+    streamingStore.addSessionWorkLog(sessionId, log);
+  }));
+
+  cleanups.push(sub.onPartial((text) => {
+    if (text) {
+      streamingStore.setSessionPartialText(sessionId, text);
+    }
+  }));
+
+  cleanups.push(sub.onThinkingPartial((thinking) => {
+    if (thinking) {
+      streamingStore.setPartialThinking(thinking, sessionId);
+    }
+  }));
+
+  sub.subscribe();
+
+  descendantSubscriptions[sessionId] = {
+    subscription: sub,
+    cleanup: () => {
+      cleanups.forEach(fn => fn && fn());
+      sub.unsubscribe();
+    },
+  };
+
+  // Hydrate streaming state for this descendant
+  hydrateDescendantState(sessionId);
+}
+
+function unsubscribeFromDescendant(sessionId) {
+  const entry = descendantSubscriptions[sessionId];
+  if (entry) {
+    entry.cleanup();
+    delete descendantSubscriptions[sessionId];
+  }
+}
+
+async function hydrateDescendantState(sessionId) {
+  if (typeof window === 'undefined') return;
+  try {
+    const response = await fetch(`/api/sessions/${sessionId}/streaming-state`);
+    if (response.ok) {
+      const snapshot = await response.json();
+      if (snapshot && (snapshot.workLogs?.length || snapshot.partialText || snapshot.thinking)) {
+        streamingStore.hydrateSessionState(sessionId, snapshot);
+      }
+    }
+  } catch (error) {
+    // Non-fatal
+  }
+}
+
+// Watch for running descendants and subscribe/unsubscribe dynamically
+watch(
+  () => sessionsStore.getAllDescendants(props.sessionId)
+    .filter(d => d.status === 'running' || d.status === 'starting')
+    .map(d => d.id),
+  (newIds, oldIds = []) => {
+    const added = newIds.filter(id => !oldIds.includes(id));
+    const removed = oldIds.filter(id => !newIds.includes(id));
+    added.forEach(id => subscribeToDescendant(id));
+    removed.forEach(id => unsubscribeFromDescendant(id));
+  },
+  { immediate: true },
+);
+
 // Hydrate streaming state from server on mount (browser only)
 onMounted(async () => {
   // Skip hydration in test environment (fetch doesn't work with relative URLs in vitest)
@@ -184,6 +261,23 @@ const session = computed(() =>
 const isRunning = computed(() => {
   const status = session.value?.status;
   return status === 'running' || status === 'starting';
+});
+
+// Collect IDs of this session + any running descendants for the live output panel
+const runningSessionIds = computed(() => {
+  const ids = [];
+  if (isRunning.value) {
+    ids.push(props.sessionId);
+  }
+  // Include running child/descendant sessions so the parent summary tab
+  // shows live output even when the parent itself is in 'waiting' status
+  const descendants = sessionsStore.getAllDescendants(props.sessionId);
+  for (const d of descendants) {
+    if (d.status === 'running' || d.status === 'starting') {
+      ids.push(d.id);
+    }
+  }
+  return ids;
 });
 const prUrl = computed(() => session.value?.prUrl || null);
 const hasPrInfo = computed(() => prUrl.value && summary.value?.prState);
@@ -285,7 +379,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  // Clean up if needed
+  // Clean up descendant streaming subscriptions
+  Object.keys(descendantSubscriptions).forEach(id => unsubscribeFromDescendant(id));
 });
 
 async function handleRegenerate() {


### PR DESCRIPTION
## Summary
- When a parent session is in `waiting` status but has running child/descendant sessions, the live output panel (`SessionLogStream`) now appears on the summary tab showing the children's streaming output
- Adds dynamic WebSocket subscriptions for running descendant sessions with proper hydration and cleanup
- Adds 11 new tests covering descendant visibility, prop passing, subscription lifecycle, and unmount cleanup

## Test plan
- [x] Existing 16 SummaryTab tests pass unchanged
- [x] 11 new descendant live output tests all pass
- [x] Full web package test suite: 3848 tests pass, 0 failures
- [ ] Manual: Open a parent session in `waiting` status with a running child — live output panel should appear at the top of the summary tab
- [ ] Manual: Verify live output disappears when all descendants finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)