### PR TITLE
feat: spread session detail sub-nav tabs evenly across available space

### DIFF
--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -78,6 +78,16 @@ describe('SessionTabsPanel', () => {
       const options = wrapper.findAll('.tab-select option');
       expect(options.length).toBe(5);
     });
+
+    it('applies the session-detail layout marker class', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.tabs.tabs-session-detail').exists()).toBe(true);
+    });
+
+    it('nests tabs-desktop inside the session-detail container', () => {
+      const wrapper = mountPanel();
+      expect(wrapper.find('.tabs-session-detail .tabs-desktop').exists()).toBe(true);
+    });
   });
 
   describe('changes indicator', () => {

--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tabs">
+  <div class="tabs tabs-session-detail">
     <router-link
       :to="`/projects/${projectId}/sessions`"
       class="tab tab-back"
@@ -134,5 +134,19 @@ function navigateToTab(tabId) {
 .back-icon svg {
   display: inline-block;
   vertical-align: middle;
+}
+
+.tabs-session-detail .tabs-desktop {
+  flex: 1;
+  min-width: 0;
+}
+
+.tabs-session-detail .tabs-desktop .tab {
+  flex: 1 1 0;
+  text-align: center;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
## Summary
- Session detail sub-navigation tabs (Summary, Changes, Canvas, Commands) now spread evenly across the available horizontal space instead of clustering left-aligned next to the back button
- Uses a `tabs-session-detail` marker class with scoped CSS flex rules in `SessionTabsPanel.vue` — no global CSS changes
- Adds `overflow: hidden` + `text-overflow: ellipsis` as a safety net for narrow viewports with long dynamic labels like `Changes (999)`

## Approach
Added a `tabs-session-detail` CSS class to the root `<div>` of `SessionTabsPanel.vue` and two scoped style rules:
- `.tabs-session-detail .tabs-desktop { flex: 1; min-width: 0; }` — expands the tabs container to fill remaining space
- `.tabs-session-detail .tabs-desktop .tab { flex: 1 1 0; text-align: center; ... }` — equal-width tabs with centered labels

The scoped approach ensures **zero side effects** on `SettingsView` and `SessionListView`, which share the same global `.tabs`/`.tab` class names but have different layouts.

## Files changed
- `packages/web/src/components/SessionTabsPanel.vue` — template marker class + scoped CSS rules
- `packages/web/src/components/SessionTabsPanel.test.js` — 2 new assertions for marker class and DOM structure

## Test plan
- [x] Unit tests: SessionTabsPanel (15/15), SessionListView (85/85), SessionDetailView (110/110)
- [x] Lint: clean
- [ ] E2E: `./scripts/pw.sh test tests/e2e/session-navigation.spec.ts`
- [ ] Manual visual verification: desktop tab layout, mobile dropdown, SettingsView/SessionListView unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)