### PR TITLE
Fix ERR_MODULE_NOT_FOUND for @circuschief/shared when running via npx

### DIFF
--- a/packages/server/src/services/sessionExecution.js
+++ b/packages/server/src/services/sessionExecution.js
@@ -21,6 +21,8 @@ import {
 import { shouldRescheduleOnError, _checkProactiveReschedule } from './sessionErrors.js';
 import { schedulerService } from './schedulerService.js';
 import { buildConversationContextForModelSwitch } from './conversationContext.js';
+import { broadcastToSession } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 
 /**
  * Create the agent for a session, using gateway + logging + VCR.
@@ -243,8 +245,6 @@ async function setupConversationAndMessage(sessionId, content, fileAttachments) 
   const activeConversation = conversations.ensureActiveConversation(sessionId);
   activeConversationIds.set(sessionId, activeConversation.id);
 
-  const { broadcastToSession } = await import('../websocket.js');
-  const { WS_MESSAGE_TYPES } = await import('@circuschief/shared');
   const message = messages.create(sessionId, 'user', content, { toolUse: null, conversationId: activeConversation.id });
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, {
     message,

--- a/scripts/start-package-server.sh
+++ b/scripts/start-package-server.sh
@@ -28,14 +28,15 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PORT_FILE="$PROJECT_ROOT/.server-port"
 WORKTREE_PORT_START=5001
 MAIN_PORT=5000
-INSTALL_DIR="$PROJECT_ROOT/.package-test"
+INSTALL_DIR=$(mktemp -d "${TMPDIR:-/tmp}/circuschief-package-test.XXXXXX")
 
-# Clean up on exit — remove marker files so pw.sh doesn't find stale state
+# Clean up on exit — remove marker files and temp directory so pw.sh doesn't find stale state
 cleanup() {
     if [ -n "$SERVER_PID" ]; then
         kill "$SERVER_PID" 2>/dev/null || true
     fi
     rm -f "$PORT_FILE" "$PROJECT_ROOT/.db-path" "$PROJECT_ROOT/.vcr-mode"
+    rm -rf "$INSTALL_DIR"
 }
 trap cleanup EXIT
 
@@ -80,8 +81,7 @@ echo "Tarball: $TARBALL_PATH"
 
 echo ""
 echo "=== Installing in isolated directory ==="
-rm -rf "$INSTALL_DIR"
-mkdir -p "$INSTALL_DIR"
+echo "Install dir: $INSTALL_DIR"
 cd "$INSTALL_DIR"
 
 # Initialize package.json for the test installation


### PR DESCRIPTION
## Summary
- Fixed `ERR_MODULE_NOT_FOUND` crash when users send follow-up messages via `npx circuschief`. The dynamic `await import('@circuschief/shared')` in `sessionExecution.js` was not rewritten by the build script (which only handles static `import ... from` syntax), so it shipped verbatim in the npm package where `@circuschief/shared` doesn't exist.
- Converted the dynamic imports to static imports at the top of the file — no circular dependency exists, so this is safe.
- Moved the `test-package` install directory from `.package-test/` (inside the monorepo) to a `mktemp` dir in `/tmp`, so Node's module resolution can no longer walk up into the monorepo's `node_modules` and silently mask missing workspace packages.

## Test plan
- [x] All 1068 E2E tests pass against the built package (`./scripts/pw.sh test-package`)
- [x] All 186 unit tests pass (`sessionExecution` + `sessionManager`)
- [x] Temp directory is properly cleaned up on exit
- [ ] Manually verify `npx circuschief` follow-up messages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)