### PR TITLE
fix: ensure overlay close handle renders above cost panel

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -994,7 +994,7 @@ defineExpose({
   background: rgba(55, 65, 81, 0.4);
   border-radius: 8px;
   cursor: pointer;
-  z-index: 10;
+  z-index: 30;
   transition: background-color 0.2s ease;
   min-width: 44px;
   min-height: 44px;

--- a/tests/e2e/session-chat-overlay.spec.ts
+++ b/tests/e2e/session-chat-overlay.spec.ts
@@ -130,6 +130,26 @@ test.describe('Session Chat Overlay', () => {
     await expect(overlay).not.toBeVisible({ timeout: 5000 });
   });
 
+  test('close handle has highest z-index in overlay', async ({ page }) => {
+    const overlay = await openOverlay(page, parentSession.id);
+
+    const closeHandle = page.locator('[data-testid="session-chat-overlay-close-handle"]');
+    await expect(closeHandle).toBeVisible();
+
+    // Verify the close handle's z-index is higher than the overlay header and controls row
+    const handleZIndex = await closeHandle.evaluate((el) =>
+      window.getComputedStyle(el).zIndex
+    );
+
+    // The close handle should have z-index: 30 (above header z-index: 20 and controls z-index: 10)
+    expect(parseInt(handleZIndex, 10)).toBeGreaterThanOrEqual(30);
+
+    // Verify the handle is clickable even with content in the overlay
+    await closeHandle.click();
+    await page.waitForTimeout(300);
+    await expect(overlay).not.toBeVisible({ timeout: 5000 });
+  });
+
   test('pressing Escape closes overlay', async ({ page }) => {
     const overlay = await openOverlay(page, parentSession.id);
 


### PR DESCRIPTION
## Summary
- Fixed z-index layering issue in `SessionChatOverlay.vue` where the close handle (anchored to the left edge of the overlay) was being painted under the sticky conversation controls row containing the `TokenCostPanel` / cost UI
- Root cause: the close handle and the controls row both had `z-index: 10` in the same stacking context (`.overlay-panel-wrapper`). With equal z-indices, DOM paint order determined the winner — the controls row comes later so it painted on top
- Bumped `.overlay-close-handle` z-index from `10` → `30`, ensuring it always sits above the overlay header (`z-index: 20`) and the controls row (`z-index: 10`)

## Changes
- **`packages/web/src/components/SessionChatOverlay.vue`** — single CSS property change: `z-index: 10` → `z-index: 30` on `.overlay-close-handle`
- **`tests/e2e/session-chat-overlay.spec.ts`** — added E2E test asserting the close handle's computed z-index is ≥ 30 and that it remains clickable

## Test plan
- [x] New E2E test passes: `close handle has highest z-index in overlay`
- [x] All 56 existing overlay E2E tests pass (no regressions)
- [x] All 21 token-usage-cost E2E tests pass (no regressions)
- [ ] Manual visual verification: open session chat overlay, confirm close handle is always visible and clickable on top of any overlapping UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)