### PR TITLE
Cascade delete child sessions when parent is deleted

### DIFF
--- a/packages/server/src/api/sessions.cascadeDelete.test.js
+++ b/packages/server/src/api/sessions.cascadeDelete.test.js
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions, messages, canvasItems, sessionNotes } from '../database.js';
+
+// Mock websocket before importing the router
+vi.mock('../websocket.js', () => ({
+  broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
+}));
+
+// Mock sessionManager
+vi.mock('../services/sessionManager.js', () => ({
+  continueSession: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn().mockResolvedValue(undefined),
+  restartSession: vi.fn(),
+  cleanupActiveSession: vi.fn(),
+}));
+
+// Mock summaryService
+vi.mock('../services/summaryService.js', () => ({
+  propagatePrUrlToParent: vi.fn(),
+  cleanupSession: vi.fn(),
+  getSummary: vi.fn(),
+  regenerateSummary: vi.fn(),
+}));
+
+// Mock gitService
+vi.mock('../services/gitService.js', () => ({
+  getOriginDefaultBranch: vi.fn().mockResolvedValue('main'),
+  getModifiedFilesCount: vi.fn().mockResolvedValue(0),
+  removeWorktree: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock hookService
+vi.mock('../services/hookService.js', () => ({
+  executeHookAsync: vi.fn(),
+}));
+
+// Mock slashCommandService
+vi.mock('../services/slashCommandService.js', () => ({
+  resolvePromptSkillOrCommand: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock draftSessionService
+vi.mock('../services/draftSessionService.js', () => ({
+  validateDraftSession: vi.fn().mockReturnValue({ valid: true }),
+  startDraft: vi.fn(),
+  DraftSessionError: class extends Error {},
+}));
+
+// Mock scheduleService
+vi.mock('../services/scheduleService.js', () => ({
+  configureSchedule: vi.fn(),
+  ScheduleError: class extends Error {},
+}));
+
+// Mock sessionDuplicator
+vi.mock('../services/sessionDuplicator.js', () => ({
+  duplicateSession: vi.fn(),
+}));
+
+// Mock commandRunner
+vi.mock('../services/commandRunner.js', () => ({
+  commandRunner: {
+    getRunsBySession: vi.fn().mockReturnValue([]),
+  },
+}));
+
+// Mock upload middleware
+vi.mock('../middleware/upload.js', () => ({
+  upload: { array: () => (req, res, next) => next() },
+  handleUploadError: (err, req, res, next) => next(),
+}));
+
+import sessionsRouter from './sessions.js';
+import { broadcastToSession, broadcastToProject } from '../websocket.js';
+import { cleanupActiveSession } from '../services/sessionManager.js';
+import { cleanupSession as summaryCleanupSession } from '../services/summaryService.js';
+
+describe('Sessions API - DELETE cascade', () => {
+  let app;
+  let projectId;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    const project = projects.create('Cascade Test Project', '/tmp/test');
+    projectId = project.id;
+  });
+
+  it('deletes direct children when parent is deleted', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child1 = sessions.create(projectId, 'Child 1', 'prompt', { parentSessionId: parent.id });
+    const child2 = sessions.create(projectId, 'Child 2', 'prompt', { parentSessionId: parent.id });
+
+    const res = await request(app).delete(`/api/sessions/${parent.id}`);
+
+    expect(res.status).toBe(204);
+    expect(sessions.getById(parent.id)).toBeNull();
+    expect(sessions.getById(child1.id)).toBeNull();
+    expect(sessions.getById(child2.id)).toBeNull();
+  });
+
+  it('cascades deletion to grandchildren', async () => {
+    const grandparent = sessions.create(projectId, 'Grandparent', 'prompt');
+    const parent = sessions.create(projectId, 'Parent', 'prompt', { parentSessionId: grandparent.id });
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    const res = await request(app).delete(`/api/sessions/${grandparent.id}`);
+
+    expect(res.status).toBe(204);
+    expect(sessions.getById(grandparent.id)).toBeNull();
+    expect(sessions.getById(parent.id)).toBeNull();
+    expect(sessions.getById(child.id)).toBeNull();
+  });
+
+  it('cascades deletion of child messages and canvas items', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    // Child has messages (created automatically via sessions.create) and a canvas item
+    const childMessagesBefore = messages.getBySessionId(child.id);
+    expect(childMessagesBefore.length).toBeGreaterThan(0);
+
+    canvasItems.create(child.id, { type: 'markdown', content: 'Child canvas', filename: 'child.md' });
+
+    await request(app).delete(`/api/sessions/${parent.id}`);
+
+    // Child is gone
+    expect(sessions.getById(child.id)).toBeNull();
+
+    // Child messages are gone (cascade in DB handles this)
+    expect(messages.getBySessionId(child.id)).toEqual([]);
+
+    // Child canvas items are gone
+    expect(canvasItems.getBySessionId(child.id)).toEqual([]);
+  });
+
+  it('cascades deletion of child session notes', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    sessionNotes.create(child.id, 'Important note');
+
+    await request(app).delete(`/api/sessions/${parent.id}`);
+
+    expect(sessions.getById(child.id)).toBeNull();
+    expect(sessionNotes.getBySessionId(child.id)).toEqual([]);
+  });
+
+  it('does not delete parent when child is deleted', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    const res = await request(app).delete(`/api/sessions/${child.id}`);
+
+    expect(res.status).toBe(204);
+    expect(sessions.getById(child.id)).toBeNull();
+    expect(sessions.getById(parent.id)).toBeTruthy();
+  });
+
+  it('only deletes children of the deleted parent, not unrelated sessions', async () => {
+    const parent1 = sessions.create(projectId, 'Parent 1', 'prompt');
+    const parent2 = sessions.create(projectId, 'Parent 2', 'prompt');
+    const child1 = sessions.create(projectId, 'Child 1', 'prompt', { parentSessionId: parent1.id });
+    const child2 = sessions.create(projectId, 'Child 2', 'prompt', { parentSessionId: parent2.id });
+
+    await request(app).delete(`/api/sessions/${parent1.id}`);
+
+    // parent1 tree deleted
+    expect(sessions.getById(parent1.id)).toBeNull();
+    expect(sessions.getById(child1.id)).toBeNull();
+    // parent2 tree intact
+    expect(sessions.getById(parent2.id)).toBeTruthy();
+    expect(sessions.getById(child2.id)).toBeTruthy();
+  });
+
+  it('handles deleting a session with no children', async () => {
+    const session = sessions.create(projectId, 'Solo', 'prompt');
+
+    const res = await request(app).delete(`/api/sessions/${session.id}`);
+
+    expect(res.status).toBe(204);
+    expect(sessions.getById(session.id)).toBeNull();
+  });
+
+  it('calls cleanupActiveSession for each deleted descendant', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    await request(app).delete(`/api/sessions/${parent.id}`);
+
+    // cleanupActiveSession is called for child first, then parent
+    expect(cleanupActiveSession).toHaveBeenCalledWith(child.id);
+    expect(cleanupActiveSession).toHaveBeenCalledWith(parent.id);
+  });
+
+  it('calls summaryCleanupSession for each deleted descendant', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    await request(app).delete(`/api/sessions/${parent.id}`);
+
+    expect(summaryCleanupSession).toHaveBeenCalledWith(child.id);
+    expect(summaryCleanupSession).toHaveBeenCalledWith(parent.id);
+  });
+
+  it('broadcasts SESSION_DELETED to session subscribers for each deleted session', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child = sessions.create(projectId, 'Child', 'prompt', { parentSessionId: parent.id });
+
+    await request(app).delete(`/api/sessions/${parent.id}`);
+
+    // broadcastToSession is called once per deleted session (child then parent)
+    const sessionCalls = broadcastToSession.mock.calls.map(c => c[0]);
+    expect(sessionCalls).toContain(child.id);
+    expect(sessionCalls).toContain(parent.id);
+  });
+
+  it('broadcasts SESSION_DELETED to project subscribers for each deleted session', async () => {
+    const parent = sessions.create(projectId, 'Parent', 'prompt');
+    const child1 = sessions.create(projectId, 'Child 1', 'prompt', { parentSessionId: parent.id });
+    const child2 = sessions.create(projectId, 'Child 2', 'prompt', { parentSessionId: parent.id });
+
+    await request(app).delete(`/api/sessions/${parent.id}`);
+
+    // broadcastToProject should be called for parent and each child
+    const projectCalls = broadcastToProject.mock.calls.map(c => c[2]);
+    const deletedSessionIds = projectCalls.map(c => c?.sessionId).filter(Boolean);
+    expect(deletedSessionIds).toContain(parent.id);
+    expect(deletedSessionIds).toContain(child1.id);
+    expect(deletedSessionIds).toContain(child2.id);
+  });
+});

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -693,13 +693,38 @@ router.post('/:id/duplicate', requireSession, async (req, res) => {
 
 // DELETE /api/sessions/:id - Delete session
 router.delete('/:id', requireSessionAndProject, async (req, res) => {
-  // Clean up active session if running
-  cleanupActiveSession(req.params.id);
+  // Collect all descendant session IDs before any deletions
+  // (database ON DELETE SET NULL would orphan them otherwise)
+  const descendantIds = sessions.getAllDescendantIds(req.params.id);
 
-  // Clean up summary service debounce timers
-  summaryService.cleanupSession(req.params.id);
+  // Helper: clean up and delete a single session by ID
+  const cleanupAndDeleteSession = async (sessionId) => {
+    // Clean up active session if running
+    cleanupActiveSession(sessionId);
 
-  // Remove git worktree if session has one (skip for child sessions - they may share parent's worktree)
+    // Clean up summary service debounce timers
+    summaryService.cleanupSession(sessionId);
+
+    // Clean up attachment files from disk
+    try {
+      attachments.deleteSessionAttachmentsFromDisk(req.workingDirectory, sessionId);
+    } catch (error) {
+      console.warn(`Failed to remove attachment files for session ${sessionId}:`, error.message);
+    }
+
+    // Broadcast deletion to close any open WebSocket subscriptions
+    broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_DELETED, { sessionId });
+
+    // Delete session (cascade will handle messages, canvas items, notes)
+    sessions.delete(sessionId);
+  };
+
+  // Delete all descendants first (leaves before branches to avoid orphaning)
+  for (const descendantId of descendantIds.reverse()) {
+    await cleanupAndDeleteSession(descendantId);
+  }
+
+  // Remove git worktree if parent session has one (skip for child sessions - they may share parent's worktree)
   if (req.session_.gitWorktree && !req.session_.parentSessionId) {
     try {
       await gitService.removeWorktree(req.project.workingDirectory, req.session_.gitWorktree, true);
@@ -709,25 +734,22 @@ router.delete('/:id', requireSessionAndProject, async (req, res) => {
     }
   }
 
-  // Clean up attachment files from disk
-  try {
-    attachments.deleteSessionAttachmentsFromDisk(req.workingDirectory, req.session_.id);
-  } catch (error) {
-    // Log but don't fail - files may already be removed
-    console.warn(`Failed to remove attachment files for session ${req.session_.id}:`, error.message);
-  }
-
-  // Broadcast deletion to close any open WebSocket subscriptions
-  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.SESSION_DELETED, { sessionId: req.params.id });
+  // Clean up and delete the parent session itself
+  await cleanupAndDeleteSession(req.params.id);
 
   // Broadcast deletion to project subscribers for real-time list updates
+  // (sends one event per deleted session so the frontend can remove them all)
   broadcastToProject(req.session_.projectId, WS_MESSAGE_TYPES.SESSION_DELETED, {
     projectId: req.session_.projectId,
     sessionId: req.params.id,
   });
 
-  // Delete session (cascade will handle messages, canvas items, notes)
-  sessions.delete(req.params.id);
+  for (const descendantId of descendantIds) {
+    broadcastToProject(req.session_.projectId, WS_MESSAGE_TYPES.SESSION_DELETED, {
+      projectId: req.session_.projectId,
+      sessionId: descendantId,
+    });
+  }
 
   // Execute on_session_deleted hook if configured (non-blocking)
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown

--- a/tests/e2e/child-session-cascade-delete.spec.ts
+++ b/tests/e2e/child-session-cascade-delete.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  seedChildSession,
+  seedCanvasItem,
+  seedSessionNote,
+  cleanupCreatedResources,
+  getSession,
+  getProjectSessions,
+  deleteSession,
+  getAPIURL,
+} from './helpers';
+
+test.describe('Child Session Cascade Delete', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    project = await seedProject('Cascade Delete Project', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('deleting a parent session also deletes its direct children', async () => {
+    // Create parent session
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent session',
+      name: 'Parent',
+      startImmediately: false,
+    });
+
+    // Create two child sessions
+    const child1 = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child session 1',
+      name: 'Child 1',
+    });
+    const child2 = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child session 2',
+      name: 'Child 2',
+    });
+
+    // Verify all sessions exist
+    expect(await getSession(parent.id)).toBeTruthy();
+    expect(await getSession(child1.id)).toBeTruthy();
+    expect(await getSession(child2.id)).toBeTruthy();
+
+    // Delete the parent
+    await deleteSession(parent.id);
+
+    // Verify parent is gone
+    expect(await getSession(parent.id)).toBeNull();
+
+    // Verify children are also deleted
+    expect(await getSession(child1.id)).toBeNull();
+    expect(await getSession(child2.id)).toBeNull();
+  });
+
+  test('deleting a parent session cascades to grandchildren', async () => {
+    // Create a 3-level hierarchy: grandparent → parent → child
+    const grandparent = await seedSession(project.id, {
+      prompt: 'Grandparent session',
+      name: 'Grandparent',
+      startImmediately: false,
+    });
+
+    const parent = await seedChildSession(project.id, grandparent.id, {
+      prompt: 'Parent session',
+      name: 'Parent',
+    });
+
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Grandchild session',
+      name: 'Grandchild',
+    });
+
+    // Verify all exist
+    expect(await getSession(grandparent.id)).toBeTruthy();
+    expect(await getSession(parent.id)).toBeTruthy();
+    expect(await getSession(child.id)).toBeTruthy();
+
+    // Delete the grandparent
+    await deleteSession(grandparent.id);
+
+    // All should be deleted
+    expect(await getSession(grandparent.id)).toBeNull();
+    expect(await getSession(parent.id)).toBeNull();
+    expect(await getSession(child.id)).toBeNull();
+  });
+
+  test('deleting a parent cascades child session data (canvas, notes)', async () => {
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent with data',
+      name: 'Parent',
+      startImmediately: false,
+    });
+
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child with data',
+      name: 'Child',
+    });
+
+    // Add data to the child session
+    await seedCanvasItem(child.id, {
+      type: 'markdown',
+      content: '# Child canvas item',
+      filename: 'child.md',
+    });
+    await seedSessionNote(child.id, { content: 'Child note' });
+
+    // Delete parent
+    await deleteSession(parent.id);
+
+    // Child should be gone (404 from session lookup)
+    const childResponse = await fetch(`${getAPIURL()}/api/sessions/${child.id}`);
+    expect(childResponse.status).toBe(404);
+
+    // Canvas items for the child should also be gone
+    const canvasResponse = await fetch(`${getAPIURL()}/api/sessions/${child.id}/canvas`);
+    expect(canvasResponse.status).toBe(404);
+
+    // Notes for the child should also be gone
+    const notesResponse = await fetch(`${getAPIURL()}/api/sessions/${child.id}/notes`);
+    expect(notesResponse.status).toBe(404);
+  });
+
+  test('deleting a child session does not delete the parent', async () => {
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent session',
+      name: 'Parent',
+      startImmediately: false,
+    });
+
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child session',
+      name: 'Child',
+    });
+
+    // Delete only the child
+    await deleteSession(child.id);
+
+    // Child should be gone
+    expect(await getSession(child.id)).toBeNull();
+
+    // Parent should still exist
+    const parentData = await getSession(parent.id);
+    expect(parentData).toBeTruthy();
+    expect(parentData.id).toBe(parent.id);
+  });
+
+  test('deleting a parent only deletes its own children, not siblings', async () => {
+    // Create two independent parent sessions
+    const parent1 = await seedSession(project.id, {
+      prompt: 'Parent 1',
+      name: 'Parent 1',
+      startImmediately: false,
+    });
+    const parent2 = await seedSession(project.id, {
+      prompt: 'Parent 2',
+      name: 'Parent 2',
+      startImmediately: false,
+    });
+
+    // Each parent has a child
+    const child1 = await seedChildSession(project.id, parent1.id, {
+      prompt: 'Child of Parent 1',
+      name: 'Child 1',
+    });
+    const child2 = await seedChildSession(project.id, parent2.id, {
+      prompt: 'Child of Parent 2',
+      name: 'Child 2',
+    });
+
+    // Delete parent1
+    await deleteSession(parent1.id);
+
+    // Parent1 and its child should be gone
+    expect(await getSession(parent1.id)).toBeNull();
+    expect(await getSession(child1.id)).toBeNull();
+
+    // Parent2 and its child should still exist
+    expect(await getSession(parent2.id)).toBeTruthy();
+    expect(await getSession(child2.id)).toBeTruthy();
+  });
+
+  test('deleting a parent removes children from project session list', async () => {
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent session',
+      name: 'Parent Session',
+      startImmediately: false,
+    });
+
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child session',
+      name: 'Child Session',
+    });
+
+    // Verify both appear in project session list
+    const sessionsBefore = await getProjectSessions(project.id);
+    const idsBefore = sessionsBefore.map((s: any) => s.id);
+    expect(idsBefore).toContain(parent.id);
+    expect(idsBefore).toContain(child.id);
+
+    // Delete parent
+    await deleteSession(parent.id);
+
+    // Verify neither appears in project session list
+    const sessionsAfter = await getProjectSessions(project.id);
+    const idsAfter = sessionsAfter.map((s: any) => s.id);
+    expect(idsAfter).not.toContain(parent.id);
+    expect(idsAfter).not.toContain(child.id);
+  });
+});


### PR DESCRIPTION
## Summary
- **Fixes orphaned child sessions**: Previously, deleting a parent session set `parent_session_id` to NULL on children (via DB `ON DELETE SET NULL`), leaving ghost sessions. Now all descendants are cascade-deleted.
- **Full cleanup per descendant**: Each deleted descendant gets proper cleanup — active session teardown, summary timer cleanup, attachment file removal, and WebSocket broadcasts.
- **Bottom-up deletion order**: Descendants are deleted leaves-first to avoid orphaning mid-level nodes.

## Test plan
- [x] 11 unit tests in `sessions.cascadeDelete.test.js` — direct children, grandchildren, data cascade (messages, canvas, notes), isolation (child-only delete, sibling trees), cleanup/broadcast verification
- [x] 6 E2E tests in `child-session-cascade-delete.spec.ts` — direct children, 3-level hierarchy, child data cleanup, one-way cascade, sibling isolation, project list updates
- [x] All existing unit tests pass (server: 3584 passed, web: 3837 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)