### PR TITLE
Change "Claude is working..." to "Agent is working..."

### DIFF
--- a/packages/web/src/components/LiveWorkLogPanel.test.js
+++ b/packages/web/src/components/LiveWorkLogPanel.test.js
@@ -63,9 +63,9 @@ describe('LiveWorkLogPanel', () => {
   }
 
   describe('rendering', () => {
-    it('shows header with "Claude is working..." text', () => {
+    it('shows header with "Agent is working..." text', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('.live-title').text()).toBe('Claude is working...');
+      expect(wrapper.find('.live-title').text()).toBe('Agent is working...');
     });
 
     it('does not show logs container when no content', () => {

--- a/packages/web/src/components/LiveWorkLogPanel.vue
+++ b/packages/web/src/components/LiveWorkLogPanel.vue
@@ -5,7 +5,7 @@
       class="live-header"
     >
       <span class="loading-spinner" />
-      <span class="live-title">Claude is working...</span>
+      <span class="live-title">Agent is working...</span>
       <span
         v-if="totalCount"
         class="live-count"
@@ -188,7 +188,7 @@ defineExpose({
   }
 }
 
-/* Hide "Claude is working..." text on extremely small screens */
+/* Hide "Agent is working..." text on extremely small screens */
 @media (max-width: 360px) {
   .live-title {
     display: none;

--- a/packages/web/src/components/RunningState.test.js
+++ b/packages/web/src/components/RunningState.test.js
@@ -27,9 +27,9 @@ function mountComponent(props = {}) {
 
 describe('RunningState', () => {
   describe('rendering', () => {
-    it('should render "Claude is working..." message', () => {
+    it('should render "Agent is working..." message', () => {
       const wrapper = mountComponent();
-      expect(wrapper.find('.running-title').text()).toBe('Claude is working...');
+      expect(wrapper.find('.running-title').text()).toBe('Agent is working...');
     });
 
     it('should render loading spinner inside stop button', () => {

--- a/packages/web/src/components/RunningState.vue
+++ b/packages/web/src/components/RunningState.vue
@@ -3,7 +3,7 @@
     <!-- Header row with status, token display, and stop button -->
     <div class="running-header">
       <div class="running-status">
-        <span class="running-title">Claude is working...</span>
+        <span class="running-title">Agent is working...</span>
       </div>
       <div class="running-actions">
         <span
@@ -150,7 +150,7 @@ const templateLink = computed(() => `/projects/${props.projectId}/templates`);
   font-style: italic;
 }
 
-/* Hide "Claude is working..." text on extremely small screens */
+/* Hide "Agent is working..." text on extremely small screens */
 @media (max-width: 360px) {
   .running-title {
     display: none;

--- a/tests/e2e/work-log-panels.spec.ts
+++ b/tests/e2e/work-log-panels.spec.ts
@@ -67,7 +67,7 @@ test.describe('Work Log Panels', () => {
 
       // Assertions
       await expect(page.locator('.running-state')).toBeVisible();
-      await expect(page.locator('.running-title')).toHaveText('Claude is working...');
+      await expect(page.locator('.running-title')).toHaveText('Agent is working...');
       await expect(page.locator('.running-state .live-work-log-panel')).toBeVisible();
     });
 


### PR DESCRIPTION
## Summary
- Replaces "Claude is working..." with "Agent is working..." across all UI components, unit tests, and E2E tests
- Updates both `RunningState.vue` and `LiveWorkLogPanel.vue` templates and their CSS comments
- Updates corresponding test assertions to match the new text

## Test plan
- [x] Unit tests pass (`RunningState.test.js`, `LiveWorkLogPanel.test.js` — 33 tests)
- [ ] E2E tests pass (`work-log-panels.spec.ts`)
- [ ] Visual verification that running state shows "Agent is working..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)