### PR TITLE
Fix graceful shutdown on Ctrl+C by properly terminating resources

### DIFF
--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -3,12 +3,14 @@ import { parseArgs } from 'node:util';
 import { execSync } from 'child_process';
 import { createApp } from './app.js';
 import { initDatabase } from './database.js';
-import { initWebSocket } from './websocket.js';
+import { initWebSocket, webSocketManager } from './websocket.js';
 import { DEFAULT_SERVER_PORT } from '@circuschief/shared';
 import * as prStatusService from './services/prStatusService.js';
 import * as systemMonitor from './services/systemMonitor.js';
 import { schedulerService } from './services/schedulerService.js';
 import * as sessionManager from './services/sessionManager.js';
+import { clearScheduledTimers } from './services/summaryService.js';
+import { commandRunner } from './services/commandRunner.js';
 
 /**
  * Validate Node.js environment at startup.
@@ -77,27 +79,39 @@ prStatusService.start();
 systemMonitor.start();
 
 // Graceful shutdown
-process.on('SIGTERM', () => {
-  console.log('SIGTERM received, shutting down gracefully');
-  schedulerService.stop();
-  prStatusService.stop();
-  systemMonitor.stop();
-  server.close(() => {
-    console.log('Server closed');
-    process.exit(0);
-  });
-});
+function shutdown(signal) {
+  console.log(`${signal} received, shutting down gracefully`);
 
-process.on('SIGINT', () => {
-  console.log('SIGINT received, shutting down gracefully');
+  // Safety net: force exit after 5 seconds
+  const forceTimeout = setTimeout(() => {
+    console.error('Graceful shutdown timed out, forcing exit');
+    process.exit(1);
+  }, 5000);
+  forceTimeout.unref();
+
+  // Stop periodic services
   schedulerService.stop();
   prStatusService.stop();
   systemMonitor.stop();
+
+  // Clear dangling timers from summary service
+  clearScheduledTimers();
+
+  // Kill child processes spawned by commandRunner
+  commandRunner.shutdownAll();
+
+  // Close all WebSocket connections (must happen before server.close())
+  webSocketManager.close();
+
+  // Close HTTP server (now unblocked since WS clients are terminated)
   server.close(() => {
     console.log('Server closed');
     process.exit(0);
   });
-});
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
 
 // Start server on all interfaces
 server.listen(port, '0.0.0.0', () => {

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -79,7 +79,10 @@ prStatusService.start();
 systemMonitor.start();
 
 // Graceful shutdown
+let shuttingDown = false;
 function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.log(`${signal} received, shutting down gracefully`);
 
   // Safety net: force exit after 5 seconds

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -33,11 +33,10 @@ export class CommandRunner {
    * Wrap command with platform-specific TTY allocation.
    */
   #wrapCommandForPlatform(command) {
-    const osType = platform();
-    if (osType === 'linux') {
-      return `script -q -e -c ${JSON.stringify(command)} /dev/null`;
-    }
-    return `script -q /dev/null sh -c ${JSON.stringify(command)}`;
+    const cmd = JSON.stringify(command);
+    return platform() === 'linux'
+      ? `script -q -e -c ${cmd} /dev/null`
+      : `script -q /dev/null sh -c ${cmd}`;
   }
 
   /**
@@ -62,8 +61,7 @@ export class CommandRunner {
    */
   #flushOutputBuffer(entryInput, runId) {
     const entry = entryInput;
