### PR TITLE
Fix PostHog analytics not reporting in npx builds

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,11 @@
+# PostHog analytics configuration for production builds.
+# Copy this file to .env.production and fill in your values.
+#
+# The build script (scripts/build-package.js) reads .env.production
+# as a fallback when no CLI flag or environment variable is provided.
+# CLI flags and env vars take precedence over values here.
+#
+# .env.production is gitignored — it will not be committed.
+
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -33,14 +33,33 @@ The PostHog API key is a **public client-side key** (always visible in the brows
 
 ### Resolution order (first non-empty wins)
 
-| Value | CLI flag | Environment variable | Default |
-|-------|----------|---------------------|---------|
-| API key | `--posthog-key=<key>` | `POSTHOG_KEY` | empty (analytics disabled) |
-| API host | `--posthog-host=<host>` | `POSTHOG_HOST` | `https://us.i.posthog.com` |
+| Value | CLI flag | Environment variable | `.env.production` | Default |
+|-------|----------|---------------------|-------------------|---------|
+| API key | `--posthog-key=<key>` | `POSTHOG_KEY` | `VITE_POSTHOG_KEY` | empty (analytics disabled) |
+| API host | `--posthog-host=<host>` | `POSTHOG_HOST` | `VITE_POSTHOG_HOST` | `https://us.i.posthog.com` |
 
-CLI flags take precedence over environment variables.
+CLI flags take precedence over environment variables, which take precedence over `.env.production`.
 
-- Omitting the key produces a working package with analytics disabled
+### Using `.env.production` (recommended for local publishing)
+
+Create a `.env.production` file in the project root (it's gitignored):
+
+```bash
+VITE_POSTHOG_KEY=phc_xxxxx
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+```
+
+Then simply run the build without any extra flags:
+
+```bash
+node scripts/build-package.js --version=0.2.0
+```
+
+The build script reads `.env.production` automatically and injects the key into the bundle. See `.env.production.example` for a template.
+
+### Notes
+
+- Omitting the key from all sources produces a working package with analytics disabled
 - `scripts/start-package-server.sh` intentionally provides no key since E2E tests don't need analytics
 - After the Vite build, the script verifies the key appears in the output bundle (if one was provided)
 

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -9,7 +9,7 @@
  * The only transform: rewrite `@circuschief/shared` imports to relative paths.
  */
 
-import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
 import { join, relative, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
@@ -19,13 +19,38 @@ const ROOT = dirname(dirname(__filename));
 const DIST = join(ROOT, 'dist-package');
 const version = process.argv.find(a => a.startsWith('--version='))?.split('=')[1] || '0.1.0';
 
+// --- Read .env.production if it exists ---
+// Parses KEY=VALUE lines (ignoring comments and blank lines) as a fallback
+// source for PostHog configuration. CLI flags and env vars take precedence.
+const dotenvVars = {};
+const envProdPath = join(ROOT, '.env.production');
+if (existsSync(envProdPath)) {
+  const lines = readFileSync(envProdPath, 'utf-8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+    // Strip surrounding quotes (single or double)
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    dotenvVars[key] = value;
+  }
+  console.log('Loaded .env.production');
+}
+
 // --- PostHog configuration ---
-// Resolution order (first non-empty wins): CLI flag → env var → default
+// Resolution order (first non-empty wins): CLI flag → env var → .env.production → default
 const posthogKey = process.argv.find(a => a.startsWith('--posthog-key='))?.split('=')[1]
   || process.env.POSTHOG_KEY
+  || dotenvVars.VITE_POSTHOG_KEY
   || '';
 const posthogHost = process.argv.find(a => a.startsWith('--posthog-host='))?.split('=')[1]
   || process.env.POSTHOG_HOST
+  || dotenvVars.VITE_POSTHOG_HOST
   || 'https://us.i.posthog.com';
 
 /** cpSync filter: exclude test files but always keep directories */
@@ -41,11 +66,11 @@ mkdirSync(DIST, { recursive: true });
 
 // --- 2. Build frontend ---
 if (!posthogKey) {
-  console.log('⚠ No PostHog key provided (--posthog-key or POSTHOG_KEY); analytics will be disabled in this build');
+  console.log('⚠ No PostHog key provided (--posthog-key, POSTHOG_KEY, or .env.production); analytics will be disabled in this build');
 }
 console.log('Building frontend...');
-// Always explicitly set VITE_POSTHOG_KEY (even when empty) to prevent Vite
-// from picking up stale values from any local .env files.
+// Explicitly set VITE_POSTHOG_KEY so the resolved value (from CLI flag,
+// env var, or .env.production) is what Vite bakes into the bundle.
 execSync('yarn workspace @circuschief/web build', {
   cwd: ROOT,
   stdio: 'inherit',


### PR DESCRIPTION
## Summary
- The build script (`build-package.js`) was not reading `.env.production` for the PostHog API key, and explicitly overrode `VITE_POSTHOG_KEY` with an empty string — preventing Vite from loading it either
- Added `.env.production` parsing as a fallback source in the build script (resolution order: CLI flag → env var → `.env.production` → default)
- Added `.env.production.example` template and updated `PUBLISHING.md` with documentation

## Test plan
- [x] All unit tests pass
- [x] Linting passes
- [x] Built v0.2.1 with `✓ PostHog key verified in frontend bundle`
- [x] Published `circuschief@0.2.1` to npm — verify PostHog events appear in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)