### PR TITLE
Rename SessionTreeOverlay to SessionChatOverlay

### DIFF
--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -545,7 +545,7 @@ function handleSlashCommandInsert({ text }) {
   });
 }
 
-// Expose flushDraft so parent components (e.g. SessionTreeOverlay) can
+// Expose flushDraft so parent components (e.g. SessionChatOverlay) can
 // force-save pending drafts before switching sessions.
 defineExpose({ flushDraft });
 </script>

--- a/packages/web/src/components/SessionChatHandle.test.js
+++ b/packages/web/src/components/SessionChatHandle.test.js
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
-import SessionTreeHandle from './SessionTreeHandle.vue';
+import SessionChatHandle from './SessionChatHandle.vue';
 
-describe('SessionTreeHandle', () => {
+describe('SessionChatHandle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   function mountComponent(props = {}) {
-    return mount(SessionTreeHandle, {
+    return mount(SessionChatHandle, {
       props: { ...props }
     });
   }
@@ -16,24 +16,24 @@ describe('SessionTreeHandle', () => {
   describe('rendering', () => {
     it('renders the handle element with correct test id', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('[data-testid="session-tree-handle"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="session-chat-handle"]').exists()).toBe(true);
     });
 
-    it('renders the handle with session-tree-handle class', () => {
+    it('renders the handle with session-chat-handle class', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('.session-tree-handle').exists()).toBe(true);
+      expect(wrapper.find('.session-chat-handle').exists()).toBe(true);
     });
 
     it('has correct ARIA attributes', () => {
       const wrapper = mountComponent();
-      const handle = wrapper.find('.session-tree-handle');
+      const handle = wrapper.find('.session-chat-handle');
       expect(handle.attributes('role')).toBe('button');
       expect(handle.attributes('aria-label')).toBe('Open session tree');
     });
 
     it('is focusable with tabindex 0', () => {
       const wrapper = mountComponent();
-      const handle = wrapper.find('.session-tree-handle');
+      const handle = wrapper.find('.session-chat-handle');
       expect(handle.attributes('tabindex')).toBe('0');
     });
 
@@ -42,13 +42,13 @@ describe('SessionTreeHandle', () => {
       expect(wrapper.find('svg.handle-icon').exists()).toBe(true);
     });
 
-    it('has z-index 900 via the session-tree-handle class', () => {
+    it('has z-index 900 via the session-chat-handle class', () => {
       const wrapper = mountComponent();
-      const handle = wrapper.find('.session-tree-handle');
+      const handle = wrapper.find('.session-chat-handle');
       expect(handle.exists()).toBe(true);
       // The z-index is applied through the scoped CSS class
       // Verify the class exists which applies z-index: 900
-      expect(handle.classes()).toContain('session-tree-handle');
+      expect(handle.classes()).toContain('session-chat-handle');
     });
   });
 
@@ -77,13 +77,13 @@ describe('SessionTreeHandle', () => {
 
     it('updates handle tooltip when session is active', () => {
       const wrapper = mountComponent({ isSessionActive: true, sessionStatus: 'running' });
-      const handle = wrapper.find('.session-tree-handle');
+      const handle = wrapper.find('.session-chat-handle');
       expect(handle.attributes('title')).toBe('Session running...');
     });
 
     it('shows default tooltip when session is not active', () => {
       const wrapper = mountComponent({ isSessionActive: false });
-      const handle = wrapper.find('.session-tree-handle');
+      const handle = wrapper.find('.session-chat-handle');
       expect(handle.attributes('title')).toBe('Open session tree');
     });
   });
@@ -91,28 +91,28 @@ describe('SessionTreeHandle', () => {
   describe('interactions', () => {
     it('emits open on click', async () => {
       const onOpen = vi.fn();
-      const wrapper = mount(SessionTreeHandle, {
+      const wrapper = mount(SessionChatHandle, {
         attrs: { onOpen },
       });
-      await wrapper.find('.session-tree-handle').trigger('click');
+      await wrapper.find('.session-chat-handle').trigger('click');
       expect(onOpen).toHaveBeenCalled();
     });
 
     it('emits open on Enter keypress', async () => {
       const onOpen = vi.fn();
-      const wrapper = mount(SessionTreeHandle, {
+      const wrapper = mount(SessionChatHandle, {
         attrs: { onOpen },
       });
-      await wrapper.find('.session-tree-handle').trigger('keydown.enter');
+      await wrapper.find('.session-chat-handle').trigger('keydown.enter');
       expect(onOpen).toHaveBeenCalled();
     });
 
     it('emits open on Space keypress', async () => {
       const onOpen = vi.fn();
-      const wrapper = mount(SessionTreeHandle, {
+      const wrapper = mount(SessionChatHandle, {
         attrs: { onOpen },
       });
-      await wrapper.find('.session-tree-handle').trigger('keydown.space');
+      await wrapper.find('.session-chat-handle').trigger('keydown.space');
       expect(onOpen).toHaveBeenCalled();
     });
   });

--- a/packages/web/src/components/SessionChatHandle.vue
+++ b/packages/web/src/components/SessionChatHandle.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="session-tree-handle"
+    class="session-chat-handle"
     tabindex="0"
     role="button"
     :aria-label="isSessionActive
@@ -9,7 +9,7 @@
     :title="isSessionActive
       ? (sessionStatus === 'starting' ? 'Session starting...' : 'Session running...')
       : 'Open session tree'"
-    data-testid="session-tree-handle"
+    data-testid="session-chat-handle"
     @click="handleOpen"
     @keydown.enter.prevent="handleOpen"
     @keydown.space.prevent="handleOpen"
@@ -59,7 +59,7 @@ function handleOpen() {
 </script>
 
 <style scoped>
-.session-tree-handle {
+.session-chat-handle {
   position: fixed;
   right: 0;
   top: 50%;
@@ -80,12 +80,12 @@ function handleOpen() {
   min-height: 44px;
 }
 
-.session-tree-handle:hover {
+.session-chat-handle:hover {
   background: rgba(8, 145, 178, 0.9);
   transform: translateY(-50%) translateX(-4px);
 }
 
-.session-tree-handle:focus-visible {
+.session-chat-handle:focus-visible {
   outline: 2px solid var(--color-primary, #06b6d4);
   outline-offset: 2px;
 }
@@ -95,7 +95,7 @@ function handleOpen() {
   transition: color 0.2s ease;
 }
 
-.session-tree-handle:hover .handle-icon {
+.session-chat-handle:hover .handle-icon {
   color: #fff;
 }
 

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createRouter, createMemoryHistory } from 'vue-router';
 import { h, defineComponent, nextTick } from 'vue';
-import SessionTreeOverlay from './SessionTreeOverlay.vue';
+import SessionChatOverlay from './SessionChatOverlay.vue';
 import { api } from '../composables/useApi.js';
 import { generateWorktreeBranch } from '@claudetools/shared';
 
@@ -153,7 +153,7 @@ vi.mock('./SessionTreePicker.vue', () => ({
   }),
 }));
 
-describe('SessionTreeOverlay', () => {
+describe('SessionChatOverlay', () => {
   let pinia;
   let router;
   const rootSession = {
@@ -196,11 +196,11 @@ describe('SessionTreeOverlay', () => {
 
   afterEach(() => {
     // Clean up teleported content
-    document.querySelectorAll('[data-testid="session-tree-overlay"]').forEach(el => el.remove());
+    document.querySelectorAll('[data-testid="session-chat-overlay"]').forEach(el => el.remove());
   });
 
   function mountOverlay(propsOverrides = {}) {
-    return mount(SessionTreeOverlay, {
+    return mount(SessionChatOverlay, {
       props: {
         sessionId: 'sess-root',
         ...propsOverrides,
@@ -223,7 +223,7 @@ describe('SessionTreeOverlay', () => {
     it('renders overlay with correct test id', async () => {
       const wrapper = mountOverlay();
       await nextTick();
-      const overlay = document.querySelector('[data-testid="session-tree-overlay"]');
+      const overlay = document.querySelector('[data-testid="session-chat-overlay"]');
       expect(overlay).toBeTruthy();
       wrapper.unmount();
     });
@@ -281,7 +281,7 @@ describe('SessionTreeOverlay', () => {
     it('renders close handle with correct test id', async () => {
       const wrapper = mountOverlay();
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle).toBeTruthy();
       wrapper.unmount();
     });
@@ -289,10 +289,10 @@ describe('SessionTreeOverlay', () => {
     it('close handle has correct ARIA attributes', async () => {
       const wrapper = mountOverlay();
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle).toBeTruthy();
       expect(handle.getAttribute('role')).toBe('button');
-      expect(handle.getAttribute('aria-label')).toBe('Close session tree');
+      expect(handle.getAttribute('aria-label')).toBe('Close session chat');
       expect(handle.getAttribute('tabindex')).toBe('0');
       wrapper.unmount();
     });
@@ -301,7 +301,7 @@ describe('SessionTreeOverlay', () => {
   describe('close behavior', () => {
     it('emits close on Escape when picker is closed', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
@@ -317,14 +317,14 @@ describe('SessionTreeOverlay', () => {
 
     it('emits close when clicking the backdrop', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
       });
       await nextTick();
       // Click the backdrop (overlay-backdrop) directly, not the content
-      const backdrop = document.querySelector('[data-testid="session-tree-overlay"]');
+      const backdrop = document.querySelector('[data-testid="session-chat-overlay"]');
       backdrop.click();
       await nextTick();
       await waitForTransition();
@@ -335,7 +335,7 @@ describe('SessionTreeOverlay', () => {
 
     it('does not emit close when clicking inside overlay content', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
@@ -351,13 +351,13 @@ describe('SessionTreeOverlay', () => {
 
     it('emits close when close handle is clicked', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
       });
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle).toBeTruthy();
       handle.click();
       await nextTick();
@@ -369,13 +369,13 @@ describe('SessionTreeOverlay', () => {
 
     it('emits close when Enter is pressed on close handle', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
       });
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle).toBeTruthy();
       handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       await nextTick();
@@ -387,13 +387,13 @@ describe('SessionTreeOverlay', () => {
 
     it('emits close when Space is pressed on close handle', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
       });
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle).toBeTruthy();
       handle.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       await nextTick();
@@ -407,7 +407,7 @@ describe('SessionTreeOverlay', () => {
   describe('close animation', () => {
     it('delays close event until after transition completes', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
@@ -415,7 +415,7 @@ describe('SessionTreeOverlay', () => {
       await nextTick();
 
       // Trigger close
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       handle.click();
       await nextTick();
 
@@ -441,7 +441,7 @@ describe('SessionTreeOverlay', () => {
       expect(wrapper.vm.closing).toBe(false);
 
       // Trigger close
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       handle.click();
       await nextTick();
 
@@ -450,19 +450,19 @@ describe('SessionTreeOverlay', () => {
       expect(wrapper.vm.visible).toBe(false);
 
       // Clean up
-      document.querySelectorAll('[data-testid="session-tree-overlay"]').forEach(el => el.remove());
+      document.querySelectorAll('[data-testid="session-chat-overlay"]').forEach(el => el.remove());
     });
 
     it('guards against rapid close attempts', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onClose },
         attachTo: document.body,
       });
       await nextTick();
 
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
 
       // Click close multiple times rapidly
       handle.click();
@@ -487,8 +487,8 @@ describe('SessionTreeOverlay', () => {
       const wrapper = mountOverlay();
       await nextTick();
 
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
-      const backdrop = document.querySelector('[data-testid="session-tree-overlay"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
+      const backdrop = document.querySelector('[data-testid="session-chat-overlay"]');
 
       // Trigger close
       handle.click();
@@ -509,12 +509,12 @@ describe('SessionTreeOverlay', () => {
 
       // Test each close trigger
       const triggers = [
-        () => document.querySelector('[data-testid="session-tree-overlay-close-handle"]').click(),
-        () => document.querySelector('[data-testid="session-tree-overlay"]').click(),
+        () => document.querySelector('[data-testid="session-chat-overlay-close-handle"]').click(),
+        () => document.querySelector('[data-testid="session-chat-overlay"]').click(),
       ];
 
       for (const trigger of triggers) {
-        const testWrapper = mount(SessionTreeOverlay, {
+        const testWrapper = mount(SessionChatOverlay, {
           props: { sessionId: 'sess-root' },
           attrs: { onClose },
           attachTo: document.body,
@@ -538,7 +538,7 @@ describe('SessionTreeOverlay', () => {
 
         // Clean up
         onClose.mockClear();
-        document.querySelectorAll('[data-testid="session-tree-overlay"]').forEach(el => el.remove());
+        document.querySelectorAll('[data-testid="session-chat-overlay"]').forEach(el => el.remove());
       }
     });
   });
@@ -559,7 +559,7 @@ describe('SessionTreeOverlay', () => {
     };
 
     function mountWithPicker(propsOverrides = {}) {
-      return mount(SessionTreeOverlay, {
+      return mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -574,7 +574,7 @@ describe('SessionTreeOverlay', () => {
     }
 
     it('does not show picker when sessionChain has only 1 session', async () => {
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: [{ session: rootSession, depth: 0 }],
@@ -666,7 +666,7 @@ describe('SessionTreeOverlay', () => {
 
     it('Escape key closes picker without closing the overlay', async () => {
       const onClose = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -782,7 +782,7 @@ describe('SessionTreeOverlay', () => {
     it('positions overlay on right side of viewport', async () => {
       const wrapper = mountOverlay();
       await nextTick();
-      const backdrop = document.querySelector('[data-testid="session-tree-overlay"]');
+      const backdrop = document.querySelector('[data-testid="session-chat-overlay"]');
       expect(backdrop).toBeTruthy();
       // Verify the backdrop class exists which has justify-content: flex-end
       expect(backdrop.classList.contains('overlay-backdrop')).toBe(true);
@@ -913,7 +913,7 @@ describe('SessionTreeOverlay', () => {
       api.createSession.mockResolvedValue(newSession);
 
       const onSessionCreated = vi.fn();
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: { sessionId: 'sess-root' },
         attrs: { onSessionCreated },
         global: { plugins: [router] },
@@ -1046,7 +1046,7 @@ describe('SessionTreeOverlay', () => {
         return null;
       });
 
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -1087,7 +1087,7 @@ describe('SessionTreeOverlay', () => {
       mockSessionsStore.fetchSession.mockResolvedValue(undefined);
       mockSessionsStore.fetchConversations.mockResolvedValue(undefined);
 
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -1126,7 +1126,7 @@ describe('SessionTreeOverlay', () => {
       });
       mockSessionsStore.fetchSession.mockRejectedValue(new Error('Network error'));
 
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -1150,7 +1150,7 @@ describe('SessionTreeOverlay', () => {
     });
 
     it('does not show spinner when selecting the already-active session', async () => {
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -1230,7 +1230,7 @@ describe('SessionTreeOverlay', () => {
       mockSessionsStore.currentSession = { ...rootSession, status: 'running' };
       const wrapper = mountOverlay();
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle.getAttribute('aria-label')).toBe('Session running...');
       expect(handle.getAttribute('title')).toBe('Session running...');
       wrapper.unmount();
@@ -1241,20 +1241,20 @@ describe('SessionTreeOverlay', () => {
       mockSessionsStore.currentSession = { ...rootSession, status: 'starting' };
       const wrapper = mountOverlay();
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
       expect(handle.getAttribute('aria-label')).toBe('Session starting...');
       expect(handle.getAttribute('title')).toBe('Session starting...');
       wrapper.unmount();
     });
 
-    it('close handle ARIA label is "Close session tree" for inactive sessions', async () => {
+    it('close handle ARIA label is "Close session chat" for inactive sessions', async () => {
       mockSessionsStore.getSessionById.mockReturnValue({ ...rootSession, status: 'waiting' });
       mockSessionsStore.currentSession = { ...rootSession, status: 'waiting' };
       const wrapper = mountOverlay();
       await nextTick();
-      const handle = document.querySelector('[data-testid="session-tree-overlay-close-handle"]');
-      expect(handle.getAttribute('aria-label')).toBe('Close session tree');
-      expect(handle.getAttribute('title')).toBe('Close session tree');
+      const handle = document.querySelector('[data-testid="session-chat-overlay-close-handle"]');
+      expect(handle.getAttribute('aria-label')).toBe('Close session chat');
+      expect(handle.getAttribute('title')).toBe('Close session chat');
       wrapper.unmount();
     });
 
@@ -1297,7 +1297,7 @@ describe('SessionTreeOverlay', () => {
         return null;
       });
 
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -1336,7 +1336,7 @@ describe('SessionTreeOverlay', () => {
         mockSessionsStore.activeConversationId = 'conv-child-1';
       });
 
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,
@@ -1374,7 +1374,7 @@ describe('SessionTreeOverlay', () => {
         mockSessionsStore.activeConversationId = null;
       });
 
-      const wrapper = mount(SessionTreeOverlay, {
+      const wrapper = mount(SessionChatOverlay, {
         props: {
           sessionId: 'sess-root',
           sessionChain: chainSessions,

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -132,16 +132,16 @@ vi.mock('./ConversationTab.vue', () => ({
   }),
 }));
 
-// Mock SessionTreePicker
-vi.mock('./SessionTreePicker.vue', () => ({
+// Mock SessionChatPicker
+vi.mock('./SessionChatPicker.vue', () => ({
   default: defineComponent({
-    name: 'SessionTreePicker',
+    name: 'SessionChatPicker',
     props: ['sessions', 'activeSessionId', 'summaries'],
     emits: ['select'],
     render() {
       return h('div', {
-        class: 'session-tree-picker-stub',
-        'data-testid': 'session-tree-picker',
+        class: 'session-chat-picker-stub',
+        'data-testid': 'session-chat-picker',
       }, this.sessions?.map(s =>
         h('div', {
           key: s.session.id,
@@ -604,22 +604,22 @@ describe('SessionChatOverlay', () => {
       const trigger = document.querySelector('[data-testid="overlay-picker-trigger"]');
 
       // Initially picker should not be shown
-      expect(document.querySelector('[data-testid="session-tree-picker"]')).toBeFalsy();
+      expect(document.querySelector('[data-testid="session-chat-picker"]')).toBeFalsy();
 
       // Click to open
       trigger.click();
       await nextTick();
-      expect(document.querySelector('[data-testid="session-tree-picker"]')).toBeTruthy();
+      expect(document.querySelector('[data-testid="session-chat-picker"]')).toBeTruthy();
 
       // Click to close
       trigger.click();
       await nextTick();
-      expect(document.querySelector('[data-testid="session-tree-picker"]')).toBeFalsy();
+      expect(document.querySelector('[data-testid="session-chat-picker"]')).toBeFalsy();
 
       wrapper.unmount();
     });
 
-    it('SessionTreePicker receives correct props', async () => {
+    it('SessionChatPicker receives correct props', async () => {
       const wrapper = mountWithPicker();
       await nextTick();
 
@@ -627,7 +627,7 @@ describe('SessionChatOverlay', () => {
       wrapper.vm.pickerOpen = true;
       await nextTick();
 
-      const picker = document.querySelector('[data-testid="session-tree-picker"]');
+      const picker = document.querySelector('[data-testid="session-chat-picker"]');
       expect(picker).toBeTruthy();
       // The mock renders session names as text content
       expect(picker.textContent).toContain('Root Session');
@@ -681,7 +681,7 @@ describe('SessionChatOverlay', () => {
       // Open picker
       wrapper.vm.pickerOpen = true;
       await nextTick();
-      expect(document.querySelector('[data-testid="session-tree-picker"]')).toBeTruthy();
+      expect(document.querySelector('[data-testid="session-chat-picker"]')).toBeTruthy();
 
       // Press Escape
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -110,7 +110,7 @@
                 <span class="dropdown-name">{{ activeSessionDisplayName }}</span>
                 <span class="dropdown-chevron">{{ pickerOpen ? '&#9650;' : '&#9660;' }}</span>
               </button>
-              <SessionTreePicker
+              <SessionChatPicker
                 v-if="pickerOpen"
                 :sessions="sessionChain"
                 :active-session-id="activeSessionId"
@@ -188,7 +188,7 @@ import { useSessionPolling } from '../composables/useSessionPolling.js';
 import { api } from '../composables/useApi.js';
 
 import ConversationTab from './ConversationTab.vue';
-import SessionTreePicker from './SessionTreePicker.vue';
+import SessionChatPicker from './SessionChatPicker.vue';
 
 const props = defineProps({
   sessionId: {
@@ -257,7 +257,7 @@ function handlePickerEscape(event) {
 
 function handleClickOutsidePicker(event) {
   if (pickerOpen.value) {
-    const picker = document.querySelector('[data-testid="session-tree-picker"]');
+    const picker = document.querySelector('[data-testid="session-chat-picker"]');
     const trigger = document.querySelector('[data-testid="overlay-picker-trigger"]');
     if (picker && !picker.contains(event.target) &&
         (!trigger || !trigger.contains(event.target))) {

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -4,7 +4,7 @@
       <div
         v-if="visible"
         class="overlay-backdrop"
-        data-testid="session-tree-overlay"
+        data-testid="session-chat-overlay"
         @click.self="close"
       >
         <div class="overlay-panel-wrapper" @click.stop>
@@ -15,11 +15,11 @@
             role="button"
             :aria-label="isOverlaySessionActive
               ? (overlaySessionStatus === 'starting' ? 'Session starting...' : 'Session running...')
-              : 'Close session tree'"
+              : 'Close session chat'"
             :title="isOverlaySessionActive
               ? (overlaySessionStatus === 'starting' ? 'Session starting...' : 'Session running...')
-              : 'Close session tree'"
-            data-testid="session-tree-overlay-close-handle"
+              : 'Close session chat'"
+            data-testid="session-chat-overlay-close-handle"
             @click="close"
             @keydown.enter.prevent="close"
             @keydown.space.prevent="close"
@@ -48,7 +48,7 @@
           </div>
 
           <!-- Existing overlay-content -->
-          <div class="overlay-content session-tree-overlay">
+          <div class="overlay-content session-chat-overlay">
           <!-- Header (no padding constraints) -->
           <div class="overlay-header">
             <!-- Row 1: Session Name -->
@@ -342,20 +342,20 @@ const backToSessionsUrl = computed(() => {
 function close() {
   // Guard: don't re-trigger if already closing
   if (closing.value) {
-    console.log('[SessionTreeOverlay] Already closing, ignoring close() call');
+    console.log('[SessionChatOverlay] Already closing, ignoring close() call');
     return;
   }
-  console.log('[SessionTreeOverlay] close() called, setting closing=true, visible=false');
+  console.log('[SessionChatOverlay] close() called, setting closing=true, visible=false');
   closing.value = true;
   visible.value = false;  // This triggers the leave transition
 }
 
 function afterLeave() {
   if (!closing.value) {
-    console.log('[SessionTreeOverlay] afterLeave() called but not closing, ignoring');
+    console.log('[SessionChatOverlay] afterLeave() called but not closing, ignoring');
     return;
   }
-  console.log('[SessionTreeOverlay] afterLeave() called, emitting close event');
+  console.log('[SessionChatOverlay] afterLeave() called, emitting close event');
   closing.value = false; // Reset state
   emit('close');  // Only emit after transition completes
 }
@@ -507,7 +507,7 @@ async function loadSessionData(sessionId) {
       todosStore.fetchTodos(sessionId, sessionsStore.activeConversationId);
     }
   } catch (err) {
-    console.error('[SessionTreeOverlay] Failed to load session data:', err);
+    console.error('[SessionChatOverlay] Failed to load session data:', err);
   }
 }
 
@@ -875,7 +875,7 @@ defineExpose({
    The .overlay-body is the sole scroll container; .messages just flows inside it.
    This prevents two nested scroll containers from fighting each other during
    streaming auto-scroll (useMessageScroll targets .overlay-body via scrollContainerRef). */
-.session-tree-overlay :deep(.messages) {
+.session-chat-overlay :deep(.messages) {
   max-height: none !important;
   overflow-y: visible;
   flex: 1;

--- a/packages/web/src/components/SessionChatPicker.test.js
+++ b/packages/web/src/components/SessionChatPicker.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
-import SessionTreePicker from './SessionTreePicker.vue';
+import SessionChatPicker from './SessionChatPicker.vue';
 
-describe('SessionTreePicker', () => {
+describe('SessionChatPicker', () => {
   let sessions;
   let summaries;
 
@@ -49,7 +49,7 @@ describe('SessionTreePicker', () => {
   });
 
   function mountComponent(propsOverrides = {}) {
-    return mount(SessionTreePicker, {
+    return mount(SessionChatPicker, {
       props: {
         sessions,
         activeSessionId: 'root-1',
@@ -106,7 +106,7 @@ describe('SessionTreePicker', () => {
         },
         depth: 0,
       }];
-      const wrapper = mount(SessionTreePicker, {
+      const wrapper = mount(SessionChatPicker, {
         props: {
           sessions: singleSession,
           activeSessionId: 'single-1',
@@ -127,7 +127,7 @@ describe('SessionTreePicker', () => {
         { session: { id: 's2', name: 'Session 2', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
         { session: { id: 's3', name: 'Session 3', status: 'error', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
       ];
-      const wrapper = mount(SessionTreePicker, {
+      const wrapper = mount(SessionChatPicker, {
         props: {
           sessions: sessionsWithStatuses,
           activeSessionId: 's1',
@@ -155,7 +155,7 @@ describe('SessionTreePicker', () => {
         },
         depth: 1,
       }));
-      const wrapper = mount(SessionTreePicker, {
+      const wrapper = mount(SessionChatPicker, {
         props: {
           sessions: manySessions,
           activeSessionId: 's-0',
@@ -196,7 +196,7 @@ describe('SessionTreePicker', () => {
         { session: { id: 'd1', name: 'Child', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 1 },
         { session: { id: 'd2', name: 'Grandchild', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 2 },
       ];
-      const wrapper = mount(SessionTreePicker, {
+      const wrapper = mount(SessionChatPicker, {
         props: {
           sessions: deepSessions,
           activeSessionId: 'd0',
@@ -230,7 +230,7 @@ describe('SessionTreePicker', () => {
   describe('selection', () => {
     it('emits select with correct session ID on click', async () => {
       const onSelect = vi.fn();
-      const wrapper = mount(SessionTreePicker, {
+      const wrapper = mount(SessionChatPicker, {
         props: { sessions, activeSessionId: 'root-1', summaries },
         attrs: { onSelect },
       });
@@ -241,7 +241,7 @@ describe('SessionTreePicker', () => {
 
     it('emits select on Enter key', async () => {
       const onSelect = vi.fn();
-      const wrapper = mount(SessionTreePicker, {
+      const wrapper = mount(SessionChatPicker, {
         props: { sessions, activeSessionId: 'root-1', summaries },
         attrs: { onSelect },
       });
@@ -329,7 +329,7 @@ describe('SessionTreePicker', () => {
   describe('keyboard navigation', () => {
     it('arrow down moves focus to next item', async () => {
       const wrapper = mountComponent({ activeSessionId: 'root-1' });
-      const container = wrapper.find('.session-tree-picker');
+      const container = wrapper.find('.session-chat-picker');
       await container.trigger('keydown', { key: 'ArrowDown' });
       // focusedIndex should have incremented
       const items = wrapper.findAll('.picker-item');
@@ -339,7 +339,7 @@ describe('SessionTreePicker', () => {
     it('arrow up moves focus to previous item', async () => {
       const wrapper = mountComponent({ activeSessionId: 'child-1' });
       // First move focus down, then up
-      const container = wrapper.find('.session-tree-picker');
+      const container = wrapper.find('.session-chat-picker');
       await container.trigger('keydown', { key: 'ArrowDown' });
       await container.trigger('keydown', { key: 'ArrowUp' });
       const items = wrapper.findAll('.picker-item');
@@ -349,7 +349,7 @@ describe('SessionTreePicker', () => {
 
     it('arrow up on first item stays on first item', async () => {
       const wrapper = mountComponent({ activeSessionId: 'root-1' });
-      const container = wrapper.find('.session-tree-picker');
+      const container = wrapper.find('.session-chat-picker');
       // Focus is at index 0 (root), pressing up should stay at 0
       await container.trigger('keydown', { key: 'ArrowUp' });
       const items = wrapper.findAll('.picker-item');
@@ -358,7 +358,7 @@ describe('SessionTreePicker', () => {
 
     it('arrow down on last item stays on last item', async () => {
       const wrapper = mountComponent({ activeSessionId: 'child-2' });
-      const container = wrapper.find('.session-tree-picker');
+      const container = wrapper.find('.session-chat-picker');
       // Move to end
       await container.trigger('keydown', { key: 'ArrowDown' });
       await container.trigger('keydown', { key: 'ArrowDown' });
@@ -372,7 +372,7 @@ describe('SessionTreePicker', () => {
   describe('accessibility', () => {
     it('has role="listbox" on container', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('.session-tree-picker').attributes('role')).toBe('listbox');
+      expect(wrapper.find('.session-chat-picker').attributes('role')).toBe('listbox');
     });
 
     it('has role="option" on each item', () => {

--- a/packages/web/src/components/SessionChatPicker.vue
+++ b/packages/web/src/components/SessionChatPicker.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="session-tree-picker"
+    class="session-chat-picker"
     role="listbox"
     aria-label="Session hierarchy"
-    data-testid="session-tree-picker"
+    data-testid="session-chat-picker"
     @keydown="handleKeydown"
   >
     <div
@@ -127,7 +127,7 @@ function handleKeydown(event) {
 </script>
 
 <style scoped>
-.session-tree-picker {
+.session-chat-picker {
   position: absolute;
   top: 100%;
   left: 0;

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -48,9 +48,9 @@ vi.mock('../components/SessionTreeHandle.vue', () => ({
     emits: ['open']
   }
 }));
-vi.mock('../components/SessionTreeOverlay.vue', () => ({
+vi.mock('../components/SessionChatOverlay.vue', () => ({
   default: {
-    name: 'SessionTreeOverlay',
+    name: 'SessionChatOverlay',
     template: '<div class="tree-overlay">Tree Overlay</div>',
     props: ['sessionId', 'sessionChain', 'summariesMap'],
     emits: ['close', 'session-created']
@@ -2652,7 +2652,7 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
       const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
@@ -2685,7 +2685,7 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      wrapper.vm.treeOverlayOpen = false;
+      wrapper.vm.chatOverlayOpen = false;
       await nextTick();
 
       const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
@@ -3338,7 +3338,7 @@ describe('SessionDetailView', () => {
       expect(wrapper.vm.overlaySessionId).toBe('child-1');
     });
 
-    it('passes overlaySessionId to SessionTreeOverlay', async () => {
+    it('passes overlaySessionId to SessionChatOverlay', async () => {
       // Populate the sessions store with parent and running child
       sessionsStore.sessions = [
         { id: 'parent-1', name: 'Parent Session', status: 'waiting', projectId: 'proj-1', parentSessionId: null },
@@ -3367,11 +3367,11 @@ describe('SessionDetailView', () => {
       await nextTick();
 
       // Open the overlay so it's rendered in the DOM
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
-      // Find the SessionTreeOverlay component and check its session-id prop
-      const treeOverlay = wrapper.findComponent({ name: 'SessionTreeOverlay' });
+      // Find the SessionChatOverlay component and check its session-id prop
+      const treeOverlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
       expect(treeOverlay.exists()).toBe(true);
       expect(treeOverlay.props('sessionId')).toBe('child-1'); // Should be the running child
     });
@@ -3430,7 +3430,7 @@ describe('SessionDetailView', () => {
       // overlaySessionId should now point to the newly-running child
       expect(wrapper.vm.overlaySessionId).toBe('child-1');
       // And the overlay should be open
-      expect(wrapper.vm.treeOverlayOpen).toBe(true);
+      expect(wrapper.vm.chatOverlayOpen).toBe(true);
     });
   });
 
@@ -3491,7 +3491,7 @@ describe('SessionDetailView', () => {
       expect(wrapper.vm.sessionChain[1].session.id).toBe('parent-1');
     });
 
-    it('passes sessionChain and summariesMap to SessionTreeOverlay', async () => {
+    it('passes sessionChain and summariesMap to SessionChatOverlay', async () => {
       const parentSession = {
         id: 'parent-1',
         name: 'Parent Session',
@@ -3538,10 +3538,10 @@ describe('SessionDetailView', () => {
       await nextTick();
 
       // Open the overlay
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
-      const treeOverlay = wrapper.findComponent({ name: 'SessionTreeOverlay' });
+      const treeOverlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
       expect(treeOverlay.exists()).toBe(true);
       expect(treeOverlay.props('sessionChain')).toEqual(wrapper.vm.sessionChain);
       expect(treeOverlay.props('summariesMap')).toEqual(wrapper.vm.summariesMap);
@@ -3602,10 +3602,10 @@ describe('SessionDetailView', () => {
       api.getProjectSessions.mockResolvedValue([parentSession, newChild]);
 
       // Open overlay and emit session-created
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
-      const treeOverlay = wrapper.findComponent({ name: 'SessionTreeOverlay' });
+      const treeOverlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
       treeOverlay.vm.$emit('session-created', 'new-child');
       await flushPromises();
       await nextTick();
@@ -3772,12 +3772,12 @@ describe('SessionDetailView', () => {
       sessionsStore.fetchMessages.mockClear();
 
       // Simulate overlay being opened and viewedSessionId changed to a child
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       sessionsStore.viewedSessionId = 'child-1';
       await nextTick();
 
       // Emit close event from the overlay
-      const overlay = wrapper.findComponent({ name: 'SessionTreeOverlay' });
+      const overlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
       overlay.vm.$emit('close');
       await nextTick();
       await flushPromises();
@@ -3821,17 +3821,17 @@ describe('SessionDetailView', () => {
       await flushPromises();
 
       // Open the overlay
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
-      expect(wrapper.vm.treeOverlayOpen).toBe(true);
+      expect(wrapper.vm.chatOverlayOpen).toBe(true);
 
       // Emit close
-      const overlay = wrapper.findComponent({ name: 'SessionTreeOverlay' });
+      const overlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
       overlay.vm.$emit('close');
       await nextTick();
 
-      expect(wrapper.vm.treeOverlayOpen).toBe(false);
+      expect(wrapper.vm.chatOverlayOpen).toBe(false);
     });
 
     it('restores parent state even when overlay did not change viewedSessionId', async () => {
@@ -3868,10 +3868,10 @@ describe('SessionDetailView', () => {
       sessionsStore.fetchMessages.mockClear();
 
       // Open and close overlay without changing viewedSessionId
-      wrapper.vm.treeOverlayOpen = true;
+      wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
-      const overlay = wrapper.findComponent({ name: 'SessionTreeOverlay' });
+      const overlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
       overlay.vm.$emit('close');
       await nextTick();
       await flushPromises();
@@ -3915,7 +3915,7 @@ describe('SessionDetailView', () => {
       await nextTick();
 
       // Overlay should be open
-      expect(wrapper.vm.treeOverlayOpen).toBe(true);
+      expect(wrapper.vm.chatOverlayOpen).toBe(true);
 
       // Query param should be cleared (router.replace removes it)
       expect(router.currentRoute.value.query.overlay).toBeUndefined();
@@ -3952,7 +3952,7 @@ describe('SessionDetailView', () => {
       await nextTick();
 
       // Overlay should remain closed
-      expect(wrapper.vm.treeOverlayOpen).toBe(false);
+      expect(wrapper.vm.chatOverlayOpen).toBe(false);
     });
   });
 });

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -40,10 +40,10 @@ vi.mock('../components/SessionHierarchyBreadcrumb.vue', () => ({
     props: ['path', 'currentSessionId']
   }
 }));
-vi.mock('../components/SessionTreeHandle.vue', () => ({
+vi.mock('../components/SessionChatHandle.vue', () => ({
   default: {
-    name: 'SessionTreeHandle',
-    template: '<div class="tree-handle">Tree Handle</div>',
+    name: 'SessionChatHandle',
+    template: '<div class="session-chat-handle">Chat Handle</div>',
     props: ['isSessionActive', 'sessionStatus'],
     emits: ['open']
   }
@@ -51,7 +51,7 @@ vi.mock('../components/SessionTreeHandle.vue', () => ({
 vi.mock('../components/SessionChatOverlay.vue', () => ({
   default: {
     name: 'SessionChatOverlay',
-    template: '<div class="tree-overlay">Tree Overlay</div>',
+    template: '<div class="session-chat-overlay">Chat Overlay</div>',
     props: ['sessionId', 'sessionChain', 'summariesMap'],
     emits: ['close', 'session-created']
   }
@@ -2414,7 +2414,7 @@ describe('SessionDetailView', () => {
   });
 
   describe('session active indicator', () => {
-    it('passes isSessionActive=true to SessionTreeHandle when running', async () => {
+    it('passes isSessionActive=true to SessionChatHandle when running', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2440,12 +2440,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(true);
       expect(treeHandle.props('sessionStatus')).toBe('running');
     });
 
-    it('passes isSessionActive=true to SessionTreeHandle when starting', async () => {
+    it('passes isSessionActive=true to SessionChatHandle when starting', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2471,12 +2471,12 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(true);
       expect(treeHandle.props('sessionStatus')).toBe('starting');
     });
 
-    it('passes isSessionActive=false to SessionTreeHandle when completed', async () => {
+    it('passes isSessionActive=false to SessionChatHandle when completed', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2502,11 +2502,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
-    it('passes isSessionActive=false to SessionTreeHandle when waiting', async () => {
+    it('passes isSessionActive=false to SessionChatHandle when waiting', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2532,11 +2532,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
-    it('passes isSessionActive=false to SessionTreeHandle when error', async () => {
+    it('passes isSessionActive=false to SessionChatHandle when error', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2562,11 +2562,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
-    it('passes sessionStatus=running to SessionTreeHandle for running status', async () => {
+    it('passes sessionStatus=running to SessionChatHandle for running status', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2592,11 +2592,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('sessionStatus')).toBe('running');
     });
 
-    it('passes sessionStatus=starting to SessionTreeHandle for starting status', async () => {
+    it('passes sessionStatus=starting to SessionChatHandle for starting status', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2622,11 +2622,11 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('sessionStatus')).toBe('starting');
     });
 
-    it('hides SessionTreeHandle when overlay is open', async () => {
+    it('hides SessionChatHandle when overlay is open', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2655,11 +2655,11 @@ describe('SessionDetailView', () => {
       wrapper.vm.chatOverlayOpen = true;
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.isVisible()).toBe(false);
     });
 
-    it('shows SessionTreeHandle when overlay is closed', async () => {
+    it('shows SessionChatHandle when overlay is closed', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -2688,7 +2688,7 @@ describe('SessionDetailView', () => {
       wrapper.vm.chatOverlayOpen = false;
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.isVisible()).toBe(true);
     });
 
@@ -2726,7 +2726,7 @@ describe('SessionDetailView', () => {
       ];
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(true);
     });
 
@@ -2764,7 +2764,7 @@ describe('SessionDetailView', () => {
       ];
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(true);
     });
 
@@ -2803,7 +2803,7 @@ describe('SessionDetailView', () => {
       ];
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(false);
     });
 
@@ -2841,7 +2841,7 @@ describe('SessionDetailView', () => {
       ];
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('sessionStatus')).toBe('running');
     });
 
@@ -2879,7 +2879,7 @@ describe('SessionDetailView', () => {
       ];
       await nextTick();
 
-      const treeHandle = wrapper.findComponent({ name: 'SessionTreeHandle' });
+      const treeHandle = wrapper.findComponent({ name: 'SessionChatHandle' });
       expect(treeHandle.props('isSessionActive')).toBe(false);
 
       // Update sessionChain to include a running child

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -53,8 +53,8 @@
         <CommandsTab v-else-if="activeTab === 'commands'" :key="route.params.id" :session-id="route.params.id" :project-id="sessionsStore.currentSession?.projectId" />
       </div>
 
-      <!-- Session Tree Handle -->
-      <SessionTreeHandle
+      <!-- Session Chat Handle -->
+      <SessionChatHandle
         v-show="!chatOverlayOpen"
         :is-session-active="isSessionActive"
         :session-status="activeSessionStatus"
@@ -91,7 +91,7 @@ import CommandsTab from '../components/CommandsTab.vue';
 import SessionHeaderPanel from '../components/SessionHeaderPanel.vue';
 import SessionTabsPanel from '../components/SessionTabsPanel.vue';
 import SessionHierarchyBreadcrumb from '../components/SessionHierarchyBreadcrumb.vue';
-import SessionTreeHandle from '../components/SessionTreeHandle.vue';
+import SessionChatHandle from '../components/SessionChatHandle.vue';
 import SessionChatOverlay from '../components/SessionChatOverlay.vue';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { api } from '../composables/useApi.js';

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -55,15 +55,15 @@
 
       <!-- Session Tree Handle -->
       <SessionTreeHandle
-        v-show="!treeOverlayOpen"
+        v-show="!chatOverlayOpen"
         :is-session-active="isSessionActive"
         :session-status="activeSessionStatus"
         @open="handleOverlayOpen"
       />
 
       <!-- Session Tree Overlay -->
-      <SessionTreeOverlay
-        v-if="treeOverlayOpen"
+      <SessionChatOverlay
+        v-if="chatOverlayOpen"
         :session-id="overlaySessionId"
         :session-chain="sessionChain"
         :summaries-map="summariesMap"
@@ -92,7 +92,7 @@ import SessionHeaderPanel from '../components/SessionHeaderPanel.vue';
 import SessionTabsPanel from '../components/SessionTabsPanel.vue';
 import SessionHierarchyBreadcrumb from '../components/SessionHierarchyBreadcrumb.vue';
 import SessionTreeHandle from '../components/SessionTreeHandle.vue';
-import SessionTreeOverlay from '../components/SessionTreeOverlay.vue';
+import SessionChatOverlay from '../components/SessionChatOverlay.vue';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { api } from '../composables/useApi.js';
 import { useWebSocket } from '../composables/useWebSocket.js';
@@ -136,12 +136,12 @@ const {
 
 const summary = ref(null);
 const isDeleting = ref(false);
-const treeOverlayOpen = ref(false);
+const chatOverlayOpen = ref(false);
 
 // Session ID to pass to the overlay - resolves to running child if present
 const overlaySessionId = ref(route.params.id);
 
-// Session chain state (lifted from SessionTreeOverlay)
+// Session chain state (lifted from SessionChatOverlay)
 const sessionChain = ref([]);
 const summariesMap = ref({});
 const hasDescendants = computed(() => sessionChain.value.length > 1);
@@ -316,7 +316,7 @@ function handleSessionCreated(msg) {
   if (!newSession?.parentSessionId) return;
 
   // Only act when overlay is closed
-  if (treeOverlayOpen.value) return;
+  if (chatOverlayOpen.value) return;
 
   // Check if the new session's parent is in our session tree
   const isChildOfTree = sessionChain.value.some(
@@ -340,11 +340,11 @@ function handleSessionCreated(msg) {
 
 function handleOverlayOpen() {
   resolveOverlayTarget();
-  treeOverlayOpen.value = true;
+  chatOverlayOpen.value = true;
 }
 
 async function handleOverlayClose() {
-  treeOverlayOpen.value = false;
+  chatOverlayOpen.value = false;
   const parentId = currentSessionId.value;
   sessionsStore.viewedSessionId = parentId;
 
@@ -461,7 +461,7 @@ onMounted(async () => {
 
   // Auto-open tree overlay if requested via query param (e.g., after new session creation)
   if (route.query.overlay === 'open') {
-    treeOverlayOpen.value = true;
+    chatOverlayOpen.value = true;
     // Clear the query param so refresh doesn't re-open.
     // Use path only — do NOT spread the route object (it's a read-only proxy).
     router.replace({ path: route.path, query: {} });
@@ -644,7 +644,7 @@ async function handleCopySessionId() {
 // Expose for testing
 defineExpose({
   overlaySessionId,
-  treeOverlayOpen,
+  chatOverlayOpen,
   sessionChain,
   summariesMap,
   handleOverlayOpen,

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -61,7 +61,7 @@
         @open="handleOverlayOpen"
       />
 
-      <!-- Session Tree Overlay -->
+      <!-- Session Chat Overlay -->
       <SessionChatOverlay
         v-if="chatOverlayOpen"
         :session-id="overlaySessionId"

--- a/tests/e2e/debug-404-errors.spec.ts
+++ b/tests/e2e/debug-404-errors.spec.ts
@@ -60,7 +60,7 @@ test.describe('Debug: 404 Network Errors', () => {
     await handle.click();
 
     // Wait for overlay
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     await page.waitForTimeout(500);
 

--- a/tests/e2e/debug-404-errors.spec.ts
+++ b/tests/e2e/debug-404-errors.spec.ts
@@ -55,7 +55,7 @@ test.describe('Debug: 404 Network Errors', () => {
     });
 
     // Click tree handle to open overlay
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
 

--- a/tests/e2e/debug-new-session-button.spec.ts
+++ b/tests/e2e/debug-new-session-button.spec.ts
@@ -66,7 +66,7 @@ test.describe('Debug: New Session Button', () => {
     });
 
     // Click tree handle to open overlay
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     console.log('Tree handle found and visible');
     await handle.click();

--- a/tests/e2e/debug-new-session-button.spec.ts
+++ b/tests/e2e/debug-new-session-button.spec.ts
@@ -73,7 +73,7 @@ test.describe('Debug: New Session Button', () => {
     console.log('Tree handle clicked');
 
     // Wait for overlay to be visible
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     console.log('Overlay is visible');
     await page.waitForTimeout(500); // Wait for animation

--- a/tests/e2e/draft-session-model-ui.spec.ts
+++ b/tests/e2e/draft-session-model-ui.spec.ts
@@ -11,7 +11,7 @@ import {
 /**
  * E2E tests for: Draft session model dropdown → PATCH sync
  *
- * Bug: When a user creates a draft session (via SessionTreeOverlay or API),
+ * Bug: When a user creates a draft session (via SessionChatOverlay or API),
  * then changes the model dropdown before sending the first message, the session
  * starts with the wrong model. This happens because:
  *   1. handleFormSubmit() reads session.pendingModel instead of the UI dropdown value

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -128,7 +128,7 @@ export async function navigateAndWait(
  * Returns a Locator scoped to the overlay container.
  */
 export async function openSessionOverlay(page: Page, timeout = 10000) {
-  const handle = page.locator('[data-testid="session-tree-handle"]');
+  const handle = page.locator('[data-testid="session-chat-handle"]');
   await handle.waitFor({ state: 'visible', timeout });
   await handle.click();
   const overlay = page.locator('.session-chat-overlay');

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -131,7 +131,7 @@ export async function openSessionOverlay(page: Page, timeout = 10000) {
   const handle = page.locator('[data-testid="session-tree-handle"]');
   await handle.waitFor({ state: 'visible', timeout });
   await handle.click();
-  const overlay = page.locator('.session-tree-overlay');
+  const overlay = page.locator('.session-chat-overlay');
   await overlay.waitFor({ state: 'visible', timeout });
   return overlay;
 }

--- a/tests/e2e/overlay-draft-messages-persist.spec.ts
+++ b/tests/e2e/overlay-draft-messages-persist.spec.ts
@@ -68,7 +68,7 @@ test.describe('Overlay: draft session messages persist after completion', () => 
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     // Wait for slide-in animation to complete (300ms + buffer)
     await page.waitForTimeout(400);

--- a/tests/e2e/overlay-draft-messages-persist.spec.ts
+++ b/tests/e2e/overlay-draft-messages-persist.spec.ts
@@ -65,7 +65,7 @@ test.describe('Overlay: draft session messages persist after completion', () => 
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -80,7 +80,7 @@ test.describe('Overlay: draft session messages persist after completion', () => 
     await expect(dropdown).toBeVisible({ timeout: 10000 });
     await dropdown.locator('.dropdown-trigger').click();
 
-    const picker = page.locator('[data-testid="session-tree-picker"]');
+    const picker = page.locator('[data-testid="session-chat-picker"]');
     await expect(picker).toBeVisible({ timeout: 5000 });
 
     // Click the child session (second item in the picker)

--- a/tests/e2e/scheduling-reschedule.spec.ts
+++ b/tests/e2e/scheduling-reschedule.spec.ts
@@ -543,7 +543,7 @@ test.describe('Category 5: Scheduling UI Components', () => {
     await openSessionOverlay(page);
 
     // Click "Edit Schedule" button (scoped to overlay to avoid duplicate from SummaryTab)
-    const overlay = page.getByTestId('session-tree-overlay');
+    const overlay = page.getByTestId('session-chat-overlay');
     const editButton = overlay.getByRole('button', { name: 'Edit Schedule' });
     await expect(editButton).toBeVisible({ timeout: 10000 });
     await editButton.click();

--- a/tests/e2e/scheduling-ui.spec.ts
+++ b/tests/e2e/scheduling-ui.spec.ts
@@ -138,7 +138,7 @@ test.describe('Scheduling UI', () => {
       // Actual (bug): Shows "56 years ago" or other incorrect past time
 
       // Wait for the scheduling info panel to appear (scoped to overlay to avoid duplicate from SummaryTab)
-      const overlay = page.getByTestId('session-tree-overlay');
+      const overlay = page.getByTestId('session-chat-overlay');
       const schedulingPanel = overlay.locator('.scheduling-info.scheduled-panel');
       await expect(schedulingPanel).toBeVisible({ timeout: 5000 });
 
@@ -162,7 +162,7 @@ test.describe('Scheduling UI', () => {
       await page.waitForLoadState('networkidle');
       await openSessionOverlay(page);
 
-      const overlayAfterReload = page.getByTestId('session-tree-overlay');
+      const overlayAfterReload = page.getByTestId('session-chat-overlay');
       const countdownTextAfterReload = overlayAfterReload.locator('.countdown-text strong');
       await expect(countdownTextAfterReload).toBeVisible({ timeout: 5000 });
 

--- a/tests/e2e/session-chat-overlay-auto-select.spec.ts
+++ b/tests/e2e/session-chat-overlay-auto-select.spec.ts
@@ -62,7 +62,7 @@ test.describe('Session Tree Overlay - Auto-select by most recent conversation ac
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     // Wait for slide-in animation to complete (300ms + buffer)
     await page.waitForTimeout(400);

--- a/tests/e2e/session-chat-overlay-auto-select.spec.ts
+++ b/tests/e2e/session-chat-overlay-auto-select.spec.ts
@@ -59,7 +59,7 @@ test.describe('Session Chat Overlay - Auto-select by most recent conversation ac
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');

--- a/tests/e2e/session-chat-overlay-auto-select.spec.ts
+++ b/tests/e2e/session-chat-overlay-auto-select.spec.ts
@@ -12,7 +12,7 @@ import {
 } from './helpers';
 
 /**
- * Tests for the session tree overlay's automatic session selection behavior.
+ * Tests for the session chat overlay's automatic session selection behavior.
  *
  * Expected behavior: When opening the overlay, it should automatically select
  * the session in the tree with the most recent **conversation activity**
@@ -20,7 +20,7 @@ import {
  * the session's status. This allows users to quickly resume where the most
  * recent work was happening.
  */
-test.describe('Session Tree Overlay - Auto-select by most recent conversation activity', () => {
+test.describe('Session Chat Overlay - Auto-select by most recent conversation activity', () => {
   test.describe.configure({ timeout: 60000 });
 
   let project: any;

--- a/tests/e2e/session-chat-overlay-scroll.spec.ts
+++ b/tests/e2e/session-chat-overlay-scroll.spec.ts
@@ -37,7 +37,7 @@ test.describe('Session Chat Overlay Scroll Behavior', () => {
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -147,7 +147,7 @@ test.describe('Session Chat Overlay Scroll Behavior', () => {
     const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
     await expect(dropdown).toBeVisible({ timeout: 10000 });
     await dropdown.locator('.dropdown-trigger').click();
-    const picker = page.locator('[data-testid="session-tree-picker"]');
+    const picker = page.locator('[data-testid="session-chat-picker"]');
     await expect(picker).toBeVisible({ timeout: 5000 });
     const items = picker.locator('[role="option"]');
     await items.nth(1).click();

--- a/tests/e2e/session-chat-overlay-scroll.spec.ts
+++ b/tests/e2e/session-chat-overlay-scroll.spec.ts
@@ -10,7 +10,7 @@ import {
   updateSessionStatus,
 } from './helpers';
 
-test.describe('Session Tree Overlay Scroll Behavior', () => {
+test.describe('Session Chat Overlay Scroll Behavior', () => {
   test.describe.configure({ timeout: 60000 });
 
   let project: any;

--- a/tests/e2e/session-chat-overlay-scroll.spec.ts
+++ b/tests/e2e/session-chat-overlay-scroll.spec.ts
@@ -40,7 +40,7 @@ test.describe('Session Tree Overlay Scroll Behavior', () => {
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     // Wait for slide-in animation to complete
     await page.waitForTimeout(400);

--- a/tests/e2e/session-chat-overlay.spec.ts
+++ b/tests/e2e/session-chat-overlay.spec.ts
@@ -11,7 +11,7 @@ import {
   getProjectSessions,
 } from './helpers';
 
-test.describe('Session Tree Overlay', () => {
+test.describe('Session Chat Overlay', () => {
   test.describe.configure({ timeout: 60000 });
 
   let project: any;

--- a/tests/e2e/session-chat-overlay.spec.ts
+++ b/tests/e2e/session-chat-overlay.spec.ts
@@ -51,7 +51,7 @@ test.describe('Session Tree Overlay', () => {
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     // Wait for slide-in animation to complete (300ms + buffer)
     await page.waitForTimeout(400);
@@ -113,14 +113,14 @@ test.describe('Session Tree Overlay', () => {
     await expect(handle).toBeVisible({ timeout: 10000 });
 
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
   });
 
   test('clicking close button closes overlay', async ({ page }) => {
     const overlay = await openOverlay(page, parentSession.id);
 
-    const closeBtn = page.locator('[data-testid="session-tree-overlay-close-handle"]');
+    const closeBtn = page.locator('[data-testid="session-chat-overlay-close-handle"]');
     await expect(closeBtn).toBeVisible();
     await closeBtn.click();
 
@@ -517,7 +517,7 @@ test.describe('Session Tree Overlay', () => {
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     await page.waitForTimeout(400);
 
@@ -525,12 +525,12 @@ test.describe('Session Tree Overlay', () => {
     await expect(rootName).toContainText('Parent Session');
 
     // Close overlay
-    await page.locator('[data-testid="session-tree-overlay-close-handle"]').click();
+    await page.locator('[data-testid="session-chat-overlay-close-handle"]').click();
     await expect(overlay).not.toBeVisible({ timeout: 5000 });
 
     // Verify we can reopen overlay and it still shows parent session
     await handle.click();
-    const overlayAgain = page.locator('[data-testid="session-tree-overlay"]');
+    const overlayAgain = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlayAgain).toBeVisible({ timeout: 5000 });
     await page.waitForTimeout(400);
 
@@ -760,7 +760,7 @@ test.describe('Session Tree Overlay', () => {
       });
 
       const handle = page.locator('[data-testid="session-tree-handle"]');
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
 
       // Get initial bounding box
       await handle.click();
@@ -786,7 +786,7 @@ test.describe('Session Tree Overlay', () => {
     test('overlay slides out to right when closed', async ({ page }) => {
       const overlay = await openOverlay(page, parentSession.id);
 
-      const closeBtn = page.locator('[data-testid="session-tree-overlay-close-handle"]');
+      const closeBtn = page.locator('[data-testid="session-chat-overlay-close-handle"]');
       await closeBtn.click();
 
       // Wait for slide-out animation to complete (250ms + buffer)
@@ -804,7 +804,7 @@ test.describe('Session Tree Overlay', () => {
       });
 
       const handle = page.locator('[data-testid="session-tree-handle"]');
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
 
       // Rapid open/close cycles
       for (let i = 0; i < 3; i++) {
@@ -887,7 +887,7 @@ test.describe('Session Tree Overlay', () => {
       const handle = page.locator('[data-testid="session-tree-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
       await expect(overlay).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(400);
 
@@ -917,7 +917,7 @@ test.describe('Session Tree Overlay', () => {
       const handle = page.locator('[data-testid="session-tree-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
       await expect(overlay).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(400);
 
@@ -946,7 +946,7 @@ test.describe('Session Tree Overlay', () => {
       const handle = page.locator('[data-testid="session-tree-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
       await expect(overlay).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(400);
 
@@ -977,7 +977,7 @@ test.describe('Session Tree Overlay', () => {
       const handle = page.locator('[data-testid="session-tree-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
       await expect(overlay).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(400);
 
@@ -998,7 +998,7 @@ test.describe('Session Tree Overlay', () => {
       const handle = page.locator('[data-testid="session-tree-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
-      const overlay = page.locator('[data-testid="session-tree-overlay"]');
+      const overlay = page.locator('[data-testid="session-chat-overlay"]');
       await expect(overlay).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(400);
 
@@ -1011,7 +1011,7 @@ test.describe('Session Tree Overlay', () => {
       await expect(dropdownName).toContainText('Child Session', { timeout: 5000 });
 
       // Close the overlay
-      await page.locator('[data-testid="session-tree-overlay-close-handle"]').click();
+      await page.locator('[data-testid="session-chat-overlay-close-handle"]').click();
       await expect(overlay).not.toBeVisible({ timeout: 5000 });
 
       // Seed a different session with no running children
@@ -1031,7 +1031,7 @@ test.describe('Session Tree Overlay', () => {
       const handle2 = page.locator('[data-testid="session-tree-handle"]');
       await expect(handle2).toBeVisible({ timeout: 10000 });
       await handle2.click();
-      const overlayAgain = page.locator('[data-testid="session-tree-overlay"]');
+      const overlayAgain = page.locator('[data-testid="session-chat-overlay"]');
       await expect(overlayAgain).toBeVisible({ timeout: 5000 });
       await page.waitForTimeout(400);
 

--- a/tests/e2e/session-chat-overlay.spec.ts
+++ b/tests/e2e/session-chat-overlay.spec.ts
@@ -48,7 +48,7 @@ test.describe('Session Chat Overlay', () => {
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -68,7 +68,7 @@ test.describe('Session Chat Overlay', () => {
       timeout: 15000,
     });
 
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
   });
 
@@ -78,7 +78,7 @@ test.describe('Session Chat Overlay', () => {
       timeout: 15000,
     });
 
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
   });
 
@@ -95,7 +95,7 @@ test.describe('Session Chat Overlay', () => {
     });
 
     // Handle is always visible on any session detail page
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
   });
 
@@ -109,7 +109,7 @@ test.describe('Session Chat Overlay', () => {
       timeout: 15000,
     });
 
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
 
     await handle.click();
@@ -249,7 +249,7 @@ test.describe('Session Chat Overlay', () => {
       const trigger = dropdown.locator('.dropdown-trigger');
       await trigger.click();
 
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
     });
 
@@ -261,7 +261,7 @@ test.describe('Session Chat Overlay', () => {
 
       // Open picker
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Should show at least parent + one child
@@ -280,7 +280,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // No items should contain ROOT or CHILD text anywhere in picker
@@ -303,7 +303,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Get all picker items
@@ -331,7 +331,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Get all picker items
@@ -364,7 +364,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // The active (currently viewed) session should have the active class
@@ -380,7 +380,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Click the second item (first child)
@@ -408,7 +408,7 @@ test.describe('Session Chat Overlay', () => {
 
       // Open picker
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Press Escape - should close picker only
@@ -428,7 +428,7 @@ test.describe('Session Chat Overlay', () => {
 
       // Open picker
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Click first item
@@ -465,7 +465,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
     });
 
@@ -477,7 +477,7 @@ test.describe('Session Chat Overlay', () => {
 
       // Open
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Close
@@ -514,7 +514,7 @@ test.describe('Session Chat Overlay', () => {
     });
 
     // Open overlay and verify it shows parent session
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -552,7 +552,7 @@ test.describe('Session Chat Overlay', () => {
     await expect(dropdown).toBeVisible({ timeout: 10000 });
 
     await dropdown.locator('.dropdown-trigger').click();
-    const picker = page.locator('[data-testid="session-tree-picker"]');
+    const picker = page.locator('[data-testid="session-chat-picker"]');
     await expect(picker).toBeVisible({ timeout: 5000 });
 
     // Just verify the picker has items - status badges are rendered conditionally
@@ -602,7 +602,7 @@ test.describe('Session Chat Overlay', () => {
       await expect(dropdown).toBeVisible({ timeout: 10000 });
 
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Click the second item (first child session) - the chain is built as [root, child1, ...]
@@ -759,7 +759,7 @@ test.describe('Session Chat Overlay', () => {
         timeout: 15000,
       });
 
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
 
       // Get initial bounding box
@@ -803,7 +803,7 @@ test.describe('Session Chat Overlay', () => {
         timeout: 15000,
       });
 
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
 
       // Rapid open/close cycles
@@ -884,7 +884,7 @@ test.describe('Session Chat Overlay', () => {
       });
 
       // Open the overlay
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -914,7 +914,7 @@ test.describe('Session Chat Overlay', () => {
       });
 
       // Open the overlay
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -943,7 +943,7 @@ test.describe('Session Chat Overlay', () => {
       });
 
       // Open the overlay
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -974,7 +974,7 @@ test.describe('Session Chat Overlay', () => {
       });
 
       // Open the overlay
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -995,7 +995,7 @@ test.describe('Session Chat Overlay', () => {
         waitFor: '.session-detail',
         timeout: 15000,
       });
-      const handle = page.locator('[data-testid="session-tree-handle"]');
+      const handle = page.locator('[data-testid="session-chat-handle"]');
       await expect(handle).toBeVisible({ timeout: 10000 });
       await handle.click();
       const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -1028,7 +1028,7 @@ test.describe('Session Chat Overlay', () => {
       });
 
       // Open overlay on the other session
-      const handle2 = page.locator('[data-testid="session-tree-handle"]');
+      const handle2 = page.locator('[data-testid="session-chat-handle"]');
       await expect(handle2).toBeVisible({ timeout: 10000 });
       await handle2.click();
       const overlayAgain = page.locator('[data-testid="session-chat-overlay"]');
@@ -1120,7 +1120,7 @@ test.describe('Session Chat Overlay', () => {
       // Open picker and verify both parent and new session are listed
       const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
       await expect(picker).toContainText('Parent Session');
       await expect(picker).toContainText('New Session');
@@ -1139,7 +1139,7 @@ test.describe('Session Chat Overlay', () => {
       // Navigate back to parent via session picker
       const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
       await dropdown.locator('.dropdown-trigger').click();
-      const picker = page.locator('[data-testid="session-tree-picker"]');
+      const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
 
       // Click the parent session item (first item in picker)

--- a/tests/e2e/session-chat-picker-all-children.spec.ts
+++ b/tests/e2e/session-chat-picker-all-children.spec.ts
@@ -44,7 +44,7 @@ test.describe('Session Tree Picker Shows All Children', () => {
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -55,7 +55,7 @@ test.describe('Session Tree Picker Shows All Children', () => {
     const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
     await expect(dropdown).toBeVisible({ timeout: 10000 });
     await dropdown.locator('.dropdown-trigger').click();
-    const picker = page.locator('[data-testid="session-tree-picker"]');
+    const picker = page.locator('[data-testid="session-chat-picker"]');
     await expect(picker).toBeVisible({ timeout: 5000 });
 
     return { overlay, picker };

--- a/tests/e2e/session-selector-switch.spec.ts
+++ b/tests/e2e/session-selector-switch.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './helpers';
 
 /**
- * Regression tests for the session selector in the SessionTreeOverlay.
+ * Regression tests for the session selector in the SessionChatOverlay.
  *
  * Bug: When switching sessions via the overlay picker, the UI showed a spinner
  * and then re-displayed the previous session's messages. The root cause was that
@@ -96,7 +96,7 @@ test.describe('Session selector switches conversation content', () => {
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     // Wait for slide-in animation to complete (300ms + buffer)
     await page.waitForTimeout(400);

--- a/tests/e2e/session-selector-switch.spec.ts
+++ b/tests/e2e/session-selector-switch.spec.ts
@@ -93,7 +93,7 @@ test.describe('Session selector switches conversation content', () => {
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');
@@ -108,7 +108,7 @@ test.describe('Session selector switches conversation content', () => {
     await expect(dropdown).toBeVisible({ timeout: 10000 });
     await dropdown.locator('.dropdown-trigger').click();
 
-    const picker = page.locator('[data-testid="session-tree-picker"]');
+    const picker = page.locator('[data-testid="session-chat-picker"]');
     await expect(picker).toBeVisible({ timeout: 5000 });
 
     const targetItem = picker.locator('[role="option"]').filter({ hasText: sessionName });

--- a/tests/e2e/session-tree-picker-all-children.spec.ts
+++ b/tests/e2e/session-tree-picker-all-children.spec.ts
@@ -47,7 +47,7 @@ test.describe('Session Tree Picker Shows All Children', () => {
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     await page.waitForTimeout(400);
 

--- a/tests/e2e/template-inheritance.spec.ts
+++ b/tests/e2e/template-inheritance.spec.ts
@@ -663,7 +663,7 @@ test.describe('Template Model Inheritance — Conversation Overlay Verification'
       waitFor: '.session-detail',
       timeout: 15000,
     });
-    const handle = page.locator('[data-testid="session-tree-handle"]');
+    const handle = page.locator('[data-testid="session-chat-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
     const overlay = page.locator('[data-testid="session-chat-overlay"]');

--- a/tests/e2e/template-inheritance.spec.ts
+++ b/tests/e2e/template-inheritance.spec.ts
@@ -666,7 +666,7 @@ test.describe('Template Model Inheritance — Conversation Overlay Verification'
     const handle = page.locator('[data-testid="session-tree-handle"]');
     await expect(handle).toBeVisible({ timeout: 10000 });
     await handle.click();
-    const overlay = page.locator('[data-testid="session-tree-overlay"]');
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 5000 });
     await page.waitForTimeout(400); // Wait for slide-in animation
     return overlay;


### PR DESCRIPTION
## Summary
- Renames the `SessionTreeOverlay` component to `SessionChatOverlay` across the entire codebase
- Renames 5 files (component, unit test, 3 E2E test files) and updates all references in 18 files total
- Updates imports, template tags, `data-testid` attributes, CSS classes, aria-labels, title attributes, console strings, internal variables (`treeOverlayOpen` → `chatOverlayOpen`), and E2E selectors

## Test plan
- [x] Grep confirms zero remaining `SessionTreeOverlay`, `session-tree-overlay`, or `treeOverlayOpen` references in `.vue/.js/.ts` files
- [x] All 3924 unit tests pass (`yarn workspace @claudetools/web test`)
- [x] Lint passes clean (`yarn lint`)
- [ ] E2E tests pass (`./scripts/pw.sh test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)