### PR TITLE
Replace 'Claude' with 'agent' in user-facing UI text

### DIFF
--- a/packages/web/src/components/CanvasTab.vue
+++ b/packages/web/src/components/CanvasTab.vue
@@ -103,7 +103,7 @@
       >
         <p>No canvas items yet. Upload a file or drag and drop here.</p>
         <p class="empty-state-hint">
-          Claude can also add images, markdown, and JSON to the canvas.
+          The agent can also add images, markdown, and JSON to the canvas.
         </p>
       </div>
 

--- a/packages/web/src/components/ConversationMessages.vue
+++ b/packages/web/src/components/ConversationMessages.vue
@@ -28,8 +28,8 @@
     <button
       v-if="hasAssistantMessages && isUsersTurn"
       class="scroll-to-claude-btn"
-      title="Jump to Claude's response"
-      aria-label="Scroll to Claude's latest response"
+      title="Jump to the agent's response"
+      aria-label="Scroll to the agent's latest response"
       @click="scrollToClaudesTurn"
     >
       💬

--- a/packages/web/src/components/InputForm.test.js
+++ b/packages/web/src/components/InputForm.test.js
@@ -342,7 +342,7 @@ describe('InputForm', () => {
         autoSendPendingPrompt: false,
       });
       expect(wrapper.find('.auto-send-row').exists()).toBe(true);
