### PR TITLE
Fix session overlay viewport offset

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1541,7 +1541,7 @@ describe('SessionChatOverlay', () => {
       wrapper.unmount();
     });
 
-    it('backdrop stylesheet uses position: fixed and align-items: stretch', () => {
+    it('backdrop stylesheet uses fixed viewport-offset geometry', () => {
       // Assert against the SFC source text (imported as raw via Vite `?raw`).
       // jsdom does not reliably attach Vue <style scoped> blocks to
       // document.styleSheets, so source-text inspection is the check used
@@ -1550,8 +1550,10 @@ describe('SessionChatOverlay', () => {
       expect(blockMatch).toBeTruthy();
       const block = blockMatch[0];
       expect(block).toMatch(/position:\s*fixed/);
-      expect(block).toMatch(/inset:\s*0/);
-      expect(block).toMatch(/align-items:\s*stretch/);
+      expect(block).toMatch(/top:\s*var\(--viewport-offset-top,\s*0px\)/);
+      expect(block).toMatch(/right:\s*0/);
+      expect(block).toMatch(/bottom:\s*0/);
+      expect(block).toMatch(/left:\s*0/);
     });
 
     it('panel-wrapper stylesheet no longer uses viewport-unit min-heights', () => {

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -1034,27 +1034,24 @@ defineExpose({
 <style scoped>
 .overlay-backdrop {
   position: fixed;
-  inset: 0;
+  top: var(--viewport-offset-top, 0px);
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1000;
   background: rgb(17, 24, 39);
-  display: flex;
-  justify-content: flex-end;
-  /* `stretch` lets the panel wrapper fill the full backdrop height
-     without viewport-unit min-heights; `inset: 0` is the sole size
-     source, so the browser tracks URL-bar / keyboard / orientation
-     changes automatically (no JS viewport sync). */
-  align-items: stretch;
+  display: block;
   overflow: hidden;
   overflow-y: hidden;
   overscroll-behavior: none;
 }
 
 .overlay-panel-wrapper {
-  position: relative;
+  position: fixed;
+  top: var(--viewport-offset-top, 0px);
+  right: 0;
+  bottom: 0;
   display: flex;
-  /* Cross-axis size comes from `align-items: stretch` on the backdrop.
-     `min-height: 0` allows the internal flex column to shrink without
-     overflowing. */
   min-height: 0;
   max-width: 900px;
   width: 100%;
@@ -1146,6 +1143,8 @@ defineExpose({
 }
 
 .overlay-header {
+  position: sticky;
+  top: 0;
   display: flex;
   flex-direction: column;
   gap: 0.375rem;

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -96,7 +96,7 @@ test.describe('SessionChatOverlay layout', () => {
     expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
   });
 
-  test('backdrop uses position: fixed and align-items: stretch', async ({ page }) => {
+  test('backdrop uses position: fixed and viewport-offset top', async ({ page }) => {
     await navigateToSession(page);
     await openOverlay(page);
 
@@ -107,16 +107,46 @@ test.describe('SessionChatOverlay layout', () => {
       const c = getComputedStyle(el);
       return {
         position: c.position,
-        alignItems: c.alignItems,
         top: c.top,
         left: c.left,
       };
     });
 
     expect(computed.position).toBe('fixed');
-    expect(computed.alignItems).toBe('stretch');
     expect(computed.top).toBe('0px');
     expect(computed.left).toBe('0px');
+  });
+
+  test('panel honors visual viewport top offset', async ({ page }) => {
+    await navigateToSession(page);
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--viewport-offset-top', '48px');
+    });
+    await openOverlay(page);
+
+    const result = await page.evaluate(() => {
+      const backdrop = document.querySelector(
+        '[data-testid="session-chat-overlay"]'
+      ) as HTMLElement;
+      const panel = document.querySelector('.overlay-panel-wrapper') as HTMLElement;
+      const header = document.querySelector('.overlay-header') as HTMLElement;
+      return {
+        backdropTop: backdrop.getBoundingClientRect().top,
+        panelTop: panel.getBoundingClientRect().top,
+        headerTop: header.getBoundingClientRect().top,
+      };
+    });
+
+    expect(result.backdropTop).toBeGreaterThanOrEqual(47);
+    expect(result.backdropTop).toBeLessThanOrEqual(49);
+    expect(result.panelTop).toBeGreaterThanOrEqual(47);
+    expect(result.panelTop).toBeLessThanOrEqual(49);
+    expect(result.headerTop).toBeGreaterThanOrEqual(47);
+    expect(result.headerTop).toBeLessThanOrEqual(49);
+
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--viewport-offset-top', '0px');
+    });
   });
 
   test('covers viewport after SessionDetailView scroll', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Anchor the session overlay backdrop and panel to `--viewport-offset-top` so iPad Safari visual viewport shifts do not move the panel above the visible viewport.
- Simplify the panel geometry by making the wrapper fixed instead of dependent on backdrop flex stretching.
- Add/update regression coverage for viewport-offset positioning and source-level layout expectations.

## Tests
- `yarn workspace @circuschief/web test SessionChatOverlay.test.js`
- `yarn test:e2e tests/e2e/session-chat-overlay-header-scroll-bug.spec.ts`
- `yarn test:e2e tests/e2e/session-chat-overlay-layout.spec.ts`

## Session Summary
Successfully tested SessionChatOverlay component with 73 Vitest tests and 28 Playwright e2e tests passing.