### PR TITLE
fix: isolate SessionChatOverlay store and deduplicate per-session logic

### DIFF
--- a/packages/web/src/components/AutoRescheduleModal.vue
+++ b/packages/web/src/components/AutoRescheduleModal.vue
@@ -109,7 +109,7 @@
 
 <script setup>
 import { ref, reactive, watch } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 
 const props = defineProps({
@@ -119,7 +119,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'saved']);
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const loading = ref(false);
 const error = ref(null);

--- a/packages/web/src/components/ConversationMessages.vue
+++ b/packages/web/src/components/ConversationMessages.vue
@@ -40,7 +40,7 @@
 <script setup>
 import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import { useMessageScroll } from '../composables/useMessageScroll.js';
 import MessageItem from './MessageItem.vue';
@@ -55,7 +55,7 @@ const props = defineProps({
   scrollContainerRef: { type: Object, default: null },
 });
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const router = useRouter();
 

--- a/packages/web/src/components/ConversationPanel.vue
+++ b/packages/web/src/components/ConversationPanel.vue
@@ -51,7 +51,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import ConversationTreeItem from './ConversationTreeItem.vue';
 
@@ -60,7 +60,7 @@ const props = defineProps({
   hideNewConversation: { type: Boolean, default: false },
 });
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 
 const isOpen = ref(false);

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -111,7 +111,7 @@
 import { ref, computed, nextTick, watch, onMounted, onUnmounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { formatDistanceToNow } from 'date-fns';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import { useTemplatesStore } from '../stores/templates.js';
 import { useProjectDefaultsStore } from '../stores/projectDefaults.js';
@@ -139,7 +139,7 @@ const props = defineProps({
   hideNewConversation: { type: Boolean, default: false },
 });
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const templatesStore = useTemplatesStore();
 const defaultsStore = useProjectDefaultsStore();

--- a/packages/web/src/components/ConversationTreeItem.vue
+++ b/packages/web/src/components/ConversationTreeItem.vue
@@ -75,9 +75,9 @@
 
 <script setup>
 import { ref, computed } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 
 const props = defineProps({
   conversation: { type: Object, required: true },

--- a/packages/web/src/components/EffortLevelSelector.vue
+++ b/packages/web/src/components/EffortLevelSelector.vue
@@ -18,7 +18,7 @@
 <script setup>
 import { ref, computed, watch, toRef } from 'vue';
 import { EFFORT_LEVELS } from '@claudetools/shared';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 
 const props = defineProps({
@@ -38,7 +38,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue']);
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const toggling = ref(false);
 

--- a/packages/web/src/components/ModeSelector.vue
+++ b/packages/web/src/components/ModeSelector.vue
@@ -16,7 +16,7 @@
 
 <script setup>
 import { ref, computed, watch, toRef } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 
 const props = defineProps({
@@ -36,7 +36,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue']);
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const togglingMode = ref(false);
 

--- a/packages/web/src/components/ScheduleSessionModal.vue
+++ b/packages/web/src/components/ScheduleSessionModal.vue
@@ -36,7 +36,7 @@
 import { ref, reactive, computed, watch, nextTick } from 'vue';
 import { api } from '../composables/useApi.js';
 import { useUiStore } from '../stores/ui.js';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 
 const props = defineProps({
   isOpen: Boolean,
@@ -46,7 +46,7 @@ const props = defineProps({
 const emit = defineEmits(['close', 'update:isOpen']);
 
 const uiStore = useUiStore();
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const loading = ref(false);
 
 const form = reactive({

--- a/packages/web/src/components/SchedulingEditModal.vue
+++ b/packages/web/src/components/SchedulingEditModal.vue
@@ -156,7 +156,7 @@
 
 <script setup>
 import { ref, reactive, computed, watch } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import ModelSelector from './ModelSelector.vue';
 import ModeSelector from './ModeSelector.vue';
@@ -169,7 +169,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'saved']);
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const loading = ref(false);
 const error = ref(null);

--- a/packages/web/src/components/SchedulingInfo.vue
+++ b/packages/web/src/components/SchedulingInfo.vue
@@ -46,7 +46,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { formatDistanceToNow, format } from 'date-fns';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import SchedulingEditModal from './SchedulingEditModal.vue';
 
@@ -57,7 +57,7 @@ const props = defineProps({
   },
 });
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const loading = ref(false);
 const showEditModal = ref(false);

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -65,9 +65,11 @@ vi.mock('../stores/todos.js', () => ({
 
 // Mock overlay store factories — return the same mock stores so existing
 // assertions against mockSessionsStore / mockTodosStore continue to work.
-// Add $dispose as a no-op since the overlay disposes on unmount.
+// Add $dispose and $cleanup as no-ops since the overlay disposes on unmount.
 mockSessionsStore.$dispose = vi.fn();
 mockTodosStore.$dispose = vi.fn();
+mockSessionsStore.$cleanup = vi.fn();
+mockTodosStore.$cleanup = vi.fn();
 
 vi.mock('../stores/createOverlaySessionsStore.js', () => ({
   createOverlaySessionsStore: () => mockSessionsStore,

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -63,6 +63,27 @@ vi.mock('../stores/todos.js', () => ({
   useTodosStore: () => mockTodosStore,
 }));
 
+// Mock overlay store factories — return the same mock stores so existing
+// assertions against mockSessionsStore / mockTodosStore continue to work.
+// Add $dispose as a no-op since the overlay disposes on unmount.
+mockSessionsStore.$dispose = vi.fn();
+mockTodosStore.$dispose = vi.fn();
+
+vi.mock('../stores/createOverlaySessionsStore.js', () => ({
+  createOverlaySessionsStore: () => mockSessionsStore,
+}));
+
+vi.mock('../stores/createOverlayTodosStore.js', () => ({
+  createOverlayTodosStore: () => mockTodosStore,
+}));
+
+vi.mock('../composables/useOverlayStore.js', () => ({
+  SESSIONS_STORE_KEY: Symbol('test-sessions-store'),
+  TODOS_STORE_KEY: Symbol('test-todos-store'),
+  useInjectedSessionsStore: () => mockSessionsStore,
+  useInjectedTodosStore: () => mockTodosStore,
+}));
+
 // Mock useSessionSubscription
 const mockSubscribe = vi.fn();
 const mockUnsubscribe = vi.fn();

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -179,13 +179,15 @@
 
 <script setup>
 /* eslint-disable max-lines */
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
+import { ref, computed, provide, onMounted, onUnmounted, watch, nextTick } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
-import { useTodosStore } from '../stores/todos.js';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useSessionSubscription.js';
 import { useSessionPolling } from '../composables/useSessionPolling.js';
 import { api } from '../composables/useApi.js';
+import { createOverlaySessionsStore } from '../stores/createOverlaySessionsStore.js';
+import { createOverlayTodosStore } from '../stores/createOverlayTodosStore.js';
+import { SESSIONS_STORE_KEY, TODOS_STORE_KEY } from '../composables/useOverlayStore.js';
 
 import ConversationTab from './ConversationTab.vue';
 import SessionChatPicker from './SessionChatPicker.vue';
@@ -209,9 +211,24 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'session-created']);
 
-const sessionsStore = useSessionsStore();
-const todosStore = useTodosStore();
+// Main store — used only for global reads (session lists, picker names, etc.)
+const mainSessionsStore = useSessionsStore();
 const uiStore = useUiStore();
+
+// Create isolated overlay stores so that per-session state (messages,
+// partialText, workLogs, etc.) does not cross-contaminate the main view.
+const overlaySessionsStore = createOverlaySessionsStore();
+const overlayTodosStore = createOverlayTodosStore();
+
+// Provide the overlay stores to all descendant components.
+// Child components using useInjectedSessionsStore() / useInjectedTodosStore()
+// will receive these isolated instances instead of the global Pinia singletons.
+provide(SESSIONS_STORE_KEY, overlaySessionsStore);
+provide(TODOS_STORE_KEY, overlayTodosStore);
+
+// Alias for the overlay store — this is what the overlay uses for all per-session operations.
+const sessionsStore = overlaySessionsStore;
+const todosStore = overlayTodosStore;
 
 // Internal state
 const visible = ref(true);
@@ -235,7 +252,7 @@ const pickerOpen = ref(false);
 const pickerAreaRef = ref(null);
 
 const activeSessionDisplayName = computed(() => {
-  const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+  const session = mainSessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
   return session?.name || 'Session';
 });
 
@@ -283,15 +300,15 @@ const {
 } = useSessionPolling({
   getSessionId: () => activeSessionId.value,
   getSessionStatus: () => {
-    const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+    const session = mainSessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
     return session?.status;
   },
-  sessionsStore,
+  sessionsStore: overlaySessionsStore,
 });
 
 // Computed
 const rootSession = computed(() => {
-  const root = sessionsStore.getRootSession(props.sessionId);
+  const root = mainSessionsStore.getRootSession(props.sessionId);
   if (root) return root;
   // Fallback: check currentSession if not found in sessions array
   const current = sessionsStore.currentSession;
@@ -308,8 +325,8 @@ const rootSessionName = computed(() => {
   if (chainRoot?.session?.name) return chainRoot.session.name;
   // Priority 2: use getRootSession from the store
   if (rootSession.value?.name) return rootSession.value.name;
-  // Priority 3: fallback to currentSession
-  return sessionsStore.currentSession?.name || 'Session';
+  // Priority 3: fallback to the main store's currentSession (parent view session)
+  return mainSessionsStore.currentSession?.name || sessionsStore.currentSession?.name || 'Session';
 });
 
 const hasDescendants = computed(() => {
@@ -317,12 +334,12 @@ const hasDescendants = computed(() => {
 });
 
 const activeSessionName = computed(() => {
-  const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+  const session = mainSessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
   return session?.name || 'Session';
 });
 
 const overlaySessionStatus = computed(() => {
-  const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+  const session = mainSessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
   return session?.status || '';
 });
 
@@ -331,7 +348,7 @@ const isOverlaySessionActive = computed(() => {
 });
 
 const backToSessionsUrl = computed(() => {
-  const session = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+  const session = mainSessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
   if (session?.projectId) {
     return `/projects/${session.projectId}/sessions`;
   }
@@ -367,7 +384,7 @@ async function selectSession(sessionId) {
 async function addChildSession() {
   if (isCreatingSession.value) return;
 
-  const currentSession = sessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
+  const currentSession = mainSessionsStore.getSessionById(activeSessionId.value) || sessionsStore.currentSession;
   if (!currentSession?.projectId) {
     uiStore.error('Cannot create session: no project context');
     return;
@@ -394,8 +411,8 @@ async function addChildSession() {
       ...(gitMode && gitBranch ? { gitMode, gitBranch } : {}),
     });
 
-    // Add to store manually (mirrors what sessionsStore.createSession does)
-    sessionsStore.sessions.unshift(newSession);
+    // Add to main store's session list (not the overlay's isolated state)
+    mainSessionsStore.sessions.unshift(newSession);
 
     // Notify parent to rebuild session chain so it includes the new child
     emit('session-created', newSession.id);
@@ -444,7 +461,8 @@ async function saveSessionName() {
       name: newName,
       manuallyNamed: true
     });
-    sessionsStore.updateSession({ ...updated, id: sessionId });
+    // Update both overlay and main store
+    overlaySessionsStore.updateSession({ ...updated, id: sessionId });
     uiStore.success('Session name updated');
     isEditingName.value = false;
     editNameValue.value = '';
@@ -559,7 +577,7 @@ function setupSubscription(sessionId) {
   );
 
   // Start polling if session is active
-  const session = sessionsStore.getSessionById(sessionId) || sessionsStore.currentSession;
+  const session = mainSessionsStore.getSessionById(sessionId) || sessionsStore.currentSession;
   if (session?.status === 'running' || session?.status === 'starting') {
     startPolling();
   }
@@ -657,6 +675,9 @@ onUnmounted(() => {
   document.removeEventListener('click', handleClickOutsidePicker, true);
   window.removeEventListener('resize', checkMobile);
   cleanupSubscription();
+  // Dispose overlay stores to free memory and prevent stale reactive subscriptions
+  overlaySessionsStore.$dispose();
+  overlayTodosStore.$dispose();
 });
 
 // Expose for testing

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -179,6 +179,18 @@
 
 <script setup>
 /* eslint-disable max-lines */
+/**
+ * OVERLAY STORE ISOLATION
+ *
+ * This component creates isolated Pinia store instances for the overlay via
+ * createOverlaySessionsStore() and createOverlayTodosStore(), and provides them
+ * to all descendant components through Vue's provide/inject.
+ *
+ * Descendant components MUST use useInjectedSessionsStore() / useInjectedTodosStore()
+ * (from composables/useOverlayStore.js) instead of importing useSessionsStore or
+ * useTodosStore directly. Direct imports bypass the overlay's provide/inject layer
+ * and would read/write to the global singleton, breaking store isolation.
+ */
 import { ref, computed, provide, onMounted, onUnmounted, watch, nextTick } from 'vue';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useUiStore } from '../stores/ui.js';
@@ -675,9 +687,10 @@ onUnmounted(() => {
   document.removeEventListener('click', handleClickOutsidePicker, true);
   window.removeEventListener('resize', checkMobile);
   cleanupSubscription();
-  // Dispose overlay stores to free memory and prevent stale reactive subscriptions
-  overlaySessionsStore.$dispose();
-  overlayTodosStore.$dispose();
+  // Clean up overlay stores: dispose subscriptions AND remove from Pinia registry
+  // to prevent state leaks on every overlay open/close cycle.
+  overlaySessionsStore.$cleanup();
+  overlayTodosStore.$cleanup();
 });
 
 // Expose for testing

--- a/packages/web/src/components/TodoDrawer.vue
+++ b/packages/web/src/components/TodoDrawer.vue
@@ -47,9 +47,9 @@
 
 <script setup>
 import { computed } from 'vue';
-import { useTodosStore } from '../stores/todos.js';
+import { useInjectedTodosStore } from '../composables/useOverlayStore.js';
 
-const todosStore = useTodosStore();
+const todosStore = useInjectedTodosStore();
 
 const previewTodos = computed(() => todosStore.items.slice(0, 4));
 

--- a/packages/web/src/components/TokenCostPanel.vue
+++ b/packages/web/src/components/TokenCostPanel.vue
@@ -57,12 +57,12 @@
 
 <script setup>
 import { ref, computed } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { formatTokenCount } from '@claudetools/shared';
 import TokenWeightsModal from './TokenWeightsModal.vue';
 
-const sessionsStore = useSessionsStore();
+const sessionsStore = useInjectedSessionsStore();
 const settingsStore = useSettingsStore();
 
 const isExpanded = ref(false);

--- a/packages/web/src/components/overlayImportGuard.test.js
+++ b/packages/web/src/components/overlayImportGuard.test.js
@@ -1,0 +1,88 @@
+/**
+ * Guard test: verifies that components rendered inside the overlay tree do NOT
+ * directly import useSessionsStore or useTodosStore. They should use the injected
+ * versions (useInjectedSessionsStore / useInjectedTodosStore) from useOverlayStore.js.
+ *
+ * Uses Vite's ?raw import suffix to read component sources at build time,
+ * which works in the jsdom test environment.
+ */
+import { describe, it, expect } from 'vitest';
+
+// Import component sources as raw text via Vite's ?raw query
+import ConversationTab from './ConversationTab.vue?raw';
+import SessionChatPicker from './SessionChatPicker.vue?raw';
+import ConversationPanel from './ConversationPanel.vue?raw';
+import ConversationMessages from './ConversationMessages.vue?raw';
+import ConversationTreeItem from './ConversationTreeItem.vue?raw';
+import TokenCostPanel from './TokenCostPanel.vue?raw';
+import SchedulingInfo from './SchedulingInfo.vue?raw';
+import SchedulingEditModal from './SchedulingEditModal.vue?raw';
+import ScheduleSessionModal from './ScheduleSessionModal.vue?raw';
+import AutoRescheduleModal from './AutoRescheduleModal.vue?raw';
+import ModeSelector from './ModeSelector.vue?raw';
+import EffortLevelSelector from './EffortLevelSelector.vue?raw';
+import TodoDrawer from './TodoDrawer.vue?raw';
+import InputForm from './InputForm.vue?raw';
+import RunningState from './RunningState.vue?raw';
+import StreamingMessage from './StreamingMessage.vue?raw';
+import MessageItem from './MessageItem.vue?raw';
+import StaleBadge from './StaleBadge.vue?raw';
+import QuickResponseSettings from './QuickResponseSettings.vue?raw';
+import LiveWorkLogPanel from './LiveWorkLogPanel.vue?raw';
+import ModelSelector from './ModelSelector.vue?raw';
+
+const overlayComponents = [
+  { name: 'ConversationTab.vue', source: ConversationTab },
+  { name: 'SessionChatPicker.vue', source: SessionChatPicker },
+  { name: 'ConversationPanel.vue', source: ConversationPanel },
+  { name: 'ConversationMessages.vue', source: ConversationMessages },
+  { name: 'ConversationTreeItem.vue', source: ConversationTreeItem },
+  { name: 'TokenCostPanel.vue', source: TokenCostPanel },
+  { name: 'SchedulingInfo.vue', source: SchedulingInfo },
+  { name: 'SchedulingEditModal.vue', source: SchedulingEditModal },
+  { name: 'ScheduleSessionModal.vue', source: ScheduleSessionModal },
+  { name: 'AutoRescheduleModal.vue', source: AutoRescheduleModal },
+  { name: 'ModeSelector.vue', source: ModeSelector },
+  { name: 'EffortLevelSelector.vue', source: EffortLevelSelector },
+  { name: 'TodoDrawer.vue', source: TodoDrawer },
+  { name: 'InputForm.vue', source: InputForm },
+  { name: 'RunningState.vue', source: RunningState },
+  { name: 'StreamingMessage.vue', source: StreamingMessage },
+  { name: 'MessageItem.vue', source: MessageItem },
+  { name: 'StaleBadge.vue', source: StaleBadge },
+  { name: 'QuickResponseSettings.vue', source: QuickResponseSettings },
+  { name: 'LiveWorkLogPanel.vue', source: LiveWorkLogPanel },
+  { name: 'ModelSelector.vue', source: ModelSelector },
+];
+
+// Regex patterns to detect direct imports from stores/sessions or stores/todos
+// Handles various relative path depths (../, ../../, etc.)
+const sessionsStoreImportRegex = /from\s+['"](?:\.\.\/)+stores\/sessions(?:\.js)?['"]/;
+const todosStoreImportRegex = /from\s+['"](?:\.\.\/)+stores\/todos(?:\.js)?['"]/;
+
+describe('Overlay Component Import Guard', () => {
+  it.each(overlayComponents.map(c => [c.name, c.source]))(
+    '%s should not directly import useSessionsStore or useTodosStore',
+    (componentFile, source) => {
+      const hasSessionsStoreImport = sessionsStoreImportRegex.test(source);
+      const hasTodosStoreImport = todosStoreImportRegex.test(source);
+
+      if (hasSessionsStoreImport) {
+        expect.fail(
+          `${componentFile} directly imports from stores/sessions. ` +
+          `Use useInjectedSessionsStore() from composables/useOverlayStore.js instead.`,
+        );
+      }
+
+      if (hasTodosStoreImport) {
+        expect.fail(
+          `${componentFile} directly imports from stores/todos. ` +
+          `Use useInjectedTodosStore() from composables/useOverlayStore.js instead.`,
+        );
+      }
+
+      expect(hasSessionsStoreImport).toBe(false);
+      expect(hasTodosStoreImport).toBe(false);
+    },
+  );
+});

--- a/packages/web/src/composables/useOverlayStore.js
+++ b/packages/web/src/composables/useOverlayStore.js
@@ -18,6 +18,18 @@ export const TODOS_STORE_KEY = Symbol('overlay-todos-store');
 /**
  * Returns the sessions store from the nearest provider, or falls back to the
  * global Pinia singleton. Must be called during component setup().
+ *
+ * @example
+ * // In a component rendered inside SessionChatOverlay's tree:
+ * import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
+ *
+ * const sessionsStore = useInjectedSessionsStore();
+ * // `sessionsStore` is the overlay's isolated instance when inside the overlay,
+ * // or the global Pinia singleton everywhere else.
+ *
+ * // DO NOT do this inside overlay-rendered components:
+ * // import { useSessionsStore } from '../stores/sessions.js';
+ * // const store = useSessionsStore();  // <-- bypasses overlay isolation!
  */
 export function useInjectedSessionsStore() {
   return inject(SESSIONS_STORE_KEY, useSessionsStore());
@@ -26,6 +38,18 @@ export function useInjectedSessionsStore() {
 /**
  * Returns the todos store from the nearest provider, or falls back to the
  * global Pinia singleton. Must be called during component setup().
+ *
+ * @example
+ * // In a component rendered inside SessionChatOverlay's tree:
+ * import { useInjectedTodosStore } from '../composables/useOverlayStore.js';
+ *
+ * const todosStore = useInjectedTodosStore();
+ * // `todosStore` is the overlay's isolated instance when inside the overlay,
+ * // or the global Pinia singleton everywhere else.
+ *
+ * // DO NOT do this inside overlay-rendered components:
+ * // import { useTodosStore } from '../stores/todos.js';
+ * // const store = useTodosStore();  // <-- bypasses overlay isolation!
  */
 export function useInjectedTodosStore() {
   return inject(TODOS_STORE_KEY, useTodosStore());

--- a/packages/web/src/composables/useOverlayStore.js
+++ b/packages/web/src/composables/useOverlayStore.js
@@ -1,0 +1,32 @@
+import { inject } from 'vue';
+import { useSessionsStore } from '../stores/sessions.js';
+import { useTodosStore } from '../stores/todos.js';
+
+/**
+ * Injection keys for overlay store isolation.
+ *
+ * When a SessionChatOverlay provides its own isolated store instances via
+ * Vue's provide/inject, all descendant components that use these composables
+ * will receive the overlay-scoped stores instead of the global Pinia singletons.
+ *
+ * Components outside the overlay tree (or in tests without a provider) fall
+ * back to the default Pinia singletons, preserving existing behaviour.
+ */
+export const SESSIONS_STORE_KEY = Symbol('overlay-sessions-store');
+export const TODOS_STORE_KEY = Symbol('overlay-todos-store');
+
+/**
+ * Returns the sessions store from the nearest provider, or falls back to the
+ * global Pinia singleton. Must be called during component setup().
+ */
+export function useInjectedSessionsStore() {
+  return inject(SESSIONS_STORE_KEY, useSessionsStore());
+}
+
+/**
+ * Returns the todos store from the nearest provider, or falls back to the
+ * global Pinia singleton. Must be called during component setup().
+ */
+export function useInjectedTodosStore() {
+  return inject(TODOS_STORE_KEY, useTodosStore());
+}

--- a/packages/web/src/composables/useOverlayStore.test.js
+++ b/packages/web/src/composables/useOverlayStore.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import { defineComponent, provide, h } from 'vue';
+
+// Mock the API module (required by stores)
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getSession: vi.fn(),
+    getSessionMessages: vi.fn(),
+    getConversationMessages: vi.fn(),
+    getSessionWorkLogs: vi.fn(),
+    stopSession: vi.fn(),
+    restartSession: vi.fn(),
+    startSession: vi.fn(),
+    sendMessage: vi.fn(),
+    updateSession: vi.fn(),
+    getConversations: vi.fn(),
+    createConversation: vi.fn(),
+    updateConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+    branchConversation: vi.fn(),
+    getSessionTodos: vi.fn(),
+    getActiveSessions: vi.fn(),
+    getProjectSessions: vi.fn(),
+    getScheduledSessions: vi.fn(),
+    createSession: vi.fn(),
+    deleteSession: vi.fn(),
+    archiveSession: vi.fn(),
+    unarchiveSession: vi.fn(),
+    toggleSessionStar: vi.fn(),
+    duplicateSession: vi.fn(),
+  },
+}));
+
+import {
+  useInjectedSessionsStore,
+  useInjectedTodosStore,
+  SESSIONS_STORE_KEY,
+  TODOS_STORE_KEY,
+} from './useOverlayStore.js';
+import { useSessionsStore } from '../stores/sessions.js';
+import { useTodosStore } from '../stores/todos.js';
+
+/**
+ * Helper to call a composable inside a component setup context.
+ * Optionally provides values via Vue's provide/inject.
+ */
+function withSetup(composable, provideMap = {}) {
+  let result;
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  const Wrapper = defineComponent({
+    setup() {
+      Object.entries(provideMap).forEach(([key, val]) => {
+        // provideMap keys are the actual Symbol keys
+        provide(key, val);
+      });
+      result = composable();
+      return () => h('div');
+    },
+  });
+  mount(Wrapper, { global: { plugins: [pinia] } });
+  return result;
+}
+
+/**
+ * Helper that wraps composable in a child component with a parent provider.
+ */
+function withProviderAndChild(composable, provideKey, provideValue) {
+  let result;
+  const pinia = createPinia();
+  setActivePinia(pinia);
+
+  const Child = defineComponent({
+    setup() {
+      result = composable();
+      return () => h('div');
+    },
+  });
+
+  const Parent = defineComponent({
+    setup() {
+      provide(provideKey, provideValue);
+      return () => h(Child);
+    },
+  });
+
+  mount(Parent, { global: { plugins: [pinia] } });
+  return result;
+}
+
+describe('useOverlayStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Symbol keys', () => {
+    it('SESSIONS_STORE_KEY and TODOS_STORE_KEY are unique symbols', () => {
+      expect(typeof SESSIONS_STORE_KEY).toBe('symbol');
+      expect(typeof TODOS_STORE_KEY).toBe('symbol');
+      expect(SESSIONS_STORE_KEY).not.toBe(TODOS_STORE_KEY);
+    });
+  });
+
+  describe('useInjectedSessionsStore', () => {
+    it('returns global singleton when no provider exists', () => {
+      const pinia = createPinia();
+      setActivePinia(pinia);
+
+      const injectedStore = withSetup(useInjectedSessionsStore);
+      const globalStore = useSessionsStore();
+
+      expect(injectedStore.$id).toBe(globalStore.$id);
+    });
+
+    it('returns provided instance when provider exists', () => {
+      const mockStore = { $id: 'mock-sessions', isMock: true };
+
+      const injectedStore = withProviderAndChild(
+        useInjectedSessionsStore,
+        SESSIONS_STORE_KEY,
+        mockStore,
+      );
+
+      expect(injectedStore).toBe(mockStore);
+      expect(injectedStore.isMock).toBe(true);
+    });
+  });
+
+  describe('useInjectedTodosStore', () => {
+    it('returns global singleton when no provider exists', () => {
+      const pinia = createPinia();
+      setActivePinia(pinia);
+
+      const injectedStore = withSetup(useInjectedTodosStore);
+      const globalStore = useTodosStore();
+
+      expect(injectedStore.$id).toBe(globalStore.$id);
+    });
+
+    it('returns provided instance when provider exists', () => {
+      const mockStore = { $id: 'mock-todos', isMock: true };
+
+      const injectedStore = withProviderAndChild(
+        useInjectedTodosStore,
+        TODOS_STORE_KEY,
+        mockStore,
+      );
+
+      expect(injectedStore).toBe(mockStore);
+      expect(injectedStore.isMock).toBe(true);
+    });
+  });
+});

--- a/packages/web/src/composables/useSessionControl.js
+++ b/packages/web/src/composables/useSessionControl.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { useSessionsStore } from '../stores/sessions.js';
+import { useInjectedSessionsStore } from './useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import { api } from './useApi.js';
 
@@ -13,7 +13,7 @@ import { api } from './useApi.js';
  * @returns {Object} Session control utilities
  */
 export function useSessionControl({ getSessionId }) {
-  const sessionsStore = useSessionsStore();
+  const sessionsStore = useInjectedSessionsStore();
   const uiStore = useUiStore();
 
   const sending = ref(false);

--- a/packages/web/src/composables/useSessionControl.test.js
+++ b/packages/web/src/composables/useSessionControl.test.js
@@ -19,6 +19,13 @@ vi.mock('../stores/sessions.js', () => ({
   useSessionsStore: () => mockSessionsStore,
 }));
 
+vi.mock('./useOverlayStore.js', () => ({
+  useInjectedSessionsStore: () => mockSessionsStore,
+  useInjectedTodosStore: () => ({}),
+  SESSIONS_STORE_KEY: Symbol('test-sessions-store'),
+  TODOS_STORE_KEY: Symbol('test-todos-store'),
+}));
+
 vi.mock('../stores/ui.js', () => ({
   useUiStore: () => mockUiStore,
 }));

--- a/packages/web/src/stores/createOverlaySessionsStore.js
+++ b/packages/web/src/stores/createOverlaySessionsStore.js
@@ -1,8 +1,10 @@
-import { defineStore } from 'pinia';
+import { defineStore, getActivePinia } from 'pinia';
 import { api } from '../composables/useApi.js';
 import { useSessionsStore } from './sessions.js';
 import { tokenGetters } from './sessions/tokenGetters.js';
 import { conversationActions } from './sessions/conversationActions.js';
+import { perSessionActions } from './sessions/perSessionActions.js';
+import { perSessionGetters } from './sessions/perSessionGetters.js';
 
 /**
  * Counter for generating unique store IDs across multiple overlay instances.
@@ -31,7 +33,7 @@ let overlayCounter = 0;
 export function createOverlaySessionsStore() {
   const storeId = `overlay-sessions-${++overlayCounter}`;
 
-  return defineStore(storeId, {
+  const store = defineStore(storeId, {
     state: () => ({
       // Per-session isolated state
       currentSession: null,
@@ -97,55 +99,8 @@ export function createOverlaySessionsStore() {
         return useSessionsStore().groupedSessions;
       },
 
-      // ==================== LOCAL GETTERS (operate on isolated state) ====================
-
-      isDraftSession: (state) => (session) => {
-        if (!session || session.status !== 'waiting') return false;
-        if (session.hasResponses !== undefined) return !session.hasResponses;
-        return !state.messages.some((msg) => msg.role === 'assistant');
-      },
-
-      isScheduledDraft: (state) => (session) => {
-        if (!session || session.status !== 'scheduled') return false;
-        if (session.hasResponses !== undefined) return !session.hasResponses;
-        return !state.messages.some((msg) => msg.role === 'assistant');
-      },
-
-      getWorkLogsForMessage: (state) => (messageId) => {
-        return state.workLogs[messageId] || [];
-      },
-      getUnassociatedWorkLogs: (state) => {
-        return state.workLogs['_unassociated'] || [];
-      },
-      partialThinking: (state) => {
-        if (!state.currentSession?.id) return null;
-        return state.partialThinkingBySession[state.currentSession.id] || null;
-      },
-      activeConversation: (state) => {
-        return state.conversations.find((c) => c.id === state.activeConversationId) || null;
-      },
-      getConversationById: (state) => (id) => {
-        return state.conversations.find((c) => c.id === id);
-      },
-      rootConversations: (state) => {
-        return state.conversations.filter((c) => !c.parentConversationId);
-      },
-      conversationTree: (state) => {
-        const buildTree = (parentId = null) => {
-          return state.conversations
-            .filter((c) => c.parentConversationId === parentId)
-            .map((conv) => ({ ...conv, children: buildTree(conv.id) }));
-        };
-        return buildTree(null);
-      },
-      getConversationChildren: (state) => (conversationId) => {
-        return state.conversations.filter((c) => c.parentConversationId === conversationId);
-      },
-      getConversationParent: (state) => (conversationId) => {
-        const conv = state.conversations.find((c) => c.id === conversationId);
-        if (!conv?.parentConversationId) return null;
-        return state.conversations.find((c) => c.id === conv.parentConversationId);
-      },
+      // ==================== LOCAL GETTERS (shared with main store) ====================
+      ...perSessionGetters,
 
       // ==================== TOKEN USAGE GETTERS (operate on local state) ====================
       ...tokenGetters,
@@ -193,179 +148,8 @@ export function createOverlaySessionsStore() {
         }
       },
 
-      // ==================== MESSAGE ACTIONS (local state) ====================
-
-      async fetchMessages(sessionId, showLoading = true, conversationId = null) {
-        if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
-
-        if (showLoading) this.loading = true;
-        this.error = null;
-        try {
-          const cid = conversationId || this.activeConversationId;
-          const fetchedMessages = cid
-            ? await api.getConversationMessages(sessionId, cid)
-            : await api.getSessionMessages(sessionId);
-
-          if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
-
-          const fetchedIds = new Set(fetchedMessages.map(m => m.id));
-          const newMessages = this.messages.filter(m => m.sessionId === sessionId && !fetchedIds.has(m.id));
-          if (newMessages.length > 0) {
-            this.messages = [...fetchedMessages, ...newMessages];
-          } else {
-            this.messages = fetchedMessages;
-          }
-        } catch (err) {
-          if (this.viewedSessionId && this.viewedSessionId === sessionId) {
-            this.error = err.message;
-          }
-        } finally {
-          if (showLoading) this.loading = false;
-        }
-      },
-
-      addMessage(message) {
-        if (this.currentSession && message.sessionId && message.sessionId !== this.currentSession.id) return;
-        if (!this.messages.some(m => m.id === message.id)) this.messages.push(message);
-      },
-
-      // ==================== WORK LOG ACTIONS (local state) ====================
-
-      async fetchWorkLogs(sessionId) {
-        if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
-        this.error = null;
-        try {
-          const grouped = await api.getSessionWorkLogs(sessionId);
-          if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
-
-          const fetchedLogIds = new Set();
-          for (const messageId of Object.keys(grouped)) {
-            for (const log of grouped[messageId] || []) fetchedLogIds.add(log.id);
-          }
-          const existingUnassociated = this.workLogs['_unassociated'] || [];
-          const newUnassociatedLogs = existingUnassociated.filter(log => !fetchedLogIds.has(log.id));
-          const fetchedUnassociated = grouped['_unassociated'] || [];
-          this.workLogs = { ...grouped, '_unassociated': [...fetchedUnassociated, ...newUnassociatedLogs] };
-        } catch (err) {
-          if (this.viewedSessionId && this.viewedSessionId === sessionId) {
-            this.error = err.message;
-          }
-        }
-      },
-
-      addWorkLog(log) {
-        if (this.currentSession && log.sessionId && log.sessionId !== this.currentSession.id) return;
-        const messageId = log.messageId || '_unassociated';
-        const currentLogs = this.workLogs[messageId] || [];
-        if (currentLogs.some(l => l.id === log.id)) return;
-        this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, log] };
-      },
-
-      setWorkLogs(workLogs) { this.workLogs = workLogs; },
-
-      clearWorkLogs() {
-        this.workLogs = {};
-        this.clearAllPartialThinking();
-      },
-
-      associateWorkLogs(messageId) {
-        const unassociated = this.workLogs['_unassociated'] || [];
-        if (unassociated.length > 0) {
-          const currentLogs = this.workLogs[messageId] || [];
-          const currentIds = new Set(currentLogs.map(l => l.id));
-          const newLogs = unassociated.filter(l => !currentIds.has(l.id));
-          this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, ...newLogs], '_unassociated': [] };
-        }
-      },
-
-      // ==================== STREAMING ACTIONS (local state) ====================
-
-      setPartialThinking(thinking, sessionId = null) {
-        const id = sessionId || this.currentSession?.id;
-        if (!id) return;
-        this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: thinking };
-      },
-
-      clearPartialThinking(sessionId = null) {
-        const id = sessionId || this.currentSession?.id;
-        if (!id) return;
-        this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: null };
-      },
-
-      clearAllPartialThinking() { this.partialThinkingBySession = {}; },
-
-      setPartialText(text) {
-        const PARTIAL_THROTTLE_MS = 150;
-        this._pendingPartialText = text;
-        if (!this._partialThrottleTimer) {
-          this.partialText = text;
-          this._partialThrottleTimer = setTimeout(() => {
-            if (this._pendingPartialText !== null && this._pendingPartialText !== this.partialText) {
-              this.partialText = this._pendingPartialText;
-            }
-            this._partialThrottleTimer = null;
-            this._pendingPartialText = null;
-          }, PARTIAL_THROTTLE_MS);
-        }
-      },
-
-      clearPartialText() {
-        this.partialText = '';
-        this._pendingPartialText = null;
-        if (this._partialThrottleTimer) {
-          clearTimeout(this._partialThrottleTimer);
-          this._partialThrottleTimer = null;
-        }
-      },
-
-      // ==================== USAGE ACTIONS (local state) ====================
-
-      updateRunningUsage(usage, conversationId = null) {
-        this.runningUsage = { ...usage, conversationId };
-      },
-
-      finalizeUsage(usage, conversationId = null) {
-        if (conversationId) {
-          const index = this.conversations.findIndex((c) => c.id === conversationId);
-          if (index !== -1) {
-            this.conversations.splice(index, 1, {
-              ...this.conversations[index],
-              inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
-              cacheReadInputTokens: usage.cacheReadInputTokens,
-              cacheCreationInputTokens: usage.cacheCreationInputTokens,
-              webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
-            });
-          }
-        }
-        if (this.currentSession) {
-          this.currentSession = {
-            ...this.currentSession,
-            inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
-            cacheReadInputTokens: usage.cacheReadInputTokens,
-            cacheCreationInputTokens: usage.cacheCreationInputTokens,
-            webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow,
-          };
-        }
-        this.runningUsage = null;
-      },
-
-      updateConversationUsage(conversationId, usage) {
-        const index = this.conversations.findIndex((c) => c.id === conversationId);
-        if (index !== -1) {
-          this.conversations.splice(index, 1, {
-            ...this.conversations[index],
-            inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
-            cacheReadInputTokens: usage.cacheReadInputTokens,
-            cacheCreationInputTokens: usage.cacheCreationInputTokens,
-            webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
-          });
-        }
-      },
-
-      clearRunningUsage() {
-        this.runningUsage = null;
-        this.clearPartialThinking();
-      },
+      // ==================== PER-SESSION ACTIONS (shared with main store) ====================
+      ...perSessionActions,
 
       // ==================== DELEGATED ACTIONS (call through to main store) ====================
 
@@ -466,4 +250,16 @@ export function createOverlaySessionsStore() {
       ...conversationActions,
     },
   })();
+
+  // Attach $cleanup() to properly dispose and remove from Pinia registry.
+  // $dispose() alone only removes subscriptions — it does NOT remove the
+  // store's state entry from pinia.state.value, leaking memory on every
+  // overlay open/close cycle.
+  store.$cleanup = () => {
+    store.$dispose();
+    const pinia = getActivePinia();
+    if (pinia) delete pinia.state.value[storeId];
+  };
+
+  return store;
 }

--- a/packages/web/src/stores/createOverlaySessionsStore.js
+++ b/packages/web/src/stores/createOverlaySessionsStore.js
@@ -1,0 +1,469 @@
+import { defineStore } from 'pinia';
+import { api } from '../composables/useApi.js';
+import { useSessionsStore } from './sessions.js';
+import { tokenGetters } from './sessions/tokenGetters.js';
+import { conversationActions } from './sessions/conversationActions.js';
+
+/**
+ * Counter for generating unique store IDs across multiple overlay instances.
+ */
+let overlayCounter = 0;
+
+/**
+ * Factory that creates an isolated Pinia sessions store for the overlay.
+ *
+ * Isolated state (per-session fields that would otherwise cross-contaminate):
+ *   currentSession, viewedSessionId, messages, conversations, activeConversationId,
+ *   workLogs, partialThinkingBySession, partialText (+ throttle internals),
+ *   runningUsage, loading, error, commandRunVersion
+ *
+ * Proxied getters (delegate to the main store for global / list-level data):
+ *   sessions, archivedSessions, activeSessions, getSessionById, getRootSession,
+ *   getChildSessions, hasChildren, getChildCount, getAllDescendants, getSessionPath,
+ *   _findSessionById, _findChildren, groupedSessions, getWorkflowEffectiveStatus,
+ *   getWorkflowAggregatedStatus, getWorkflowSessions
+ *
+ * Delegated actions (affect global session lists - call through to main store):
+ *   updateSessionStatus, updateSession, stopSession, restartSession, startSession,
+ *   sendMessage, updateSessionModel, updateSessionThinking, updateSessionMode,
+ *   updateSessionFields, updateNextTemplate, updateAutoSendPendingPrompt
+ */
+export function createOverlaySessionsStore() {
+  const storeId = `overlay-sessions-${++overlayCounter}`;
+
+  return defineStore(storeId, {
+    state: () => ({
+      // Per-session isolated state
+      currentSession: null,
+      viewedSessionId: null,
+      messages: [],
+      conversations: [],
+      activeConversationId: null,
+      workLogs: {},
+      partialThinkingBySession: {},
+      partialText: '',
+      _partialThrottleTimer: null,
+      _pendingPartialText: null,
+      runningUsage: null,
+      loading: false,
+      error: null,
+      commandRunVersion: 0,
+    }),
+
+    getters: {
+      // ==================== PROXIED GETTERS (delegate to main store) ====================
+
+      sessions: () => useSessionsStore().sessions,
+      archivedSessions: () => useSessionsStore().archivedSessions,
+      activeSessions: () => useSessionsStore().activeSessions,
+
+      _findSessionById() {
+        return (id) => useSessionsStore()._findSessionById(id);
+      },
+      _findChildren() {
+        return (parentId) => useSessionsStore()._findChildren(parentId);
+      },
+      getSessionById() {
+        return (id) => useSessionsStore().getSessionById(id);
+      },
+      getChildSessions() {
+        return (parentId) => useSessionsStore().getChildSessions(parentId);
+      },
+      hasChildren() {
+        return (sessionId) => useSessionsStore().hasChildren(sessionId);
+      },
+      getChildCount() {
+        return (sessionId) => useSessionsStore().getChildCount(sessionId);
+      },
+      getAllDescendants() {
+        return (sessionId) => useSessionsStore().getAllDescendants(sessionId);
+      },
+      getSessionPath() {
+        return (sessionId) => useSessionsStore().getSessionPath(sessionId);
+      },
+      getRootSession() {
+        return (sessionId) => useSessionsStore().getRootSession(sessionId);
+      },
+      getWorkflowEffectiveStatus() {
+        return (rootSessionId) => useSessionsStore().getWorkflowEffectiveStatus(rootSessionId);
+      },
+      getWorkflowAggregatedStatus() {
+        return (rootSessionId) => useSessionsStore().getWorkflowAggregatedStatus(rootSessionId);
+      },
+      getWorkflowSessions() {
+        return (rootSessionId) => useSessionsStore().getWorkflowSessions(rootSessionId);
+      },
+      groupedSessions() {
+        return useSessionsStore().groupedSessions;
+      },
+
+      // ==================== LOCAL GETTERS (operate on isolated state) ====================
+
+      isDraftSession: (state) => (session) => {
+        if (!session || session.status !== 'waiting') return false;
+        if (session.hasResponses !== undefined) return !session.hasResponses;
+        return !state.messages.some((msg) => msg.role === 'assistant');
+      },
+
+      isScheduledDraft: (state) => (session) => {
+        if (!session || session.status !== 'scheduled') return false;
+        if (session.hasResponses !== undefined) return !session.hasResponses;
+        return !state.messages.some((msg) => msg.role === 'assistant');
+      },
+
+      getWorkLogsForMessage: (state) => (messageId) => {
+        return state.workLogs[messageId] || [];
+      },
+      getUnassociatedWorkLogs: (state) => {
+        return state.workLogs['_unassociated'] || [];
+      },
+      partialThinking: (state) => {
+        if (!state.currentSession?.id) return null;
+        return state.partialThinkingBySession[state.currentSession.id] || null;
+      },
+      activeConversation: (state) => {
+        return state.conversations.find((c) => c.id === state.activeConversationId) || null;
+      },
+      getConversationById: (state) => (id) => {
+        return state.conversations.find((c) => c.id === id);
+      },
+      rootConversations: (state) => {
+        return state.conversations.filter((c) => !c.parentConversationId);
+      },
+      conversationTree: (state) => {
+        const buildTree = (parentId = null) => {
+          return state.conversations
+            .filter((c) => c.parentConversationId === parentId)
+            .map((conv) => ({ ...conv, children: buildTree(conv.id) }));
+        };
+        return buildTree(null);
+      },
+      getConversationChildren: (state) => (conversationId) => {
+        return state.conversations.filter((c) => c.parentConversationId === conversationId);
+      },
+      getConversationParent: (state) => (conversationId) => {
+        const conv = state.conversations.find((c) => c.id === conversationId);
+        if (!conv?.parentConversationId) return null;
+        return state.conversations.find((c) => c.id === conv.parentConversationId);
+      },
+
+      // ==================== TOKEN USAGE GETTERS (operate on local state) ====================
+      ...tokenGetters,
+    },
+
+    actions: {
+      // ==================== LOCAL SESSION LIST HELPER ====================
+
+      _updateSessionInAllLists(sessionId, updates) {
+        // Update local currentSession
+        if (this.currentSession?.id === sessionId) {
+          this.currentSession = { ...this.currentSession, ...updates };
+        }
+        // Also delegate to the main store so global session lists stay in sync
+        useSessionsStore()._updateSessionInAllLists(sessionId, updates);
+      },
+
+      // ==================== SESSION FETCH (local state + main store sync) ====================
+
+      async fetchSession(id, showLoading = true) {
+        if (showLoading) this.loading = true;
+        this.error = null;
+        try {
+          const fetchedSession = await api.getSession(id);
+
+          // Guard: only set currentSession if still viewing this session
+          if (this.viewedSessionId && this.viewedSessionId !== id) {
+            return;
+          }
+
+          this.currentSession = fetchedSession;
+
+          // Also update the main store's session list so getSessionById() works
+          const mainStore = useSessionsStore();
+          const existingIndex = mainStore.sessions.findIndex((s) => s.id === id);
+          if (existingIndex !== -1) {
+            mainStore.sessions[existingIndex] = fetchedSession;
+          } else {
+            mainStore.sessions.push(fetchedSession);
+          }
+        } catch (err) {
+          this.error = err.message;
+        } finally {
+          if (showLoading) this.loading = false;
+        }
+      },
+
+      // ==================== MESSAGE ACTIONS (local state) ====================
+
+      async fetchMessages(sessionId, showLoading = true, conversationId = null) {
+        if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+
+        if (showLoading) this.loading = true;
+        this.error = null;
+        try {
+          const cid = conversationId || this.activeConversationId;
+          const fetchedMessages = cid
+            ? await api.getConversationMessages(sessionId, cid)
+            : await api.getSessionMessages(sessionId);
+
+          if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+
+          const fetchedIds = new Set(fetchedMessages.map(m => m.id));
+          const newMessages = this.messages.filter(m => m.sessionId === sessionId && !fetchedIds.has(m.id));
+          if (newMessages.length > 0) {
+            this.messages = [...fetchedMessages, ...newMessages];
+          } else {
+            this.messages = fetchedMessages;
+          }
+        } catch (err) {
+          if (this.viewedSessionId && this.viewedSessionId === sessionId) {
+            this.error = err.message;
+          }
+        } finally {
+          if (showLoading) this.loading = false;
+        }
+      },
+
+      addMessage(message) {
+        if (this.currentSession && message.sessionId && message.sessionId !== this.currentSession.id) return;
+        if (!this.messages.some(m => m.id === message.id)) this.messages.push(message);
+      },
+
+      // ==================== WORK LOG ACTIONS (local state) ====================
+
+      async fetchWorkLogs(sessionId) {
+        if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+        this.error = null;
+        try {
+          const grouped = await api.getSessionWorkLogs(sessionId);
+          if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+
+          const fetchedLogIds = new Set();
+          for (const messageId of Object.keys(grouped)) {
+            for (const log of grouped[messageId] || []) fetchedLogIds.add(log.id);
+          }
+          const existingUnassociated = this.workLogs['_unassociated'] || [];
+          const newUnassociatedLogs = existingUnassociated.filter(log => !fetchedLogIds.has(log.id));
+          const fetchedUnassociated = grouped['_unassociated'] || [];
+          this.workLogs = { ...grouped, '_unassociated': [...fetchedUnassociated, ...newUnassociatedLogs] };
+        } catch (err) {
+          if (this.viewedSessionId && this.viewedSessionId === sessionId) {
+            this.error = err.message;
+          }
+        }
+      },
+
+      addWorkLog(log) {
+        if (this.currentSession && log.sessionId && log.sessionId !== this.currentSession.id) return;
+        const messageId = log.messageId || '_unassociated';
+        const currentLogs = this.workLogs[messageId] || [];
+        if (currentLogs.some(l => l.id === log.id)) return;
+        this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, log] };
+      },
+
+      setWorkLogs(workLogs) { this.workLogs = workLogs; },
+
+      clearWorkLogs() {
+        this.workLogs = {};
+        this.clearAllPartialThinking();
+      },
+
+      associateWorkLogs(messageId) {
+        const unassociated = this.workLogs['_unassociated'] || [];
+        if (unassociated.length > 0) {
+          const currentLogs = this.workLogs[messageId] || [];
+          const currentIds = new Set(currentLogs.map(l => l.id));
+          const newLogs = unassociated.filter(l => !currentIds.has(l.id));
+          this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, ...newLogs], '_unassociated': [] };
+        }
+      },
+
+      // ==================== STREAMING ACTIONS (local state) ====================
+
+      setPartialThinking(thinking, sessionId = null) {
+        const id = sessionId || this.currentSession?.id;
+        if (!id) return;
+        this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: thinking };
+      },
+
+      clearPartialThinking(sessionId = null) {
+        const id = sessionId || this.currentSession?.id;
+        if (!id) return;
+        this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: null };
+      },
+
+      clearAllPartialThinking() { this.partialThinkingBySession = {}; },
+
+      setPartialText(text) {
+        const PARTIAL_THROTTLE_MS = 150;
+        this._pendingPartialText = text;
+        if (!this._partialThrottleTimer) {
+          this.partialText = text;
+          this._partialThrottleTimer = setTimeout(() => {
+            if (this._pendingPartialText !== null && this._pendingPartialText !== this.partialText) {
+              this.partialText = this._pendingPartialText;
+            }
+            this._partialThrottleTimer = null;
+            this._pendingPartialText = null;
+          }, PARTIAL_THROTTLE_MS);
+        }
+      },
+
+      clearPartialText() {
+        this.partialText = '';
+        this._pendingPartialText = null;
+        if (this._partialThrottleTimer) {
+          clearTimeout(this._partialThrottleTimer);
+          this._partialThrottleTimer = null;
+        }
+      },
+
+      // ==================== USAGE ACTIONS (local state) ====================
+
+      updateRunningUsage(usage, conversationId = null) {
+        this.runningUsage = { ...usage, conversationId };
+      },
+
+      finalizeUsage(usage, conversationId = null) {
+        if (conversationId) {
+          const index = this.conversations.findIndex((c) => c.id === conversationId);
+          if (index !== -1) {
+            this.conversations.splice(index, 1, {
+              ...this.conversations[index],
+              inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
+              cacheReadInputTokens: usage.cacheReadInputTokens,
+              cacheCreationInputTokens: usage.cacheCreationInputTokens,
+              webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
+            });
+          }
+        }
+        if (this.currentSession) {
+          this.currentSession = {
+            ...this.currentSession,
+            inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
+            cacheReadInputTokens: usage.cacheReadInputTokens,
+            cacheCreationInputTokens: usage.cacheCreationInputTokens,
+            webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow,
+          };
+        }
+        this.runningUsage = null;
+      },
+
+      updateConversationUsage(conversationId, usage) {
+        const index = this.conversations.findIndex((c) => c.id === conversationId);
+        if (index !== -1) {
+          this.conversations.splice(index, 1, {
+            ...this.conversations[index],
+            inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
+            cacheReadInputTokens: usage.cacheReadInputTokens,
+            cacheCreationInputTokens: usage.cacheCreationInputTokens,
+            webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
+          });
+        }
+      },
+
+      clearRunningUsage() {
+        this.runningUsage = null;
+        this.clearPartialThinking();
+      },
+
+      // ==================== DELEGATED ACTIONS (call through to main store) ====================
+
+      updateSessionStatus(sessionId, status) {
+        // Update local currentSession
+        const session = this.currentSession?.id === sessionId ? this.currentSession : null;
+        const wasRunning = session?.status === 'running';
+        const updates = { status };
+        if (wasRunning && (status === 'waiting' || status === 'completed')) updates.hasResponses = true;
+        if (this.currentSession?.id === sessionId) {
+          this.currentSession = { ...this.currentSession, ...updates };
+        }
+        // Also update main store
+        useSessionsStore().updateSessionStatus(sessionId, status);
+      },
+
+      updateSession(sessionData) {
+        if (!sessionData?.id) return;
+        // Update local currentSession
+        if (this.currentSession?.id === sessionData.id) {
+          this.currentSession = { ...this.currentSession, ...sessionData };
+        }
+        // Also update main store
+        useSessionsStore().updateSession(sessionData);
+      },
+
+      async stopSession(id) {
+        return useSessionsStore().stopSession(id);
+      },
+
+      async restartSession(id) {
+        return useSessionsStore().restartSession(id);
+      },
+
+      async startSession(id, prompt = undefined, model = undefined) {
+        return useSessionsStore().startSession(id, prompt, model);
+      },
+
+      async sendMessage(sessionId, content, files = [], model = null) {
+        return useSessionsStore().sendMessage(sessionId, content, files, model);
+      },
+
+      async updateSessionModel(sessionId, model, providerId = undefined) {
+        const result = await useSessionsStore().updateSessionModel(sessionId, model, providerId);
+        // Sync local currentSession
+        if (this.currentSession?.id === sessionId) {
+          const updateData = { model };
+          if (providerId !== undefined) updateData.providerId = providerId;
+          if (this.currentSession.status === 'waiting') updateData.pendingModel = model;
+          this.currentSession = { ...this.currentSession, ...updateData };
+        }
+        return result;
+      },
+
+      async updateSessionThinking(sessionId, thinkingEnabled) {
+        return this.updateSessionFields(sessionId, { thinkingEnabled });
+      },
+
+      async updateSessionMode(sessionId, mode) {
+        return this.updateSessionFields(sessionId, { mode });
+      },
+
+      async updateSessionFields(sessionId, updates) {
+        const result = await useSessionsStore().updateSessionFields(sessionId, updates);
+        // Sync local currentSession
+        if (this.currentSession?.id === sessionId) {
+          this.currentSession = { ...this.currentSession, ...updates };
+        }
+        return result;
+      },
+
+      async updateNextTemplate(sessionId, nextTemplateId) {
+        return this.updateSessionFields(sessionId, { nextTemplateId });
+      },
+
+      async updateAutoSendPendingPrompt(sessionId, autoSendPendingPrompt) {
+        return this.updateSessionFields(sessionId, { autoSendPendingPrompt });
+      },
+
+      // ==================== COMMAND RUN (delegate to main store) ====================
+
+      updateSessionCommandRun(sessionId, buttonId, runData) {
+        useSessionsStore().updateSessionCommandRun(sessionId, buttonId, runData);
+        this.commandRunVersion++;
+      },
+
+      removeSessionCommandRun(sessionId, buttonId) {
+        useSessionsStore().removeSessionCommandRun(sessionId, buttonId);
+        this.commandRunVersion++;
+      },
+
+      updateSessionCommandRuns(sessionId, runs) {
+        useSessionsStore().updateSessionCommandRuns(sessionId, runs);
+        this.commandRunVersion++;
+      },
+
+      // ==================== CONVERSATION ACTIONS (spread from shared module) ====================
+      ...conversationActions,
+    },
+  })();
+}

--- a/packages/web/src/stores/createOverlaySessionsStore.test.js
+++ b/packages/web/src/stores/createOverlaySessionsStore.test.js
@@ -1,0 +1,646 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, getActivePinia } from 'pinia';
+import { createOverlaySessionsStore } from './createOverlaySessionsStore.js';
+import { useSessionsStore } from './sessions.js';
+
+// Mock the API module
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getSession: vi.fn(),
+    getSessionMessages: vi.fn(),
+    getConversationMessages: vi.fn(),
+    getSessionWorkLogs: vi.fn(),
+    stopSession: vi.fn(),
+    restartSession: vi.fn(),
+    startSession: vi.fn(),
+    sendMessage: vi.fn(),
+    updateSession: vi.fn(),
+    getConversations: vi.fn(),
+    createConversation: vi.fn(),
+    updateConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+    branchConversation: vi.fn(),
+    getSessionTodos: vi.fn(),
+    getActiveSessions: vi.fn(),
+    getProjectSessions: vi.fn(),
+    getScheduledSessions: vi.fn(),
+    createSession: vi.fn(),
+    deleteSession: vi.fn(),
+    archiveSession: vi.fn(),
+    unarchiveSession: vi.fn(),
+    toggleSessionStar: vi.fn(),
+    duplicateSession: vi.fn(),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+
+describe('createOverlaySessionsStore', () => {
+  beforeEach(() => {
+    // Create a fresh Pinia instance for each test
+    setActivePinia(createPinia());
+    // Reset all API mocks before each test
+    vi.clearAllMocks();
+  });
+
+  it('factory creates unique stores', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Each store should have a unique ID
+    expect(store1.$id).not.toBe(store2.$id);
+    expect(store1.$id).toMatch(/^overlay-sessions-\d+$/);
+    expect(store2.$id).toMatch(/^overlay-sessions-\d+$/);
+  });
+
+  it('isolated state: messages do not leak between instances', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set messages in store1
+    store1.messages = [{ id: 'msg1', role: 'user', content: 'Hello' }];
+
+    // Verify store2 messages are still empty
+    expect(store2.messages).toEqual([]);
+    expect(store1.messages).toHaveLength(1);
+  });
+
+  it('isolated state: partialText does not leak', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set partial text in store1
+    store1.setPartialText('hello');
+
+    // Verify store2 partialText is still empty
+    expect(store2.partialText).toBe('');
+    expect(store1.partialText).toBe('hello');
+  });
+
+  it('isolated state: currentSession does not leak', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set currentSession in store1
+    store1.currentSession = { id: 'x', name: 'Test Session' };
+
+    // Verify store2 currentSession is still null
+    expect(store2.currentSession).toBeNull();
+    expect(store1.currentSession).toEqual({ id: 'x', name: 'Test Session' });
+  });
+
+  it('proxied getters delegate to main store', () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    const testSession = { id: 'sess-1', name: 'Test Session', status: 'waiting' };
+    mainStore.sessions.push(testSession);
+
+    // Verify sessions getter returns the same array reference
+    expect(overlayStore.sessions).toBe(mainStore.sessions);
+    expect(overlayStore.sessions).toHaveLength(1);
+
+    // Verify getSessionById delegates correctly
+    expect(overlayStore.getSessionById('sess-1')).toEqual(testSession);
+  });
+
+  it('fetchSession populates local currentSession', async () => {
+    const overlayStore = createOverlaySessionsStore();
+    const mainStore = useSessionsStore();
+
+    const mockSession = { id: 'sess-1', name: 'Test', status: 'waiting' };
+    api.getSession.mockResolvedValue(mockSession);
+
+    await overlayStore.fetchSession('sess-1');
+
+    // Verify local currentSession is set
+    expect(overlayStore.currentSession).toEqual(mockSession);
+    expect(overlayStore.currentSession.id).toBe('sess-1');
+
+    // Verify main store sessions contains it
+    expect(mainStore.sessions).toContainEqual(mockSession);
+  });
+
+  it('fetchSession does NOT overwrite main store currentSession', async () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set main store currentSession
+    mainStore.currentSession = { id: 'main-session', name: 'Main' };
+
+    // Mock API for overlay session
+    const overlaySession = { id: 'overlay-session', name: 'Overlay' };
+    api.getSession.mockResolvedValue(overlaySession);
+
+    // Fetch session in overlay
+    await overlayStore.fetchSession('overlay-session');
+
+    // Verify main store currentSession is unchanged
+    expect(mainStore.currentSession.id).toBe('main-session');
+
+    // Verify overlay store currentSession is set
+    expect(overlayStore.currentSession.id).toBe('overlay-session');
+  });
+
+  it('fetchMessages populates local messages only', async () => {
+    const overlayStore = createOverlaySessionsStore();
+    const mainStore = useSessionsStore();
+
+    const mockMessages = [
+      { id: 'msg1', role: 'user', content: 'Hello', sessionId: 'sess-1' },
+    ];
+    api.getSessionMessages.mockResolvedValue(mockMessages);
+
+    await overlayStore.fetchMessages('sess-1');
+
+    // Verify overlay messages are populated
+    expect(overlayStore.messages).toHaveLength(1);
+    expect(overlayStore.messages[0].id).toBe('msg1');
+
+    // Verify main store messages are empty
+    expect(mainStore.messages).toEqual([]);
+  });
+
+  it('delegated actions call main store', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    api.stopSession.mockResolvedValue({ id: 'sess-1', status: 'completed' });
+
+    await overlayStore.stopSession('sess-1');
+
+    // Verify API was called
+    expect(api.stopSession).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('updateSessionStatus updates both local and main', () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set up session in both stores
+    const session = { id: 'x', status: 'running', name: 'Test' };
+    overlayStore.currentSession = { ...session };
+    mainStore.sessions.push({ ...session });
+
+    // Update status
+    overlayStore.updateSessionStatus('x', 'completed');
+
+    // Verify overlay currentSession updated
+    expect(overlayStore.currentSession.status).toBe('completed');
+    expect(overlayStore.currentSession.hasResponses).toBe(true);
+
+    // Verify main store sessions updated
+    expect(mainStore.sessions[0].status).toBe('completed');
+    expect(mainStore.sessions[0].hasResponses).toBe(true);
+  });
+
+  it('updateSession updates both local and main', async () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set up session in both stores
+    const session = { id: 'x', name: 'old', status: 'waiting' };
+    overlayStore.currentSession = { ...session };
+    mainStore.sessions.push({ ...session });
+
+    // Mock API
+    api.updateSession.mockResolvedValue({ id: 'x', name: 'new' });
+
+    // Update session
+    await overlayStore.updateSession({ id: 'x', name: 'new' });
+
+    // Verify overlay currentSession updated
+    expect(overlayStore.currentSession.name).toBe('new');
+
+    // Verify main store sessions updated
+    expect(mainStore.sessions[0].name).toBe('new');
+  });
+
+  it('streaming: setPartialThinking / clearPartialThinking', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set up currentSession
+    overlayStore.currentSession = { id: 'sess-1', name: 'Test' };
+
+    // Set partial thinking
+    overlayStore.setPartialThinking('thinking text');
+
+    // Verify partial thinking is set for the session
+    expect(overlayStore.partialThinkingBySession['sess-1']).toBe('thinking text');
+
+    // Clear partial thinking
+    overlayStore.clearPartialThinking();
+
+    // Verify partial thinking is cleared
+    expect(overlayStore.partialThinkingBySession['sess-1']).toBeNull();
+  });
+
+  it('usage: finalizeUsage updates currentSession and conversations', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set up state
+    overlayStore.currentSession = { id: 's1', name: 'Test' };
+    overlayStore.conversations = [
+      { id: 'c1', name: 'Conv 1', inputTokens: 0, outputTokens: 0 },
+    ];
+
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadInputTokens: 10,
+      cacheCreationInputTokens: 5,
+      webSearchRequests: 0,
+      contextWindow: 200000,
+      model: 'claude',
+    };
+
+    // Finalize usage
+    overlayStore.finalizeUsage(usage, 'c1');
+
+    // Verify currentSession updated
+    expect(overlayStore.currentSession.inputTokens).toBe(100);
+    expect(overlayStore.currentSession.outputTokens).toBe(50);
+    expect(overlayStore.currentSession.cacheReadInputTokens).toBe(10);
+    expect(overlayStore.currentSession.cacheCreationInputTokens).toBe(5);
+
+    // Verify conversation updated
+    expect(overlayStore.conversations[0].inputTokens).toBe(100);
+    expect(overlayStore.conversations[0].outputTokens).toBe(50);
+
+    // Verify runningUsage cleared
+    expect(overlayStore.runningUsage).toBeNull();
+  });
+
+  it('conversationActions operate on local state', async () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    const mockConversations = [
+      { id: 'conv-1', name: 'Main', isActive: true, inputTokens: 0 },
+    ];
+    api.getConversations.mockResolvedValue(mockConversations);
+
+    await overlayStore.fetchConversations('sess-1');
+
+    // Verify overlay conversations are populated
+    expect(overlayStore.conversations).toHaveLength(1);
+    expect(overlayStore.conversations[0].id).toBe('conv-1');
+    expect(overlayStore.activeConversationId).toBe('conv-1');
+
+    // Verify main store conversations are still empty
+    expect(mainStore.conversations).toEqual([]);
+  });
+
+  it('$cleanup disposes and removes from Pinia registry', () => {
+    const overlayStore = createOverlaySessionsStore();
+    const storeId = overlayStore.$id;
+
+    // Verify store is in Pinia registry
+    const pinia = getActivePinia();
+    expect(pinia.state.value[storeId]).toBeDefined();
+
+    // Cleanup
+    overlayStore.$cleanup();
+
+    // Verify store is removed from registry
+    expect(pinia.state.value[storeId]).toBeUndefined();
+  });
+
+  it('fetchSession guards against navigation during fetch', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set viewedSessionId to guard against navigation
+    overlayStore.viewedSessionId = 'sess-1';
+
+    const mockSession = { id: 'sess-1', name: 'Test' };
+    api.getSession.mockResolvedValue(mockSession);
+
+    // Start fetch
+    const fetchPromise = overlayStore.fetchSession('sess-1');
+
+    // Simulate navigation to different session before API returns
+    overlayStore.viewedSessionId = 'sess-2';
+
+    await fetchPromise;
+
+    // Verify currentSession was NOT set (navigation guard prevented it)
+    expect(overlayStore.currentSession).toBeNull();
+  });
+
+  it('fetchMessages guards against navigation during fetch', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set viewedSessionId to guard against navigation
+    overlayStore.viewedSessionId = 'sess-1';
+
+    const mockMessages = [{ id: 'msg1', role: 'user', content: 'Hello' }];
+    api.getSessionMessages.mockResolvedValue(mockMessages);
+
+    // Start fetch
+    const fetchPromise = overlayStore.fetchMessages('sess-1');
+
+    // Simulate navigation to different session before API returns
+    overlayStore.viewedSessionId = 'sess-2';
+
+    await fetchPromise;
+
+    // Verify messages were NOT set (navigation guard prevented it)
+    expect(overlayStore.messages).toEqual([]);
+  });
+
+  it('isolated state: conversations do not leak', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set conversations in store1
+    store1.conversations = [{ id: 'conv1', name: 'Test Conversation' }];
+
+    // Verify store2 conversations are still empty
+    expect(store2.conversations).toEqual([]);
+    expect(store1.conversations).toHaveLength(1);
+  });
+
+  it('isolated state: workLogs do not leak', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set workLogs in store1
+    store1.workLogs = {
+      'msg1': [{ id: 'log1', output: 'Test output' }],
+    };
+
+    // Verify store2 workLogs are still empty
+    expect(store2.workLogs).toEqual({});
+    expect(store1.workLogs['msg1']).toHaveLength(1);
+  });
+
+  it('isolated state: activeConversationId does not leak', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set activeConversationId in store1
+    store1.activeConversationId = 'conv-1';
+
+    // Verify store2 activeConversationId is still null
+    expect(store2.activeConversationId).toBeNull();
+    expect(store1.activeConversationId).toBe('conv-1');
+  });
+
+  it('isolated state: loading/error do not leak', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+
+    // Set loading/error in store1
+    store1.loading = true;
+    store1.error = 'Test error';
+
+    // Verify store2 loading/error are still at defaults
+    expect(store2.loading).toBe(false);
+    expect(store2.error).toBeNull();
+    expect(store1.loading).toBe(true);
+    expect(store1.error).toBe('Test error');
+  });
+
+  it('delegated action: restartSession calls through to main store', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    api.restartSession.mockResolvedValue({ id: 'sess-1', status: 'running' });
+
+    await overlayStore.restartSession('sess-1');
+
+    expect(api.restartSession).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('delegated action: startSession calls through to main store', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    api.startSession.mockResolvedValue({ id: 'sess-1', status: 'running' });
+
+    await overlayStore.startSession('sess-1', 'Test prompt', 'claude-sonnet-4');
+
+    expect(api.startSession).toHaveBeenCalledWith('sess-1', 'Test prompt', 'claude-sonnet-4');
+  });
+
+  it('delegated action: sendMessage calls through to main store', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    api.sendMessage.mockResolvedValue({ id: 'msg1', content: 'Response' });
+
+    await overlayStore.sendMessage('sess-1', 'Hello', [], 'claude-sonnet-4');
+
+    expect(api.sendMessage).toHaveBeenCalledWith('sess-1', 'Hello', [], 'claude-sonnet-4');
+  });
+
+  it('updateSessionStatus sets hasResponses when transitioning from running to waiting', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set up running session
+    overlayStore.currentSession = { id: 'x', status: 'running' };
+
+    // Update to waiting
+    overlayStore.updateSessionStatus('x', 'waiting');
+
+    // Verify hasResponses is set
+    expect(overlayStore.currentSession.hasResponses).toBe(true);
+  });
+
+  it('updateSessionStatus sets hasResponses when transitioning from running to completed', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set up running session
+    overlayStore.currentSession = { id: 'x', status: 'running' };
+
+    // Update to completed
+    overlayStore.updateSessionStatus('x', 'completed');
+
+    // Verify hasResponses is set
+    expect(overlayStore.currentSession.hasResponses).toBe(true);
+  });
+
+  it('addMessage only adds messages matching currentSession', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set current session
+    overlayStore.currentSession = { id: 'sess-1', name: 'Test' };
+
+    // Add matching message
+    overlayStore.addMessage({ id: 'msg1', sessionId: 'sess-1', content: 'Hello' });
+    expect(overlayStore.messages).toHaveLength(1);
+
+    // Try to add non-matching message
+    overlayStore.addMessage({ id: 'msg2', sessionId: 'sess-2', content: 'World' });
+    expect(overlayStore.messages).toHaveLength(1);
+  });
+
+  it('addMessage prevents duplicates', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    overlayStore.currentSession = { id: 'sess-1', name: 'Test' };
+
+    const message = { id: 'msg1', sessionId: 'sess-1', content: 'Hello' };
+
+    // Add message twice
+    overlayStore.addMessage(message);
+    overlayStore.addMessage(message);
+
+    // Should only appear once
+    expect(overlayStore.messages).toHaveLength(1);
+  });
+
+  it('clearPartialText clears text and throttle timer', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    // Set partial text
+    overlayStore.setPartialText('test');
+    expect(overlayStore.partialText).toBe('test');
+
+    // Clear
+    overlayStore.clearPartialText();
+
+    expect(overlayStore.partialText).toBe('');
+    expect(overlayStore._pendingPartialText).toBeNull();
+    expect(overlayStore._partialThrottleTimer).toBeNull();
+  });
+
+  it('updateRunningUsage sets runningUsage with conversationId', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    const usage = {
+      inputTokens: 50,
+      outputTokens: 25,
+      cacheReadInputTokens: 5,
+    };
+
+    overlayStore.updateRunningUsage(usage, 'conv-1');
+
+    expect(overlayStore.runningUsage).toEqual({
+      ...usage,
+      conversationId: 'conv-1',
+    });
+  });
+
+  it('clearRunningUsage clears usage and partial thinking', () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    overlayStore.currentSession = { id: 'sess-1' };
+    overlayStore.runningUsage = { inputTokens: 100 };
+    overlayStore.setPartialThinking('thinking...');
+
+    overlayStore.clearRunningUsage();
+
+    expect(overlayStore.runningUsage).toBeNull();
+    expect(overlayStore.partialThinkingBySession['sess-1']).toBeNull();
+  });
+
+  it('fetchSession updates existing session in main store', async () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    // Pre-populate main store with a session
+    mainStore.sessions.push({ id: 'sess-1', name: 'Old Name', status: 'waiting' });
+
+    // Mock updated session
+    const updatedSession = { id: 'sess-1', name: 'New Name', status: 'running' };
+    api.getSession.mockResolvedValue(updatedSession);
+
+    await overlayStore.fetchSession('sess-1');
+
+    // Verify session was updated (not duplicated) in main store
+    expect(mainStore.sessions).toHaveLength(1);
+    expect(mainStore.sessions[0].name).toBe('New Name');
+    expect(mainStore.sessions[0].status).toBe('running');
+  });
+
+  it('proxied getter: archivedSessions delegates to main store', () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    mainStore.archivedSessions.push({ id: 'arch-1', archived: true });
+
+    expect(overlayStore.archivedSessions).toBe(mainStore.archivedSessions);
+    expect(overlayStore.archivedSessions).toHaveLength(1);
+  });
+
+  it('proxied getter: activeSessions delegates to main store', () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    mainStore.sessions.push({ id: 'sess-1', status: 'running', archived: false });
+
+    expect(overlayStore.activeSessions).toBe(mainStore.activeSessions);
+  });
+
+  it('proxied getter: hasChildren delegates to main store', () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    mainStore.sessions.push(
+      { id: 'parent-1', name: 'Parent' },
+      { id: 'child-1', name: 'Child', parentSessionId: 'parent-1' }
+    );
+
+    expect(overlayStore.hasChildren('parent-1')).toBe(mainStore.hasChildren('parent-1'));
+  });
+
+  it('proxied getter: getChildCount delegates to main store', () => {
+    const mainStore = useSessionsStore();
+    const overlayStore = createOverlaySessionsStore();
+
+    mainStore.sessions.push(
+      { id: 'parent-1', name: 'Parent' },
+      { id: 'child-1', name: 'Child 1', parentSessionId: 'parent-1' },
+      { id: 'child-2', name: 'Child 2', parentSessionId: 'parent-1' }
+    );
+
+    expect(overlayStore.getChildCount('parent-1')).toBe(2);
+    expect(overlayStore.getChildCount('parent-1')).toBe(mainStore.getChildCount('parent-1'));
+  });
+
+  it('fetchSession handles API errors gracefully', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    api.getSession.mockRejectedValue(new Error('Network error'));
+
+    await overlayStore.fetchSession('sess-1');
+
+    expect(overlayStore.error).toBe('Network error');
+    expect(overlayStore.currentSession).toBeNull();
+    expect(overlayStore.loading).toBe(false);
+  });
+
+  it('fetchMessages handles API errors gracefully', async () => {
+    const overlayStore = createOverlaySessionsStore();
+
+    overlayStore.viewedSessionId = 'sess-1';
+    api.getSessionMessages.mockRejectedValue(new Error('Network error'));
+
+    await overlayStore.fetchMessages('sess-1');
+
+    expect(overlayStore.error).toBe('Network error');
+    expect(overlayStore.messages).toEqual([]);
+    expect(overlayStore.loading).toBe(false);
+  });
+
+  it('multiple overlay stores can coexist with independent state', () => {
+    const store1 = createOverlaySessionsStore();
+    const store2 = createOverlaySessionsStore();
+    const store3 = createOverlaySessionsStore();
+
+    // Set different state in each
+    store1.currentSession = { id: 's1', name: 'Store 1' };
+    store2.currentSession = { id: 's2', name: 'Store 2' };
+    store3.currentSession = { id: 's3', name: 'Store 3' };
+
+    store1.messages = [{ id: 'm1', content: 'Message 1' }];
+    store2.messages = [{ id: 'm2', content: 'Message 2' }];
+    store3.messages = [{ id: 'm3', content: 'Message 3' }];
+
+    // Verify each store has independent state
+    expect(store1.currentSession.id).toBe('s1');
+    expect(store2.currentSession.id).toBe('s2');
+    expect(store3.currentSession.id).toBe('s3');
+
+    expect(store1.messages[0].id).toBe('m1');
+    expect(store2.messages[0].id).toBe('m2');
+    expect(store3.messages[0].id).toBe('m3');
+  });
+});

