### PR TITLE
docs: sync build-and-distribution.md with actual publish flow

### DIFF
--- a/docs/build-and-distribution.md
+++ b/docs/build-and-distribution.md
@@ -2,13 +2,13 @@
 
 ## How it works
 
-Circus Chief is distributed as an npm package. End users run it via `npx circuschief` — no build step required on their machine.
+Circus Chief is distributed as an npm package named `circuschief`. End users run it via `npx circuschief` — no build step required on their machine.
 
 The build/publish/run flow:
 
-1. **Build** (`yarn build`): Vite compiles the Vue.js frontend into static assets (`packages/web/dist/`). Server-side code requires no compilation.
-2. **Publish** (`npm publish`): The package ships with the pre-built frontend included.
-3. **Run** (`npx circuschief`): The Express server starts and serves the pre-built frontend as static files.
+1. **Build** (`node scripts/build-package.js`): Vite compiles the Vue.js frontend into static assets, then the script assembles a publish-ready tree under `dist-package/`. Server-side code requires no compilation — the JS sources are copied as-is and `@circuschief/shared` imports are rewritten to relative paths so the package can run without workspace tooling.
+2. **Publish** (`scripts/publish.sh`): Runs the build, then `npm publish` from `dist-package/`. The package ships with the pre-built frontend included.
+3. **Run** (`npx circuschief`): The `bin/cli.js` shim sets `NODE_ENV=production` and starts the Express server, which serves the pre-built frontend as static files.
 
 ## Build-time vs runtime variables
 
@@ -16,12 +16,12 @@ Because the frontend is pre-compiled, there are two categories of environment va
 
 | Category | When resolved | Who controls it | Examples |
 |----------|---------------|-----------------|----------|
-| **Build-time** (`VITE_*`) | During `yarn build` — Vite string-replaces them into the JS bundle | Publisher / CI | `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST` |
+| **Build-time** (`VITE_*`) | During the frontend build — Vite string-replaces them into the JS bundle | Publisher / CI | `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST` |
 | **Runtime** (`process.env`) | When the server starts | End user | `PORT`, `DB_PATH`, `NODE_ENV` |
 
 End users **cannot** configure `VITE_*` variables — they are baked into the JS bundle before the package is published. This is intentional for variables like analytics keys, which are the publisher's concern, not the user's.
 
-## Building for production
+## Building for local development
 
 ```bash
 # Install dependencies
@@ -34,24 +34,112 @@ yarn build
 NODE_ENV=production yarn workspace @circuschief/server start
 ```
 
-## Publishing to npm
+## Building the publishable package
+
+`scripts/build-package.js` produces `dist-package/`, a self-contained tree shaped like the monorepo so that `__dirname`-relative paths (e.g. `schema.sql`, `../../web/dist`) keep working.
 
 ```bash
-# Build with analytics enabled
-yarn build
-
-# Verify the PostHog key is in the bundle (optional)
-grep -l phc_ packages/web/dist/assets/*.js
-
-# Publish
-npm publish
+# Build the publishable package (defaults to version 0.1.0 if --version is omitted)
+node scripts/build-package.js --version=0.2.0
 ```
