### PR TITLE
fix: prevent stale error messages during session transitions

### DIFF
--- a/packages/web/src/composables/useSessionInitializer.js
+++ b/packages/web/src/composables/useSessionInitializer.js
@@ -60,6 +60,7 @@ export function useSessionInitializer({
     // Clear all session-specific store state to prevent stale data during transitions
     sessionsStore.messages = [];
     sessionsStore.conversations = [];
+    sessionsStore.activeConversationId = null;
     sessionsStore.workLogs = {};
     sessionsStore.clearPartialText();
     todosStore.clearTodos();

--- a/packages/web/src/composables/useSessionInitializer.test.js
+++ b/packages/web/src/composables/useSessionInitializer.test.js
@@ -291,6 +291,7 @@ describe('useSessionInitializer', () => {
       // Pre-populate store state
       sessionsStore.messages = [{ id: 'msg-1' }];
       sessionsStore.conversations = [{ id: 'conv-1' }];
+      sessionsStore.activeConversationId = 'conv-1';
       sessionsStore.workLogs = { 'log-1': {} };
 
       await initializeSession('session-1');
@@ -298,6 +299,7 @@ describe('useSessionInitializer', () => {
 
       expect(sessionsStore.messages).toEqual([]);
       expect(sessionsStore.conversations).toEqual([]);
+      expect(sessionsStore.activeConversationId).toBeNull();
       expect(sessionsStore.workLogs).toEqual({});
     });
 

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -405,7 +405,7 @@ export const useSessionsStore = defineStore('sessions', {
         }
         console.log(`[STORE] fetchMessages: updated store with ${this.messages.length} messages`);
       } catch (err) {
-        if (!this.viewedSessionId || this.viewedSessionId === sessionId) {
+        if (this.viewedSessionId && this.viewedSessionId === sessionId) {
           this.error = err.message;
         }
         console.error(`[STORE] fetchMessages: error fetching messages for session ${sessionId}:`, err.message);
@@ -439,7 +439,7 @@ export const useSessionsStore = defineStore('sessions', {
         const fetchedUnassociated = grouped['_unassociated'] || [];
         this.workLogs = { ...grouped, '_unassociated': [...fetchedUnassociated, ...newUnassociatedLogs] };
       } catch (err) {
-        if (!this.viewedSessionId || this.viewedSessionId === sessionId) {
+        if (this.viewedSessionId && this.viewedSessionId === sessionId) {
           this.error = err.message;
         }
       }

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -475,6 +475,17 @@ describe('Sessions Store', () => {
         expect(store.workLogs['msg-1']).toEqual([{ id: 'log-1', content: 'test' }]);
       });
 
+      it('does not set error when viewedSessionId is null on failed fetch', async () => {
+        const store = useSessionsStore();
+        store.viewedSessionId = null;
+
+        api.getSessionWorkLogs.mockRejectedValue(new Error('API Error'));
+
+        await store.fetchWorkLogs('any-session');
+
+        expect(store.error).toBeNull();
+      });
+
       it('proceeds normally when viewedSessionId matches sessionId', async () => {
         const store = useSessionsStore();
         store.viewedSessionId = 'session-A';
@@ -758,6 +769,7 @@ describe('Sessions Store', () => {
 
       it('handles fetch error gracefully', async () => {
         const store = useSessionsStore();
+        store.viewedSessionId = 'session-1';
 
         api.getConversations.mockRejectedValue(new Error('Network error'));
 
@@ -813,6 +825,21 @@ describe('Sessions Store', () => {
         expect(api.getConversations).toHaveBeenCalledWith('any-session');
         expect(store.conversations).toEqual(mockConversations);
         expect(store.activeConversationId).toBe('conv-1');
+      });
+
+      it('does not set error when viewedSessionId is null on failed fetch', async () => {
+        const store = useSessionsStore();
+        store.viewedSessionId = null;
+        store.conversations = [{ id: 'existing', name: 'Existing', isActive: true }];
+        store.activeConversationId = 'existing';
+
+        api.getConversations.mockRejectedValue(new Error('API Error'));
+
+        await store.fetchConversations('any-session');
+
+        expect(store.error).toBeNull();
+        expect(store.conversations).toEqual([{ id: 'existing', name: 'Existing', isActive: true }]);
+        expect(store.activeConversationId).toBe('existing');
       });
 
       it('proceeds normally when viewedSessionId matches sessionId', async () => {
@@ -3895,6 +3922,7 @@ describe('Sessions Store', () => {
 
     it('handles errors and sets error state', async () => {
       const store = useSessionsStore();
+      store.viewedSessionId = 'session-123';
       const errorMessage = 'Failed to fetch messages';
 
       api.getSessionMessages.mockRejectedValue(new Error(errorMessage));
@@ -4067,7 +4095,7 @@ describe('Sessions Store', () => {
       expect(store.error).toBe('API Error');
     });
 
-    it('sets error when viewedSessionId is null on failed fetch', async () => {
+    it('does not set error when viewedSessionId is null on failed fetch', async () => {
       const store = useSessionsStore();
       store.viewedSessionId = null;
 
@@ -4075,7 +4103,7 @@ describe('Sessions Store', () => {
 
       await store.fetchMessages('any-session', false);
 
-      expect(store.error).toBe('API Error');
+      expect(store.error).toBeNull();
     });
 
     it('skips API call when viewedSessionId does not match sessionId', async () => {

--- a/packages/web/src/stores/sessions/conversationActions.js
+++ b/packages/web/src/stores/sessions/conversationActions.js
@@ -21,7 +21,7 @@ export const conversationActions = {
       this.activeConversationId = active?.id || this.conversations[0]?.id || null;
     } catch (err) {
       // Only set error/clear state if still on this session
-      if (!this.viewedSessionId || this.viewedSessionId === sessionId) {
+      if (this.viewedSessionId && this.viewedSessionId === sessionId) {
         this.error = err.message;
         this.conversations = [];
         this.activeConversationId = null;


### PR DESCRIPTION
## Summary
- Fixed a race condition where async API fetches (messages, conversations, work logs) could set error state after the user had already navigated away from a session
- Changed guard conditions from `!viewedSessionId || viewedSessionId === sessionId` to `viewedSessionId && viewedSessionId === sessionId` so errors are only set when actively viewing the session
- Clear `activeConversationId` during session transitions in `useSessionInitializer` to prevent stale conversation references
- Added test coverage for `activeConversationId` cleanup in `useSessionInitializer` and updated existing tests to reflect the corrected guard behavior

## Test plan
- [x] Unit tests cover all three error guard changes (fetchMessages, fetchConversations, fetchWorkLogs)
- [x] Unit test verifies `activeConversationId` is cleared during cleanup
- [ ] Verify no red error messages appear when navigating between sessions quickly
- [ ] Verify error messages still appear correctly when a fetch fails while viewing a session
- [ ] Verify session transitions feel clean with no stale state artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)