--- a/packages/web/src/stores/createOverlayTodosStore.js
+++ b/packages/web/src/stores/createOverlayTodosStore.js
@@ -1,0 +1,70 @@
+import { defineStore } from 'pinia';
+import { api } from '../composables/useApi.js';
+
+/**
+ * Counter for generating unique store IDs across multiple overlay instances.
+ */
+let overlayTodosCounter = 0;
+
+/**
+ * Factory that creates an isolated Pinia todos store for the overlay.
+ * Mirrors the main todos store exactly but with an independent instance
+ * so that overlay todo state does not contaminate the main view.
+ */
+export function createOverlayTodosStore() {
+  const storeId = `overlay-todos-${++overlayTodosCounter}`;
+
+  return defineStore(storeId, {
+    state: () => ({
+      items: [],
+      loading: false,
+      error: null,
+      expanded: false,
+      currentConversationId: null,
+    }),
+
+    getters: {
+      hasTodos: (state) => state.items.length > 0,
+      pendingCount: (state) => state.items.filter((t) => t.status === 'pending').length,
+      inProgressCount: (state) => state.items.filter((t) => t.status === 'in_progress').length,
+      completedCount: (state) => state.items.filter((t) => t.status === 'completed').length,
+    },
+
+    actions: {
+      async fetchTodos(sessionId, conversationId = null) {
+        this.loading = true;
+        this.error = null;
+        this.currentConversationId = conversationId;
+        try {
+          this.items = await api.getSessionTodos(sessionId, conversationId);
+        } catch (err) {
+          this.error = err.message;
+        } finally {
+          this.loading = false;
+        }
+      },
+
+      updateTodos(todos, conversationId = null) {
+        if (conversationId === null || this.currentConversationId === null || conversationId === this.currentConversationId) {
+          this.items = todos;
+        }
+      },
+
+      clearTodos() {
+        this.items = [];
+        this.loading = false;
+        this.error = null;
+        this.currentConversationId = null;
+        this.expanded = false;
+      },
+
+      toggleExpanded() {
+        this.expanded = !this.expanded;
+      },
+
+      setExpanded(value) {
+        this.expanded = value;
+      },
+    },
+  })();
+}

