### PR TITLE
Fix ES module hoisting bug in npm package and add publish script

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -189,7 +189,7 @@ console.log('Writing bin/cli.js...');
 const cli = `#!/usr/bin/env node
 
 process.env.NODE_ENV = 'production';
-import '../src/index.js';
+await import('../src/index.js');
 `;
 
 writeFileSync(join(DIST, 'packages/server/bin/cli.js'), cli);

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+##
+# Publish circuschief to npm.
+#
+# Usage:
+#   ./scripts/publish.sh <version> <otp>
+#
+# Examples:
+#   ./scripts/publish.sh 0.2.0 123456
+#   ./scripts/publish.sh 1.0.0 789012
+##
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <version> <otp>"
+  echo ""
+  echo "  version   Semver version to publish (e.g. 0.2.0)"
+  echo "  otp       npm one-time password for 2FA"
+  echo ""
+  echo "Example:"
+  echo "  $0 0.2.0 123456"
+  exit 1
+fi
+
+VERSION="$1"
+OTP="$2"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "========================================"
+echo " Publishing circuschief v${VERSION}"
+echo "========================================"
+echo ""
+
+# --- 1. Verify npm login ---
+echo "Checking npm login..."
+NPM_USER=$(npm whoami 2>/dev/null || true)
+if [ -z "$NPM_USER" ]; then
+  echo "ERROR: Not logged in to npm. Run 'npm login' first."
+  exit 1
+fi
+echo "Logged in as: $NPM_USER"
+echo ""
+
+# --- 2. Build the package ---
+echo "Building package..."
+node "$SCRIPT_DIR/build-package.js" --version="$VERSION"
+echo ""
+
+# --- 3. Publish ---
+echo "Publishing to npm..."
+cd "$ROOT/dist-package"
+npm publish --otp="$OTP"
+echo ""
+
+echo "========================================"
+echo " Successfully published circuschief@${VERSION}"
+echo "========================================"
+echo ""
+echo "Install & run:"
+echo "  npx circuschief"
+echo "  npx circuschief@${VERSION}"


### PR DESCRIPTION
## Summary
- **Fixed "Cannot GET /" bug in published npm package** — static `import` in `cli.js` was hoisted above `process.env.NODE_ENV = 'production'`, causing the server to skip serving static files when run via `npx circuschief`. Replaced with dynamic `await import()` so `NODE_ENV` is set before the module loads. Fix was published as v0.1.1.
- **Added `scripts/publish.sh`** — a deployment automation script that accepts version and OTP as arguments, streamlining future npm releases into a single command (`./scripts/publish.sh 0.2.0 123456`).

## Test plan
- [ ] Run `node scripts/build-package.js --version=0.0.0-test` and verify `dist-package/packages/server/bin/cli.js` uses `await import()` instead of static `import`
- [ ] Run `./scripts/start-package-server.sh` and verify the app loads correctly at the assigned port (no "Cannot GET /" error)
- [ ] Run `./scripts/publish.sh` with no arguments and verify it prints usage instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)