### PR TITLE
fix: keep scroll-to-claude button visible in session overlay

### DIFF
--- a/packages/web/src/components/ConversationMessages.vue
+++ b/packages/web/src/components/ConversationMessages.vue
@@ -26,7 +26,7 @@
 
     <!-- Jump to Claude's turn button - shows when at bottom and it's user's turn -->
     <button
-      v-if="hasAssistantMessages && isNearBottom && isUsersTurn"
+      v-if="hasAssistantMessages && isUsersTurn"
       class="scroll-to-claude-btn"
       @click="scrollToClaudesTurn"
       title="Jump to Claude's response"

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -913,6 +913,18 @@ defineExpose({
   flex: 1;
 }
 
+/* In the overlay the scroll-to-claude button sits inside the overlay-body scroll
+   container's normal flow, between messages and InputForm/TodoDrawer/RunningState.
+   When the user scrolls, the button can scroll out of view. Making it
+   position:sticky anchors it to the bottom-right of the overlay-body viewport
+   so it stays visible whenever it appears, regardless of scroll position. */
+.session-chat-overlay :deep(.scroll-to-claude-btn) {
+  position: sticky;
+  bottom: 0.5rem;
+  float: right;
+  z-index: 10;
+}
+
 @media (max-width: 768px) {
   .overlay-body {
     padding: 0 0.5rem;


### PR DESCRIPTION
## Summary
- The ↑ (scroll-to-claude) button in the session chat overlay was disappearing when scrolled away from the bottom
- Added `position: sticky` CSS override in `SessionChatOverlay.vue` so the button stays anchored to the bottom-right of the overlay viewport
- Removed the `isNearBottom` condition from the button's `v-if` — the button now shows whenever there are assistant messages and it's the user's turn, since `position: sticky` handles keeping it in view

## Test plan
- [ ] Open a session chat overlay with assistant messages
- [ ] Verify the ↑ button is visible at bottom-right regardless of scroll position
- [ ] Verify clicking ↑ scrolls to Claude's latest response
- [ ] Verify normal (non-overlay) conversation view still works correctly
- [ ] All 3932 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)