### PR TITLE
Add project settings icon to session list header

### DIFF
--- a/packages/web/src/views/SessionListView.css
+++ b/packages/web/src/views/SessionListView.css
@@ -38,6 +38,29 @@
   stroke-linejoin: round;
 }
 
+.settings-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--color-primary);
+  transition: color 0.15s, transform 0.15s;
+  padding: 0.25rem;
+}
+
+.settings-link:hover {
+  color: var(--color-primary-bright, #06ffff);
+  transform: scale(1.1);
+}
+
+.settings-icon {
+  width: 100%;
+  height: 100%;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .tabs {
   display: flex;
   gap: 0;

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -22,6 +22,26 @@
               <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6m4-3l6 6m0 0l-6 6m6-6H9" />
             </svg>
           </a>
+          <router-link
+            :to="`/projects/${route.params.id}/edit`"
+            class="settings-link"
+            title="Project settings"
+          >
+            <svg
+              class="settings-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" />
+              <circle
+                cx="12"
+                cy="12"
+                r="3"
+              />
+            </svg>
+          </router-link>
         </div>
       </div>
       <router-link


### PR DESCRIPTION
## Summary
- Adds a gear/settings icon next to the project name in the SessionListView header that navigates to the edit project page (`/projects/:id/edit`)
- Previously there was no way to reach the edit project view from the project detail (session list) page
- Follows the exact same styling pattern as the existing repo link icon — compact and works well on small screens

## Test plan
- [ ] Navigate to a project's session list and verify the gear icon appears next to the project name
- [ ] Click the gear icon and verify it navigates to the project edit page
- [ ] Test on mobile viewport widths (≤480px) to confirm the icon doesn't crowd the header
- [ ] Verify the hover effect matches the repo link icon (color change + slight scale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)