### PR TITLE
Remove circuschief.io domain references in favor of Circus Chief

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Circus Chief (circuschief.io) is a local-first web application for managing Claude Code sessions with a visual canvas for artifacts. It allows users to view/manage sessions, share a visual canvas (images, documents, data), and interact with active Claude Code sessions from a web browser.
+Circus Chief is a local-first web application for managing Claude Code sessions with a visual canvas for artifacts. It allows users to view/manage sessions, share a visual canvas (images, documents, data), and interact with active Claude Code sessions from a web browser.
 
 ## Common Commands
 
@@ -103,15 +103,15 @@ Dark mode only using Tailwind CSS. Key colors:
 
 **CRITICAL: Never use `cd` to change to a hardcoded project path before running commands.**
 
-When running in a circuschief.io session, your working directory is already set correctly. This may be:
+When running in a Circus Chief session, your working directory is already set correctly. This may be:
 - The main project directory
 - A git worktree for branch isolation
 
 ### Do NOT do this:
 ```bash
 # BAD - bypasses worktree isolation
-cd /home/ubuntu/workspace/circuschief.io && git status
-cd /home/ubuntu/workspace/circuschief.io && yarn test
+cd /home/ubuntu/workspace/circus-chief && git status
+cd /home/ubuntu/workspace/circus-chief && yarn test
 ```
 
 ### Do this instead:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 circuschief.io contributors
