### PR TITLE
Restrict cleanup script to git worktree sessions only

### DIFF
--- a/packages/server/src/api/sessions-archive.js
+++ b/packages/server/src/api/sessions-archive.js
@@ -19,8 +19,9 @@ router.post('/:id/archive', requireSessionAndProject, async (req, res) => {
   const updated = sessions.update(req.params.id, { archived: true });
 
   // Execute project cleanup command if cleanup requested and project has one configured
+  // Only run for worktree sessions - branch-mode sessions have nothing to clean up
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown
-  if (cleanup && req.project?.onSessionDeleted && !req.session_.parentSessionId) {
+  if (cleanup && req.project?.onSessionDeleted && req.session_.gitWorktree && !req.session_.parentSessionId) {
     executeHookAsync(req.project.onSessionDeleted, req.workingDirectory, {
       sessionId: req.session_.id,
       projectId: req.project.id,

--- a/packages/server/src/api/sessions-archive.js
+++ b/packages/server/src/api/sessions-archive.js
@@ -20,7 +20,7 @@ router.post('/:id/archive', requireSessionAndProject, async (req, res) => {
 
   // Execute project cleanup command if cleanup requested and project has one configured
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown
-  if (cleanup && req.project?.onSessionDeleted && !req.session_.parentSessionId) {
+  if (cleanup && req.project?.onSessionDeleted && req.session_.gitWorktree && !req.session_.parentSessionId) {
     executeHookAsync(req.project.onSessionDeleted, req.workingDirectory, {
       sessionId: req.session_.id,
       projectId: req.project.id,

--- a/packages/server/src/api/sessions-archive.js
+++ b/packages/server/src/api/sessions-archive.js
@@ -20,7 +20,7 @@ router.post('/:id/archive', requireSessionAndProject, async (req, res) => {
 
   // Execute project cleanup command if cleanup requested and project has one configured
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown
-  if (cleanup && req.project?.onSessionDeleted && req.session_.gitWorktree && !req.session_.parentSessionId) {
+  if (cleanup && req.project?.onSessionDeleted && !req.session_.parentSessionId) {
     executeHookAsync(req.project.onSessionDeleted, req.workingDirectory, {
       sessionId: req.session_.id,
       projectId: req.project.id,

--- a/packages/server/src/api/sessions-archive.test.js
+++ b/packages/server/src/api/sessions-archive.test.js
@@ -126,8 +126,8 @@ describe('Sessions Archive API', () => {
       expect(executeHookAsync).not.toHaveBeenCalled();
     });
 
-    it('executes onSessionDeleted hook for non-worktree sessions with cleanup true', async () => {
-      // Session has no gitWorktree (branch mode or no git) — hook should still fire
+    it('does not execute onSessionDeleted hook for non-worktree sessions with cleanup true', async () => {
+      // Session has no gitWorktree (branch mode or no git) — hook should NOT fire
       projects.update(project.id, { onSessionDeleted: './cleanup.sh' });
 
       const res = await request(app)
@@ -135,15 +135,7 @@ describe('Sessions Archive API', () => {
         .send({ cleanup: true });
 
       expect(res.status).toBe(200);
-      expect(executeHookAsync).toHaveBeenCalledWith(
-        './cleanup.sh',
-        expect.any(String),
-        expect.objectContaining({
-          sessionId: session.id,
-          projectId: project.id,
-          sessionName: 'Test Session',
-        })
-      );
+      expect(executeHookAsync).not.toHaveBeenCalled();
     });
 
     it('does not execute onSessionDeleted hook when project has no hook configured', async () => {

--- a/packages/server/src/api/sessions-archive.test.js
+++ b/packages/server/src/api/sessions-archive.test.js
@@ -115,11 +115,24 @@ describe('Sessions Archive API', () => {
     });
 
     it('does not execute onSessionDeleted hook when cleanup is false', async () => {
+      sessions.update(session.id, { gitWorktree: '/path/to/wt' });
       projects.update(project.id, { onSessionDeleted: './cleanup.sh' });
 
       const res = await request(app)
         .post(`/api/sessions/${session.id}/archive`)
         .send({ cleanup: false });
+
+      expect(res.status).toBe(200);
+      expect(executeHookAsync).not.toHaveBeenCalled();
+    });
+
+    it('does not execute onSessionDeleted hook for non-worktree sessions even with cleanup true', async () => {
+      // Session has no gitWorktree (branch mode or no git)
+      projects.update(project.id, { onSessionDeleted: './cleanup.sh' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/archive`)
+        .send({ cleanup: true });
 
       expect(res.status).toBe(200);
       expect(executeHookAsync).not.toHaveBeenCalled();

--- a/packages/server/src/api/sessions-archive.test.js
+++ b/packages/server/src/api/sessions-archive.test.js
@@ -126,8 +126,8 @@ describe('Sessions Archive API', () => {
       expect(executeHookAsync).not.toHaveBeenCalled();
     });
 
-    it('does not execute onSessionDeleted hook for non-worktree sessions even with cleanup true', async () => {
-      // Session has no gitWorktree (branch mode or no git)
+    it('executes onSessionDeleted hook for non-worktree sessions with cleanup true', async () => {
+      // Session has no gitWorktree (branch mode or no git) — hook should still fire
       projects.update(project.id, { onSessionDeleted: './cleanup.sh' });
 
       const res = await request(app)
@@ -135,7 +135,15 @@ describe('Sessions Archive API', () => {
         .send({ cleanup: true });
 
       expect(res.status).toBe(200);
-      expect(executeHookAsync).not.toHaveBeenCalled();
+      expect(executeHookAsync).toHaveBeenCalledWith(
+        './cleanup.sh',
+        expect.any(String),
+        expect.objectContaining({
+          sessionId: session.id,
+          projectId: project.id,
+          sessionName: 'Test Session',
+        })
+      );
     });
 
     it('does not execute onSessionDeleted hook when project has no hook configured', async () => {

--- a/packages/server/src/api/sessions-lifecycle.js
+++ b/packages/server/src/api/sessions-lifecycle.js
@@ -175,8 +175,9 @@ router.delete('/:id', requireSessionAndProject, async (req, res) => {
   }
 
   // Execute on_session_deleted hook if configured (non-blocking)
+  // Only run for worktree sessions - branch-mode sessions have nothing to clean up
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown
-  if (req.project?.onSessionDeleted && !req.session_.parentSessionId) {
+  if (req.project?.onSessionDeleted && req.session_.gitWorktree && !req.session_.parentSessionId) {
     executeHookAsync(req.project.onSessionDeleted, req.workingDirectory, {
       sessionId: req.session_.id,
       projectId: req.project.id,

--- a/packages/server/src/api/sessions-lifecycle.js
+++ b/packages/server/src/api/sessions-lifecycle.js
@@ -176,7 +176,7 @@ router.delete('/:id', requireSessionAndProject, async (req, res) => {
 
   // Execute on_session_deleted hook if configured (non-blocking)
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown
-  if (req.project?.onSessionDeleted && req.session_.gitWorktree && !req.session_.parentSessionId) {
+  if (req.project?.onSessionDeleted && !req.session_.parentSessionId) {
     executeHookAsync(req.project.onSessionDeleted, req.workingDirectory, {
       sessionId: req.session_.id,
       projectId: req.project.id,

--- a/packages/server/src/api/sessions-lifecycle.js
+++ b/packages/server/src/api/sessions-lifecycle.js
@@ -176,7 +176,7 @@ router.delete('/:id', requireSessionAndProject, async (req, res) => {
 
   // Execute on_session_deleted hook if configured (non-blocking)
   // Skip for child sessions - they share parent's resources and shouldn't trigger teardown
-  if (req.project?.onSessionDeleted && !req.session_.parentSessionId) {
+  if (req.project?.onSessionDeleted && req.session_.gitWorktree && !req.session_.parentSessionId) {
     executeHookAsync(req.project.onSessionDeleted, req.workingDirectory, {
       sessionId: req.session_.id,
       projectId: req.project.id,

--- a/packages/server/src/api/sessions-patch.js
+++ b/packages/server/src/api/sessions-patch.js
@@ -115,6 +115,8 @@ const FIELD_DEFINITIONS = [
   { field: 'autoSendPendingPrompt', transform: Boolean },
   { field: 'providerId', validate: validateProviderId },
   { field: 'prUrl', validate: validatePrUrl },
+  // Git fields
+  { field: 'gitWorktree' },
   // Scheduling fields
   { field: 'scheduledAt' },
   { field: 'autoRescheduleEnabled', transform: Boolean },

--- a/packages/server/test/file-attachments.test.js
+++ b/packages/server/test/file-attachments.test.js
@@ -1107,16 +1107,18 @@ describe('File Attachments API', () => {
         onSessionDeleted: 'echo "cleanup"',
       });
 
-      // Create parent session
+      // Create parent session with worktree (required for cleanup hook to execute)
       const parentSession = sessions.create(project.id, 'Parent Session', 'prompt', 'standard');
+      const worktreePath = join(testTempDir, '.worktrees', parentSession.id);
+      sessions.update(parentSession.id, { gitWorktree: worktreePath });
 
       // Delete parent session
       await request(app).delete(`/api/sessions/${parentSession.id}`).expect(204);
 
-      // Verify executeHookAsync WAS called
+      // Verify executeHookAsync WAS called (workingDirectory resolves to gitWorktree when set)
       expect(executeHookAsync).toHaveBeenCalledWith(
         'echo "cleanup"',
-        testTempDir,
+        worktreePath,
         {
           sessionId: parentSession.id,
           projectId: project.id,

--- a/packages/web/src/components/ArchiveConfirmModal.vue
+++ b/packages/web/src/components/ArchiveConfirmModal.vue
@@ -40,9 +40,9 @@
               <input
                 v-model="runCleanup"
                 type="checkbox"
-                aria-label="Run project cleanup script"
+                aria-label="Run git worktree cleanup"
               >
-              <span>Run project cleanup script</span>
+              <span>Run git worktree cleanup</span>
             </label>
           </div>
         </div>

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -4029,7 +4029,7 @@ describe('SessionDetailView', () => {
 
     it('passes hasCleanupScript=true when project has onSessionDeleted and session is not a child', async () => {
       projectsStore.currentProject = { id: 'proj-1', onSessionDeleted: './cleanup.sh' };
-      const wrapper = await mountWithSession();
+      const wrapper = await mountWithSession({ gitWorktree: '.worktrees/session-1' });
 
       const headerPanel = wrapper.findComponent({ name: 'SessionHeaderPanel' });
       await headerPanel.vm.$emit('archive');

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -99,7 +99,7 @@
       <ArchiveConfirmModal
         :is-open="showArchiveModal"
         :session-name="sessionsStore.currentSession?.name || 'this session'"
-        :has-cleanup-script="!!(projectsStore.currentProject?.onSessionDeleted && !sessionsStore.currentSession?.parentSessionId)"
+        :has-cleanup-script="!!(projectsStore.currentProject?.onSessionDeleted && sessionsStore.currentSession?.gitWorktree && !sessionsStore.currentSession?.parentSessionId)"
         :loading="archiving"
         @confirm="confirmArchive"
         @cancel="cancelArchive"

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -2613,7 +2613,7 @@ describe('SessionListView batch summary fetching', () => {
     it('passes hasCleanupScript=true when project has onSessionDeleted and session is not a child', async () => {
       mockProjectsStore.currentProject = { id: 'test-project-id', name: 'Test Project', workingDirectory: '/test/path', onSessionDeleted: './cleanup.sh' };
       mockSessionsStore = createSessionsStoreMock([
-        { id: 'session-1', name: 'Session 1', status: 'completed' },
+        { id: 'session-1', name: 'Session 1', status: 'completed', gitWorktree: '.worktrees/session-1' },
       ]);
       useSessionsStore.mockReturnValue(mockSessionsStore);
 

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -331,7 +331,7 @@
     <ArchiveConfirmModal
       :is-open="showArchiveModal"
       :session-name="sessionToArchive?.name || 'this session'"
-      :has-cleanup-script="!!(projectsStore.currentProject?.onSessionDeleted && !sessionToArchive?.parentSessionId)"
+      :has-cleanup-script="!!(projectsStore.currentProject?.onSessionDeleted && sessionToArchive?.gitWorktree && !sessionToArchive?.parentSessionId)"
       :loading="archiving"
       @confirm="confirmArchive"
       @cancel="cancelArchive"

--- a/tests/e2e/archive-worktree-cleanup.spec.ts
+++ b/tests/e2e/archive-worktree-cleanup.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  updateSessionFields,
+  cleanupCreatedResources,
+  navigateAndWait,
+} from './helpers';
+
+test.describe('Archive Modal - Worktree Cleanup Checkbox', () => {
+  let projectWithHook: any;
+  let projectWithoutHook: any;
+
+  test.beforeEach(async () => {
+    projectWithHook = await seedProject('WT Cleanup Test', '/tmp/test', {
+      onSessionDeleted: 'echo cleanup',
+    });
+    projectWithoutHook = await seedProject('No Hook Test', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('shows cleanup checkbox for worktree session on session detail view', async ({ page }) => {
+    const session = await seedSession(projectWithHook.id, {
+      prompt: 'Worktree session',
+      name: 'WT Session Detail',
+      startImmediately: false,
+    });
+    await updateSessionFields(session.id, { gitWorktree: '/tmp/fake-wt' });
+
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+
+    // Open kebab menu and click Archive
+    await page.click('button[aria-label="Session actions"]');
+    await expect(page.locator('.menu-items')).toBeVisible({ timeout: 5000 });
+    await page.locator('button.menu-item').filter({ hasText: 'Archive' }).click({ timeout: 10000 });
+
+    // Verify modal is visible
+    const modal = page.locator('.modal-backdrop');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify cleanup checkbox is visible with correct text
+    const cleanupOption = modal.locator('.cleanup-option');
+    await expect(cleanupOption).toBeVisible();
+    await expect(cleanupOption).toContainText('Run git worktree cleanup');
+
+    // Cancel the modal
+    await modal.locator('.btn-secondary').filter({ hasText: 'Cancel' }).click();
+  });
+
+  test('hides cleanup checkbox for non-worktree session on session detail view', async ({ page }) => {
+    const session = await seedSession(projectWithHook.id, {
+      prompt: 'Branch session',
+      name: 'Branch Session Detail',
+      startImmediately: false,
+    });
+    // No gitWorktree set - defaults to null
+
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+
+    // Open kebab menu and click Archive
+    await page.click('button[aria-label="Session actions"]');
+    await expect(page.locator('.menu-items')).toBeVisible({ timeout: 5000 });
+    await page.locator('button.menu-item').filter({ hasText: 'Archive' }).click({ timeout: 10000 });
+
+    // Verify modal is visible
+    const modal = page.locator('.modal-backdrop');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify cleanup checkbox is NOT visible
+    const cleanupOption = modal.locator('.cleanup-option');
+    await expect(cleanupOption).not.toBeVisible();
+
+    // Cancel the modal
+    await modal.locator('.btn-secondary').filter({ hasText: 'Cancel' }).click();
+  });
+
+  test('shows cleanup checkbox for worktree session on session list view', async ({ page }) => {
+    const session = await seedSession(projectWithHook.id, {
+      prompt: 'Worktree session',
+      name: 'WT Session List',
+      startImmediately: false,
+    });
+    await updateSessionFields(session.id, { gitWorktree: '/tmp/fake-wt' });
+
+    await navigateAndWait(page, `/projects/${projectWithHook.id}/sessions`);
+
+    // Click archive button on the session card
+    await page.locator('button.archive-btn[title="Archive session"]').first().click();
+
+    // Verify modal is visible
+    const modal = page.locator('.modal-backdrop');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify cleanup checkbox is visible with correct text
+    const cleanupOption = modal.locator('.cleanup-option');
+    await expect(cleanupOption).toBeVisible();
+    await expect(cleanupOption).toContainText('Run git worktree cleanup');
+
+    // Cancel the modal
+    await modal.locator('.btn-secondary').filter({ hasText: 'Cancel' }).click();
+  });
+
+  test('hides cleanup checkbox for non-worktree session on session list view', async ({ page }) => {
+    const session = await seedSession(projectWithHook.id, {
+      prompt: 'Branch session',
+      name: 'Branch Session List',
+      startImmediately: false,
+    });
+    // No gitWorktree set
+
+    await navigateAndWait(page, `/projects/${projectWithHook.id}/sessions`);
+
+    // Click archive button on the session card
+    await page.locator('button.archive-btn[title="Archive session"]').first().click();
+
+    // Verify modal is visible
+    const modal = page.locator('.modal-backdrop');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify cleanup checkbox is NOT visible
+    const cleanupOption = modal.locator('.cleanup-option');
+    await expect(cleanupOption).not.toBeVisible();
+
+    // Cancel the modal
+    await modal.locator('.btn-secondary').filter({ hasText: 'Cancel' }).click();
+  });
+
+  test('hides cleanup checkbox when project has no onSessionDeleted hook', async ({ page }) => {
+    const session = await seedSession(projectWithoutHook.id, {
+      prompt: 'Worktree session no hook',
+      name: 'WT No Hook',
+      startImmediately: false,
+    });
+    await updateSessionFields(session.id, { gitWorktree: '/tmp/fake-wt' });
+
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+
+    // Open kebab menu and click Archive
+    await page.click('button[aria-label="Session actions"]');
+    await expect(page.locator('.menu-items')).toBeVisible({ timeout: 5000 });
+    await page.locator('button.menu-item').filter({ hasText: 'Archive' }).click({ timeout: 10000 });
+
+    // Verify modal is visible
+    const modal = page.locator('.modal-backdrop');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify cleanup checkbox is NOT visible (no hook configured)
+    const cleanupOption = modal.locator('.cleanup-option');
+    await expect(cleanupOption).not.toBeVisible();
+
+    // Cancel the modal
+    await modal.locator('.btn-secondary').filter({ hasText: 'Cancel' }).click();
+  });
+});

--- a/tests/e2e/session-hooks.spec.ts
+++ b/tests/e2e/session-hooks.spec.ts
@@ -52,31 +52,43 @@ test.describe('Session Lifecycle Hooks', () => {
   });
 
   test('onSessionDeleted hook executes on session deletion for worktree sessions', async () => {
-    // Create a project with onSessionDeleted hook configured
+    // Create a project with onSessionDeleted hook configured.
+    // The hook uses env vars (CIRCUSCHIEF_SESSION_ID) and an absolute marker
+    // path, so it doesn't depend on any specific contents or existence of the
+    // worktree cwd at execution time.
     const project = await seedProject('hook-test-deleted', process.cwd(), {
       onSessionDeleted: `touch ${markerDir}/session-deleted-\${CIRCUSCHIEF_SESSION_ID}.txt`,
     });
 
-    // Create a session in the project with a gitWorktree (required for hook to fire)
+    // Create a session in the project with a gitWorktree (required for hook to fire).
+    // The hook's cwd is the worktree path, which must exist on disk for exec()
+    // to spawn. We create a real temp directory to stand in for the worktree.
+    const fakeWorktree = await mkdtemp(join(tmpdir(), 'circuschief-test-wt-'));
     const session = await seedSession(project.id, {
       prompt: 'Test session for onSessionDeleted hook',
       name: 'Hook Test Session Delete',
       startImmediately: false,
     });
-    await updateSessionFields(session.id, { gitWorktree: `/tmp/fake-wt-${session.id}` });
+    await updateSessionFields(session.id, { gitWorktree: fakeWorktree });
 
-    // Delete the session
-    const response = await fetch(`${API_URL}/api/sessions/${session.id}`, {
-      method: 'DELETE',
-    });
-    expect(response.ok).toBe(true);
+    try {
+      // Delete the session
+      const response = await fetch(`${API_URL}/api/sessions/${session.id}`, {
+        method: 'DELETE',
+      });
+      expect(response.ok).toBe(true);
 
-    // Wait for the marker file to exist (hook executes asynchronously)
-    const markerFile = join(markerDir, `session-deleted-${session.id}.txt`);
-    const fileExists = await waitForFile(markerFile, 5000);
+      // Wait for the marker file to exist (hook executes asynchronously)
+      const markerFile = join(markerDir, `session-deleted-${session.id}.txt`);
+      const fileExists = await waitForFile(markerFile, 5000);
 
-    // Assert marker file exists
-    expect(fileExists).toBe(true);
+      // Assert marker file exists
+      expect(fileExists).toBe(true);
+    } finally {
+      // Cleanup the stand-in worktree directory (gitService.removeWorktree
+      // may have failed silently since this isn't a real git worktree)
+      await rm(fakeWorktree, { recursive: true, force: true });
+    }
   });
 
   test('onSessionDeleted hook does not execute for non-worktree sessions', async () => {

--- a/tests/e2e/session-hooks.spec.ts
+++ b/tests/e2e/session-hooks.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import {
   seedProject,
   seedSession,
+  updateSessionFields,
   waitForFile,
   readMarkerFile,
   cleanupCreatedResources,
@@ -50,18 +51,19 @@ test.describe('Session Lifecycle Hooks', () => {
     expect(fileExists).toBe(true);
   });
 
-  test('onSessionDeleted hook executes on session deletion', async () => {
+  test('onSessionDeleted hook executes on session deletion for worktree sessions', async () => {
     // Create a project with onSessionDeleted hook configured
     const project = await seedProject('hook-test-deleted', process.cwd(), {
       onSessionDeleted: `touch ${markerDir}/session-deleted-\${CIRCUSCHIEF_SESSION_ID}.txt`,
     });
 
-    // Create a session in the project
+    // Create a session in the project with a gitWorktree (required for hook to fire)
     const session = await seedSession(project.id, {
       prompt: 'Test session for onSessionDeleted hook',
       name: 'Hook Test Session Delete',
       startImmediately: false,
     });
+    await updateSessionFields(session.id, { gitWorktree: `/tmp/fake-wt-${session.id}` });
 
     // Delete the session
     const response = await fetch(`${API_URL}/api/sessions/${session.id}`, {
@@ -75,6 +77,35 @@ test.describe('Session Lifecycle Hooks', () => {
 
     // Assert marker file exists
     expect(fileExists).toBe(true);
+  });
+
+  test('onSessionDeleted hook does not execute for non-worktree sessions', async () => {
+    // Create a project with onSessionDeleted hook configured
+    const project = await seedProject('hook-test-no-wt', process.cwd(), {
+      onSessionDeleted: `touch ${markerDir}/session-deleted-nowt-\${CIRCUSCHIEF_SESSION_ID}.txt`,
+    });
+
+    // Create a session WITHOUT a gitWorktree (branch mode)
+    const session = await seedSession(project.id, {
+      prompt: 'Test session without worktree',
+      name: 'No Worktree Session Delete',
+      startImmediately: false,
+    });
+    // No gitWorktree set — hook should NOT fire
+
+    // Delete the session
+    const response = await fetch(`${API_URL}/api/sessions/${session.id}`, {
+      method: 'DELETE',
+    });
+    expect(response.ok).toBe(true);
+
+    // Wait a short time to confirm the marker file is NOT created
+    const markerFile = join(markerDir, `session-deleted-nowt-${session.id}.txt`);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const fileExists = await waitForFile(markerFile, 0).catch(() => false);
+
+    // Assert marker file was NOT created
+    expect(fileExists).toBe(false);
   });
 
   test('hook receives correct environment variables', async () => {


### PR DESCRIPTION
## Summary

- Only show the "Run git worktree cleanup" checkbox in the archive modal when the session is a git worktree session (has `gitWorktree` set)
- Add server-side defense-in-depth guards on both archive and delete paths to prevent hook execution for non-worktree sessions
- Rename the cleanup label from "Run project cleanup script" to "Run git worktree cleanup" for clarity

## Test plan

- [x] Unit tests pass (13/13 archive tests, including new non-worktree guard test)
- [x] E2E tests pass (5/5 new Playwright tests covering worktree/non-worktree in detail and list views)
- [ ] Manual verification: archive a worktree session → cleanup checkbox visible
- [ ] Manual verification: archive a branch-mode session → cleanup checkbox hidden
- [ ] Manual verification: delete a non-worktree session → hook does not execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)