### PR TITLE
Fix mobile keyboard UX in session chat overlay (A104)

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -60,6 +60,7 @@
             <div
               ref="overlayHeaderRef"
               class="overlay-header"
+              :class="{ 'header-compact': inputFocused && isMobile && !isEditingName }"
               @touchmove="handleHeaderTouchmove"
             >
               <!-- Row 1: Session Name -->
@@ -432,6 +433,10 @@ const overlayHeaderRef = ref(null);
 let headerCheckIntervalId = null;
 let headerCheckRafId = null;
 
+// Track whether the prompt textarea is focused (for compact header on mobile)
+const inputFocused = ref(false);
+let focusOutRaf = null;
+
 // Template ref to the ConversationTab for flushing drafts before session switch
 const conversationTabRef = ref(null);
 
@@ -798,6 +803,43 @@ function handleEscape(event) {
 }
 
 /**
+ * Handle focusin on the overlay body — detect when the prompt textarea gains focus.
+ * Uses event delegation from .overlay-body so we catch the bubbling event from
+ * InputForm → ResizableTextarea's <textarea>.
+ */
+function handleOverlayFocusin(e) {
+  if (e.target.tagName === 'TEXTAREA') {
+    // Cancel any pending focusout that would have cleared inputFocused
+    if (focusOutRaf) {
+      cancelAnimationFrame(focusOutRaf);
+      focusOutRaf = null;
+    }
+    inputFocused.value = true;
+
+    // After keyboard animation completes, scroll textarea into view
+    setTimeout(() => {
+      e.target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }, 350);
+  }
+}
+
+/**
+ * Handle focusout on the overlay body — detect when the prompt textarea loses focus.
+ * Uses requestAnimationFrame delay to avoid flashing the header when focus moves
+ * from textarea to another element (e.g. Send button).
+ */
+function handleOverlayFocusout(e) {
+  if (e.target.tagName === 'TEXTAREA') {
+    // Defer: if focus moves to another element in the overlay (e.g. Send button),
+    // focusin will fire on the next target and we skip collapsing.
+    focusOutRaf = requestAnimationFrame(() => {
+      focusOutRaf = null;
+      inputFocused.value = false;
+    });
+  }
+}
+
+/**
  * Prevent touch-drag on the overlay header from scrolling the overlay,
  * while allowing touch-move inside interactive children that need it:
  * - SessionChatPicker dropdown (scrollable list)
@@ -825,6 +867,9 @@ function handleHeaderTouchmove(event) {
  *    element visible regardless of what caused the displacement.
  */
 function ensureHeaderVisible() {
+  // Don't fight with keyboard-aware scroll when the user is typing
+  if (inputFocused.value) return;
+
   const header = overlayHeaderRef.value;
   if (!header) return;
 
@@ -917,6 +962,15 @@ onMounted(async () => {
   window.addEventListener('resize', checkMobile);
   checkMobile();
 
+  // Register focusin/focusout BEFORE the await so they're ready immediately.
+  // overlayBodyRef is a template ref on .overlay-body which is always rendered
+  // (it does not depend on switchingSession), so it is available at mount time.
+  const body = overlayBodyRef.value;
+  if (body) {
+    body.addEventListener('focusin', handleOverlayFocusin);
+    body.addEventListener('focusout', handleOverlayFocusout);
+  }
+
   // Load data for the active session, then reveal ConversationTab.
   // switchingSession starts as true, so ConversationTab won't mount until
   // currentSession is set to the correct overlay session.
@@ -950,6 +1004,12 @@ onUnmounted(() => {
   document.removeEventListener('keydown', handleEscape);
   document.removeEventListener('click', handleClickOutsidePicker, true);
   window.removeEventListener('resize', checkMobile);
+  const body = overlayBodyRef.value;
+  if (body) {
+    body.removeEventListener('focusin', handleOverlayFocusin);
+    body.removeEventListener('focusout', handleOverlayFocusout);
+  }
+  if (focusOutRaf) cancelAnimationFrame(focusOutRaf);
   cleanupSubscription();
   if (headerCheckIntervalId) clearInterval(headerCheckIntervalId);
   if (headerCheckRafId) cancelAnimationFrame(headerCheckRafId);
@@ -957,6 +1017,19 @@ onUnmounted(() => {
   // to prevent state leaks on every overlay open/close cycle.
   overlaySessionsStore.$cleanup();
   overlayTodosStore.$cleanup();
+});
+
+// Re-scroll textarea into view after the compact header transition frees space.
+watch(inputFocused, (focused) => {
+  if (focused && isMobile.value) {
+    // After the header collapse transition (200ms) + buffer, re-center the textarea
+    setTimeout(() => {
+      const activeEl = document.activeElement;
+      if (activeEl?.tagName === 'TEXTAREA') {
+        activeEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    }, 250);
+  }
 });
 
 // Expose for testing
@@ -971,6 +1044,7 @@ defineExpose({
   pickerOpen,
   handlePickerSelect,
   ensureHeaderVisible,
+  inputFocused,
 });
 </script>
 
@@ -1150,6 +1224,34 @@ defineExpose({
   flex-shrink: 0;
   z-index: 20;
   width: 100%;
+  transition: padding 0.2s ease, gap 0.2s ease;
+}
+
+/* Compact header: collapse to a single row showing only the session name */
+.overlay-header.header-compact {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+}
+
+/* Hide the session selector row and actions row in compact mode */
+.overlay-header.header-compact .overlay-header-selector,
+.overlay-header.header-compact .overlay-header-actions {
+  display: none;
+}
+
+/* Shrink the session name text */
+.overlay-header.header-compact .overlay-root-name {
+  font-size: 0.8125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Hide the edit-name trigger in compact mode */
+.overlay-header.header-compact .name-edit-trigger {
+  display: none;
 }
 
 .overlay-header-row {

--- a/tests/e2e/session-chat-overlay-mobile-focus.spec.ts
+++ b/tests/e2e/session-chat-overlay-mobile-focus.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  seedChildSession,
+  updateSessionStatus,
+  seedConversationHistory,
+  waitForSessionToExist,
+  cleanupCreatedResources,
+  navigateAndWait,
+} from './helpers';
+
+let project: any;
+let parentSession: any;
+let childSession: any;
+
+async function openOverlay(page: any, sessionId: string) {
+  await navigateAndWait(page, `/sessions/${sessionId}`, {
+    waitFor: '.session-detail',
+    timeout: 15000,
+  });
+  const handle = page.locator('[data-testid="session-chat-handle"]');
+  await expect(handle).toBeVisible({ timeout: 10000 });
+  await handle.click();
+  const overlay = page.locator('[data-testid="session-chat-overlay"]');
+  await expect(overlay).toBeVisible({ timeout: 5000 });
+  await page.waitForTimeout(400); // Wait for slide-in animation
+  return overlay;
+}
+
+test.describe('Session Chat Overlay - Mobile Focus Behavior', () => {
+  test.beforeEach(async () => {
+    project = await seedProject('Mobile Focus Test', '/tmp/mobile-focus-test');
+    parentSession = await seedSession(project.id, {
+      prompt: 'Parent session prompt',
+      name: 'Parent Session',
+    });
+    await waitForSessionToExist(parentSession.id);
+    childSession = await seedChildSession(project.id, parentSession.id, {
+      prompt: 'Child session prompt',
+      name: 'Child Session',
+    });
+    await waitForSessionToExist(childSession.id);
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('header collapses to compact mode when textarea is focused on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await updateSessionStatus(parentSession.id, 'waiting');
+    const overlay = await openOverlay(page, parentSession.id);
+
+    // Verify header rows are visible before focus
+    await expect(overlay.locator('.overlay-header-actions')).toBeVisible();
+    await expect(overlay.locator('.overlay-header-selector')).toBeVisible();
+
+    // Focus the textarea
+    const textarea = overlay.locator('textarea').first();
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await textarea.focus();
+
+    // Verify compact mode is applied
+    await expect(overlay.locator('.overlay-header.header-compact')).toBeVisible({ timeout: 3000 });
+
+    // Verify hidden rows
+    await expect(overlay.locator('.overlay-header-actions')).not.toBeVisible();
+    await expect(overlay.locator('.overlay-header-selector')).not.toBeVisible();
+
+    // Session name should still be visible
+    await expect(overlay.locator('.overlay-root-name')).toBeVisible();
+  });
+
+  test('header re-expands when textarea loses focus on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await updateSessionStatus(parentSession.id, 'waiting');
+    const overlay = await openOverlay(page, parentSession.id);
+
+    // Focus then blur the textarea
+    const textarea = overlay.locator('textarea').first();
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await textarea.focus();
+    await expect(overlay.locator('.overlay-header.header-compact')).toBeVisible({ timeout: 3000 });
+
+    await textarea.blur();
+    // Wait for requestAnimationFrame to fire
+    await page.waitForTimeout(100);
+
+    // Header should be back to full size
+    await expect(overlay.locator('.overlay-header.header-compact')).not.toBeVisible({ timeout: 3000 });
+    await expect(overlay.locator('.overlay-header-actions')).toBeVisible();
+  });
+
+  test('header does not collapse on desktop when textarea is focused', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await updateSessionStatus(parentSession.id, 'waiting');
+    const overlay = await openOverlay(page, parentSession.id);
+
+    const textarea = overlay.locator('textarea').first();
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await textarea.focus();
+
+    // Should NOT collapse — isMobile is false at 1280px
+    await expect(overlay.locator('.overlay-header.header-compact')).not.toBeVisible();
+    await expect(overlay.locator('.overlay-header-actions')).toBeVisible();
+    await expect(overlay.locator('.overlay-header-selector')).toBeVisible();
+  });
+
+  test('textarea remains visible within viewport after focus on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    // Seed enough messages to force scroll, then set status to waiting so textarea appears
+    await seedConversationHistory(parentSession.id, 20);
+    await updateSessionStatus(parentSession.id, 'waiting');
+    const overlay = await openOverlay(page, parentSession.id);
+
+    const textarea = overlay.locator('textarea').first();
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await textarea.focus();
+    await page.waitForTimeout(500); // Allow scroll + header collapse animation
+
+    const box = await textarea.boundingBox();
+    expect(box).not.toBeNull();
+    // Textarea should be within the viewport (CSS pixel coordinates relative to viewport)
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(667);
+  });
+
+  test('header does not collapse while editing session name on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await updateSessionStatus(parentSession.id, 'waiting');
+    const overlay = await openOverlay(page, parentSession.id);
+
+    // Start editing the session name
+    const editTrigger = overlay.locator('.name-edit-trigger');
+    await expect(editTrigger).toBeVisible({ timeout: 3000 });
+    await editTrigger.click();
+    await expect(overlay.locator('.name-edit-input')).toBeVisible({ timeout: 3000 });
+
+    // Now focus the prompt textarea (user tabs down or taps it)
+    const textarea = overlay.locator('textarea').first();
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+    await textarea.focus();
+
+    // Header should NOT collapse because isEditingName is true
+    await expect(overlay.locator('.overlay-header.header-compact')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes keyboard pushing textarea off-screen on mobile devices
- Collapses header to compact mode when textarea is focused on mobile
- Ensures textarea remains visible and accessible during keyboard interaction

## Problem
On mobile devices (<768px), when users tap the prompt textarea in the session chat overlay:
1. The software keyboard pushes the textarea out of view
2. The sticky header consumes valuable vertical space
3. Users cannot see what they're typing

## Solution
- **Compact header mode**: When textarea is focused on mobile, header collapses to show only the session name
- **Auto-scroll**: Textarea scrolls into view (centered) when focused
- **Smart behavior**: Full header preserved when:
  - Editing session name
  - On desktop viewports (>768px)
- **Event delegation**: Uses focusin/focusout with requestAnimationFrame deferral to avoid iOS race conditions

## Changes
- `SessionChatOverlay.vue`: Added `inputFocused` state, focus event handlers, compact header styling
- `session-chat-overlay-mobile-focus.spec.ts`: New E2E tests covering:
  - Header compaction on focus
  - Re-expansion on blur
  - Desktop behavior unchanged
  - Textarea viewport visibility
  - Name-edit mode preservation

## Test plan
- [x] Unit/E2E tests added for mobile focus behavior
- [ ] Manual testing on mobile viewport (375x667)
- [ ] Manual testing on desktop viewport (1280x800)
- [ ] Manual testing on iPad/tablet viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)