+   Copyright 2025 Circus Chief contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/server/src/services/ghService.test.js
+++ b/packages/server/src/services/ghService.test.js
@@ -426,10 +426,10 @@ describe('ghService', () => {
 
   describe('extractPrInfo', () => {
     it('extracts PR info from valid GitHub URL', () => {
-      const result = extractPrInfo('https://github.com/anthropics/circuschief.io/pull/123');
+      const result = extractPrInfo('https://github.com/anthropics/circus-chief/pull/123');
       expect(result).toEqual({
         owner: 'anthropics',
-        repo: 'circuschief.io',
+        repo: 'circus-chief',
         number: 123,
       });
     });
@@ -465,32 +465,32 @@ describe('ghService', () => {
   describe('validatePrRepository', () => {
     it('validates PR from expected repository', () => {
       const result = validatePrRepository(
-        'https://github.com/anthropics/circuschief.io/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/anthropics/circus-chief/pull/123',
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result).toEqual({ valid: true, mismatch: false, error: null });
     });
 
     it('detects PR from different owner', () => {
       const result = validatePrRepository(
-        'https://github.com/user/circuschief.io/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/user/circus-chief/pull/123',
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(false);
       expect(result.mismatch).toBe(true);
-      expect(result.error).toContain('user/circuschief.io');
-      expect(result.error).toContain('anthropics/circuschief.io');
+      expect(result.error).toContain('user/circus-chief');
+      expect(result.error).toContain('anthropics/circus-chief');
     });
 
     it('detects PR from different repo', () => {
       const result = validatePrRepository(
         'https://github.com/anthropics/different-repo/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(false);
       expect(result.mismatch).toBe(true);
       expect(result.error).toContain('anthropics/different-repo');
-      expect(result.error).toContain('anthropics/circuschief.io');
+      expect(result.error).toContain('anthropics/circus-chief');
     });
 
     it('handles trailing slash in expected repo URL', () => {

--- a/packages/server/src/services/prUrlService.test.js
+++ b/packages/server/src/services/prUrlService.test.js
@@ -41,8 +41,8 @@ describe('prUrlService', () => {
 
   describe('parsePrUrl', () => {
     it('parses a valid GitHub PR URL', () => {
-      const result = parsePrUrl('https://github.com/anthropics/circuschief.io/pull/123');
-      expect(result).toEqual({ owner: 'anthropics', repo: 'circuschief.io', number: 123 });
+      const result = parsePrUrl('https://github.com/anthropics/circus-chief/pull/123');
+      expect(result).toEqual({ owner: 'anthropics', repo: 'circus-chief', number: 123 });
     });
 
     it('returns null for null input', () => {
@@ -70,8 +70,8 @@ describe('prUrlService', () => {
   describe('validatePrUrl', () => {
     it('validates matching repository', () => {
       const result = validatePrUrl(
-        'https://github.com/anthropics/circuschief.io/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/anthropics/circus-chief/pull/123',
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(true);
       expect(result.mismatch).toBe(false);
@@ -80,8 +80,8 @@ describe('prUrlService', () => {
     it('rejects PR from different owner', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const result = validatePrUrl(
-        'https://github.com/user/circuschief.io/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/user/circus-chief/pull/123',
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(false);
       expect(result.mismatch).toBe(true);
@@ -92,7 +92,7 @@ describe('prUrlService', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const result = validatePrUrl(
         'https://github.com/anthropics/different-repo/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(false);
       expect(result.mismatch).toBe(true);

--- a/packages/server/src/services/sessionPrompts.js
+++ b/packages/server/src/services/sessionPrompts.js
@@ -365,7 +365,7 @@ This session is running in an isolated git worktree:
 - Worktree path: ${session.gitWorktree}
 - Branch: ${session.gitBranch || 'unknown'}
 
-CRITICAL: Do NOT use \`cd\` to navigate to the main repository. Your working directory is already set to the worktree. Running \`cd /home/ubuntu/workspace/circuschief.io && ...\` will escape the worktree isolation and affect the main repository instead.`;
+CRITICAL: Do NOT use \`cd\` to navigate to the main repository. Your working directory is already set to the worktree. Running \`cd /home/ubuntu/workspace/circus-chief && ...\` will escape the worktree isolation and affect the main repository instead.`;
 }
 
 /**

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -1863,10 +1863,10 @@ describe('summaryService', () => {
 
   describe('parsePrUrl', () => {
     it('parses valid GitHub PR URL', () => {
-      const result = parsePrUrl('https://github.com/anthropics/circuschief.io/pull/123');
+      const result = parsePrUrl('https://github.com/anthropics/circus-chief/pull/123');
       expect(result).toEqual({
         owner: 'anthropics',
-        repo: 'circuschief.io',
+        repo: 'circus-chief',
         number: 123,
       });
     });
@@ -1907,39 +1907,39 @@ describe('summaryService', () => {
   describe('validatePrUrl', () => {
     it('validates PR from expected repository', () => {
       const result = validatePrUrl(
-        'https://github.com/anthropics/circuschief.io/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/anthropics/circus-chief/pull/123',
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(true);
       expect(result.mismatch).toBe(false);
       expect(result.error).toBeNull();
       expect(result.prComponents).toEqual({
         owner: 'anthropics',
-        repo: 'circuschief.io',
+        repo: 'circus-chief',
         number: 123,
       });
     });
 
     it('detects PR from different owner', () => {
       const result = validatePrUrl(
-        'https://github.com/user/circuschief.io/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/user/circus-chief/pull/123',
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(false);
       expect(result.mismatch).toBe(true);
-      expect(result.error).toContain('user/circuschief.io');
-      expect(result.error).toContain('anthropics/circuschief.io');
+      expect(result.error).toContain('user/circus-chief');
+      expect(result.error).toContain('anthropics/circus-chief');
     });
 
     it('detects PR from different repo', () => {
       const result = validatePrUrl(
         'https://github.com/anthropics/different-repo/pull/123',
-        'https://github.com/anthropics/circuschief.io'
+        'https://github.com/anthropics/circus-chief'
       );
       expect(result.valid).toBe(false);
       expect(result.mismatch).toBe(true);
       expect(result.error).toContain('anthropics/different-repo');
-      expect(result.error).toContain('anthropics/circuschief.io');
+      expect(result.error).toContain('anthropics/circus-chief');
     });
 
     it('accepts PR when no expected repo URL provided', () => {
@@ -2339,12 +2339,12 @@ describe('summaryService', () => {
   describe('PR URL extraction from messages', () => {
     it('extracts PR URL from user message containing GitHub PR link', async () => {
       // Add a message with a PR URL
-      messages.create(sessionId, 'user', 'Check out this PR: https://github.com/anthropics/circuschief.io/pull/123');
+      messages.create(sessionId, 'user', 'Check out this PR: https://github.com/anthropics/circus-chief/pull/123');
 
       await summaryService.extractPrUrlIfNeeded(sessionId);
 
       const session = sessions.getById(sessionId);
-      expect(session.prUrl).toBe('https://github.com/anthropics/circuschief.io/pull/123');
+      expect(session.prUrl).toBe('https://github.com/anthropics/circus-chief/pull/123');
     });
 
     it('extracts PR URL from assistant message containing GitHub PR link', async () => {


### PR DESCRIPTION
## Summary
- Replaced all `circuschief.io` domain references with "Circus Chief" (prose) or `circus-chief` (paths/URLs) across documentation, licensing, source code, and test files
- Updated 6 files: `CLAUDE.md`, `LICENSE`, `sessionPrompts.js`, and 3 test files (`ghService`, `prUrlService`, `summaryService`)
- Auto-generated test cassettes and quality baseline data were intentionally excluded (they contain recorded paths that would need re-recording)

## Test plan
- [x] All 328 affected unit tests pass
- [ ] Verify no remaining `circuschief.io` references in source code
- [ ] Confirm E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)