### PR TITLE
feat: show model name in Latest Response section of summary tab

### DIFF
--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -773,6 +773,78 @@ describe('SummaryTab', () => {
 
       expect(wrapper.find('.expand-toggle').exists()).toBe(false);
     });
+
+    it('shows model badge when latest response has a model field', async () => {
+      api.getWorkflowLatestResponse.mockResolvedValue({
+        message: {
+          content: 'Response from Opus',
+          timestamp: Date.now(),
+          role: 'assistant',
+          model: 'claude-opus-4-6',
+        },
+        sessionName: 'Test Session',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelBadge = wrapper.find('.response-model');
+      expect(modelBadge.exists()).toBe(true);
+      expect(modelBadge.text()).toBe('Opus 4.6');
+    });
+
+    it('does not show model badge when latest response has no model field', async () => {
+      api.getWorkflowLatestResponse.mockResolvedValue({
+        message: {
+          content: 'Response without model',
+          timestamp: Date.now(),
+          role: 'assistant',
+        },
+        sessionName: 'Test Session',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.response-model').exists()).toBe(false);
+    });
+
+    it('does not show model badge when model field is null', async () => {
+      api.getWorkflowLatestResponse.mockResolvedValue({
+        message: {
+          content: 'Response with null model',
+          timestamp: Date.now(),
+          role: 'assistant',
+          model: null,
+        },
+        sessionName: 'Test Session',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.response-model').exists()).toBe(false);
+    });
+
+    it('formats unknown model IDs into readable names', async () => {
+      api.getWorkflowLatestResponse.mockResolvedValue({
+        message: {
+          content: 'Response from unknown model',
+          timestamp: Date.now(),
+          role: 'assistant',
+          model: 'some-custom-model-20250101',
+        },
+        sessionName: 'Test Session',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const modelBadge = wrapper.find('.response-model');
+      expect(modelBadge.exists()).toBe(true);
+      // formatModelId strips date suffix and title-cases
+      expect(modelBadge.text()).toBe('Some Custom Model');
+    });
   });
 
   describe('Work Time Display', () => {
@@ -1034,6 +1106,44 @@ describe('SummaryTab', () => {
 
       // Should still show the original response
       expect(wrapper.text()).toContain('Initial API response');
+    });
+
+    it('shows model badge from real-time assistant message', async () => {
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.latest-response').exists()).toBe(false);
+
+      // Fire onMessage with an assistant message that includes a model
+      const onMessageCb = getOnMessageCallback();
+      onMessageCb({
+        role: 'assistant',
+        content: 'Real-time response with model',
+        timestamp: Date.now(),
+        model: 'claude-sonnet-4-6',
+      });
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.latest-response').exists()).toBe(true);
+      const modelBadge = wrapper.find('.response-model');
+      expect(modelBadge.exists()).toBe(true);
+      expect(modelBadge.text()).toBe('Sonnet 4.6');
+    });
+
+    it('does not show model badge when real-time message has no model', async () => {
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const onMessageCb = getOnMessageCallback();
+      onMessageCb({
+        role: 'assistant',
+        content: 'Real-time response without model',
+        timestamp: Date.now(),
+      });
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.latest-response').exists()).toBe(true);
+      expect(wrapper.find('.response-model').exists()).toBe(false);
     });
 
     it('shows session name from current session in real-time update', async () => {

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -11,6 +11,9 @@
       <div class="latest-response-header">
         <h3>Latest Response</h3>
         <div class="latest-response-meta">
+          <span v-if="latestResponseModel" class="response-model">
+            {{ latestResponseModel }}
+          </span>
           <span v-if="latestResponse.sessionName" class="response-session-name">
             from {{ latestResponse.sessionName }}
           </span>
@@ -141,6 +144,7 @@ import SummaryContent from './SummaryContent.vue';
 import SessionLogStream from './SessionLogStream.vue';
 import MarkdownViewer from './MarkdownViewer.vue';
 import SchedulingInfo from './SchedulingInfo.vue';
+import { useModelInfo } from '../composables/useModelInfo.js';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
@@ -149,6 +153,7 @@ const props = defineProps({
 const uiStore = useUiStore();
 const sessionsStore = useSessionsStore();
 const streamingStore = useSessionStreamingStore();
+const { getModelDisplayName } = useModelInfo();
 const { onSummaryUpdate, onSummaryGenerating, onWorkLog, onPartial, onThinkingPartial, onMessage } = useSessionSubscription(props.sessionId);
 
 // Restore collapsed log state for this session
@@ -400,6 +405,11 @@ function formatPrState(state) {
   };
   return labels[state] || state;
 }
+
+const latestResponseModel = computed(() => {
+  const model = latestResponse.value?.message?.model;
+  return model ? getModelDisplayName(model) : null;
+});
 
 const isContentLong = computed(() =>
   latestResponse.value?.message?.content?.length > 500
@@ -716,6 +726,15 @@ async function handleRegenerate() {
   gap: 0.75rem;
   font-size: 0.75rem;
   color: var(--color-text-soft);
+}
+
+.response-model {
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  background: rgba(99, 179, 237, 0.1);
+  color: var(--color-primary, #63b3ed);
+  font-weight: 500;
+  font-size: 0.6875rem;
 }
 
 .response-session-name {


### PR DESCRIPTION
## Summary

- The "Latest Response" section in the session detail Summary tab now shows a small badge indicating which model produced the response (e.g., `Opus 4.6`, `Sonnet 4.6`).
- Reuses the existing `useModelInfo` composable so display names match what's shown elsewhere in the app, with graceful fallback formatting for unknown / third-party model IDs.
- Renders consistently for both the initial API-fetched response and real-time WebSocket message updates.

## Implementation

- `SummaryTab.vue`
  - Imports `useModelInfo` and adds a `latestResponseModel` computed that derives a display name from `latestResponse.value?.message?.model`.
  - Renders a `.response-model` badge in the header metadata area with `v-if` so it hides cleanly when no model is present.
  - Adds CSS styling consistent with the existing dark-mode accent palette.

## Test plan

- [x] Added 6 new unit tests in `SummaryTab.test.js`:
  - Shows model badge when `model` is present in the API response (`claude-opus-4-6` -> `Opus 4.6`)
  - Hides model badge when `model` field is absent
  - Hides model badge when `model` is `null`
  - Formats unknown model IDs into readable names via `formatModelId` fallback
  - Shows model badge from real-time WebSocket assistant messages (`claude-sonnet-4-6` -> `Sonnet 4.6`)
  - Hides model badge when real-time assistant message has no model
- [x] Full SummaryTab suite: 52/52 passing
- [x] Full web test suite: 3938 passing, 0 failing
- [ ] Manual smoke test in the running app to confirm badge styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)