### PR TITLE
Simplify and DRY up DEFAULT_SESSION_TITLE_PROMPT

### DIFF
--- a/packages/server/src/services/summaryPrompts.js
+++ b/packages/server/src/services/summaryPrompts.js
@@ -14,11 +14,8 @@ export const MAX_MESSAGES = 10;
 
 // Default prompt for strategic session titles
 export const DEFAULT_SESSION_TITLE_PROMPT = `Guidelines for generating session titles:
-- The title should capture the SESSION'S STRATEGIC GOAL, not current tactical activity
-- Focus on WHAT the user ultimately wants to achieve (e.g., "Add dark mode support")
-- NOT the current step (e.g., "Fix TypeScript error", "Update tests")
+- state the goal of the session - ignore the goal of the conversation, we're interested in the goal of the session as a whole
 - If a PR was created, format as "PR #N: <strategic goal>"
-- PRESERVE the existing title if it still reflects the strategic goal
 - Only change the title if the session's fundamental purpose has changed
 - Keep titles concise (max 60 characters)`;
 

--- a/packages/server/src/services/summaryPrompts.js
+++ b/packages/server/src/services/summaryPrompts.js
@@ -3,6 +3,8 @@
  * Pure functions with no side effects.
  */
 
+import { DEFAULT_SESSION_TITLE_PROMPT } from '@claudetools/shared';
+
 // Maximum retry attempts for failed parsing
 export const MAX_RETRIES = 2;
 
@@ -12,12 +14,8 @@ export const MIN_MESSAGES_FOR_SUMMARY = 3;
 // Maximum number of recent messages to include in generation (optimized for token efficiency)
 export const MAX_MESSAGES = 10;
 
-// Default prompt for strategic session titles
-export const DEFAULT_SESSION_TITLE_PROMPT = `Guidelines for generating session titles:
-- state the goal of the session - ignore the goal of the conversation, we're interested in the goal of the session as a whole
-- If a PR was created, format as "PR #N: <strategic goal>"
-- Only change the title if the session's fundamental purpose has changed
-- Keep titles concise (max 60 characters)`;
+// Re-export from shared for backward compatibility
+export { DEFAULT_SESSION_TITLE_PROMPT };
 
 // System prompt for summary generation (static instructions that benefit from prompt caching)
 export const SUMMARY_SYSTEM_PROMPT = `You are updating a session summary for a Claude Code session.

--- a/packages/server/src/services/summaryPrompts.test.js
+++ b/packages/server/src/services/summaryPrompts.test.js
@@ -41,8 +41,8 @@ describe('summaryPrompts', () => {
   });
 
   describe('DEFAULT_SESSION_TITLE_PROMPT', () => {
-    it('includes strategic goal guidance', () => {
-      expect(DEFAULT_SESSION_TITLE_PROMPT).toContain('STRATEGIC GOAL');
+    it('includes session goal guidance', () => {
+      expect(DEFAULT_SESSION_TITLE_PROMPT).toContain('goal of the session');
     });
 
     it('includes PR format guidance', () => {
@@ -159,7 +159,7 @@ describe('summaryPrompts', () => {
     it('uses default session title prompt when none provided', () => {
       const recentMessages = [{ role: 'user', content: 'Test' }];
       const result = buildIncrementalPrompt(null, recentMessages, 'running', null);
-      expect(result).toContain('STRATEGIC GOAL');
+      expect(result).toContain('goal of the session');
     });
 
     it('uses custom session title prompt when provided', () => {

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -277,8 +277,8 @@ describe('summaryService', () => {
     it('uses default session title prompt when none provided', () => {
       const recentMessages = [{ role: 'user', content: 'Test' }];
       const result = buildIncrementalPrompt(null, recentMessages, 'running', null);
-      expect(result).toContain('STRATEGIC GOAL');
-      expect(result).toContain('PRESERVE the existing title');
+      expect(result).toContain('goal of the session');
+      expect(result).toContain('If a PR was created');
       expect(result).toContain('max 60 characters');
     });
 
@@ -287,7 +287,7 @@ describe('summaryService', () => {
       const recentMessages = [{ role: 'user', content: 'Test' }];
       const result = buildIncrementalPrompt(null, recentMessages, 'running', { projectTitlePrompt: customPrompt });
       expect(result).toContain(customPrompt);
-      expect(result).not.toContain('STRATEGIC GOAL'); // Should not have default when custom provided
+      expect(result).not.toContain('goal of the session'); // Should not have default when custom provided
     });
 
     it('includes previous title in context when existing summary provided', () => {

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -35,13 +35,10 @@ When creating plan files or design documents, always write them to a temporary d
 - This keeps plans organized and separate from the main codebase`;
 
 /**
- * Default prompt for generating strategic session titles
+ * Default prompt for generating session titles
  */
 export const DEFAULT_SESSION_TITLE_PROMPT = `Guidelines for generating session titles:
-- The title should capture the SESSION'S STRATEGIC GOAL, not current tactical activity
-- Focus on WHAT the user ultimately wants to achieve (e.g., "Add dark mode support")
-- NOT the current step (e.g., "Fix TypeScript error", "Update tests")
+- state the goal of the session - ignore the goal of the conversation, we're interested in the goal of the session as a whole
 - If a PR was created, format as "PR #N: <strategic goal>"
-- PRESERVE the existing title if it still reflects the strategic goal
 - Only change the title if the session's fundamental purpose has changed
 - Keep titles concise (max 60 characters)`;


### PR DESCRIPTION
## Summary
- Simplifies the `DEFAULT_SESSION_TITLE_PROMPT` — replaces verbose "STRATEGIC GOAL" framing with clearer "goal of the session" wording
- DRYs up the duplicate definition: `summaryPrompts.js` now imports from `@claudetools/shared` instead of maintaining a copy

## Test plan
- [x] All 130 server test files pass (1 pre-existing timeout in `commandButtons.test.js` unrelated to this change)
- [x] `summaryPrompts.test.js` and `summaryService.test.js` assertions updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)