### PR TITLE
feat: Add ResizableTextarea to template prompt input (Issue #5302)

### DIFF
--- a/packages/web/src/views/TemplateDetailView.test.js
+++ b/packages/web/src/views/TemplateDetailView.test.js
@@ -42,6 +42,16 @@ vi.mock('../components/EffortLevelSelector.vue', () => ({
   },
 }));
 
+// Mock ResizableTextarea component
+vi.mock('../components/ResizableTextarea.vue', () => ({
+  default: {
+    name: 'ResizableTextarea',
+    template: '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value); $emit(\'input\', $event)" />',
+    props: ['modelValue', 'minHeight', 'maxHeight'],
+    emits: ['update:modelValue', 'input'],
+  },
+}));
+
 describe('TemplateDetailView - New Form Fields', () => {
   let pinia;
   let router;
@@ -608,6 +618,50 @@ describe('TemplateDetailView - New Form Fields', () => {
       const callArgs = templatesStore.updateTemplate.mock.calls[0];
       // Mode should be 'yolo', not undefined
       expect(callArgs[1].mode).toBe('yolo');
+    });
+  });
+
+  describe('ResizableTextarea Integration', () => {
+    it('renders ResizableTextarea for the prompt field', async () => {
+      const wrapper = mount(TemplateDetailView, {
+        global: {
+          plugins: [pinia, router],
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      const resizableTextarea = wrapper.findComponent({ name: 'ResizableTextarea' });
+      expect(resizableTextarea.exists()).toBe(true);
+      expect(resizableTextarea.props('modelValue')).toBe('Test prompt');
+      expect(resizableTextarea.props('minHeight')).toBe(120);
+    });
+
+    it('updates prompt via ResizableTextarea v-model', async () => {
+      const wrapper = mount(TemplateDetailView, {
+        global: {
+          plugins: [pinia, router],
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      const resizableTextarea = wrapper.findComponent({ name: 'ResizableTextarea' });
+      await resizableTextarea.vm.$emit('update:modelValue', 'New prompt text');
+      await nextTick();
+
+      expect(resizableTextarea.props('modelValue')).toBe('New prompt text');
+
+      // Verify the updated prompt is included in form submission
+      const form = wrapper.find('form');
+      await form.trigger('submit.prevent');
+      await flushPromises();
+
+      expect(templatesStore.updateTemplate).toHaveBeenCalled();
+      const callArgs = templatesStore.updateTemplate.mock.calls[0];
+      expect(callArgs[1].prompt).toBe('New prompt text');
     });
   });
 });

--- a/packages/web/src/views/TemplateDetailView.vue
+++ b/packages/web/src/views/TemplateDetailView.vue
@@ -44,12 +44,12 @@
         <!-- Prompt Field -->
         <div class="form-group">
           <label for="prompt">Prompt</label>
-          <textarea
+          <ResizableTextarea
             id="prompt"
             v-model="formData.prompt"
             class="form-input form-textarea"
             placeholder="Session prompt. Use {{parentSession.summary}} to reference parent session data."
-            rows="6"
+            :min-height="120"
             required
           />
           <InterpolationHelp />
@@ -231,6 +231,7 @@ import { api } from '../api/index.js';
 import ModelSelector from '../components/ModelSelector.vue';
 import EffortLevelSelector from '../components/EffortLevelSelector.vue';
 import InterpolationHelp from '../components/InterpolationHelp.vue';
+import ResizableTextarea from '../components/ResizableTextarea.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -431,10 +432,9 @@ onMounted(async () => {
   color: var(--color-text-soft);
 }
 
-textarea.form-textarea {
+:deep(textarea.form-textarea) {
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  resize: vertical;
   min-height: 120px;
   line-height: 1.5;
 }


### PR DESCRIPTION
## Summary

This PR integrates the `ResizableTextarea` component into the `TemplateDetailView` for improved user experience when editing template prompts. The component provides dynamic height adjustment based on content, replacing the standard HTML textarea with automatic resizing capabilities.

## Changes

- **Component Integration**: Replaced standard `<textarea>` with `<ResizableTextarea>` component in the prompt field
- **Configuration**: Added `min-height` prop set to 120px for consistent sizing
- **Testing**: Added mock for `ResizableTextarea` component in tests
- **Test Coverage**: Added integration tests to verify component rendering and v-model binding
- **Styling**: Updated CSS with `:deep` selector for proper scoping of form-textarea styles

## Files Modified

- `packages/web/src/views/TemplateDetailView.vue` - Integrated ResizableTextarea component
- `packages/web/src/views/TemplateDetailView.test.js` - Added component mock and integration tests

## Test Plan

- [x] Component renders without errors
- [x] ResizableTextarea receives correct initial value
- [x] Min-height prop is properly configured
- [x] V-model binding works correctly for prompt updates
- [x] CSS styling is properly applied with `:deep` selector

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)