### PR TITLE
feat: Mark Kanban as experimental, disabled by default for new projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### Stay on top of your agents
 
 - **AI-generated session summaries** — scan what every session accomplished without reading the full conversation, with PRs automatically linked (requires GitHub CLI)
-- **Kanban board** — organize sessions into workflow stages with drag-and-drop and lane automation
+- **Kanban board (experimental)** — organize sessions into workflow stages with drag-and-drop and lane automation. Disabled by default for new projects; enable it per-project from the project settings page. Expect rough edges while this feature matures.
 - **Command buttons with live status** — kick off builds, tests, or CI tasks and see pass/fail indicators right on the session list
 - **Star, archive, and filter** to keep your session list manageable
 
@@ -31,8 +31,8 @@
 
 - **Session scheduling** — queue sessions to run at specific times
 - **Auto-retry on token exhaustion or provider downtime** — configurable delay, max retries, and proactive rescheduling before hitting limits
-- **Kanban lane automation** — trigger templates automatically as sessions move between lanes
-- **Ask the agent to orchestrate** — agents can create sessions and place them in kanban lanes via the API, so you can ask one agent to fan out work across files or folders and track it all on the board
+- **Kanban lane automation (experimental)** — trigger templates automatically as sessions move between lanes (requires enabling the Kanban board for the project)
+- **Ask the agent to orchestrate (experimental)** — agents can create sessions and place them in kanban lanes via the API, so you can ask one agent to fan out work across files or folders and track it all on the board (requires enabling the Kanban board for the project)
 
 ### Git-native workflow
 

--- a/packages/server/src/api/kanban.test.js
+++ b/packages/server/src/api/kanban.test.js
@@ -37,7 +37,7 @@ describe('Kanban API', () => {
     app.use(express.json());
     app.use('/api/projects/:projectId/kanban', kanbanRouter);
 
-    const project = projects.create('Test Project', '/tmp/test');
+    const project = projects.create('Test Project', '/tmp/test', null, { kanbanEnabled: true });
     projectId = project.id;
   });
 

--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -64,18 +64,23 @@ router.post('/', async (req, res) => {
     return res.status(400).json({ error: result.error.issues[0].message });
   }
 
-  const { name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, worktreePath } = result.data;
+  const { name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, worktreePath, kanbanEnabled } = result.data;
 
   const pathError = await validateWorktreePath(worktreePath);
   if (pathError) {
     return res.status(400).json({ error: pathError });
   }
 
-  const project = projects.create(name, workingDirectory, systemPrompt || null, {
+  const createOptions = {
     onSessionCreated: onSessionCreated || null,
     onSessionDeleted: onSessionDeleted || null,
     worktreePath: worktreePath || null,
-  });
+  };
+  if (kanbanEnabled !== undefined) {
+    createOptions.kanbanEnabled = kanbanEnabled;
+  }
+
+  const project = projects.create(name, workingDirectory, systemPrompt || null, createOptions);
   res.status(201).json(project);
 });
 

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -642,6 +642,51 @@ describe('Projects API', () => {
     });
   });
 
