### PR TITLE
feat: add scheduling info to session summary tab

### DIFF
--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -34,6 +34,14 @@ vi.mock('vue-router', () => ({
   }),
 }));
 
+vi.mock('./SchedulingInfo.vue', () => ({
+  default: {
+    name: 'SchedulingInfo',
+    props: ['session'],
+    template: '<div class="scheduling-info-stub" data-testid="scheduling-info">SchedulingInfo</div>',
+  },
+}));
+
 import SummaryTab from './SummaryTab.vue';
 import { api } from '../composables/useApi.js';
 import { useSessionsStore } from '../stores/sessions.js';
@@ -82,6 +90,11 @@ describe('SummaryTab', () => {
             props: ['content'],
           },
           SessionLogStream: { template: '<div class="session-log-stream-stub"></div>' },
+          SchedulingInfo: {
+            name: 'SchedulingInfo',
+            template: '<div class="scheduling-info-stub" data-testid="scheduling-info">SchedulingInfo</div>',
+            props: ['session'],
+          },
         },
       },
     });
@@ -179,6 +192,11 @@ describe('SummaryTab', () => {
               props: ['sessionId'],
               template: '<div class="session-log-stream-stub">SessionLogStream</div>',
             },
+            SchedulingInfo: {
+              name: 'SchedulingInfo',
+              template: '<div class="scheduling-info-stub">SchedulingInfo</div>',
+              props: ['session'],
+            },
           },
         },
       });
@@ -207,6 +225,11 @@ describe('SummaryTab', () => {
               name: 'SessionLogStream',
               props: ['sessionId'],
               template: '<div class="session-log-stream-stub">SessionLogStream</div>',
+            },
+            SchedulingInfo: {
+              name: 'SchedulingInfo',
+              template: '<div class="scheduling-info-stub">SchedulingInfo</div>',
+              props: ['session'],
             },
           },
         },
@@ -240,6 +263,7 @@ describe('SummaryTab', () => {
                 name: 'SessionLogStream',
                 template: '<div class="session-log-stream-stub">SessionLogStream</div>',
               },
+              SchedulingInfo: true,
             },
           },
         });
@@ -270,6 +294,11 @@ describe('SummaryTab', () => {
               props: ['sessionIds'],
               template: '<div class="session-log-stream-stub">{{ sessionIds }}</div>',
             },
+            SchedulingInfo: {
+              name: 'SchedulingInfo',
+              template: '<div class="scheduling-info-stub">SchedulingInfo</div>',
+              props: ['session'],
+            },
           },
         },
       });
@@ -299,6 +328,11 @@ describe('SummaryTab', () => {
             SessionLogStream: {
               name: 'SessionLogStream',
               template: '<div class="session-log-stream-stub">SessionLogStream</div>',
+            },
+            SchedulingInfo: {
+              name: 'SchedulingInfo',
+              template: '<div class="scheduling-info-stub">SchedulingInfo</div>',
+              props: ['session'],
             },
           },
         },
@@ -331,6 +365,11 @@ describe('SummaryTab', () => {
             SessionLogStream: {
               name: 'SessionLogStream',
               template: '<div class="session-log-stream-stub">SessionLogStream</div>',
+            },
+            SchedulingInfo: {
+              name: 'SchedulingInfo',
+              template: '<div class="scheduling-info-stub">SchedulingInfo</div>',
+              props: ['session'],
             },
           },
         },
@@ -435,6 +474,57 @@ describe('SummaryTab', () => {
       await flushAll(wrapper);
 
       expect(wrapper.find('.expand-toggle').exists()).toBe(false);
+    });
+  });
+
+  describe('Scheduling Info', () => {
+    it('renders SchedulingInfo when session status is scheduled', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'scheduled',
+        scheduledAt: Date.now() + 3600000,
+      };
+      sessionsStore.sessions = [sessionsStore.currentSession];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.findComponent({ name: 'SchedulingInfo' }).exists()).toBe(true);
+    });
+
+    it('does not render SchedulingInfo for non-scheduled sessions', async () => {
+      // Default session has status: 'waiting'
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.findComponent({ name: 'SchedulingInfo' }).exists()).toBe(false);
+    });
+
+    it('passes session prop to SchedulingInfo', async () => {
+      const scheduledSession = {
+        id: 'sess-123',
+        status: 'scheduled',
+        scheduledAt: Date.now() + 3600000,
+      };
+      sessionsStore.currentSession = scheduledSession;
+      sessionsStore.sessions = [scheduledSession];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const schedulingInfo = wrapper.findComponent({ name: 'SchedulingInfo' });
+      expect(schedulingInfo.exists()).toBe(true);
+      expect(schedulingInfo.props('session')).toEqual(scheduledSession);
+    });
+
+    it('does not render SchedulingInfo when session is null', async () => {
+      sessionsStore.currentSession = null;
+      sessionsStore.sessions = [];
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.findComponent({ name: 'SchedulingInfo' }).exists()).toBe(false);
     });
   });
 

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -31,6 +31,9 @@
       </button>
     </div>
 
