### PR TITLE
Add Claude Opus 4.7 model support

### DIFF
--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -196,4 +196,7 @@ export const allMigrations = validateMigrations([
 
   // --- Seed default global quick responses ---
   m.get('quick_responses-seed-defaults'),
+
+  // --- Update built-in Opus model to 4.7 ---
+  m.get('providers-update-built-in-opus-4-7'),
 ]);

--- a/packages/server/src/db/migrations/miscMigrations.js
+++ b/packages/server/src/db/migrations/miscMigrations.js
@@ -28,7 +28,8 @@ function seedBuiltInProvider(db) {
   const defaultModels = [
     { id: 'anthropic-haiku', modelId: 'claude-haiku-4-5-20251001', displayName: 'Haiku 4.5', description: 'Fast & lightweight', tier: 'haiku' },
     { id: 'anthropic-sonnet', modelId: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: 'Balanced', tier: 'sonnet' },
-    { id: 'anthropic-opus', modelId: 'claude-opus-4-7', displayName: 'Opus 4.7', description: 'Most capable (default)', tier: 'opus' },
+    { id: 'anthropic-opus', modelId: 'claude-opus-4-6', displayName: 'Opus 4.6', description: 'Previous generation', tier: 'opus' },
+    { id: 'anthropic-opus-4-7', modelId: 'claude-opus-4-7', displayName: 'Opus 4.7', description: 'Most capable (default)', tier: 'opus' },
   ];
 
   const insertModel = db.prepare(
@@ -240,16 +241,24 @@ export const miscMigrations = [
     up(db) { seedDefaultQuickResponses(db); },
   },
 
-  // --- Update built-in Opus model to 4.7 ---
+  // --- Add Opus 4.7 as a new built-in model (keep Opus 4.6 for existing sessions) ---
   {
     name: 'providers-update-built-in-opus-4-7',
     up(db) {
       const providerId = 'anthropic-default';
+
+      // Mark existing Opus 4.6 row as previous generation
       db.prepare(
         `UPDATE provider_models
-         SET model_id = ?, display_name = ?, description = ?
+         SET description = ?
          WHERE provider_id = ? AND id = ?`
-      ).run('claude-opus-4-7', 'Opus 4.7', 'Most capable (default)', providerId, 'anthropic-opus');
+      ).run('Previous generation', providerId, 'anthropic-opus');
+
+      // Insert new Opus 4.7 row (OR IGNORE in case seed already created it)
+      db.prepare(
+        `INSERT OR IGNORE INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run('anthropic-opus-4-7', providerId, 'claude-opus-4-7', 'Opus 4.7', 'Most capable (default)', 'opus', Date.now());
     },
   },
 ];

--- a/packages/server/src/db/migrations/miscMigrations.js
+++ b/packages/server/src/db/migrations/miscMigrations.js
@@ -28,7 +28,7 @@ function seedBuiltInProvider(db) {
   const defaultModels = [
     { id: 'anthropic-haiku', modelId: 'claude-haiku-4-5-20251001', displayName: 'Haiku 4.5', description: 'Fast & lightweight', tier: 'haiku' },
     { id: 'anthropic-sonnet', modelId: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', description: 'Balanced', tier: 'sonnet' },
-    { id: 'anthropic-opus', modelId: 'claude-opus-4-6', displayName: 'Opus 4.6', description: 'Most capable (default)', tier: 'opus' },
+    { id: 'anthropic-opus', modelId: 'claude-opus-4-7', displayName: 'Opus 4.7', description: 'Most capable (default)', tier: 'opus' },
   ];
 
   const insertModel = db.prepare(
@@ -238,5 +238,18 @@ export const miscMigrations = [
   {
     name: 'quick_responses-seed-defaults',
     up(db) { seedDefaultQuickResponses(db); },
+  },
+
+  // --- Update built-in Opus model to 4.7 ---
+  {
+    name: 'providers-update-built-in-opus-4-7',
+    up(db) {
+      const providerId = 'anthropic-default';
+      db.prepare(
+        `UPDATE provider_models
+         SET model_id = ?, display_name = ?, description = ?
+         WHERE provider_id = ? AND id = ?`
+      ).run('claude-opus-4-7', 'Opus 4.7', 'Most capable (default)', providerId, 'anthropic-opus');
+    },
   },
 ];

--- a/packages/shared/src/types.js
+++ b/packages/shared/src/types.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * @typedef {'claude-sonnet-4-6' | 'claude-opus-4-6' | 'claude-haiku-4-5-20251001'} ClaudeModel
+ * @typedef {'claude-sonnet-4-6' | 'claude-opus-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5-20251001'} ClaudeModel
  */
 
 /**
@@ -117,9 +117,10 @@ export const TOOL_TEMPLATE_PAYLOAD_TYPES = ['command', 'prompt'];
 export const CLAUDE_MODELS = [
   { id: 'claude-haiku-4-5-20251001', name: 'Haiku 4.5', description: 'Fast & lightweight' },
   { id: 'claude-sonnet-4-6', name: 'Sonnet 4.6', description: 'Balanced' },
-  { id: 'claude-opus-4-6', name: 'Opus 4.6', description: 'Most capable (default)' },
+  { id: 'claude-opus-4-6', name: 'Opus 4.6', description: 'Previous generation' },
+  { id: 'claude-opus-4-7', name: 'Opus 4.7', description: 'Most capable (default)' },
 ];
-export const DEFAULT_MODEL = 'claude-opus-4-6';
+export const DEFAULT_MODEL = 'claude-opus-4-7';
 
 /**
  * @typedef {Object} KanbanBoard

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -7,7 +7,7 @@ import { useProvidersStore } from '../stores/providers.js';
 import { CLAUDE_MODELS } from '@circuschief/shared';
 
 // Use actual model data from the shared package
-const [haiku, sonnet, opus] = CLAUDE_MODELS;
+const [haiku, sonnet, opusLegacy, opus] = CLAUDE_MODELS;
 
 // Global helper to flush all async updates and force DOM re-render
 async function flushAll(wrapper) {
@@ -58,10 +58,10 @@ describe('ModelSelector', () => {
       expect(wrapper.find('select').exists()).toBe(true);
     });
 
-    it('renders all three model options', () => {
+    it('renders all four model options', () => {
       const wrapper = mountComponent();
       const options = wrapper.findAll('option');
-      expect(options).toHaveLength(3);
+      expect(options).toHaveLength(4);
     });
 
     it('displays model names in options', () => {
@@ -69,7 +69,8 @@ describe('ModelSelector', () => {
       const options = wrapper.findAll('option');
       expect(options[0].text()).toBe(haiku.name);
       expect(options[1].text()).toBe(sonnet.name);
-      expect(options[2].text()).toBe(opus.name);
+      expect(options[2].text()).toBe(opusLegacy.name);
+      expect(options[3].text()).toBe(opus.name);
     });
 
     it('sets correct values for options', () => {
@@ -77,7 +78,8 @@ describe('ModelSelector', () => {
       const options = wrapper.findAll('option');
       expect(options[0].element.value).toBe(haiku.id);
       expect(options[1].element.value).toBe(sonnet.id);
-      expect(options[2].element.value).toBe(opus.id);
+      expect(options[2].element.value).toBe(opusLegacy.id);
+      expect(options[3].element.value).toBe(opus.id);
     });
   });
 
@@ -300,8 +302,8 @@ describe('ModelSelector', () => {
     it('renders an empty option when allowEmpty is true', () => {
       const wrapper = mountComponent({ allowEmpty: true, modelValue: '' });
       const options = wrapper.findAll('option');
-      // 1 empty option + 3 model options
-      expect(options).toHaveLength(4);
+      // 1 empty option + 4 model options
+      expect(options).toHaveLength(5);
       expect(options[0].text()).toBe('Use system default');
       expect(options[0].element.value).toBe('');
     });
@@ -309,7 +311,7 @@ describe('ModelSelector', () => {
     it('does not render an empty option when allowEmpty is false (default)', () => {
       const wrapper = mountComponent({ modelValue: sonnet.id });
       const options = wrapper.findAll('option');
-      expect(options).toHaveLength(3);
+      expect(options).toHaveLength(4);
     });
 
     it('uses custom emptyLabel text', () => {
@@ -392,7 +394,8 @@ describe('ModelSelector', () => {
           models: [
             { id: 'anthropic-haiku', modelId: 'claude-haiku-4-5-20251001', displayName: 'Haiku 4.5', tier: 'haiku' },
             { id: 'anthropic-sonnet', modelId: 'claude-sonnet-4-6', displayName: 'Sonnet 4.6', tier: 'sonnet' },
-            { id: 'anthropic-opus', modelId: 'claude-opus-4-6', displayName: 'Opus 4.6', tier: 'opus' },
+            { id: 'anthropic-opus-legacy', modelId: 'claude-opus-4-6', displayName: 'Opus 4.6', tier: 'opus' },
+            { id: 'anthropic-opus', modelId: 'claude-opus-4-7', displayName: 'Opus 4.7', tier: 'opus' },
           ],
         },
       ];
@@ -406,6 +409,7 @@ describe('ModelSelector', () => {
       expect(options[0].text()).toBe('Haiku 4.5');
       expect(options[1].text()).toBe('Sonnet 4.6');
       expect(options[2].text()).toBe('Opus 4.6');
+      expect(options[3].text()).toBe('Opus 4.7');
     });
 
     it('displays modelId for custom provider models', async () => {

--- a/packages/web/src/composables/useModelInfo.test.js
+++ b/packages/web/src/composables/useModelInfo.test.js
@@ -8,6 +8,11 @@ describe('useModelInfo', () => {
       expect(getModelDisplayName('claude-opus-4-6')).toBe('Opus 4.6');
     });
 
+    it('returns "Opus 4.7" for claude-opus-4-7', () => {
+      const { getModelDisplayName } = useModelInfo();
+      expect(getModelDisplayName('claude-opus-4-7')).toBe('Opus 4.7');
+    });
+
     it('returns "Sonnet 4.6" for claude-sonnet-4-6', () => {
       const { getModelDisplayName } = useModelInfo();
       expect(getModelDisplayName('claude-sonnet-4-6')).toBe('Sonnet 4.6');
@@ -40,9 +45,14 @@ describe('useModelInfo', () => {
   });
 
   describe('getModelDescription', () => {
-    it('returns "Most capable (default)" for Opus model', () => {
+    it('returns "Previous generation" for Opus 4.6 model', () => {
       const { getModelDescription } = useModelInfo();
-      expect(getModelDescription('claude-opus-4-6')).toBe('Most capable (default)');
+      expect(getModelDescription('claude-opus-4-6')).toBe('Previous generation');
+    });
+
+    it('returns "Most capable (default)" for Opus 4.7 model', () => {
+      const { getModelDescription } = useModelInfo();
+      expect(getModelDescription('claude-opus-4-7')).toBe('Most capable (default)');
     });
 
     it('returns "Balanced" for Sonnet model', () => {
@@ -68,12 +78,22 @@ describe('useModelInfo', () => {
   });
 
   describe('getModelInfo', () => {
-    it('returns object with name and description for valid model', () => {
+    it('returns object with name and description for Opus 4.6', () => {
       const { getModelInfo } = useModelInfo();
       const info = getModelInfo('claude-opus-4-6');
 
       expect(info).toEqual({
         name: 'Opus 4.6',
+        description: 'Previous generation',
+      });
+    });
+
+    it('returns object with name and description for Opus 4.7', () => {
+      const { getModelInfo } = useModelInfo();
+      const info = getModelInfo('claude-opus-4-7');
+
+      expect(info).toEqual({
+        name: 'Opus 4.7',
         description: 'Most capable (default)',
       });
     });

--- a/tests/e2e/opus-4-7-model.spec.ts
+++ b/tests/e2e/opus-4-7-model.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  openSessionOverlay,
+  cleanupCreatedResources,
+  API_URL,
+  TEST_PREFIX,
+  getProviders,
+} from './helpers';
+
+/**
+ * E2E tests for Claude Opus 4.7 model availability.
+ *
+ * Verifies that the Opus 4.7 model appears in both:
+ * 1. The providers API response (backend)
+ * 2. The model selector dropdown (frontend)
+ *
+ * Also verifies that Opus 4.6 remains available for backward compatibility
+ * (existing sessions may still reference it).
+ */
+test.describe('Opus 4.7 Model Availability', () => {
+  let project: any;
+
+  test.beforeEach(async () => {
+    project = await seedProject('Opus 4.7 Test', '/tmp/opus-47-test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('providers API includes both claude-opus-4-6 and claude-opus-4-7', async () => {
+    const providers = await getProviders();
+
+    // Find the built-in Anthropic provider
+    const builtIn = providers.find((p: any) => p.isBuiltIn);
+    expect(builtIn, 'Built-in Anthropic provider should exist').toBeTruthy();
+
+    // Get all model IDs from the built-in provider
+    const modelIds = builtIn.models.map((m: any) => m.modelId);
+    console.log('Built-in provider model IDs:', modelIds);
+
+    // Both Opus versions must be present
+    expect(modelIds, 'Should include claude-opus-4-6').toContain('claude-opus-4-6');
+    expect(modelIds, 'Should include claude-opus-4-7').toContain('claude-opus-4-7');
+
+    // Verify Opus 4.7 display name and tier
+    const opus47 = builtIn.models.find((m: any) => m.modelId === 'claude-opus-4-7');
+    expect(opus47.displayName).toBe('Opus 4.7');
+    expect(opus47.tier).toBe('opus');
+
+    // Verify Opus 4.6 is marked as previous generation
+    const opus46 = builtIn.models.find((m: any) => m.modelId === 'claude-opus-4-6');
+    expect(opus46.displayName).toBe('Opus 4.6');
+    expect(opus46.description).toBe('Previous generation');
+  });
+
+  test('model selector dropdown includes both Opus 4.6 and 4.7 options', async ({ page }) => {
+    // Create a draft session so we can see the model selector
+    const session = await seedSession(project.id, {
+      prompt: 'Test Opus 4.7 availability in model selector',
+      startImmediately: false,
+      gitMode: 'none',
+      gitBranch: 'main',
+    });
+
+    // Navigate to session and open the chat overlay
+    await page.goto(`/sessions/${session.id}/summary`);
+    await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
+
+    // Wait for model selector to be visible
+    const modelSelect = page.locator('#model-select');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for options to load (providers store fetch)
+    await page.waitForFunction(() => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      return select && select.options.length >= 4;
+    }, { timeout: 10000 });
+
+    // Gather all option values from the dropdown
+    const optionValues = await page.evaluate(() => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      return Array.from(select.options).map(opt => ({
+        value: opt.value,
+        text: opt.textContent?.trim(),
+      }));
+    });
+    console.log('Model selector options:', JSON.stringify(optionValues, null, 2));
+
+    // Assert that both Opus versions are available
+    const opus47Option = optionValues.find(opt => opt.value === 'claude-opus-4-7');
+    expect(
+      opus47Option,
+      `Opus 4.7 should be in the model selector. Found: ${optionValues.map(o => o.value).join(', ')}`
+    ).toBeTruthy();
+    expect(opus47Option!.text).toContain('Opus 4.7');
+
+    const opus46Option = optionValues.find(opt => opt.value === 'claude-opus-4-6');
+    expect(
+      opus46Option,
+      `Opus 4.6 should still be in the model selector for backward compatibility. Found: ${optionValues.map(o => o.value).join(', ')}`
+    ).toBeTruthy();
+    expect(opus46Option!.text).toContain('Opus 4.6');
+  });
+
+  test('can select Opus 4.7 model on a draft session', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Test selecting Opus 4.7',
+      startImmediately: false,
+      gitMode: 'none',
+      gitBranch: 'main',
+    });
+
+    await page.goto(`/sessions/${session.id}/summary`);
+    await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
+
+    const modelSelect = page.locator('#model-select');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for options to be populated
+    await page.waitForFunction(() => {
+      const select = document.querySelector('#model-select') as HTMLSelectElement;
+      return select && Array.from(select.options).some(opt => opt.value === 'claude-opus-4-7');
+    }, { timeout: 10000 });
+
+    // Select Opus 4.7 and wait for the PATCH request
+    const patchPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/api/sessions/') && resp.request().method() === 'PATCH',
+      { timeout: 10000 }
+    );
+    await modelSelect.selectOption('claude-opus-4-7');
+    const patchResponse = await patchPromise;
+    expect(patchResponse.ok()).toBe(true);
+
+    // Verify the session was updated via API
+    const updatedRes = await fetch(`${API_URL}/api/sessions/${session.id}`);
+    const updated = await updatedRes.json();
+    expect(updated.model).toBe('claude-opus-4-7');
+  });
+
+  test('existing session with Opus 4.6 still shows correct model in dropdown', async ({ page }) => {
+    // Create a session explicitly using Opus 4.6 (simulates a pre-existing session)
+    const session = await seedSession(project.id, {
+      prompt: 'Existing session with Opus 4.6',
+      model: 'claude-opus-4-6',
+      startImmediately: false,
+      gitMode: 'none',
+      gitBranch: 'main',
+    });
+
+    await page.goto(`/sessions/${session.id}/summary`);
+    await page.waitForLoadState('networkidle');
+    await openSessionOverlay(page);
+
+    const modelSelect = page.locator('#model-select');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for the model selector to initialize with the session's model
+    await page.waitForFunction(
+      (expectedModel) => {
+        const select = document.querySelector('#model-select') as HTMLSelectElement;
+        return select && select.value === expectedModel;
+      },
+      'claude-opus-4-6',
+      { timeout: 10000 }
+    );
+
+    // The selected value should be claude-opus-4-6
+    const selectedValue = await modelSelect.inputValue();
+    expect(selectedValue).toBe('claude-opus-4-6');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds support for the newly released Claude Opus 4.7 model
- Updates the default model from Opus 4.6 to Opus 4.7
- Includes database migration to update existing installations
- Updates all affected tests

## Changes
- **Model Constants**: Added `claude-opus-4-7` to `CLAUDE_MODELS` array and `ClaudeModel` typedef
- **Default Model**: Changed `DEFAULT_MODEL` from `claude-opus-4-6` to `claude-opus-4-7`
- **Model Descriptions**: Updated Opus 4.6 to "Previous generation" and Opus 4.7 to "Most capable (default)"
- **Database Migration**: Added `providers-update-built-in-opus-4-7` migration to update the built-in Anthropic provider's Opus model
- **Test Updates**: 
  - Updated `ModelSelector.test.js` to handle 4 models instead of 3
  - Updated `useModelInfo.test.js` with new test cases for Opus 4.7
  - Updated existing Opus 4.6 tests to reflect its new "Previous generation" description

## Test plan
- [x] All unit tests pass (`yarn test`)
- [x] No lint errors (`yarn lint`)
- [x] Manual verification that Opus 4.7 appears in model selector
- [x] Database migration correctly updates existing provider_models entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)