### PR TITLE
fix: iPad session chat overlay scroll issues

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -50,7 +50,7 @@
           <!-- Existing overlay-content -->
           <div class="overlay-content session-chat-overlay">
           <!-- Header (no padding constraints) -->
-          <div class="overlay-header">
+          <div class="overlay-header" @touchmove="handleHeaderTouchmove">
             <!-- Row 1: Session Name -->
             <div class="overlay-header-row">
               <!-- Editing mode -->
@@ -591,16 +591,45 @@ function handleEscape(event) {
   }
 }
 
-// Body scroll lock to prevent horizontal layout shift when overlay is open
-let savedBodyOverflow = '';
+/**
+ * Prevent touch-drag on the overlay header from scrolling the overlay,
+ * while allowing touch-move inside interactive children that need it:
+ * - SessionChatPicker dropdown (scrollable list)
+ * - Name-edit input (text selection via touch)
+ */
+function handleHeaderTouchmove(event) {
+  if (event.target.closest('[data-testid="session-chat-picker"]')) return;
+  if (event.target.closest('.name-edit-input')) return;
+  event.preventDefault();
+}
+
+// Body scroll lock — iOS-compatible "fixed body" pattern.
+// On iOS Safari, `overflow: hidden` alone is insufficient: it doesn't reset
+// the existing scroll offset and touch gestures can still move the body.
+// Setting `position: fixed` truly freezes the page.
+let savedScrollY = 0;
+let savedBodyStyles = {};
 
 function lockBodyScroll() {
-  savedBodyOverflow = document.body.style.overflow;
+  savedScrollY = window.scrollY;
+  savedBodyStyles = {
+    overflow: document.body.style.overflow,
+    position: document.body.style.position,
+    top: document.body.style.top,
+    width: document.body.style.width,
+  };
   document.body.style.overflow = 'hidden';
+  document.body.style.position = 'fixed';
+  document.body.style.top = `-${savedScrollY}px`;
+  document.body.style.width = '100%';
 }
 
 function unlockBodyScroll() {
-  document.body.style.overflow = savedBodyOverflow;
+  document.body.style.overflow = savedBodyStyles.overflow || '';
+  document.body.style.position = savedBodyStyles.position || '';
+  document.body.style.top = savedBodyStyles.top || '';
+  document.body.style.width = savedBodyStyles.width || '';
+  window.scrollTo(0, savedScrollY);
 }
 
 // Lifecycle
@@ -720,6 +749,7 @@ defineExpose({
   align-items: flex-start;
   overflow: hidden;
   overflow-y: hidden;
+  overscroll-behavior: none;
 }
 
 .overlay-panel-wrapper {
@@ -730,6 +760,7 @@ defineExpose({
   max-width: 900px;
   width: 100%;
   overflow: visible;
+  overscroll-behavior: none;
 }
 
 .overlay-close-handle {
@@ -803,6 +834,7 @@ defineExpose({
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .overlay-header {
@@ -877,7 +909,7 @@ defineExpose({
    streaming auto-scroll (useMessageScroll targets .overlay-body via scrollContainerRef). */
 .session-chat-overlay :deep(.messages) {
   max-height: none !important;
-  overflow-y: visible;
+  overflow-y: visible !important;
   flex: 1;
 }
 


### PR DESCRIPTION
## Summary

Fixes three scroll-related issues on iPad/Safari in the SessionChatOverlay:

1. **Header drag scrolls overlay** — Dragging on the header (session title, selector, action buttons) was scrolling the entire overlay upward
2. **Form area drag scrolls overlay** — Dragging on blank space at the bottom of the form area sometimes scrolled the overlay
3. **Overlay inherits page scroll offset on open** — If the session detail view was scrolled down (collapsing Safari's URL bar), opening the overlay positioned the header above the fold

### Root Cause

The existing `lockBodyScroll()` only set `document.body.style.overflow = 'hidden'`, which on iOS Safari:
- Does **not** reset the existing scroll offset (`window.scrollY`)
- Does **not** prevent touch gestures from moving the body
- Causes `position: fixed; inset: 0` overlays to open relative to the layout viewport (not the visual viewport), pushing the header above the fold when the URL bar is collapsed

### Changes

| Change | Purpose |
|--------|---------|
| iOS-compatible body scroll lock (position: fixed pattern) | Primary fix: freeze body, save/restore scroll position, prevent visual jump |
| `overscroll-behavior: none` on `.overlay-backdrop`, `.overlay-panel-wrapper` | Defense-in-depth: prevent overscroll bounce on overlay shell |
| `overscroll-behavior: contain` on `.overlay-body` | Prevent scroll chaining from message area to parent |
| `handleHeaderTouchmove()` handler on `.overlay-header` | Block touch-scroll on header; allow picker scroll and text selection |
| `!important` on `overflow-y: visible` for `.messages` | Harden against CSS specificity issues |

## Test plan

- [x] Run existing E2E tests: `./scripts/pw.sh test --grep="overlay"` — **77 passed, 0 failed**
- [ ] Manual iPad verification (real device or Xcode simulator):
  - Open overlay after scrolling page down (URL bar collapsed) — header should be at top
  - Touch-drag on header — overlay should not scroll
  - Touch-drag in form area — overlay should not scroll
  - Page scroll position restores on overlay close
  - SessionChatPicker dropdown still scrollable
  - Name-edit input text selection works

🤖 Generated with [Claude Code](https://claude.ai/code)