+  describe('POST /api/projects kanbanEnabled default', () => {
+    it('defaults kanbanEnabled to false when creating project without option', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-default-kanban-'));
+      try {
+        const res = await request(app).post('/api/projects').send({
+          name: 'Default Kanban Project',
+          workingDirectory: newDir,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.kanbanEnabled).toBe(false);
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves kanbanEnabled=true when explicitly opted-in on POST', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-explicit-kanban-'));
+      try {
+        const res = await request(app).post('/api/projects').send({
+          name: 'Explicit Kanban Project',
+          workingDirectory: newDir,
+          kanbanEnabled: true,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.kanbanEnabled).toBe(true);
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns kanbanEnabled=true for pre-existing projects with the DB flag set', async () => {
+      // Simulate an existing project created before the default flipped
+      const existingProject = projects.create('Pre-existing Kanban Project', tempDir, null, {
+        kanbanEnabled: true,
+      });
+
+      const res = await request(app).get(`/api/projects/${existingProject.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.kanbanEnabled).toBe(true);
+    });
+  });
+
   describe('GET /api/projects', () => {
     it('returns all projects', async () => {
       const res = await request(app).get('/api/projects');

--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -36,7 +36,7 @@ export class ProjectRepository extends BaseRepository {
       onSessionDeleted = null,
       prPollInterval = 60000,
       repoUrl = null,
-      kanbanEnabled = true,
+      kanbanEnabled = false,
       worktreePath = null,
     } = options;
     this.db

--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -20,7 +20,10 @@ export class ProjectRepository extends BaseRepository {
       prPollInterval: row.pr_poll_interval,
       repoUrl: row.repo_url,
       worktreePath: row.worktree_path,
-      kanbanEnabled: row.kanban_enabled === undefined ? true : Boolean(row.kanban_enabled),
+      // Kanban is an experimental feature, disabled by default for new projects.
+      // Fallback to `false` when the column is absent so missing data is
+      // treated as opt-out (consistent with create()).
+      kanbanEnabled: row.kanban_enabled === undefined ? false : Boolean(row.kanban_enabled),
       sessionCount: row.session_count ?? 0,
       lastActivityAt: row.last_activity_at ?? null,
       createdAt: row.created_at,

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -133,6 +133,46 @@ describe('ProjectRepository', () => {
 
   });
 
+  describe('row mapping (#mapProject)', () => {
+    it('maps kanban_enabled=1 to kanbanEnabled=true', () => {
+      const mapped = repo.map({
+        id: 'x',
+        name: 'n',
+        working_directory: '/tmp',
+        kanban_enabled: 1,
+        created_at: 0,
+        updated_at: 0,
+      });
+      expect(mapped.kanbanEnabled).toBe(true);
+    });
+
+    it('maps kanban_enabled=0 to kanbanEnabled=false', () => {
+      const mapped = repo.map({
+        id: 'x',
+        name: 'n',
+        working_directory: '/tmp',
+        kanban_enabled: 0,
+        created_at: 0,
+        updated_at: 0,
+      });
+      expect(mapped.kanbanEnabled).toBe(false);
+    });
+
+    it('falls back to kanbanEnabled=false when the column is missing', () => {
+      // Simulates a row that somehow lacks the kanban_enabled column.
+      // With Kanban now an experimental opt-in feature, missing data should
+      // be treated as disabled (consistent with create()).
+      const mapped = repo.map({
+        id: 'x',
+        name: 'n',
+        working_directory: '/tmp',
+        created_at: 0,
+        updated_at: 0,
+      });
+      expect(mapped.kanbanEnabled).toBe(false);
+    });
+  });
+
   describe('getById', () => {
     it('retrieves project by ID', () => {
       const created = repo.create('Test', '/tmp/test');

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -109,6 +109,28 @@ describe('ProjectRepository', () => {
       expect(project.worktreePath).toBeNull();
     });
 
+    it('defaults kanbanEnabled to false when option omitted', () => {
+      const project = repo.create('Test Project', '/tmp/test');
+
+      expect(project.kanbanEnabled).toBe(false);
+    });
+
+    it('preserves kanbanEnabled=true when explicitly provided', () => {
+      const project = repo.create('Test Project', '/tmp/test', null, {
+        kanbanEnabled: true,
+      });
+
+      expect(project.kanbanEnabled).toBe(true);
+    });
+
+    it('preserves kanbanEnabled=false when explicitly provided', () => {
+      const project = repo.create('Test Project', '/tmp/test', null, {
+        kanbanEnabled: false,
+      });
+
+      expect(project.kanbanEnabled).toBe(false);
+    });
+
   });
 
   describe('getById', () => {

--- a/packages/server/src/services/kanbanService.test.js
+++ b/packages/server/src/services/kanbanService.test.js
@@ -49,7 +49,7 @@ describe('kanbanService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    const project = projects.create('Test Project', '/tmp/test');
+    const project = projects.create('Test Project', '/tmp/test', null, { kanbanEnabled: true });
     projectId = project.id;
 
     const board = kanbanBoards.create(projectId);
@@ -89,7 +89,7 @@ describe('kanbanService', () => {
     });
 
     it('lazy-creates board if none exists', () => {
-      const project2 = projects.create('Project 2', '/tmp/test2');
+      const project2 = projects.create('Project 2', '/tmp/test2', null, { kanbanEnabled: true });
       const board = getFullBoard(project2.id);
 
       expect(board).not.toBeNull();

--- a/packages/shared/src/contracts/projects.js
+++ b/packages/shared/src/contracts/projects.js
@@ -8,7 +8,7 @@ export const CreateProjectRequest = z.object({
   onSessionDeleted: z.string().nullable().optional(),
   prPollInterval: z.number().int().min(10000).optional(), // Min 10 seconds
   repoUrl: z.string().url().nullable().optional(),
-  kanbanEnabled: z.boolean().optional(), // Default true
+  kanbanEnabled: z.boolean().optional(), // Default false (experimental feature)
   worktreePath: z.string().nullable().optional(),
 });
 

--- a/packages/web/src/views/ProjectEditView.test.js
+++ b/packages/web/src/views/ProjectEditView.test.js
@@ -1083,4 +1083,61 @@ describe('ProjectEditView with Session Defaults', () => {
       expect(text).toContain('project-specific or global responses');
     });
   });
+
+  describe('Kanban Experimental labeling', () => {
+    it('renders "Experimental" badge in the Kanban Board section summary', async () => {
+      projectsStore.currentProject = {
+        id: 'proj-1',
+        name: 'Test',
+        workingDirectory: '/tmp'
+      };
+
+      const wrapper = mount(ProjectEditView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: { PathChooser: true, QuickResponseSettings: true }
+        }
+      });
+
+      await flushAll(wrapper);
+
+      // Locate the Kanban details section
+      const kanbanDetails = wrapper.findAll('details').find(d =>
+        d.text().includes('Kanban Board')
+      );
+      expect(kanbanDetails).toBeDefined();
+
+      const summaryText = kanbanDetails.find('summary').text();
+      expect(summaryText).toContain('Experimental');
+    });
+
+    it('shows experimental warning copy inside the Kanban Board section', async () => {
+      projectsStore.currentProject = {
+        id: 'proj-1',
+        name: 'Test',
+        workingDirectory: '/tmp'
+      };
+
+      const wrapper = mount(ProjectEditView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: { PathChooser: true, QuickResponseSettings: true }
+        }
+      });
+
+      await flushAll(wrapper);
+
+      // Expand the Kanban details section
+      const kanbanDetails = wrapper.findAll('details').find(d =>
+        d.text().includes('Kanban Board')
+      );
+      expect(kanbanDetails).toBeDefined();
+      kanbanDetails.element.open = true;
+      await flushAll(wrapper);
+
+      const sectionText = kanbanDetails.text();
+      expect(sectionText).toContain('Experimental');
+      expect(sectionText).toContain('may change or be removed');
+    });
+  });
 });

--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -319,7 +319,12 @@
       </details>
 
       <details class="advanced-settings">
-        <summary>Kanban Board</summary>
+        <summary>
+          Kanban Board
+          <span class="inline-block rounded bg-amber-900/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-amber-300 ml-2">
+            Experimental
+          </span>
+        </summary>
         <div class="form-group">
           <label class="checkbox-label">
             <input
@@ -329,7 +334,7 @@
             Enable Kanban board
           </label>
           <p class="form-help">
-            Enable a Kanban board to visually organize sessions into lanes. Sessions can be dragged between lanes, and lanes can trigger automated workflows.
+            <strong>Experimental.</strong> This feature is in active development and may change or be removed. Enable a Kanban board to visually organize sessions into lanes. Sessions can be dragged between lanes, and lanes can trigger automated workflows.
           </p>
         </div>
       </details>

--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -319,12 +319,7 @@
       </details>
 
       <details class="advanced-settings">
-        <summary>
-          Kanban Board
-          <span class="inline-block rounded bg-amber-900/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-amber-300 ml-2">
-            Experimental
-          </span>
-        </summary>
+        <summary>Kanban Board <span class="inline-block rounded bg-amber-900/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-amber-300 ml-2">Experimental</span></summary>
         <div class="form-group">
           <label class="checkbox-label">
             <input

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -10,22 +10,29 @@ const mockRoute = reactive({
   name: 'SessionList',
 });
 
+// Track router navigation for assertions in tests
+const mockRouterPush = vi.fn((path) => {
+  // Update the mock route based on the path so activeTab reflects navigation
+  if (path.includes('/archived')) {
+    mockRoute.name = 'ArchivedSessions';
+  } else if (path.includes('/templates')) {
+    mockRoute.name = 'ProjectTemplates';
+  } else if (path.includes('/commands')) {
+    mockRoute.name = 'ProjectCommands';
+  } else if (path.includes('/kanban')) {
+    mockRoute.name = 'ProjectKanban';
+  } else {
+    mockRoute.name = 'SessionList';
+  }
+});
+const mockRouterReplace = vi.fn();
+
 // Mock vue-router
 vi.mock('vue-router', () => ({
   useRoute: vi.fn(() => mockRoute),
   useRouter: vi.fn(() => ({
-    push: vi.fn((path) => {
-      // Update the mock route based on the path
-      if (path.includes('/archived')) {
-        mockRoute.name = 'ArchivedSessions';
-      } else if (path.includes('/templates')) {
-        mockRoute.name = 'ProjectTemplates';
-      } else if (path.includes('/commands')) {
-        mockRoute.name = 'ProjectCommands';
-      } else {
-        mockRoute.name = 'SessionList';
-      }
-    }),
+    push: mockRouterPush,
+    replace: mockRouterReplace,
   })),
   RouterLink: defineComponent({
     name: 'RouterLink',
@@ -3015,5 +3022,133 @@ describe('Add Session button responsive labels', () => {
     const emptyStateBtn = wrapper.find('.empty-state .btn-primary');
     expect(emptyStateBtn.exists()).toBe(true);
     expect(emptyStateBtn.text()).toBe('New Session');
+  });
+});
+
+describe('SessionListView Kanban Experimental behavior', () => {
+  let mockProjectsStore;
+  let mockSessionsStore;
+  let mockCommandButtonsStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+
+    Object.assign(mockRoute, {
+      params: { id: 'test-project-id' },
+      name: 'SessionList',
+    });
+
+    mockGetKanbanBoard.mockReset();
+    mockGetKanbanBoard.mockResolvedValue({ lanes: [], cards: [] });
+
+    mockSessionsStore = createSessionsStoreMock([
+      { id: 'session-1', name: 'Session 1', status: 'completed' },
+    ]);
+    useSessionsStore.mockReturnValue(mockSessionsStore);
+
+    mockCommandButtonsStore = {
+      buttons: [],
+      runs: {},
+      loading: false,
+      error: null,
+      fetchButtons: vi.fn().mockResolvedValue(),
+      fetchLatestRunsForProject: vi.fn().mockResolvedValue(),
+      getButtonsByProjectId: vi.fn(() => []),
+      getLatestRunForButton: vi.fn(() => null),
+    };
+    useCommandButtonsStore.mockReturnValue(mockCommandButtonsStore);
+  });
+
+  async function flushAll(wrapper) {
+    await flushPromises();
+    await nextTick();
+    if (wrapper && wrapper.vm) {
+      await wrapper.vm.$forceUpdate();
+      await nextTick();
+    }
+  }
+
+  it('renders Kanban tab with Experimental badge when kanbanEnabled=true', async () => {
+    mockProjectsStore = {
+      currentProject: {
+        id: 'test-project-id',
+        name: 'Test Project',
+        workingDirectory: '/tmp',
+        kanbanEnabled: true,
+      },
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    const tabsText = wrapper.find('.tabs-desktop').text();
+    expect(tabsText).toContain('Kanban');
+    expect(tabsText).toContain('Experimental');
+  });
+
+  it('labels the mobile Kanban option as experimental when kanbanEnabled=true', async () => {
+    mockProjectsStore = {
+      currentProject: {
+        id: 'test-project-id',
+        name: 'Test Project',
+        workingDirectory: '/tmp',
+        kanbanEnabled: true,
+      },
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    const mobileSelect = wrapper.find('.tabs-mobile select');
+    expect(mobileSelect.exists()).toBe(true);
+    expect(mobileSelect.text()).toContain('Kanban (experimental)');
+  });
+
+  it('does not render the Kanban tab when kanbanEnabled=false', async () => {
+    mockProjectsStore = {
+      currentProject: {
+        id: 'test-project-id',
+        name: 'Test Project',
+        workingDirectory: '/tmp',
+        kanbanEnabled: false,
+      },
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    const tabsText = wrapper.find('.tabs-desktop').text();
+    expect(tabsText).not.toContain('Kanban');
+
+    const mobileSelect = wrapper.find('.tabs-mobile select');
+    expect(mobileSelect.text()).not.toContain('Kanban');
+  });
+
+  it('redirects to /sessions when the kanban route is reached but kanbanEnabled=false', async () => {
+    mockRoute.name = 'ProjectKanban';
+    mockProjectsStore = {
+      currentProject: {
+        id: 'test-project-id',
+        name: 'Test Project',
+        workingDirectory: '/tmp',
+        kanbanEnabled: false,
+      },
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      '/projects/test-project-id/sessions'
+    );
   });
 });

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -356,7 +356,7 @@ vi.mock('../composables/useApi.js', () => ({
 vi.mock('../components/SessionCard.vue', () => ({
   default: defineComponent({
     name: 'SessionCard',
-    props: ['session', 'showSummary', 'summary', 'summaryLoading', 'summaryError', 'showArchive', 'showUnarchive', 'prUrl', 'prSummary'],
+    props: ['session', 'showSummary', 'summary', 'summaryLoading', 'summaryError', 'showArchive', 'showUnarchive', 'prUrl', 'prSummary', 'kanbanEnabled'],
     emits: ['retrySummary', 'archive', 'unarchive'],
     template: '<div class="session-card" :data-session-id="session.id" :data-summary="JSON.stringify(summary)" :data-pr-url="prUrl" :data-pr-summary="JSON.stringify(prSummary)"><slot /></div>',
   }),
@@ -3150,5 +3150,42 @@ describe('SessionListView Kanban Experimental behavior', () => {
     expect(mockRouterReplace).toHaveBeenCalledWith(
       '/projects/test-project-id/sessions'
     );
+  });
+
+  it('passes kanbanEnabled=false to SessionCard when project has Kanban disabled', async () => {
+    mockProjectsStore = {
+      currentProject: {
+        id: 'test-project-id',
+        name: 'Test Project',
+        workingDirectory: '/tmp',
+        kanbanEnabled: false,
+      },
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    const sessionCard = wrapper.findComponent({ name: 'SessionCard' });
+    expect(sessionCard.exists()).toBe(true);
+    expect(sessionCard.props('kanbanEnabled')).toBe(false);
+  });
+
+  it('passes kanbanEnabled=false to SessionCard when currentProject is not yet loaded', async () => {
+    mockProjectsStore = {
+      currentProject: null,
+      fetchProject: vi.fn(),
+    };
+    useProjectsStore.mockReturnValue(mockProjectsStore);
+
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    const sessionCard = wrapper.findComponent({ name: 'SessionCard' });
+    if (sessionCard.exists()) {
+      // Fallback should be false, not true, now that Kanban is experimental/opt-in.
+      expect(sessionCard.props('kanbanEnabled')).toBe(false);
+    }
   });
 });

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -100,6 +100,9 @@
             @click="router.push(`/projects/${route.params.id}/kanban`)"
           >
             Kanban
+            <span class="ml-1 rounded bg-amber-900/50 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-amber-300">
+              Experimental
+            </span>
           </button>
         </div>
         <router-link
@@ -138,7 +141,7 @@
             v-if="projectsStore.currentProject?.kanbanEnabled"
             value="kanban"
           >
-            Kanban
+            Kanban (experimental)
           </option>
         </select>
       </div>
@@ -448,6 +451,18 @@ watch(
       await loadArchivedSessions();
     } else if (newRouteName === 'ScheduledSessions') {
       await fetchScheduledSessions();
+    }
+  },
+  { immediate: true }
+);
+
+// Redirect away from the Kanban tab when the feature is experimentally disabled
+// for the current project. Covers direct navigation to /projects/:id/kanban.
+watch(
+  [activeTab, () => projectsStore.currentProject?.kanbanEnabled],
+  ([tab, kanbanEnabled]) => {
+    if (tab === 'kanban' && kanbanEnabled === false) {
+      router.replace(`/projects/${route.params.id}/sessions`);
     }
   },
   { immediate: true }

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -223,7 +223,7 @@
             :summary-loading="loadingSummaries[group.parent.id]"
             :summary-error="summaryErrors[group.parent.id]"
             :show-archive="true"
-            :kanban-enabled="projectsStore.currentProject?.kanbanEnabled ?? true"
+            :kanban-enabled="projectsStore.currentProject?.kanbanEnabled ?? false"
             :pr-url="group.parent.prUrl"
             :pr-summary="summaries[group.parent.id]"
             @retry-summary="retryFetchSummary"

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,5 +1,5 @@
 import { Page, Locator } from '@playwright/test';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { execSync } from 'child_process';
@@ -397,6 +397,16 @@ export async function seedProject(
     kanbanEnabled?: boolean;
   }
 ) {
+  // Ensure the working directory exists on disk so that anything which uses it
+  // as a `cwd` (e.g. commandRunner spawning shells) doesn't fail with the
+  // confusing "spawn sh ENOENT" error that Node.js emits when cwd is missing.
+  try {
+    mkdirSync(workingDirectory, { recursive: true });
+  } catch {
+    // best-effort: if we can't create it (permissions, invalid path), let the
+    // server respond as it normally would.
+  }
+
   const testName = `${TEST_PREFIX}${name}`;
   const body: any = { name: testName, workingDirectory };
 

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -394,6 +394,7 @@ export async function seedProject(
   options?: {
     onSessionCreated?: string;
     onSessionDeleted?: string;
+    kanbanEnabled?: boolean;
   }
 ) {
   const testName = `${TEST_PREFIX}${name}`;
@@ -405,6 +406,9 @@ export async function seedProject(
   }
   if (options?.onSessionDeleted) {
     body.onSessionDeleted = options.onSessionDeleted;
+  }
+  if (options?.kanbanEnabled !== undefined) {
+    body.kanbanEnabled = options.kanbanEnabled;
   }
 
   const response = await fetch(`${API_URL}/api/projects`, {

--- a/tests/e2e/kanban-board.spec.ts
+++ b/tests/e2e/kanban-board.spec.ts
@@ -14,7 +14,9 @@ test.describe('Kanban Board', () => {
 
   test.beforeEach(async () => {
     await cleanupCreatedResources();
-    project = await seedProject('Kanban Test Project', '/tmp/test-kanban');
+    project = await seedProject('Kanban Test Project', '/tmp/test-kanban', {
+      kanbanEnabled: true,
+    });
   });
 
   test.afterEach(async () => {

--- a/tests/e2e/kanban-disabled-by-default.spec.ts
+++ b/tests/e2e/kanban-disabled-by-default.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  cleanupCreatedResources,
+  navigateAndWait,
+  API_URL,
+} from './helpers';
+
+test.describe('Kanban experimental default (off)', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+    // No kanbanEnabled option → should default to false (experimental opt-in)
+    project = await seedProject('Kanban Default Off Project', '/tmp/test-kanban-off');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('new projects do not expose the Kanban tab and redirect /kanban to /sessions', async ({ page }) => {
+    // Sanity check: confirm the API responded with kanbanEnabled=false so the
+    // rest of the UI expectations below are meaningful.
+    const apiResponse = await fetch(`${API_URL}/api/projects/${project.id}`);
+    expect(apiResponse.ok).toBe(true);
+    const payload = await apiResponse.json();
+    expect(payload.kanbanEnabled).toBe(false);
+
+    // Navigate to the sessions list. The Kanban tab should be absent because
+    // the project was created with the default (off) experimental flag.
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.tabs-desktop',
+    });
+
+    const desktopTabs = page.locator('.tabs-desktop');
+    await expect(desktopTabs).toBeVisible();
+    await expect(desktopTabs).not.toContainText('Kanban');
+
+    // Directly navigating to the kanban route should redirect to the sessions
+    // list rather than surfacing the experimental board.
+    await page.goto(`/projects/${project.id}/kanban`);
+    await page.waitForURL(`**/projects/${project.id}/sessions`);
+    expect(page.url()).toContain(`/projects/${project.id}/sessions`);
+  });
+
+  test('opting in via the API re-enables the Kanban tab with an Experimental badge', async ({ page }) => {
+    // Opt-in by PATCH/PUT so we exercise the same path a user would trigger
+    // from the Project Edit view.
+    const response = await fetch(`${API_URL}/api/projects/${project.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kanbanEnabled: true }),
+    });
+    expect(response.ok).toBe(true);
+
+    await navigateAndWait(page, `/projects/${project.id}/sessions`, {
+      waitFor: '.tabs-desktop',
+    });
+
+    const kanbanTab = page.locator('.tabs-desktop .tab', { hasText: 'Kanban' });
+    await expect(kanbanTab).toBeVisible();
+    await expect(kanbanTab).toContainText('Experimental');
+  });
+});

