### PR TITLE
Fix sub-nav layout: increase mobile breakpoint to 700px

### DIFF
--- a/packages/web/src/views/SessionListView.css
+++ b/packages/web/src/views/SessionListView.css
@@ -155,7 +155,7 @@
   height: 1rem;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 700px) {
   .page-header {
     flex-direction: column;
     gap: 1rem;
@@ -193,14 +193,14 @@
 }
 
 /* Hide mobile-only elements on desktop */
-@media (min-width: 481px) {
+@media (min-width: 701px) {
   .mobile-only {
     display: none !important;
   }
 }
 
 /* Show desktop-only elements on desktop */
-@media (min-width: 481px) {
+@media (min-width: 701px) {
   .desktop-only {
     display: inline-flex !important;
   }


### PR DESCRIPTION
## Summary

Fixes the session list sub-navigation layout issue where the "+ Session" button was being pushed to the far right edge of the viewport on medium-width screens.

## Problem

With 5 tabs (Sessions, Archived, Templates, Commands, Scheduled) plus the "+ Session" button in a single row, the desktop tab layout was getting cramped on screens between 480-700px wide. The `justify-content: space-between` on the tab row was pushing the button all the way to the right edge, creating a disconnected, awkward appearance.

## Solution

Increased the mobile navigation breakpoint from `480px` to `700px`. This means:

- On screens **below 700px**: The mobile dropdown `<select>` navigation is used, which cleanly handles all tab options in a compact form
- On screens **above 700px**: The desktop tab row with the "+ Session" button is shown, with enough horizontal space for all elements to sit comfortably together

## Changes

- Updated three responsive breakpoints in `packages/web/src/views/SessionListView.css`:
  - `@media (max-width: 480px)` → `@media (max-width: 700px)`
  - `@media (min-width: 481px)` → `@media (min-width: 701px)` (2 occurrences)

## Test Plan

- [ ] View the session list on screens between 480-700px wide — should now see mobile dropdown nav instead of cramped desktop tabs
- [ ] View on screens above 700px wide — should see desktop tabs with "+ Session" button positioned naturally after the tabs
- [ ] Verify mobile view still works correctly on phones (< 480px)
- [ ] Check that the button no longer gets pushed to the viewport edge

## Screenshots

(Attach before/after screenshots after testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)