### PR TITLE
feat: enhance publish script with auto-bump and test suite

### DIFF
--- a/docs/build-and-distribution.md
+++ b/docs/build-and-distribution.md
@@ -111,21 +111,30 @@ Regular `./scripts/pw.sh test` is still the fast path for normal development —
 Use `scripts/publish.sh`, which wraps the build and `npm publish`:
 
 ```bash
-# Usage: ./scripts/publish.sh <version> <otp>
-./scripts/publish.sh 0.2.0 123456
+# Usage: ./scripts/publish.sh [-y] [version] <otp>
+
+# Examples:
+./scripts/publish.sh 123456             # auto-bump minor, publish
+./scripts/publish.sh 0.2.0 123456       # publish exactly 0.2.0
+./scripts/publish.sh -y 123456          # auto-bump without prompt
 ```
+
+Options:
+
+- `-y, --yes` — Skip confirmation prompt when auto-bumping version.
 
 Arguments:
 
-- `version` — semver version to publish (e.g. `0.2.0`). Passed through to `build-package.js` as `--version=`.
-- `otp` — npm one-time password for 2FA. Passed to `npm publish --otp=`.
+- `version` — Optional semver version to publish (e.g. `0.2.0`). If omitted, the script bumps the minor version of the latest published npm version. Passed through to `build-package.js` as `--version=`.
+- `otp` — Required npm one-time password for 2FA (6 digits). Passed to `npm publish --otp=`.
 
 What the script does:
 
 1. Verifies you're logged in (`npm whoami`) and aborts with an error if not.
-2. Runs `node scripts/build-package.js --version=$VERSION`.
-3. Runs `npm publish --otp=$OTP` from inside `dist-package/`.
-4. Prints install/run hints (`npx circuschief`, `npx circuschief@<version>`).
+2. If `version` is omitted, queries npm for the latest published version and auto-bumps the minor version (e.g. `1.4.2` → `1.5.0`). Prompts for confirmation unless `-y` is passed.
+3. Runs `node scripts/build-package.js --version=$VERSION`.
+4. Runs `npm publish --otp=$OTP` from inside `dist-package/`.
+5. Prints install/run hints (`npx circuschief`, `npx circuschief@<version>`).
 
 Before publishing, make sure `VITE_POSTHOG_KEY` is available via one of the sources listed below so analytics actually ship in the bundle.
 


### PR DESCRIPTION
## Summary

This PR enhances the publish script with intelligent version management and adds comprehensive test coverage.

## Changes

### Enhanced `scripts/publish.sh`
- **Auto-bump functionality**: When version is omitted, the script now automatically bumps the minor version from the latest published npm version (e.g., `1.4.2` → `1.5.0`)
- **Confirmation prompt**: Auto-bump requires user confirmation unless `-y` flag is provided
- **Smart argument parsing**: Single argument is intelligently disambiguated between version and OTP based on pattern matching
- **Better error handling**: Validates OTP format, detects pre-release versions, and handles edge cases like never-published packages
- **New `-y/--yes` flag**: Skip confirmation when auto-bumping version (useful for CI/CD)

### New `scripts/publish.test.sh`
- Comprehensive test harness for the publish script
- Tests argument parsing, disambiguation, and auto-bump logic
- Mocks `npm` command for isolated testing
- 10+ test cases covering edge cases and error conditions
- New npm script: `yarn test:publish-script`

### Updated Documentation
- `docs/build-and-distribution.md` updated to reflect new usage
- Added examples for auto-bump, explicit version, and `-y` flag
- Documented the auto-bump logic and behavior

## Examples

```bash
# Auto-bump minor version and publish (interactive)
./scripts/publish.sh 123456

# Publish exact version
./scripts/publish.sh 0.2.0 123456

# Auto-bump without confirmation (CI/CD friendly)
./scripts/publish.sh -y 123456

# Run tests
yarn test:publish-script
```

## Test plan

- [x] Run `yarn test:publish-script` - all tests pass
- [x] Manual testing of auto-bump with various npm states (published, never-published, pre-release)
- [x] Verification of argument disambiguation (version vs OTP)
- [x] Documentation review and updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)