--- a/tests/e2e/kanban-lane-settings.spec.ts
+++ b/tests/e2e/kanban-lane-settings.spec.ts
@@ -14,7 +14,9 @@ test.describe('Kanban Lane Settings - Position Changes', () => {
 
   test.beforeEach(async () => {
     await cleanupCreatedResources();
-    project = await seedProject('Kanban Position Test', '/tmp/test-kanban-pos');
+    project = await seedProject('Kanban Position Test', '/tmp/test-kanban-pos', {
+      kanbanEnabled: true,
+    });
   });
 
   test.afterEach(async () => {

--- a/tests/e2e/kanban-move-card.spec.ts
+++ b/tests/e2e/kanban-move-card.spec.ts
@@ -14,7 +14,9 @@ test.describe('Kanban Move Card Modal', () => {
 
   test.beforeEach(async () => {
     await cleanupCreatedResources();
-    project = await seedProject('Kanban Move Test Project', '/tmp/test-kanban-move');
+    project = await seedProject('Kanban Move Test Project', '/tmp/test-kanban-move', {
+      kanbanEnabled: true,
+    });
     session = await seedSession(project.id, {
       prompt: 'Test move card',
       name: 'Move Test Session',

--- a/tests/e2e/kanban-on-enter-automation.spec.ts
+++ b/tests/e2e/kanban-on-enter-automation.spec.ts
@@ -87,7 +87,9 @@ test.describe('Kanban on-enter automation', () => {
 
   test.beforeEach(async () => {
     await cleanupCreatedResources();
-    project = await seedProject('Kanban Automation Test', '/tmp/test-kanban-auto');
+    project = await seedProject('Kanban Automation Test', '/tmp/test-kanban-auto', {
+      kanbanEnabled: true,
+    });
     session = await seedSession(project.id, {
       prompt: 'Parent session',
       name: 'Automation Parent',

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { mkdtempSync } from 'fs';
+import { mkdirSync, mkdtempSync } from 'fs';
 import { cleanupAll, getProject, seedProject, API_URL } from './helpers';
 
 test.describe('Project Management', () => {
@@ -12,6 +12,11 @@ test.describe('Project Management', () => {
   });
 
   test('can create a new project', async ({ page }) => {
+    // Ensure the working directory exists so worktree path validation
+    // (which requires the parent of the auto-detected worktree path to be
+    // writable) doesn't reject the form submission.
+    mkdirSync('/tmp/test-project', { recursive: true });
+
     await page.goto('/');
     await page.click('text=Add Repository');
 
@@ -144,6 +149,9 @@ test.describe('Project Management', () => {
   });
 
   test('can create project with custom system prompt', async ({ page }) => {
+    // Ensure the working directory exists so worktree path validation passes.
+    mkdirSync('/tmp/test-project', { recursive: true });
+
     await page.goto('/');
     await page.click('text=Add Repository');
 


### PR DESCRIPTION
## Summary

Marks the Kanban board feature as experimental and changes the default behavior from enabled to disabled for newly created projects. Existing projects with Kanban enabled continue to work as before (backward compatible).

## Motivation

The Kanban feature is still in active development and may undergo significant changes. By marking it as experimental and disabling it by default, we set appropriate user expectations and reduce support burden while allowing the feature to evolve.

## Changes

### Backend
- **ProjectRepository.create**: default `kanbanEnabled` flipped from `true` to `false`.
- **ProjectRepository.#mapProject**: `row.kanban_enabled === undefined` fallback also flipped to `false` for consistency (missing data => opt-out).
- **Contracts**: comment updated to reflect "Default false (experimental feature)".
- **API**: `POST /api/projects` now explicitly forwards `kanbanEnabled` when provided so existing opt-in behavior is preserved.
- **No DB migration**: the schema default remains `1` to preserve existing project settings.

### Frontend
- **ProjectEditView**: added amber "Experimental" badge and warning copy ("may change or be removed") on the Kanban section.
- **SessionListView (desktop)**: "Experimental" badge on the Kanban tab button.
- **SessionListView (mobile)**: "(experimental)" suffix on the Kanban `<option>`.
- **SessionListView**: redirect watcher that replaces the URL to `/sessions` when a user lands on `/projects/:id/kanban` for a project with Kanban disabled.
- **SessionListView**: `SessionCard` now receives `kanbanEnabled ?? false` (was `?? true`) so the fallback also respects experimental-off.

### Tests — unit
- `ProjectRepository.test.js`: default-false, explicit-true, explicit-false cases **plus** row-mapping tests (truthy / falsy / missing column).
- `projects.test.js` (API): default, explicit opt-in, backward compatibility via pre-existing project.
- `ProjectEditView.test.js`: Experimental badge + warning copy.
- `SessionListView.test.js`: Experimental badge (desktop), "(experimental)" suffix (mobile), tab hidden when disabled, redirect from `/kanban`, and new assertions that `SessionCard` receives `kanbanEnabled=false` when the project opts out / is still loading.
- `kanbanService.test.js` and `kanban.test.js`: updated to opt in explicitly via the new default.

### Tests — E2E
- `tests/e2e/helpers.ts`: `seedProject()` accepts an optional `kanbanEnabled` flag.
- All existing Kanban suites (`kanban-board`, `kanban-lane-settings`, `kanban-move-card`, `kanban-on-enter-automation`) now explicitly enable Kanban via the helper.
- **New spec `tests/e2e/kanban-disabled-by-default.spec.ts`**: verifies a fresh project has `kanbanEnabled=false`, the Kanban tab is not rendered, direct navigation to `/kanban` redirects to `/sessions`, and opting in via `PUT /api/projects/:id` re-enables the tab with the Experimental badge.

### Documentation
- README: flagged both the Kanban board and lane-automation entries as experimental, explained the per-project enablement workflow, and noted that orchestration features piggyback on the Kanban flag.

## Backward Compatibility

Fully backward compatible. Existing projects with `kanban_enabled=1` in the database continue to have Kanban enabled. The change only affects the default for newly created projects.

## Verification

- yarn workspace @circuschief/server test — 3,834 passed / 19 skipped.
- yarn workspace @circuschief/web test — 4,360 passed / 103 skipped.
- yarn lint — clean.

Generated with Claude Code