### PR TITLE
feat: show scheduled time on session cards for scheduled child sessions

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -1247,6 +1247,129 @@ describe('SessionCard', () => {
       const scheduledTime = wrapper.find('.scheduled-time');
       expect(scheduledTime.exists()).toBe(false);
     });
+
+    it('shows nearest future scheduled time from child sessions', () => {
+      const futureTime = Date.now() + 30 * 60 * 1000; // 30 min from now
+      mockSessionsStoreData.sessions = [
+        {
+          id: 'child-1',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: futureTime,
+        },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+
+      const scheduledTime = wrapper.find('.scheduled-time');
+      expect(scheduledTime.exists()).toBe(true);
+      expect(scheduledTime.text()).toContain('minute');
+      expect(scheduledTime.attributes('title')).toMatch(/\d{1,2}:\d{2}/);
+    });
+
+    it('shows earliest future time when multiple children are scheduled', () => {
+      const soonestTime = Date.now() + 10 * 60 * 1000; // 10 min from now
+      const laterTime = Date.now() + 60 * 60 * 1000;   // 60 min from now
+      mockSessionsStoreData.sessions = [
+        {
+          id: 'child-1',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: laterTime,
+        },
+        {
+          id: 'child-2',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: soonestTime,
+        },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+
+      const scheduledTime = wrapper.find('.scheduled-time');
+      expect(scheduledTime.exists()).toBe(true);
+      expect(scheduledTime.text()).toContain('10'); // should show ~10 minutes
+    });
+
+    it('hides scheduled time when all children have past scheduledAt', () => {
+      const pastTime = Date.now() - 30 * 60 * 1000; // 30 min ago
+      mockSessionsStoreData.sessions = [
+        {
+          id: 'child-1',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: pastTime,
+        },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+
+      const scheduledTime = wrapper.find('.scheduled-time');
+      expect(scheduledTime.exists()).toBe(false);
+    });
+
+    it('ignores past times and shows only future scheduled time', () => {
+      const pastTime = Date.now() - 30 * 60 * 1000;
+      const futureTime = Date.now() + 15 * 60 * 1000;
+      mockSessionsStoreData.sessions = [
+        {
+          id: 'child-past',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: pastTime,
+        },
+        {
+          id: 'child-future',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: futureTime,
+        },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+
+      const scheduledTime = wrapper.find('.scheduled-time');
+      expect(scheduledTime.exists()).toBe(true);
+      expect(scheduledTime.text()).toContain('15'); // future time, not past
+    });
+
+    it('ignores children with scheduledAt null', () => {
+      mockSessionsStoreData.sessions = [
+        {
+          id: 'child-1',
+          parentSessionId: 'session-123',
+          status: 'scheduled',
+          scheduledAt: null,
+        },
+      ];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+
+      const scheduledTime = wrapper.find('.scheduled-time');
+      expect(scheduledTime.exists()).toBe(false);
+    });
+
+    it('shows no time when parent has no scheduled children', () => {
+      mockSessionsStoreData.sessions = [];
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+
+      const scheduledTime = wrapper.find('.scheduled-time');
+      expect(scheduledTime.exists()).toBe(false);
+    });
   });
 
   describe('kanbanEnabled prop', () => {

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -284,15 +284,43 @@ const runningSessionIds = computed(() => {
 
 const hasRunningSession = computed(() => runningSessionIds.value.length > 0);
 
-// Scheduled time display (for this specific session when it's scheduled)
+/** Find the nearest upcoming scheduledAt from any session in the workflow tree. */
+const nearestScheduledAt = computed(() => {
+  const now = Date.now();
+
+  // Check the session itself first (most relevant).
+  // Note: For self-scheduled sessions, we show the time even if it's in the past —
+  // this preserves backward compatibility and signals a potential scheduling issue.
+  if (props.session.status === 'scheduled' && props.session.scheduledAt) {
+    return props.session.scheduledAt;
+  }
+
+  // Find the earliest future scheduled time among children.
+  // Only future times are shown for children (past scheduled times mean the
+  // session should have already been triggered).
+  const allSessions = getWorkflowSessions();
+  let earliest = null;
+  for (const s of allSessions) {
+    // Skip the root session (already checked above)
+    if (s.id === props.session.id) continue;
+    if (s.status === 'scheduled' && s.scheduledAt) {
+      const t = new Date(s.scheduledAt).getTime();
+      if (t >= now && (earliest === null || t < earliest)) {
+        earliest = t;
+      }
+    }
+  }
+  return earliest;
+});
+
 const scheduledTimeDisplay = computed(() => {
-  if (props.session.status !== 'scheduled' || !props.session.scheduledAt) return null;
-  return formatDistanceToNow(new Date(props.session.scheduledAt), { addSuffix: true });
+  if (!nearestScheduledAt.value) return null;
+  return formatDistanceToNow(new Date(nearestScheduledAt.value), { addSuffix: true });
 });
 
 const scheduledAbsoluteTime = computed(() => {
-  if (props.session.status !== 'scheduled' || !props.session.scheduledAt) return null;
-  return format(new Date(props.session.scheduledAt), 'MMM d, h:mm a');
+  if (!nearestScheduledAt.value) return null;
+  return format(new Date(nearestScheduledAt.value), 'MMM d, h:mm a');
 });
 
 const buttonStatusesToDisplay = computed(() => {

--- a/tests/e2e/session-card-display.spec.ts
+++ b/tests/e2e/session-card-display.spec.ts
@@ -112,6 +112,41 @@ test.describe('Session Card Display', () => {
       const scheduledTime = page.locator('.scheduled-time');
       await expect(scheduledTime).toHaveCount(0);
     });
+
+    test('parent session with scheduled child shows child scheduled time', async ({ page }) => {
+      const futureTime = Date.now() + 30 * 60 * 1000;
+
+      // Create parent session
+      const parent = await seedSession(project.id, {
+        prompt: 'Parent workflow',
+        name: 'Parent Session',
+        startImmediately: false,
+      });
+
+      // Create scheduled child session
+      await seedSession(project.id, {
+        prompt: 'Child task',
+        name: 'Scheduled Child',
+        startImmediately: false,
+        parentSessionId: parent.id,
+        scheduledAt: futureTime,
+        status: 'scheduled',
+      });
+
+      await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+        waitFor: '.session-card',
+      });
+
+      // Parent card should show the scheduled time from its child
+      const scheduledTime = page.locator('.scheduled-time');
+      await expect(scheduledTime).toBeVisible({ timeout: 10000 });
+      await expect(scheduledTime).toContainText('in');
+
+      // Should also show absolute time on hover
+      const titleAttr = await scheduledTime.getAttribute('title');
+      expect(titleAttr).toBeTruthy();
+      expect(titleAttr).toMatch(/\w+ \d+, \d+:\d+/);
+    });
   });
 
   test.describe('Files changed badge', () => {


### PR DESCRIPTION
## Summary

- Session cards in the list view now display the nearest upcoming scheduled time from any session in the workflow tree (not just the root session itself)
- The `nearestScheduledAt` computed property was introduced in `SessionCard.vue` to find the earliest future `scheduledAt` across all child sessions
- Previously only the root session's own `scheduledAt` was surfaced; now parent cards reflect pending scheduled activity from children

## Test plan

- [ ] Unit tests added to `SessionCard.test.js` covering: nearest child time shown, earliest-wins when multiple children, past times hidden, null `scheduledAt` ignored, no children shows nothing
- [ ] E2E test added to `session-card-display.spec.ts`: parent session with a scheduled child shows the child's scheduled time on the parent's card
- [ ] Run `yarn workspace @claudetools/web test src/components/SessionCard.test.js` to verify unit tests pass
- [ ] Run `./scripts/pw.sh test tests/e2e/session-card-display.spec.ts` to verify E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)