+
+What the script does:
+
+1. Cleans and recreates `dist-package/`.
+2. Builds the frontend with `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` injected.
+3. If a PostHog key was provided, **verifies** the key appears in one of the built JS bundles and fails the build if it doesn't.
+4. Copies `packages/web/dist/`, `packages/server/src/` (minus `*.test.js`), `packages/server/bin/`, and `packages/shared/src/` + `package.json` into `dist-package/packages/...`.
+5. Rewrites all `from '@circuschief/shared'` / `from '@circuschief/shared/...'` imports in the copied server code to relative paths into `packages/shared/src/`. **Only static `import ... from '...'` syntax is handled** — `require()` and dynamic `import()` of `@circuschief/shared` would need script changes.
+6. Writes a publish-ready `dist-package/package.json` with:
+   - `name: circuschief`, the given `--version`, `type: module`, `bin.circuschief`, `engines.node: >=18`
+   - Merged runtime deps from `server` + `shared` (workspace reference to `@circuschief/shared` removed)
+   - A `files` array limiting the published tarball to `packages/server/bin/`, `packages/server/src/`, `packages/shared/src/`, `packages/shared/package.json`, and `packages/web/dist/`
+7. Overwrites `packages/server/bin/cli.js` with a production shim that sets `NODE_ENV=production` and imports `../src/index.js`.
+
+### Testing the package locally
+
+```bash
+node scripts/build-package.js --version=0.0.0-test
+cd dist-package
+npm pack
+# Then from any directory:
+npx ./circuschief-0.0.0-test.tgz
+```
+
+## Running E2E tests against the built package
+
+The normal `./scripts/pw.sh test` flow runs Playwright against a dev server started from the repo source. To catch issues that only appear in the published artifact — missing files from the `files` whitelist, broken `@circuschief/shared` import rewrites, a stale `cli.js`, missing runtime dependencies, etc. — use the `test-package` variant:
+
+```bash
+./scripts/pw.sh test-package                           # Run all E2E tests against the built package
+./scripts/pw.sh test-package --grep="login"            # Filter by test name
+./scripts/pw.sh test-package tests/e2e/auth.spec.ts    # Run a specific test file
+
+# VCR mode is forwarded through to the package server
+VCR_MODE=record ./scripts/pw.sh test-package
+```
+
+### What `test-package` does
+
+Under the hood, `pw.sh test-package` sets `USE_PACKAGE_SERVER=true` and delegates server startup to `scripts/start-package-server.sh`, which reproduces a realistic end-user install:
+
+1. Runs `node scripts/build-package.js` to produce `dist-package/`.
+2. `cd dist-package && npm pack` to produce a `circuschief-<version>.tgz` tarball.
+3. Creates an isolated temp install directory (`$TMPDIR/circuschief-package-test.XXXXXX`) with a minimal `package.json`.
+4. `npm install`s the tarball into that directory — this is the same path `npx circuschief` takes for real users.
+5. Symlinks the repo's `tests/` directory into the install dir so VCR cassettes (resolved relative to cwd) are reachable.
+6. Picks a port using the same worktree-aware rules as `start-server.sh` (main repo → 5000 if free, worktrees → 5001+), writes it to `.server-port`, and writes the absolute DB path to `.db-path`.
+7. Starts the server via `node node_modules/.bin/circuschief -p <port>` with `DB_PATH` set to an absolute path in the temp dir.
+8. On exit, kills the server and removes the temp dir, `.server-port`, `.db-path`, and `.vcr-mode` marker files.
+
+Meanwhile `pw.sh test-package`:
+
+- Reads `.db-path` and re-exports `DB_PATH` so seed scripts (e.g. `scripts/seed-*.mjs`) write to the **same** database the package server is using — otherwise seeds would go to a default cwd-relative file and the server would see an empty DB.
+- Sets `BASE_URL` / `API_URL` to `http://localhost:<port>` and runs Playwright (Docker if available, `npx playwright` otherwise).
+- Uses a longer startup timeout (180s vs 120s) to cover the extra build + `npm install` steps.
+
+### When to use `test-package`
+
+- **Before publishing** — run it after `scripts/publish.sh`'s build succeeds but before you actually publish, to prove the tarball works end-to-end.
+- **After changes to `scripts/build-package.js`** — any change to the import-rewriter, the `files` whitelist, the production `cli.js`, or the merged dependency list should be covered by a `test-package` run.
+- **After touching anything in `packages/server/bin/`** or runtime code paths that differ between `yarn dev` and the packaged artifact.
+
+Regular `./scripts/pw.sh test` is still the fast path for normal development — `test-package` adds a full build + `npm pack` + `npm install` on every invocation.
+
+## Publishing to npm
+
+Use `scripts/publish.sh`, which wraps the build and `npm publish`:
+
+```bash
+# Usage: ./scripts/publish.sh <version> <otp>
+./scripts/publish.sh 0.2.0 123456
+```
+
+Arguments:
+
+- `version` — semver version to publish (e.g. `0.2.0`). Passed through to `build-package.js` as `--version=`.
+- `otp` — npm one-time password for 2FA. Passed to `npm publish --otp=`.
+
+What the script does:
+
+1. Verifies you're logged in (`npm whoami`) and aborts with an error if not.
+2. Runs `node scripts/build-package.js --version=$VERSION`.
+3. Runs `npm publish --otp=$OTP` from inside `dist-package/`.
+4. Prints install/run hints (`npx circuschief`, `npx circuschief@<version>`).
+
+Before publishing, make sure `VITE_POSTHOG_KEY` is available via one of the sources listed below so analytics actually ship in the bundle.
 
 ## Analytics
 
 This application uses [PostHog](https://posthog.com) for anonymous usage analytics (page views, clicks). **Session recording is disabled.**
 
-- Analytics are configured at build time via `VITE_POSTHOG_KEY` in `.env.production`
-- When the key is empty (local dev, CI, contributor forks), analytics are completely disabled — no PostHog code loads, no network requests are made
-- The PostHog client API key is a public key (like a Google Analytics tracking ID), not a secret
-- Browser Do Not Track (`respect_dnt: true`) is honored
+- Analytics are configured at build time via `VITE_POSTHOG_KEY`.
+- `scripts/build-package.js` resolves the key from the following sources, first non-empty wins:
+  1. `--posthog-key=...` CLI flag on `build-package.js`
+  2. `POSTHOG_KEY` environment variable
+  3. `VITE_POSTHOG_KEY` from `.env.production` in the repo root
+- The PostHog host is resolved the same way (`--posthog-host=...` / `POSTHOG_HOST` / `VITE_POSTHOG_HOST`) and defaults to `https://us.i.posthog.com`.
+- When no key is provided (local dev, CI, contributor forks), analytics are completely disabled — no PostHog code loads, no network requests are made, and the build prints a warning instead of failing.
+- When a key is provided, the build **fails** if the key is not found in the generated JS bundle, so you can't accidentally ship a build with analytics missing.
+- The PostHog client API key is a public key (like a Google Analytics tracking ID), not a secret.
+- Browser Do Not Track (`respect_dnt: true`) is honored.


### PR DESCRIPTION
## Summary

- `docs/build-and-distribution.md` described a simple `yarn build` + `npm publish` flow, but the real path goes through `scripts/publish.sh` → `scripts/build-package.js` → `dist-package/`, with `@circuschief/shared` import rewrites, a verified PostHog injection step, and a production `cli.js` shim that sets `NODE_ENV=production`.
- Split the "Building" section into "Building for local development" (unchanged `yarn build` flow) and "Building the publishable package" (the real `build-package.js` behavior, `files` whitelist, merged deps, production `cli.js`, local tarball testing recipe).
- Rewrote "Publishing to npm" to document `./scripts/publish.sh <version> <otp>` including the `npm whoami` precheck and 2FA/OTP requirement.
- Expanded "Analytics" to document the full PostHog key/host resolution order (`--posthog-key` / `POSTHOG_KEY` / `.env.production`), the default host, the no-key warning, and the "key not in bundle → build fails" safeguard.
- Added a new "Running E2E tests against the built package" section covering `./scripts/pw.sh test-package`, what `start-package-server.sh` does (build → `npm pack` → isolated temp install → symlinked `tests/` for VCR cassettes → worktree-aware port selection → absolute `DB_PATH`), how `pw.sh test-package` re-exports `DB_PATH` and bumps the startup timeout, and when to use it (before publishing, after changes to `build-package.js` or `packages/server/bin/`).

Documentation-only change — no scripts or source code were modified.

## Test plan

- [ ] Skim the rendered markdown on GitHub to confirm formatting renders as intended
- [ ] Spot-check command examples against `scripts/publish.sh`, `scripts/build-package.js`, `scripts/start-package-server.sh`, and `scripts/pw.sh`
- [ ] Confirm there are no stale references to the old `yarn build` + `npm publish` + manual `grep -l phc_` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)