--- a/packages/web/src/stores/createOverlayTodosStore.js
+++ b/packages/web/src/stores/createOverlayTodosStore.js
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia';
+import { defineStore, getActivePinia } from 'pinia';
 import { api } from '../composables/useApi.js';
 
 /**
@@ -14,7 +14,7 @@ let overlayTodosCounter = 0;
 export function createOverlayTodosStore() {
   const storeId = `overlay-todos-${++overlayTodosCounter}`;
 
-  return defineStore(storeId, {
+  const store = defineStore(storeId, {
     state: () => ({
       items: [],
       loading: false,
@@ -67,4 +67,16 @@ export function createOverlayTodosStore() {
       },
     },
   })();
+
+  // Attach $cleanup() to properly dispose and remove from Pinia registry.
+  // $dispose() alone only removes subscriptions — it does NOT remove the
+  // store's state entry from pinia.state.value, leaking memory on every
+  // overlay open/close cycle.
+  store.$cleanup = () => {
+    store.$dispose();
+    const pinia = getActivePinia();
+    if (pinia) delete pinia.state.value[storeId];
+  };
+
+  return store;
 }

--- a/packages/web/src/stores/createOverlayTodosStore.test.js
+++ b/packages/web/src/stores/createOverlayTodosStore.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, getActivePinia } from 'pinia';
+
+vi.mock('../composables/useApi.js', () => ({
+  api: {
+    getSessionTodos: vi.fn(),
+  },
+}));
+
+import { api } from '../composables/useApi.js';
+import { createOverlayTodosStore } from './createOverlayTodosStore.js';
+
+describe('createOverlayTodosStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('factory creates unique stores', () => {
+    const store1 = createOverlayTodosStore();
+    const store2 = createOverlayTodosStore();
+
+    expect(store1.$id).not.toBe(store2.$id);
+    expect(store1.$id).toMatch(/^overlay-todos-\d+$/);
+    expect(store2.$id).toMatch(/^overlay-todos-\d+$/);
+  });
+
+  it('isolated state: items don\'t leak', () => {
+    const store1 = createOverlayTodosStore();
+    const store2 = createOverlayTodosStore();
+
+    store1.items = [{ id: 'todo1', status: 'pending' }];
+
+    expect(store1.items).toHaveLength(1);
+    expect(store2.items).toHaveLength(0);
+    expect(store2.items).toEqual([]);
+  });
+
+  it('fetchTodos populates items', async () => {
+    const mockTodos = [{ id: 't1', status: 'pending' }];
+    api.getSessionTodos.mockResolvedValue(mockTodos);
+
+    const store = createOverlayTodosStore();
+    await store.fetchTodos('session-1');
+
+    expect(store.items).toHaveLength(1);
+    expect(store.items[0].id).toBe('t1');
+    expect(store.loading).toBe(false);
+    expect(store.error).toBe(null);
+    expect(api.getSessionTodos).toHaveBeenCalledWith('session-1', null);
+  });
+
+  it('fetchTodos sets error on failure', async () => {
+    api.getSessionTodos.mockRejectedValue(new Error('fail'));
+
+    const store = createOverlayTodosStore();
+    await store.fetchTodos('session-1');
+
+    expect(store.error).toBe('fail');
+    expect(store.items).toEqual([]);
+    expect(store.loading).toBe(false);
+  });
+
+  it('updateTodos filters by conversationId', () => {
+    const store = createOverlayTodosStore();
+    store.currentConversationId = 'conv-1';
+
+    // Update with different conversationId should be ignored
+    store.updateTodos([{ id: 't1' }], 'conv-2');
+    expect(store.items).toEqual([]);
+
+    // Update with matching conversationId should work
+    store.updateTodos([{ id: 't2' }], 'conv-1');
+    expect(store.items).toHaveLength(1);
+    expect(store.items[0].id).toBe('t2');
+  });
+
+  it('clearTodos resets all state', () => {
+    const store = createOverlayTodosStore();
+
+    // Set up some state
+    store.items = [{ id: 't1', status: 'pending' }];
+    store.expanded = true;
+    store.currentConversationId = 'conv-1';
+    store.error = 'some error';
+    store.loading = true;
+
+    // Clear all state
+    store.clearTodos();
+
+    expect(store.items).toEqual([]);
+    expect(store.expanded).toBe(false);
+    expect(store.currentConversationId).toBe(null);
+    expect(store.error).toBe(null);
+    expect(store.loading).toBe(false);
+  });
+
+  it('getters work correctly', () => {
+    const store = createOverlayTodosStore();
+
+    // Initially no todos
+    expect(store.hasTodos).toBe(false);
+    expect(store.pendingCount).toBe(0);
+    expect(store.inProgressCount).toBe(0);
+    expect(store.completedCount).toBe(0);
+
+    // Add mixed status todos
+    store.items = [
+      { id: 't1', status: 'pending' },
+      { id: 't2', status: 'pending' },
+      { id: 't3', status: 'in_progress' },
+      { id: 't4', status: 'completed' },
+      { id: 't5', status: 'completed' },
+      { id: 't6', status: 'completed' },
+    ];
+
+    expect(store.hasTodos).toBe(true);
+    expect(store.pendingCount).toBe(2);
+    expect(store.inProgressCount).toBe(1);
+    expect(store.completedCount).toBe(3);
+  });
+
+  it('toggleExpanded flips value', () => {
+    const store = createOverlayTodosStore();
+
+    expect(store.expanded).toBe(false);
+
+    store.toggleExpanded();
+    expect(store.expanded).toBe(true);
+
+    store.toggleExpanded();
+    expect(store.expanded).toBe(false);
+  });
+
+  it('setExpanded sets value', () => {
+    const store = createOverlayTodosStore();
+
+    expect(store.expanded).toBe(false);
+
+    store.setExpanded(true);
+    expect(store.expanded).toBe(true);
+
+    store.setExpanded(false);
+    expect(store.expanded).toBe(false);
+
+    store.setExpanded(true);
+    expect(store.expanded).toBe(true);
+  });
+
+  it('$cleanup disposes and removes from Pinia registry', () => {
+    const store = createOverlayTodosStore();
+    const storeId = store.$id;
+    const pinia = getActivePinia();
+
+    // Verify store exists in registry
+    expect(pinia.state.value[storeId]).toBeDefined();
+
+    // Cleanup the store
+    store.$cleanup();
+
+    // Verify store is removed from registry
+    expect(pinia.state.value[storeId]).toBeUndefined();
+  });
+});

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -4,6 +4,8 @@ import { useSessionFiltersStore } from './sessionFilters.js';
 import { tokenGetters } from './sessions/tokenGetters.js';
 import { sessionActions } from './sessions/sessionActions.js';
 import { conversationActions } from './sessions/conversationActions.js';
+import { perSessionActions } from './sessions/perSessionActions.js';
+import { perSessionGetters } from './sessions/perSessionGetters.js';
 
 export const useSessionsStore = defineStore('sessions', {
   state: () => ({
@@ -217,55 +219,8 @@ export const useSessionsStore = defineStore('sessions', {
       return grouped;
     },
 
-    isDraftSession: (state) => (session) => {
-      if (!session || session.status !== 'waiting') return false;
-      if (session.hasResponses !== undefined) return !session.hasResponses;
-      return !state.messages.some((msg) => msg.role === 'assistant');
-    },
-
-    isScheduledDraft: (state) => (session) => {
-      if (!session || session.status !== 'scheduled') return false;
-      if (session.hasResponses !== undefined) return !session.hasResponses;
-      return !state.messages.some((msg) => msg.role === 'assistant');
-    },
-
-    // ==================== DELEGATED CONVERSATION GETTERS ====================
-
-    getWorkLogsForMessage: (state) => (messageId) => {
-      return state.workLogs[messageId] || [];
-    },
-    getUnassociatedWorkLogs: (state) => {
-      return state.workLogs['_unassociated'] || [];
-    },
-    partialThinking: (state) => {
-      if (!state.currentSession?.id) return null;
-      return state.partialThinkingBySession[state.currentSession.id] || null;
-    },
-    activeConversation: (state) => {
-      return state.conversations.find((c) => c.id === state.activeConversationId) || null;
-    },
-    getConversationById: (state) => (id) => {
-      return state.conversations.find((c) => c.id === id);
-    },
-    rootConversations: (state) => {
-      return state.conversations.filter((c) => !c.parentConversationId);
-    },
-    conversationTree: (state) => {
-      const buildTree = (parentId = null) => {
-        return state.conversations
-          .filter((c) => c.parentConversationId === parentId)
-          .map((conv) => ({ ...conv, children: buildTree(conv.id) }));
-      };
-      return buildTree(null);
-    },
-    getConversationChildren: (state) => (conversationId) => {
-      return state.conversations.filter((c) => c.parentConversationId === conversationId);
-    },
-    getConversationParent: (state) => (conversationId) => {
-      const conv = state.conversations.find((c) => c.id === conversationId);
-      if (!conv?.parentConversationId) return null;
-      return state.conversations.find((c) => c.id === conv.parentConversationId);
-    },
+    // ==================== PER-SESSION GETTERS (shared with overlay store) ====================
+    ...perSessionGetters,
 
     // ==================== TOKEN USAGE GETTERS ====================
     ...tokenGetters,
@@ -371,190 +326,8 @@ export const useSessionsStore = defineStore('sessions', {
       this.commandRunVersion++;
     },
 
-    // ==================== MESSAGE ACTIONS ====================
-
-    async fetchMessages(sessionId, showLoading = true, conversationId = null) {
-      // Early guard: skip the API call if the user has navigated away from this session
-      if (this.viewedSessionId && this.viewedSessionId !== sessionId) {
-        console.log(`[STORE] fetchMessages: skipping for ${sessionId} (viewed: ${this.viewedSessionId})`);
-        return;
-      }
-
-      if (showLoading) this.loading = true;
-      this.error = null;
-      try {
-        const cid = conversationId || this.activeConversationId;
-        const fetchedMessages = cid
-          ? await api.getConversationMessages(sessionId, cid)
-          : await api.getSessionMessages(sessionId);
-
-        // Post-fetch guard: don't overwrite if the user navigated away while awaiting
-        if (this.viewedSessionId && this.viewedSessionId !== sessionId) {
-          console.log(`[STORE] fetchMessages: discarding stale results for ${sessionId} (viewed: ${this.viewedSessionId})`);
-          return;
-        }
-
-        console.log(`[STORE] fetchMessages: session ${sessionId}, conversationId: ${cid || 'none'}, received ${fetchedMessages.length} messages, activeConversationId: ${this.activeConversationId}`);
-        const fetchedIds = new Set(fetchedMessages.map(m => m.id));
-        const newMessages = this.messages.filter(m => m.sessionId === sessionId && !fetchedIds.has(m.id));
-        if (newMessages.length > 0) {
-          console.log(`[STORE] fetchMessages: merging ${fetchedMessages.length} fetched + ${newMessages.length} WebSocket-delivered messages`);
-          this.messages = [...fetchedMessages, ...newMessages];
-        } else {
-          this.messages = fetchedMessages;
-        }
-        console.log(`[STORE] fetchMessages: updated store with ${this.messages.length} messages`);
-      } catch (err) {
-        if (this.viewedSessionId && this.viewedSessionId === sessionId) {
-          this.error = err.message;
-        }
-        console.error(`[STORE] fetchMessages: error fetching messages for session ${sessionId}:`, err.message);
-      } finally { if (showLoading) this.loading = false; }
-    },
-
-    addMessage(message) {
-      if (this.currentSession && message.sessionId && message.sessionId !== this.currentSession.id) return;
-      if (!this.messages.some(m => m.id === message.id)) this.messages.push(message);
-    },
-
-    // ==================== WORK LOG ACTIONS ====================
-
-    async fetchWorkLogs(sessionId) {
-      // Pre-fetch guard: skip if user navigated away
-      if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
-
-      this.error = null;
-      try {
-        const grouped = await api.getSessionWorkLogs(sessionId);
-
-        // Post-fetch guard: discard if user navigated away during await
-        if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
-
-        const fetchedLogIds = new Set();
-        for (const messageId of Object.keys(grouped)) {
-          for (const log of grouped[messageId] || []) fetchedLogIds.add(log.id);
-        }
-        const existingUnassociated = this.workLogs['_unassociated'] || [];
-        const newUnassociatedLogs = existingUnassociated.filter(log => !fetchedLogIds.has(log.id));
-        const fetchedUnassociated = grouped['_unassociated'] || [];
-        this.workLogs = { ...grouped, '_unassociated': [...fetchedUnassociated, ...newUnassociatedLogs] };
-      } catch (err) {
-        if (this.viewedSessionId && this.viewedSessionId === sessionId) {
-          this.error = err.message;
-        }
-      }
-    },
-
-    addWorkLog(log) {
-      if (this.currentSession && log.sessionId && log.sessionId !== this.currentSession.id) return;
-      const messageId = log.messageId || '_unassociated';
-      const currentLogs = this.workLogs[messageId] || [];
-      if (currentLogs.some(l => l.id === log.id)) return;
-      this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, log] };
-    },
-
-    setWorkLogs(workLogs) { this.workLogs = workLogs; },
-
-    clearWorkLogs() {
-      this.workLogs = {};
-      this.clearAllPartialThinking();
-    },
-
-    associateWorkLogs(messageId) {
-      const unassociated = this.workLogs['_unassociated'] || [];
-      if (unassociated.length > 0) {
-        const currentLogs = this.workLogs[messageId] || [];
-        const currentIds = new Set(currentLogs.map(l => l.id));
-        const newLogs = unassociated.filter(l => !currentIds.has(l.id));
-        this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, ...newLogs], '_unassociated': [] };
-      }
-    },
-
-    // ==================== STREAMING ACTIONS ====================
-
-    setPartialThinking(thinking, sessionId = null) {
-      const id = sessionId || this.currentSession?.id;
-      if (!id) return;
-      this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: thinking };
-    },
-
-    clearPartialThinking(sessionId = null) {
-      const id = sessionId || this.currentSession?.id;
-      if (!id) return;
-      this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: null };
-    },
-
-    clearAllPartialThinking() { this.partialThinkingBySession = {}; },
-
-    setPartialText(text) {
-      const PARTIAL_THROTTLE_MS = 150;
-      this._pendingPartialText = text;
-      if (!this._partialThrottleTimer) {
-        this.partialText = text;
-        this._partialThrottleTimer = setTimeout(() => {
-          if (this._pendingPartialText !== null && this._pendingPartialText !== this.partialText) {
-            this.partialText = this._pendingPartialText;
-          }
-          this._partialThrottleTimer = null;
-          this._pendingPartialText = null;
-        }, PARTIAL_THROTTLE_MS);
-      }
-    },
-
-    clearPartialText() {
-      this.partialText = '';
-      this._pendingPartialText = null;
-      if (this._partialThrottleTimer) { clearTimeout(this._partialThrottleTimer); this._partialThrottleTimer = null; }
-    },
-
-    // ==================== USAGE ACTIONS ====================
-
-    updateRunningUsage(usage, conversationId = null) {
-      this.runningUsage = { ...usage, conversationId };
-    },
-
-    finalizeUsage(usage, conversationId = null) {
-      if (conversationId) {
-        const index = this.conversations.findIndex((c) => c.id === conversationId);
-        if (index !== -1) {
-          this.conversations.splice(index, 1, {
-            ...this.conversations[index],
-            inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
-            cacheReadInputTokens: usage.cacheReadInputTokens,
-            cacheCreationInputTokens: usage.cacheCreationInputTokens,
-            webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
-          });
-        }
-      }
-      if (this.currentSession) {
-        this.currentSession = {
-          ...this.currentSession,
-          inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
-          cacheReadInputTokens: usage.cacheReadInputTokens,
-          cacheCreationInputTokens: usage.cacheCreationInputTokens,
-          webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow,
-        };
-      }
-      this.runningUsage = null;
-    },
-
-    updateConversationUsage(conversationId, usage) {
-      const index = this.conversations.findIndex((c) => c.id === conversationId);
-      if (index !== -1) {
-        this.conversations.splice(index, 1, {
-          ...this.conversations[index],
-          inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
-          cacheReadInputTokens: usage.cacheReadInputTokens,
-          cacheCreationInputTokens: usage.cacheCreationInputTokens,
-          webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
-        });
-      }
-    },
-
-    clearRunningUsage() {
-      this.runningUsage = null;
-      this.clearPartialThinking();
-    },
+    // ==================== PER-SESSION ACTIONS (shared with overlay store) ====================
+    ...perSessionActions,
 
     // ==================== CONVERSATION ACTIONS ====================
     ...conversationActions,

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -3933,7 +3933,7 @@ describe('Sessions Store', () => {
       expect(store.loading).toBe(false);
     });
 
-    it('logs fetch details including message count and activeConversationId', async () => {
+    it('fetches messages using getConversationMessages when activeConversationId is set', async () => {
       const store = useSessionsStore();
       store.activeConversationId = 'conv-123';
 
@@ -3943,25 +3943,11 @@ describe('Sessions Store', () => {
 
       api.getConversationMessages.mockResolvedValue(mockMessages);
 
-      const consoleLogSpy = vi.spyOn(console, 'log');
-
       await store.fetchMessages('session-456', false);
 
       // Should use getConversationMessages since activeConversationId is set
       expect(api.getConversationMessages).toHaveBeenCalledWith('session-456', 'conv-123');
-
-      // Verify logging includes session ID, message count, and conversation ID
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[STORE] fetchMessages: session session-456')
-      );
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('received 1 messages')
-      );
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('activeConversationId: conv-123')
-      );
-
-      consoleLogSpy.mockRestore();
+      expect(store.messages).toEqual(mockMessages);
     });
 
     it('uses getConversationMessages when conversationId parameter is provided', async () => {
@@ -4049,22 +4035,17 @@ describe('Sessions Store', () => {
       expect(store.messages).toHaveLength(2);
     });
 
-    it('logs error when fetch fails', async () => {
+    it('sets error state when fetch fails', async () => {
       const store = useSessionsStore();
       const errorMessage = 'Network error';
+      // viewedSessionId must match the fetched session for the error guard to set store.error
+      store.viewedSessionId = 'session-789';
 
       api.getSessionMessages.mockRejectedValue(new Error(errorMessage));
 
-      const consoleErrorSpy = vi.spyOn(console, 'error');
-
       await store.fetchMessages('session-789', false);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[STORE] fetchMessages: error fetching messages for session session-789'),
-        errorMessage
-      );
-
-      consoleErrorSpy.mockRestore();
+      expect(store.error).toBe(errorMessage);
     });
 
     it('does not set error when viewedSessionId changes during a failed fetch', async () => {

--- a/packages/web/src/stores/sessions/perSessionActions.js
+++ b/packages/web/src/stores/sessions/perSessionActions.js
@@ -1,0 +1,186 @@
+import { api } from '../../composables/useApi.js';
+
+/**
+ * Per-session actions shared between the main sessions store and overlay stores.
+ * These operate on the store's own local state (messages, workLogs, partialText, etc.)
+ * and are spread directly into the Pinia store actions, so `this` refers to the store instance.
+ *
+ * NOTE: fetchSession is intentionally NOT included here — the main store and overlay
+ * store have fundamentally different implementations (the main store walks the parent
+ * chain and fetches child sessions from the project).
+ */
+export const perSessionActions = {
+  // ==================== MESSAGE ACTIONS ====================
+
+  async fetchMessages(sessionId, showLoading = true, conversationId = null) {
+    if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+
+    if (showLoading) this.loading = true;
+    this.error = null;
+    try {
+      const cid = conversationId || this.activeConversationId;
+      const fetchedMessages = cid
+        ? await api.getConversationMessages(sessionId, cid)
+        : await api.getSessionMessages(sessionId);
+
+      if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+
+      const fetchedIds = new Set(fetchedMessages.map(m => m.id));
+      const newMessages = this.messages.filter(m => m.sessionId === sessionId && !fetchedIds.has(m.id));
+      if (newMessages.length > 0) {
+        this.messages = [...fetchedMessages, ...newMessages];
+      } else {
+        this.messages = fetchedMessages;
+      }
+    } catch (err) {
+      if (this.viewedSessionId && this.viewedSessionId === sessionId) {
+        this.error = err.message;
+      }
+    } finally {
+      if (showLoading) this.loading = false;
+    }
+  },
+
+  addMessage(message) {
+    if (this.currentSession && message.sessionId && message.sessionId !== this.currentSession.id) return;
+    if (!this.messages.some(m => m.id === message.id)) this.messages.push(message);
+  },
+
+  // ==================== WORK LOG ACTIONS ====================
+
+  async fetchWorkLogs(sessionId) {
+    if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+    this.error = null;
+    try {
+      const grouped = await api.getSessionWorkLogs(sessionId);
+      if (this.viewedSessionId && this.viewedSessionId !== sessionId) return;
+
+      const fetchedLogIds = new Set();
+      for (const messageId of Object.keys(grouped)) {
+        for (const log of grouped[messageId] || []) fetchedLogIds.add(log.id);
+      }
+      const existingUnassociated = this.workLogs['_unassociated'] || [];
+      const newUnassociatedLogs = existingUnassociated.filter(log => !fetchedLogIds.has(log.id));
+      const fetchedUnassociated = grouped['_unassociated'] || [];
+      this.workLogs = { ...grouped, '_unassociated': [...fetchedUnassociated, ...newUnassociatedLogs] };
+    } catch (err) {
+      if (this.viewedSessionId && this.viewedSessionId === sessionId) {
+        this.error = err.message;
+      }
+    }
+  },
+
+  addWorkLog(log) {
+    if (this.currentSession && log.sessionId && log.sessionId !== this.currentSession.id) return;
+    const messageId = log.messageId || '_unassociated';
+    const currentLogs = this.workLogs[messageId] || [];
+    if (currentLogs.some(l => l.id === log.id)) return;
+    this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, log] };
+  },
+
+  setWorkLogs(workLogs) { this.workLogs = workLogs; },
+
+  clearWorkLogs() {
+    this.workLogs = {};
+    this.clearAllPartialThinking();
+  },
+
+  associateWorkLogs(messageId) {
+    const unassociated = this.workLogs['_unassociated'] || [];
+    if (unassociated.length > 0) {
+      const currentLogs = this.workLogs[messageId] || [];
+      const currentIds = new Set(currentLogs.map(l => l.id));
+      const newLogs = unassociated.filter(l => !currentIds.has(l.id));
+      this.workLogs = { ...this.workLogs, [messageId]: [...currentLogs, ...newLogs], '_unassociated': [] };
+    }
+  },
+
+  // ==================== STREAMING ACTIONS ====================
+
+  setPartialThinking(thinking, sessionId = null) {
+    const id = sessionId || this.currentSession?.id;
+    if (!id) return;
+    this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: thinking };
+  },
+
+  clearPartialThinking(sessionId = null) {
+    const id = sessionId || this.currentSession?.id;
+    if (!id) return;
+    this.partialThinkingBySession = { ...this.partialThinkingBySession, [id]: null };
+  },
+
+  clearAllPartialThinking() { this.partialThinkingBySession = {}; },
+
+  setPartialText(text) {
+    const PARTIAL_THROTTLE_MS = 150;
+    this._pendingPartialText = text;
+    if (!this._partialThrottleTimer) {
+      this.partialText = text;
+      this._partialThrottleTimer = setTimeout(() => {
+        if (this._pendingPartialText !== null && this._pendingPartialText !== this.partialText) {
+          this.partialText = this._pendingPartialText;
+        }
+        this._partialThrottleTimer = null;
+        this._pendingPartialText = null;
+      }, PARTIAL_THROTTLE_MS);
+    }
+  },
+
+  clearPartialText() {
+    this.partialText = '';
+    this._pendingPartialText = null;
+    if (this._partialThrottleTimer) {
+      clearTimeout(this._partialThrottleTimer);
+      this._partialThrottleTimer = null;
+    }
+  },
+
+  // ==================== USAGE ACTIONS ====================
+
+  updateRunningUsage(usage, conversationId = null) {
+    this.runningUsage = { ...usage, conversationId };
+  },
+
+  finalizeUsage(usage, conversationId = null) {
+    if (conversationId) {
+      const index = this.conversations.findIndex((c) => c.id === conversationId);
+      if (index !== -1) {
+        this.conversations.splice(index, 1, {
+          ...this.conversations[index],
+          inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
+          cacheReadInputTokens: usage.cacheReadInputTokens,
+          cacheCreationInputTokens: usage.cacheCreationInputTokens,
+          webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
+        });
+      }
+    }
+    if (this.currentSession) {
+      this.currentSession = {
+        ...this.currentSession,
+        inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
+        cacheReadInputTokens: usage.cacheReadInputTokens,
+        cacheCreationInputTokens: usage.cacheCreationInputTokens,
+        webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow,
+      };
+    }
+    this.runningUsage = null;
+  },
+
+  updateConversationUsage(conversationId, usage) {
+    const index = this.conversations.findIndex((c) => c.id === conversationId);
+    if (index !== -1) {
+      this.conversations.splice(index, 1, {
+        ...this.conversations[index],
+        inputTokens: usage.inputTokens, outputTokens: usage.outputTokens,
+        cacheReadInputTokens: usage.cacheReadInputTokens,
+        cacheCreationInputTokens: usage.cacheCreationInputTokens,
+        webSearchRequests: usage.webSearchRequests, contextWindow: usage.contextWindow, model: usage.model,
+      });
+    }
+  },
+
+  clearRunningUsage() {
+    this.runningUsage = null;
+    this.clearPartialThinking();
+  },
+};

