### PR TITLE
fix: improve New Session view layout for iPad

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -87,6 +87,7 @@ input, textarea, select {
 .btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   border: 1px solid var(--color-border);

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -594,8 +594,6 @@ h1 {
 
 .form {
   width: 100%;
-  max-width: 640px;
-  margin: 0 auto;
 }
 
 .form-help {
@@ -620,6 +618,8 @@ h1 {
 
 .btn-submit {
   flex: 1;
+  justify-content: center;
+  text-align: center;
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   font-size: 1.05rem;


### PR DESCRIPTION
## Summary
- Removed the `max-width: 640px` cap on the new session form so it fills the full container width on iPad/tablet screens instead of floating at ~80%
- Added `justify-content: center` to the submit button (and the global `.btn` base class) so "Start Session" / "Create Draft" text is properly centered
- Both fixes target the awkward appearance on iPad-width viewports (~768–1024px)

## Test plan
- [ ] Open the New Session view on an iPad or a browser resized to ~768–1024px wide
- [ ] Verify the form fills the available width (no wasted space on sides)
- [ ] Verify the "Start Session" button text is centered
- [ ] Toggle to "Create Draft" and confirm it's also centered
- [ ] Check that other buttons across the app still look correct with the global `justify-content: center` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)