+    <!-- Scheduling Info (only for scheduled sessions) -->
+    <SchedulingInfo v-if="isScheduled" :session="session" />
+
     <!-- Session Overview Section -->
     <div v-if="hasPrInfo || summary?.shortSummary || loading" class="session-overview card">
       <div class="overview-header">
@@ -113,6 +116,7 @@ import { useSessionStreamingStore } from '../stores/sessionStreaming.js';
 import SummaryContent from './SummaryContent.vue';
 import SessionLogStream from './SessionLogStream.vue';
 import MarkdownViewer from './MarkdownViewer.vue';
+import SchedulingInfo from './SchedulingInfo.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -185,6 +189,7 @@ const isRunning = computed(() => {
   const status = session.value?.status;
   return status === 'running' || status === 'starting';
 });
+const isScheduled = computed(() => session.value?.status === 'scheduled');
 const prUrl = computed(() => session.value?.prUrl || null);
 const hasPrInfo = computed(() => prUrl.value && summary.value?.prState);
 const hasWarnings = computed(() => summary.value?.hasMergeConflicts || summary.value?.ciStatus === 'failure');

--- a/tests/e2e/scheduling-reschedule.spec.ts
+++ b/tests/e2e/scheduling-reschedule.spec.ts
@@ -542,8 +542,9 @@ test.describe('Category 5: Scheduling UI Components', () => {
     await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await openSessionOverlay(page);
 
-    // Click "Edit Schedule" button
-    const editButton = page.getByRole('button', { name: 'Edit Schedule' });
+    // Click "Edit Schedule" button (scoped to overlay to avoid duplicate from SummaryTab)
+    const overlay = page.getByTestId('session-tree-overlay');
+    const editButton = overlay.getByRole('button', { name: 'Edit Schedule' });
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();
 

--- a/tests/e2e/scheduling-ui.spec.ts
+++ b/tests/e2e/scheduling-ui.spec.ts
@@ -137,12 +137,13 @@ test.describe('Scheduling UI', () => {
       // Expected: Should show "in about 1 hour" or similar future time
       // Actual (bug): Shows "56 years ago" or other incorrect past time
 
-      // Wait for the scheduling info panel to appear
-      const schedulingPanel = page.locator('.scheduling-info.scheduled-panel');
+      // Wait for the scheduling info panel to appear (scoped to overlay to avoid duplicate from SummaryTab)
+      const overlay = page.getByTestId('session-tree-overlay');
+      const schedulingPanel = overlay.locator('.scheduling-info.scheduled-panel');
       await expect(schedulingPanel).toBeVisible({ timeout: 5000 });
 
       // Get the countdown text element
-      const countdownText = page.locator('.countdown-text strong');
+      const countdownText = overlay.locator('.countdown-text strong');
       await expect(countdownText).toBeVisible({ timeout: 3000 });
 
       // Get the text content
@@ -161,7 +162,8 @@ test.describe('Scheduling UI', () => {
       await page.waitForLoadState('networkidle');
       await openSessionOverlay(page);
 
-      const countdownTextAfterReload = page.locator('.countdown-text strong');
+      const overlayAfterReload = page.getByTestId('session-tree-overlay');
+      const countdownTextAfterReload = overlayAfterReload.locator('.countdown-text strong');
       await expect(countdownTextAfterReload).toBeVisible({ timeout: 5000 });
 
       const timeTextAfterReload = await countdownTextAfterReload.textContent();


### PR DESCRIPTION
## Summary
- Adds the `SchedulingInfo` component to the `SummaryTab`, visible only when a session has `status === 'scheduled'`
- Shows countdown timer, absolute scheduled time, auto-reschedule status, and edit/cancel actions
- Places `SchedulingInfo` as a sibling element above the session overview card (same pattern as ConversationTab)
- Adds comprehensive unit tests covering conditional rendering, prop passing, and edge cases (null session)

## Test plan
- [x] All 20 SummaryTab unit tests pass
- [ ] Manual verification: create a scheduled session and confirm SchedulingInfo appears in the summary tab
- [ ] Verify SchedulingInfo is hidden for non-scheduled sessions (waiting, running, completed, etc.)
- [ ] Verify edit/cancel actions in SchedulingInfo work correctly from the summary tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)