--- a/packages/web/src/stores/sessions/perSessionGetters.js
+++ b/packages/web/src/stores/sessions/perSessionGetters.js
@@ -1,0 +1,62 @@
+/**
+ * Per-session getters shared between the main sessions store and overlay stores.
+ * These operate on the store's own local state (messages, conversations, workLogs, etc.)
+ * and are spread directly into the Pinia store getters.
+ */
+export const perSessionGetters = {
+  isDraftSession: (state) => (session) => {
+    if (!session || session.status !== 'waiting') return false;
+    if (session.hasResponses !== undefined) return !session.hasResponses;
+    return !state.messages.some((msg) => msg.role === 'assistant');
+  },
+
+  isScheduledDraft: (state) => (session) => {
+    if (!session || session.status !== 'scheduled') return false;
+    if (session.hasResponses !== undefined) return !session.hasResponses;
+    return !state.messages.some((msg) => msg.role === 'assistant');
+  },
+
+  getWorkLogsForMessage: (state) => (messageId) => {
+    return state.workLogs[messageId] || [];
+  },
+
+  getUnassociatedWorkLogs: (state) => {
+    return state.workLogs['_unassociated'] || [];
+  },
+
+  partialThinking: (state) => {
+    if (!state.currentSession?.id) return null;
+    return state.partialThinkingBySession[state.currentSession.id] || null;
+  },
+
+  activeConversation: (state) => {
+    return state.conversations.find((c) => c.id === state.activeConversationId) || null;
+  },
+
+  getConversationById: (state) => (id) => {
+    return state.conversations.find((c) => c.id === id);
+  },
+
+  rootConversations: (state) => {
+    return state.conversations.filter((c) => !c.parentConversationId);
+  },
+
+  conversationTree: (state) => {
+    const buildTree = (parentId = null) => {
+      return state.conversations
+        .filter((c) => c.parentConversationId === parentId)
+        .map((conv) => ({ ...conv, children: buildTree(conv.id) }));
+    };
+    return buildTree(null);
+  },
+
+  getConversationChildren: (state) => (conversationId) => {
+    return state.conversations.filter((c) => c.parentConversationId === conversationId);
+  },
+
+  getConversationParent: (state) => (conversationId) => {
+    const conv = state.conversations.find((c) => c.id === conversationId);
+    if (!conv?.parentConversationId) return null;
+    return state.conversations.find((c) => c.id === conv.parentConversationId);
+  },
+};

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -3785,10 +3785,8 @@ describe('SessionDetailView', () => {
       // viewedSessionId should be restored to the parent
       expect(sessionsStore.viewedSessionId).toBe('parent-1');
 
-      // Parent session data should be refetched
+      // With overlay store isolation, only a lightweight re-fetch of the session is needed
       expect(sessionsStore.fetchSession).toHaveBeenCalledWith('parent-1', false);
-      expect(sessionsStore.fetchConversations).toHaveBeenCalledWith('parent-1');
-      expect(sessionsStore.fetchMessages).toHaveBeenCalledWith('parent-1', false);
     });
 
     it('closes the overlay panel on close event', async () => {
@@ -3876,10 +3874,8 @@ describe('SessionDetailView', () => {
       await nextTick();
       await flushPromises();
 
-      // Should still refetch to ensure consistency
+      // With overlay store isolation, only a lightweight re-fetch of the session is needed
       expect(sessionsStore.fetchSession).toHaveBeenCalledWith('parent-1', false);
-      expect(sessionsStore.fetchConversations).toHaveBeenCalledWith('parent-1');
-      expect(sessionsStore.fetchMessages).toHaveBeenCalledWith('parent-1', false);
     });
   });
 

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -350,7 +350,7 @@ async function handleOverlayClose() {
   // With overlay store isolation the main store is never touched by the overlay.
   // A lightweight re-fetch picks up any server-side changes made while the overlay
   // was open (e.g. status changes, new messages from other clients).
-  sessionsStore.fetchSession(currentSessionId.value, false);
+  await sessionsStore.fetchSession(currentSessionId.value, false);
 }
 
 // Use composable for session initialization and WebSocket management

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -345,14 +345,12 @@ function handleOverlayOpen() {
 
 async function handleOverlayClose() {
   chatOverlayOpen.value = false;
-  const parentId = currentSessionId.value;
-  sessionsStore.viewedSessionId = parentId;
+  sessionsStore.viewedSessionId = currentSessionId.value;
 
-  // Restore parent session's data since the overlay may have overwritten
-  // currentSession, activeConversationId, conversations, and messages
-  await sessionsStore.fetchSession(parentId, false);
-  await sessionsStore.fetchConversations(parentId);
-  await sessionsStore.fetchMessages(parentId, false);
+  // With overlay store isolation the main store is never touched by the overlay.
+  // A lightweight re-fetch picks up any server-side changes made while the overlay
+  // was open (e.g. status changes, new messages from other clients).
+  sessionsStore.fetchSession(currentSessionId.value, false);
 }
 
 // Use composable for session initialization and WebSocket management


### PR DESCRIPTION
## Summary

- **Extract shared per-session store logic**: Created `perSessionActions.js` and `perSessionGetters.js` to eliminate ~400 lines of duplicated code between the main `sessions.js` store and `createOverlaySessionsStore.js`
- **Fix memory leak in overlay stores**: Added `$cleanup()` method to both overlay store factories that properly removes state entries from the Pinia registry (previously `$dispose()` only removed subscriptions, leaking state on each overlay open/close)
- **Restore missing `await`**: Fixed `handleOverlayClose` in `SessionDetailView.vue` so `fetchSession` completes before downstream code runs
- **Add overlay import guard test**: 21 components verified via Vite `?raw` imports to ensure none bypass the `provide/inject` isolation by directly importing `useSessionsStore` or `useTodosStore`
- **Add unit tests**: Comprehensive test suites for `createOverlaySessionsStore`, `createOverlayTodosStore`, and `useOverlayStore` composable
- **Remove debug logging**: Cleaned up leftover `console.log` statements from `fetchMessages`

## Test plan

- [x] All 4007 existing web unit tests pass
- [x] Overlay import guard test verifies isolation for all 21 overlay-rendered components
- [x] New overlay sessions store tests cover: factory uniqueness, state isolation, proxied getters, fetchSession, fetchMessages, delegated actions, streaming, usage tracking, conversations, and $cleanup
- [x] New overlay todos store tests cover: factory, isolation, CRUD, error handling, conversation filtering, getters, and $cleanup
- [x] New useOverlayStore tests cover: symbol uniqueness, fallback to global singleton, and provider injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)