### PR TITLE
Remove parentSession template vars from template create/edit UI

### DIFF
--- a/packages/web/src/components/InterpolationHelp.vue
+++ b/packages/web/src/components/InterpolationHelp.vue
@@ -1,6 +1,6 @@
 <template>
   <p class="form-help">
-    Available variables: <code v-pre>{{parentSession.summary}}</code>, <code v-pre>{{parentSession.status}}</code>, <code v-pre>{{parentSession.name}}</code>, <code v-pre>{{rootSession.id}}</code>, <code v-pre>{{rootSession.name}}</code>, <code v-pre>{{rootSession.summary}}</code>, <code v-pre>{{rootSession.status}}</code>
+    Available variables: <code v-pre>{{rootSession.id}}</code>, <code v-pre>{{rootSession.name}}</code>, <code v-pre>{{rootSession.summary}}</code>, <code v-pre>{{rootSession.status}}</code>
   </p>
 </template>
 

--- a/packages/web/src/components/TemplatesPanel.vue
+++ b/packages/web/src/components/TemplatesPanel.vue
@@ -36,7 +36,7 @@
           <textarea
             v-model="formData.prompt"
             class="form-input form-textarea"
-            placeholder="Session prompt. Use {{parentSession.summary}} to reference parent session data."
+            placeholder="Session prompt. Use {{rootSession.summary}} to reference root session data."
             rows="4"
             required
           />

--- a/packages/web/src/views/TemplateDetailView.vue
+++ b/packages/web/src/views/TemplateDetailView.vue
@@ -48,7 +48,7 @@
             id="prompt"
             v-model="formData.prompt"
             class="form-input form-textarea"
-            placeholder="Session prompt. Use {{parentSession.summary}} to reference parent session data."
+            placeholder="Session prompt. Use {{rootSession.summary}} to reference root session data."
             :min-height="120"
             required
           />


### PR DESCRIPTION
## Summary
- Removes `parentSession.*` template variable references from the template creation and editing views (`InterpolationHelp.vue`, `TemplatesPanel.vue`, `TemplateDetailView.vue`)
- Replaces placeholders and help text with `rootSession.*` equivalents
- Backend `templateTriggerService.js` still supports parentSession interpolation at runtime — this is a frontend UI-only change

## Test plan
- [x] All 139 test files pass (4133 tests) with `yarn workspace @claudetools/web test`
- [ ] Manual verification: template create/edit views no longer show parentSession variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)