-      expect(wrapper.find('.auto-send-text').text()).toBe('Send automatically when Claude finishes');
+      expect(wrapper.find('.auto-send-text').text()).toBe('Send automatically when the agent finishes');
     });
 
     it('should hide auto-send checkbox when running without content', () => {

--- a/packages/web/src/components/InputForm.vue
+++ b/packages/web/src/components/InputForm.vue
@@ -33,7 +33,7 @@
           class="auto-send-checkbox"
           @change="$emit('autoSendToggle', $event.target.checked)"
         >
-        <span class="auto-send-text">Send automatically when Claude finishes</span>
+        <span class="auto-send-text">Send automatically when the agent finishes</span>
       </label>
     </div>
 

--- a/packages/web/src/components/RunningState.test.js
+++ b/packages/web/src/components/RunningState.test.js
@@ -133,7 +133,7 @@ describe('RunningState', () => {
         nextTemplate: { id: 'tmpl-1', name: 'Deploy' },
         projectId: 'proj-1',
       });
-      expect(wrapper.find('.template-pending-description').text()).toContain('will trigger when Claude finishes');
+      expect(wrapper.find('.template-pending-description').text()).toContain('will trigger when the agent finishes');
     });
 
     it('should link to project templates page', () => {

--- a/packages/web/src/components/RunningState.vue
+++ b/packages/web/src/components/RunningState.vue
@@ -42,7 +42,7 @@
       >
         {{ nextTemplate.name }}
       </a>
-      <span class="template-pending-description">will trigger when Claude finishes</span>
+      <span class="template-pending-description">will trigger when the agent finishes</span>
     </div>
   </div>
 </template>

--- a/packages/web/src/components/TemplateSelector.test.js
+++ b/packages/web/src/components/TemplateSelector.test.js
@@ -58,7 +58,7 @@ describe('TemplateSelector', () => {
     it('renders help text when no template is selected', () => {
       const wrapper = mountComponent();
       expect(wrapper.find('.selector-help').exists()).toBe(true);
-      expect(wrapper.find('.selector-help').text()).toContain('When Claude finishes responding');
+      expect(wrapper.find('.selector-help').text()).toContain('When the agent finishes responding');
     });
 
     it('renders the select dropdown', () => {

--- a/packages/web/src/components/TemplateSelector.vue
+++ b/packages/web/src/components/TemplateSelector.vue
@@ -64,7 +64,7 @@
       v-else
       class="selector-help"
     >
-      When Claude finishes responding, a new session will automatically start using this template.
+      When the agent finishes responding, a new session will automatically start using this template.
     </p>
     <div
       v-if="saving"

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -63,7 +63,7 @@
           id="prompt"
           ref="textareaRef"
           class="form-input form-textarea"
-          placeholder="What would you like Claude to help you with?"
+          placeholder="What would you like the agent to help you with?"
           :min-height="textareaMinHeight"
           required
           @input="handleInput"

--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -157,7 +157,7 @@
             Enable thinking (extended thinking) by default
           </label>
           <p class="form-help">
-            Enable Claude's extended thinking capability for new sessions.
+            Enable the agent's extended thinking capability for new sessions.
           </p>
         </div>
 
@@ -188,7 +188,7 @@
             </option>
           </select>
           <p class="form-help">
-            Set the default effort level for new sessions. Controls how much effort Claude puts into responses.
+            Set the default effort level for new sessions. Controls how much effort the agent puts into responses.
           </p>
         </div>
 
@@ -259,7 +259,7 @@
             select-class="form-input"
           />
           <p class="form-help">
-            Choose the default Claude model for new sessions in this project.
+            Choose the default model for new sessions in this project.
           </p>
         </div>
 

--- a/packages/web/src/views/ProvidersView.vue
+++ b/packages/web/src/views/ProvidersView.vue
@@ -10,7 +10,7 @@
     </div>
 
     <p class="page-description">
-      Configure custom model providers to use Claude through alternative endpoints like AWS Bedrock,
+      Configure custom model providers to use the agent through alternative endpoints like AWS Bedrock,
       Google Vertex AI, or self-hosted proxies.
     </p>
 

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -189,7 +189,7 @@
         v-else-if="sessionsStore.sessions.length === 0"
         class="empty-state"
       >
-        <p>No sessions yet. Start a new session to interact with Claude.</p>
+        <p>No sessions yet. Start a new session to interact with the agent.</p>
         <router-link
           :to="`/projects/${route.params.id}/sessions/new`"
           class="btn btn-primary"

--- a/tests/e2e/queue-prompt.spec.ts
+++ b/tests/e2e/queue-prompt.spec.ts
@@ -113,7 +113,7 @@ test.describe('Queue Prompt - Auto-Send Checkbox', () => {
     await page.locator('textarea').fill('My prompt');
 
     await expect(page.locator('.auto-send-row')).toBeVisible();
-    await expect(page.locator('.auto-send-text')).toContainText('Send automatically when Claude finishes');
+    await expect(page.locator('.auto-send-text')).toContainText('Send automatically when the agent finishes');
   });
 
   test('auto-send checkbox is hidden when textarea is empty during running', async ({ page }) => {


### PR DESCRIPTION
## Summary
Replace all user-facing references from "Claude" to "the agent" or "agent" throughout the web UI. This aligns the terminology with the agentic nature of Claude Code while maintaining clarity for users.

## Changes
Updated 13 files with 16 text replacements across:

### Vue Components (9 files)
- **NewSessionView.vue** - Prompt placeholder text
- **ProvidersView.vue** - Provider configuration description
- **ProjectEditView.vue** - Thinking capability, effort level, and model selection help text
- **SessionListView.vue** - Empty state message
- **RunningState.vue** - Template pending description
- **ConversationMessages.vue** - Navigation button title/aria-label
- **TemplateSelector.vue** - Help text for auto-templates
- **CanvasTab.vue** - Empty state hint
- **InputForm.vue** - Auto-send checkbox label

### Test Files (4 files)
- **RunningState.test.js** - Assertion for template pending description
- **TemplateSelector.test.js** - Assertion for help text
- **InputForm.test.js** - Assertion for auto-send checkbox
- **queue-prompt.spec.ts** - E2E assertion for auto-send checkbox

## Exclusions
The following intentionally retain "Claude" terminology:
- Model IDs (e.g., `claude-sonnet-4-6`) - API identifiers
- Model display names (e.g., "Claude Sonnet 4.6") - Proper names from provider
- Internal function names and CSS classes - Developer-facing code
- System prompts - Backend configuration
- Server-side code - Not user-facing UI

## Test Plan
- [x] All unit tests updated to assert new text
- [x] E2E tests updated for new text
- [ ] Manual verification of UI text changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)