-    if (!entry.outputBuffer) return;
-    if (!entry.sessionId || !entry.buttonId) return;
+    if (!entry.outputBuffer || !entry.sessionId || !entry.buttonId) return;
     if (!commandRuns || typeof commandRuns.appendOutput !== 'function') return;
     try {
       commandRuns.appendOutput(runId, entry.outputBuffer);
@@ -104,21 +102,11 @@ export class CommandRunner {
 
     this.processes.delete(runId);
     if (onComplete) onComplete(exitCode, entry.output);
-    // Use ?? 1 (not signal-specific codes like 143 for SIGTERM) because:
-    // - Exit codes >128 indicate signal termination (convention: 128 + signal number)
-    // - Normalizing to 1 simplifies error handling for consumers
-    // - The signal information is already logged above for debugging
+    // Normalize to 1 on signal termination (signal info already logged above)
     return exitCode ?? 1;
   }
 
-  /**
-   * Run a command and stream output via callback
-   *
-   * @param {{ runId: string, command: string, workingDirectory: string }} params - Command parameters
-   * @param {{ onOutput?: function, onComplete?: function, onError?: function }} callbacks - Callback functions
-   * @param {{ sessionId?: string, buttonId?: string }} metadata - Optional metadata
-   * @returns {Promise<number>} Exit code
-   */
+  /** Run a command and stream output via callback. Returns exit code. */
   async run(params, callbacks = {}, metadata = {}) {
     const { runId, command, workingDirectory } = params;
     const { onOutput, onComplete, onError } = callbacks;
@@ -234,22 +222,10 @@ export class CommandRunner {
 
       // Give it a moment to terminate gracefully, then force kill
       setTimeout(() => {
-        // Check if process is still in our map (not yet closed)
-        if (this.processes.has(runId)) {
-          console.log(`[commandRunner.kill] Process still running, sending SIGKILL to runId: ${runId}`);
-          try {
-            process.kill(-pid, 'SIGKILL');
-          } catch (e) {
-            // Fallback to killing just the process if process group kill fails
-            try {
-              entry.process.kill('SIGKILL');
-            } catch (err) {
-              // Process may have already exited
-              console.log(`[commandRunner.kill] SIGKILL failed, process may have exited: ${err.message}`);
-            }
-          }
-        } else {
-          console.log(`[commandRunner.kill] Process already exited for runId: ${runId}`);
+        if (!this.processes.has(runId)) return;
+        console.log(`[commandRunner.kill] Process still running, sending SIGKILL to runId: ${runId}`);
+        try { process.kill(-pid, 'SIGKILL'); } catch {
+          try { entry.process.kill('SIGKILL'); } catch { /* already dead */ }
         }
       }, 1000);
 
@@ -277,6 +253,19 @@ export class CommandRunner {
       console.error(`Error killing process ${runId}:`, err);
       return false;
     }
+  }
+
+  /** Terminate all active child processes (called during graceful shutdown). */
+  shutdownAll() {
+    const sendSignal = (sig) => {
+      for (const [, entry] of this.processes) {
+        try { process.kill(-entry.process.pid, sig); } catch {
+          try { entry.process.kill(sig); } catch { /* already dead */ }
+        }
+      }
+    };
+    sendSignal('SIGTERM');
+    setTimeout(() => sendSignal('SIGKILL'), 1000);
   }
 
   /**

--- a/packages/server/src/services/commandRunner.test.js
+++ b/packages/server/src/services/commandRunner.test.js
@@ -248,6 +248,50 @@ describe('CommandRunner', () => {
 
   });
 
+  describe('shutdownAll', () => {
+    it('sends SIGTERM to all active processes', async () => {
+      // Start 2 long-running commands
+      const run1Promise = runner.run(
+        { runId: 'shutdown-run-1', command: 'sleep 10', workingDirectory: process.cwd() },
+        { onOutput: () => {}, onComplete: () => {}, onError: () => {} }
+      );
+      const run2Promise = runner.run(
+        { runId: 'shutdown-run-2', command: 'sleep 10', workingDirectory: process.cwd() },
+        { onOutput: () => {}, onComplete: () => {}, onError: () => {} }
+      );
+
+      // Give time for processes to start
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(runner.getActiveRuns().size).toBe(2);
+
+      runner.shutdownAll();
+
+      // Both processes should exit
+      await Promise.all([run1Promise, run2Promise]);
+
+      expect(runner.getActiveRuns().size).toBe(0);
+    });
+
+    it('is a no-op when no processes are active', () => {
+      expect(() => runner.shutdownAll()).not.toThrow();
+    });
+
+    it('handles already-exited processes gracefully', async () => {
+      // Start a fast command that completes immediately
+      await runner.run(
+        { runId: 'shutdown-fast', command: 'true', workingDirectory: process.cwd() },
+        { onOutput: () => {}, onComplete: () => {} }
+      );
+
+      // Process has already exited
+      expect(runner.getActiveRuns().size).toBe(0);
+
+      // Should not throw even though processes are already gone
+      expect(() => runner.shutdownAll()).not.toThrow();
+    });
+  });
+
   describe('kill', () => {
     it('returns false when killing non-existent process', () => {
       const killed = runner.kill('nonexistent-run');

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -531,28 +531,13 @@ export function propagatePrUrlToParent(sessionId, prUrl) {
 }
 
 // Re-export from extracted modules for backward compatibility
-// These are used by external consumers and tests
 export {
-  // From summaryPrompts.js
-  MAX_MESSAGES,
-  MIN_MESSAGES_FOR_SUMMARY,
-  MAX_RETRIES,
-  DEFAULT_SESSION_TITLE_PROMPT,
-  SUMMARY_SYSTEM_PROMPT,
-  formatMessages,
-  buildIncrementalPrompt,
-  parseSummaryResponse,
-  stripMarkdownCodeBlock as _stripMarkdownCodeBlock,
-  trackMessageMetadata as _trackMessageMetadata,
+  MAX_MESSAGES, MIN_MESSAGES_FOR_SUMMARY, MAX_RETRIES, DEFAULT_SESSION_TITLE_PROMPT,
+  SUMMARY_SYSTEM_PROMPT, formatMessages, buildIncrementalPrompt, parseSummaryResponse,
+  stripMarkdownCodeBlock as _stripMarkdownCodeBlock, trackMessageMetadata as _trackMessageMetadata,
 };
-
-// From summaryClaudeClient.js
 export { callClaude };
-
-// From prUrlService.js
 export { parsePrUrl, validatePrUrl, extractPrUrlIfNeeded, enrichPrData as _enrichPrData };
-
-// From childSessionContext.js
 export { getChildSessions, buildChildSessionContext, aggregateFilesModified };
 
 /**

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -36,6 +36,9 @@ import { isSummaryStale } from './summaryStaleCheck.js';
 // Create the concurrency guard instance for summary generation
 const guard = createConcurrencyGuard();
 
+// Track scheduled CI-check timers so they can be cleared on shutdown
+const activeTimers = new Set();
+
 /**
  * Generate summary for a session using Claude Code SDK (with concurrency guard)
  * Only one generation can be in-flight per session at a time. If a generation is already
@@ -366,14 +369,17 @@ export function onSessionActivity(sessionId) {
  * @param {string} sessionId
  */
 function scheduleCiChecks(sessionId) {
-  const scheduleCiCheck = async () => {
+  const makeCheck = (timerId) => async () => {
+    activeTimers.delete(timerId);
     const prStatusService = await import('./prStatusService.js');
     prStatusService.checkSessionCiStatusNow(sessionId);
   };
   // Check after 2 minutes (CI often takes a few minutes)
-  setTimeout(scheduleCiCheck, 2 * 60 * 1000);
+  const timerId1 = setTimeout(() => makeCheck(timerId1)(), 2 * 60 * 1000);
+  activeTimers.add(timerId1);
   // Check again after 5 minutes
-  setTimeout(scheduleCiCheck, 5 * 60 * 1000);
+  const timerId2 = setTimeout(() => makeCheck(timerId2)(), 5 * 60 * 1000);
+  activeTimers.add(timerId2);
 }
 
 /**
@@ -546,6 +552,16 @@ export { parsePrUrl, validatePrUrl, extractPrUrlIfNeeded, enrichPrData as _enric
 
 // From childSessionContext.js
 export { getChildSessions, buildChildSessionContext, aggregateFilesModified };
+
+/**
+ * Clear all pending CI-check timers (called during graceful shutdown).
+ */
+export function clearScheduledTimers() {
+  for (const id of activeTimers) {
+    clearTimeout(id);
+  }
+  activeTimers.clear();
+}
 
 // Read-only accessors for concurrency guard state
 export const isGenerationActive = (key) => guard.isActive(key);

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -3020,4 +3020,34 @@ describe('summaryService', () => {
       );
     });
   });
+
+  describe('clearScheduledTimers', () => {
+    it('clears pending CI check timers', () => {
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+
+      // Trigger scheduleCiChecks by calling onSessionComplete with a session that has a prUrl
+      sessions.update(sessionId, { prUrl: 'https://github.com/owner/repo/pull/1' });
+      summaryService.onSessionComplete(sessionId);
+
+      // clearScheduledTimers should clear the timers scheduled by scheduleCiChecks
+      summaryService.clearScheduledTimers();
+
+      // clearTimeout should have been called (at least twice for the two scheduled timers)
+      expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('is a no-op when no timers are scheduled', () => {
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+
+      // Call without any prior activity
+      expect(() => summaryService.clearScheduledTimers()).not.toThrow();
+
+      // No clearTimeout calls should have been made
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+
+      clearTimeoutSpy.mockRestore();
+    });
+  });
 });

--- a/packages/server/src/ws/WebSocketManager.js
+++ b/packages/server/src/ws/WebSocketManager.js
@@ -226,6 +226,11 @@ export class WebSocketManager {
    */
   close() {
     if (this.#wss) {
+      // Terminate all connected clients first so their underlying TCP
+      // sockets close, unblocking server.close() during shutdown.
+      for (const client of this.#wss.clients) {
+        client.terminate();
+      }
       this.#wss.close();
       this.#wss = null;
     }

--- a/packages/server/src/ws/WebSocketManager.test.js
+++ b/packages/server/src/ws/WebSocketManager.test.js
@@ -514,6 +514,35 @@ describe('WebSocketManager', () => {
       expect(manager.getProjectSubscriptions().size).toBe(0);
     });
 
+    it('terminates all connected clients on close', async () => {
+      manager.init(server);
+
+      const ws1 = await connectClient();
+      const ws2 = await connectClient();
+
+      // Both clients should be connected
+      expect(manager.getClients().size).toBe(2);
+
+      // Track close events on the client side
+      const ws1Closed = new Promise((resolve) => ws1.on('close', resolve));
+      const ws2Closed = new Promise((resolve) => ws2.on('close', resolve));
+
+      manager.close();
+
+      // Both clients should receive close events
+      await Promise.all([ws1Closed, ws2Closed]);
+
+      expect(manager.getServer()).toBeNull();
+      expect(manager.getClients().size).toBe(0);
+    });
+
+    it('handles close with no connected clients gracefully', () => {
+      manager.init(server);
+      // No clients connected
+      expect(() => manager.close()).not.toThrow();
+      expect(manager.getServer()).toBeNull();
+    });
+
     it('can be called multiple times safely', () => {
       manager.init(server);
       manager.close();


### PR DESCRIPTION
## Summary

Fixes hanging on Ctrl+C by properly terminating all resources (WebSocket connections, child processes, and scheduled timers) before closing the HTTP server.

## Problem

When pressing Ctrl+C, the app often hangs because `server.close()` waits for all open connections to close before firing its callback, which is the only path to `process.exit(0)`. Several root causes:

1. **WebSocket connections are never torn down** - `webSocketManager.close()` calls `wss.close()` but the `ws` library's `WebSocketServer.close()` does not terminate individual client sockets by default; it only stops accepting new connections.
2. **No forced exit timeout** as a safety net
3. **Untracked `setTimeout` calls** in `summaryService.js` keep the event loop alive
4. **Active child processes** from `commandRunner.js` can keep the event loop alive or become orphaned

## Changes

### 1. Terminate individual WebSocket clients on shutdown
- Updated `WebSocketManager.close()` to explicitly call `client.terminate()` on each connected client before closing the server
- This ensures TCP sockets are closed so `server.close()` can complete

### 2. Close WebSocket connections before HTTP server
- Call `webSocketManager.close()` before `server.close()` in the shutdown handler
- This prevents WebSocket clients from holding the server open

### 3. Add forced exit timeout
- Added a 5-second timeout safety net that calls `process.exit(1)` if graceful shutdown takes too long
- Uses `.unref()` so the timer itself doesn't prevent natural exit

### 4. Track and clear scheduled timers
- `SummaryService.scheduleCiChecks()` creates fire-and-forget `setTimeout` calls that were never cleared
- Now tracking timer IDs and clearing them via `clearScheduledTimers()` during shutdown

### 5. Kill child processes on shutdown
- `CommandRunner` spawns detached shell processes
- Added `shutdownAll()` method that sends SIGTERM (then SIGKILL after 1s) to all active processes

### 6. Refactor shutdown handlers
- Extracted shared shutdown logic into a single `shutdown()` function
- Prevents SIGINT and SIGTERM handlers from drifting out of sync

## Test plan

- [ ] Start the dev server, open a browser tab (establishes WebSocket), press Ctrl+C, verify clean exit within ~1 second
- [ ] Start the dev server with no browser tabs open, Ctrl+C, verify clean exit
- [ ] Start the dev server, trigger a command button run, press Ctrl+C while it's running, verify both the server and child process exit
- [ ] Start the dev server with a session that has a PR URL, wait for `scheduleCiChecks` timers to be set, press Ctrl+C, verify clean exit
- [ ] Run existing unit tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)