### PR TITLE
feat: Add HTTP Basic Authentication

### DIFF
--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import apiRouter from './api/index.js';
+import { createBasicAuthMiddleware } from './middleware/basicAuth.js';
 import { MAX_JSON_SIZE } from '@circuschief/shared';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -12,13 +13,20 @@ const __dirname = dirname(__filename);
  * Create Express application
  * @param {Object} options
  * @param {boolean} options.production - Enable production mode
+ * @param {{ username: string, password: string }|null} options.auth - Basic auth credentials
  * @returns {express.Application}
  */
 export function createApp(options = {}) {
   const app = express();
 
-  // CORS (allow all in dev)
-  app.use(cors());
+  // CORS — allow Authorization header when auth is enabled for preflight
+  if (options.auth) {
+    app.use(cors({
+      allowedHeaders: ['Content-Type', 'Authorization'],
+    }));
+  } else {
+    app.use(cors());
+  }
 
   // Body parsing
   app.use(express.json({ limit: MAX_JSON_SIZE }));
@@ -27,8 +35,11 @@ export function createApp(options = {}) {
   // Multipart form data parsing is handled per-route with specific middleware
   // to avoid conflicts between upload.single() and upload.array() across different endpoints
 
+  // Auth middleware — protects API routes only, not static files or SPA fallback
+  const authMiddleware = createBasicAuthMiddleware(options.auth);
+
   // API routes
-  app.use('/api', apiRouter);
+  app.use('/api', authMiddleware, apiRouter);
 
   // Static files and SPA fallback (production only - in dev, Vite serves frontend)
   if (options.production) {

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -19,14 +19,11 @@ const __dirname = dirname(__filename);
 export function createApp(options = {}) {
   const app = express();
 
-  // CORS — allow Authorization header when auth is enabled for preflight
-  if (options.auth) {
-    app.use(cors({
-      allowedHeaders: ['Content-Type', 'Authorization'],
-    }));
-  } else {
-    app.use(cors());
-  }
+  // CORS — always allow Content-Type; include Authorization when auth is enabled
+  const corsOptions = options.auth
+    ? { allowedHeaders: ['Content-Type', 'Authorization'] }
+    : { allowedHeaders: ['Content-Type'] };
+  app.use(cors(corsOptions));
 
   // Body parsing
   app.use(express.json({ limit: MAX_JSON_SIZE }));

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -12,6 +12,7 @@ function showHelp() {
 
 Options:
   -p, --port <number>  Port to listen on (env: PORT, default: ${DEFAULT_SERVER_PORT})
+  --auth <user:pass>   Enable HTTP Basic Auth (env: CC_AUTH)
   --no-analytics       Disable anonymous usage analytics
   -h, --help           Show this help message
   -V, --version        Show version number`);
@@ -54,6 +55,10 @@ export function parseCliOptions(argv = process.argv) {
           type: 'boolean',
           default: false,
         },
+        auth: {
+          type: 'string',
+          default: process.env.CC_AUTH || '',
+        },
       },
     }));
   } catch (err) {
@@ -78,5 +83,27 @@ export function parseCliOptions(argv = process.argv) {
     process.exit(1);
   }
 
-  return { port, disableAnalytics: values['no-analytics'] };
+  // Parse auth credentials if provided
+  let auth = null;
+  const authValue = values.auth;
+  if (authValue) {
+    const colonIndex = authValue.indexOf(':');
+    if (colonIndex === -1) {
+      console.error('Error: --auth format must be <user:pass>');
+      process.exit(1);
+    }
+    const username = authValue.slice(0, colonIndex);
+    const password = authValue.slice(colonIndex + 1);
+    if (!username) {
+      console.error('Error: --auth username must not be empty');
+      process.exit(1);
+    }
+    if (!password) {
+      console.error('Error: --auth password must not be empty');
+      process.exit(1);
+    }
+    auth = { username, password };
+  }
+
+  return { port, disableAnalytics: values['no-analytics'], auth };
 }

--- a/packages/server/src/cli.test.js
+++ b/packages/server/src/cli.test.js
@@ -22,6 +22,7 @@ describe('parseCliOptions', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     process.env = { ...originalEnv };
     delete process.env.PORT;
+    delete process.env.CC_AUTH;
   });
 
   afterEach(() => {
@@ -31,17 +32,17 @@ describe('parseCliOptions', () => {
 
   it('returns default port when no arguments provided', () => {
     const result = parseCliOptions(['node', 'cli.js']);
-    expect(result).toEqual({ port: 5000, disableAnalytics: false });
+    expect(result).toEqual({ port: 5000, disableAnalytics: false, auth: null });
   });
 
   it('parses custom port with -p flag', () => {
     const result = parseCliOptions(['node', 'cli.js', '-p', '8080']);
-    expect(result).toEqual({ port: 8080, disableAnalytics: false });
+    expect(result).toEqual({ port: 8080, disableAnalytics: false, auth: null });
   });
 
   it('parses custom port with --port flag', () => {
     const result = parseCliOptions(['node', 'cli.js', '--port', '3000']);
-    expect(result).toEqual({ port: 3000, disableAnalytics: false });
+    expect(result).toEqual({ port: 3000, disableAnalytics: false, auth: null });
   });
 
   it('exits with error for non-numeric port', () => {
@@ -116,25 +117,25 @@ describe('parseCliOptions', () => {
 
   it('accepts minimum valid port (1)', () => {
     const result = parseCliOptions(['node', 'cli.js', '-p', '1']);
-    expect(result).toEqual({ port: 1, disableAnalytics: false });
+    expect(result).toEqual({ port: 1, disableAnalytics: false, auth: null });
   });
 
   it('accepts maximum valid port (65535)', () => {
     const result = parseCliOptions(['node', 'cli.js', '-p', '65535']);
-    expect(result).toEqual({ port: 65535, disableAnalytics: false });
+    expect(result).toEqual({ port: 65535, disableAnalytics: false, auth: null });
   });
 
   describe('PORT environment variable', () => {
     it('respects PORT env var when no CLI flag is given', () => {
       process.env.PORT = '8080';
       const result = parseCliOptions(['node', 'cli.js']);
-      expect(result).toEqual({ port: 8080, disableAnalytics: false });
+      expect(result).toEqual({ port: 8080, disableAnalytics: false, auth: null });
     });
 
     it('CLI --port flag takes precedence over PORT env var', () => {
       process.env.PORT = '8080';
       const result = parseCliOptions(['node', 'cli.js', '--port', '3000']);
-      expect(result).toEqual({ port: 3000, disableAnalytics: false });
+      expect(result).toEqual({ port: 3000, disableAnalytics: false, auth: null });
     });
 
     it('exits with error for invalid PORT env var', () => {
@@ -160,7 +161,7 @@ describe('parseCliOptions', () => {
 
     it('can combine --no-analytics with --port', () => {
       const result = parseCliOptions(['node', 'cli.js', '-p', '8080', '--no-analytics']);
-      expect(result).toEqual({ port: 8080, disableAnalytics: true });
+      expect(result).toEqual({ port: 8080, disableAnalytics: true, auth: null });
     });
   });
 
@@ -175,6 +176,68 @@ describe('parseCliOptions', () => {
       expect(logSpy).toHaveBeenCalledWith('unknown');
 
       readFileSync.mockRestore();
+    });
+  });
+
+  describe('--auth flag', () => {
+    it('returns auth null by default', () => {
+      const result = parseCliOptions(['node', 'cli.js']);
+      expect(result.auth).toBeNull();
+    });
+
+    it('parses valid --auth user:pass', () => {
+      const result = parseCliOptions(['node', 'cli.js', '--auth', 'admin:secret123']);
+      expect(result.auth).toEqual({ username: 'admin', password: 'secret123' });
+    });
+
+    it('handles passwords containing colons', () => {
+      const result = parseCliOptions(['node', 'cli.js', '--auth', 'admin:pass:word']);
+      expect(result.auth).toEqual({ username: 'admin', password: 'pass:word' });
+    });
+
+    it('reads from CC_AUTH env var', () => {
+      process.env.CC_AUTH = 'user:pass';
+      const result = parseCliOptions(['node', 'cli.js']);
+      expect(result.auth).toEqual({ username: 'user', password: 'pass' });
+    });
+
+    it('CLI --auth takes precedence over CC_AUTH env var', () => {
+      process.env.CC_AUTH = 'envuser:envpass';
+      const result = parseCliOptions(['node', 'cli.js', '--auth', 'cliuser:clipass']);
+      expect(result.auth).toEqual({ username: 'cliuser', password: 'clipass' });
+    });
+
+    it('exits with error for --auth with no colon', () => {
+      expect(() => parseCliOptions(['node', 'cli.js', '--auth', 'nocolon'])).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--auth format must be <user:pass>')
+      );
+    });
+
+    it('exits with error for empty username', () => {
+      expect(() => parseCliOptions(['node', 'cli.js', '--auth', ':password'])).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('username must not be empty')
+      );
+    });
+
+    it('exits with error for empty password', () => {
+      expect(() => parseCliOptions(['node', 'cli.js', '--auth', 'user:'])).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('password must not be empty')
+      );
+    });
+
+    it('can combine --auth with --port and --no-analytics', () => {
+      const result = parseCliOptions(['node', 'cli.js', '-p', '8080', '--no-analytics', '--auth', 'admin:secret']);
+      expect(result).toEqual({
+        port: 8080,
+        disableAnalytics: true,
+        auth: { username: 'admin', password: 'secret' },
+      });
     });
   });
 });

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -32,7 +32,7 @@ function validateNodeEnvironment() {
   }
 }
 
-const { port, disableAnalytics } = parseCliOptions();
+const { port, disableAnalytics, auth } = parseCliOptions();
 process.env.PORT = String(port);
 const production = process.env.NODE_ENV === 'production';
 const dbPath = process.env.DB_PATH || getDefaultDbPath();
@@ -63,13 +63,18 @@ if (disableAnalytics) {
 }
 
 // Create Express app
-const app = createApp({ production });
+const app = createApp({ production, auth });
 
 // Create HTTP server
 const server = createServer(app);
 
 // Initialize WebSocket for app
-initWebSocket(server);
+initWebSocket(server, auth);
+
+// Log auth status
+if (auth) {
+  console.log(`Basic authentication enabled (user: ${auth.username})`);
+}
 
 // Initialize and start scheduler service (gated off under VCR_MODE)
 schedulerService.startIfEnabled(sessionManager);

--- a/packages/server/src/middleware/basicAuth.js
+++ b/packages/server/src/middleware/basicAuth.js
@@ -1,0 +1,44 @@
+/**
+ * Create HTTP Basic Authentication middleware.
+ *
+ * When no credentials are configured, returns a pass-through middleware.
+ * When credentials are configured, validates the Authorization: Basic header.
+ *
+ * Uses 'xBasic' scheme in WWW-Authenticate to suppress the browser's native
+ * auth dialog, allowing the frontend to show its own styled login form.
+ *
+ * @param {{ username: string, password: string }|null} credentials
+ * @returns {import('express').RequestHandler}
+ */
+export function createBasicAuthMiddleware(credentials) {
+  // No credentials configured — pass through
+  if (!credentials) {
+    return (_req, _res, next) => next();
+  }
+
+  // Pre-compute the expected base64 token
+  const expectedToken = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
+
+  return (req, res, next) => {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader) {
+      res.setHeader('WWW-Authenticate', 'xBasic realm="Circus Chief"');
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    // Expect "Basic <base64>"
+    const parts = authHeader.split(' ');
+    if (parts.length !== 2 || parts[0] !== 'Basic') {
+      res.setHeader('WWW-Authenticate', 'xBasic realm="Circus Chief"');
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    if (parts[1] !== expectedToken) {
+      res.setHeader('WWW-Authenticate', 'xBasic realm="Circus Chief"');
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    next();
+  };
+}

--- a/packages/server/src/middleware/basicAuth.js
+++ b/packages/server/src/middleware/basicAuth.js
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from 'crypto';
+
 /**
  * Create HTTP Basic Authentication middleware.
  *
@@ -6,6 +8,8 @@
  *
  * Uses 'xBasic' scheme in WWW-Authenticate to suppress the browser's native
  * auth dialog, allowing the frontend to show its own styled login form.
+ *
+ * Token comparison uses crypto.timingSafeEqual to prevent timing attacks.
  *
  * @param {{ username: string, password: string }|null} credentials
  * @returns {import('express').RequestHandler}
@@ -16,8 +20,8 @@ export function createBasicAuthMiddleware(credentials) {
     return (_req, _res, next) => next();
   }
 
-  // Pre-compute the expected base64 token
-  const expectedToken = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
+  // Pre-compute the expected base64 token as a Buffer for constant-time comparison
+  const expectedBuffer = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
 
   return (req, res, next) => {
     const authHeader = req.headers.authorization;
@@ -34,7 +38,12 @@ export function createBasicAuthMiddleware(credentials) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    if (parts[1] !== expectedToken) {
+    // Constant-time comparison to prevent timing attacks
+    const providedBuffer = parts[1];
+    if (
+      providedBuffer.length !== expectedBuffer.length ||
+      !timingSafeEqual(Buffer.from(providedBuffer), Buffer.from(expectedBuffer))
+    ) {
       res.setHeader('WWW-Authenticate', 'xBasic realm="Circus Chief"');
       return res.status(401).json({ error: 'Authentication required' });
     }

--- a/packages/server/src/middleware/basicAuth.test.js
+++ b/packages/server/src/middleware/basicAuth.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createBasicAuthMiddleware } from './basicAuth.js';
+
+describe('createBasicAuthMiddleware', () => {
+  let mockReq, mockRes, mockNext;
+
+  beforeEach(() => {
+    mockReq = {
+      headers: {},
+    };
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+      setHeader: vi.fn(),
+    };
+    mockNext = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  describe('when no credentials configured', () => {
+    it('should pass through when credentials is null', () => {
+      const middleware = createBasicAuthMiddleware(null);
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should pass through when credentials is undefined', () => {
+      const middleware = createBasicAuthMiddleware(undefined);
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when credentials are configured', () => {
+    const credentials = { username: 'admin', password: 'secret123' };
+
+    it('should call next() for valid credentials', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+      const token = Buffer.from('admin:secret123').toString('base64');
+      mockReq.headers.authorization = `Basic ${token}`;
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when Authorization header is missing', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(mockRes.setHeader).toHaveBeenCalledWith('WWW-Authenticate', 'xBasic realm="Circus Chief"');
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for wrong credentials', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+      const token = Buffer.from('admin:wrongpassword').toString('base64');
+      mockReq.headers.authorization = `Basic ${token}`;
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for malformed Authorization header', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+      mockReq.headers.authorization = 'Bearer some-token';
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for Authorization header with no scheme', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+      mockReq.headers.authorization = 'just-a-string';
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should use xBasic scheme in WWW-Authenticate to suppress browser dialog', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith('WWW-Authenticate', 'xBasic realm="Circus Chief"');
+    });
+  });
+});

--- a/packages/server/src/middleware/basicAuth.test.js
+++ b/packages/server/src/middleware/basicAuth.test.js
@@ -94,6 +94,18 @@ describe('createBasicAuthMiddleware', () => {
       expect(mockNext).not.toHaveBeenCalled();
     });
 
+    it('should return 401 for token of different length (timing-safe)', () => {
+      const middleware = createBasicAuthMiddleware(credentials);
+      // Use a short token that's clearly a different length
+      mockReq.headers.authorization = 'Basic short';
+
+      middleware(mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
     it('should use xBasic scheme in WWW-Authenticate to suppress browser dialog', () => {
       const middleware = createBasicAuthMiddleware(credentials);
 

--- a/packages/server/src/ws/WebSocketManager.js
+++ b/packages/server/src/ws/WebSocketManager.js
@@ -23,12 +23,28 @@ export class WebSocketManager {
   /**
    * Initialize WebSocket server
    * @param {import('http').Server} server - HTTP server to attach to
+   * @param {{ username: string, password: string }|null} [authCredentials] - Optional auth credentials
    * @returns {WebSocketServer}
    */
-  init(server) {
+  init(server, authCredentials = null) {
     this.#wss = new WebSocketServer({ server, path: '/ws' });
 
-    this.#wss.on('connection', (ws) => {
+    // Pre-compute expected auth token if credentials are configured
+    const expectedAuthToken = authCredentials
+      ? Buffer.from(`${authCredentials.username}:${authCredentials.password}`).toString('base64')
+      : null;
+
+    this.#wss.on('connection', (ws, req) => {
+      // Validate WebSocket auth if credentials are configured
+      if (expectedAuthToken) {
+        const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+        const token = url.searchParams.get('token');
+        if (token !== expectedAuthToken) {
+          ws.close(4001, 'Authentication required');
+          return;
+        }
+      }
+
       this.#clients.add(ws);
 
       ws.on('message', (data) => {

--- a/packages/server/src/ws/WebSocketManager.test.js
+++ b/packages/server/src/ws/WebSocketManager.test.js
@@ -494,6 +494,77 @@ describe('WebSocketManager', () => {
     });
   });
 
+  describe('auth', () => {
+    const credentials = { username: 'admin', password: 'secret123' };
+
+    it('rejects connection without token when auth is enabled', async () => {
+      manager.init(server, credentials);
+
+      const ws = new WebSocket(`ws://localhost:${port}/ws`);
+      const closeEvent = await new Promise((resolve) => ws.on('close', resolve));
+
+      expect(closeEvent).toBe(4001);
+      expect(manager.getClients().size).toBe(0);
+    });
+
+    it('rejects connection with wrong token', async () => {
+      manager.init(server, credentials);
+      const wrongToken = Buffer.from('admin:wrongpassword').toString('base64');
+
+      const ws = new WebSocket(`ws://localhost:${port}/ws?token=${wrongToken}`);
+      const closeEvent = await new Promise((resolve) => ws.on('close', resolve));
+
+      expect(closeEvent).toBe(4001);
+      expect(manager.getClients().size).toBe(0);
+    });
+
+    it('accepts connection with valid token', async () => {
+      manager.init(server, credentials);
+      const token = Buffer.from('admin:secret123').toString('base64');
+
+      const ws = new WebSocket(`ws://localhost:${port}/ws?token=${token}`);
+      await new Promise((resolve) => ws.on('open', resolve));
+
+      expect(manager.getClients().size).toBe(1);
+      ws.close();
+    });
+
+    it('accepts connection without token when auth is null', async () => {
+      manager.init(server, null);
+
+      const ws = await connectClient();
+      expect(manager.getClients().size).toBe(1);
+      ws.close();
+    });
+
+    it('accepts connection without token when auth is not provided', async () => {
+      manager.init(server);
+
+      const ws = await connectClient();
+      expect(manager.getClients().size).toBe(1);
+      ws.close();
+    });
+
+    it('client with valid token can subscribe and receive messages', async () => {
+      manager.init(server, credentials);
+      const token = Buffer.from('admin:secret123').toString('base64');
+
+      const ws = new WebSocket(`ws://localhost:${port}/ws?token=${token}`);
+      await new Promise((resolve) => ws.on('open', resolve));
+
+      ws.send(createMessage(WS_MESSAGE_TYPES.SUBSCRIBE_SESSION, { sessionId: 'sess-123' }));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const msgPromise = waitForMessage(ws);
+      manager.broadcastToSession('sess-123', 'TEST_MSG', { data: 'hello' });
+      const msg = await msgPromise;
+      expect(msg.type).toBe('TEST_MSG');
+      expect(msg.data).toBe('hello');
+
+      ws.close();
+    });
+  });
+
   describe('close', () => {
     it('closes server and clears state', async () => {
       manager.init(server);

--- a/packages/server/src/ws/index.js
+++ b/packages/server/src/ws/index.js
@@ -6,10 +6,11 @@ import { webSocketManager } from './WebSocketManager.js';
 /**
  * Initialize WebSocket server
  * @param {import('http').Server} server
+ * @param {{ username: string, password: string }|null} [authCredentials] - Optional auth credentials
  * @returns {import('ws').WebSocketServer}
  */
-export function initWebSocket(server) {
-  return webSocketManager.init(server);
+export function initWebSocket(server, authCredentials = null) {
+  return webSocketManager.init(server, authCredentials);
 }
 
 /**

--- a/packages/web/src/api/fetchWithAuth.js
+++ b/packages/web/src/api/fetchWithAuth.js
@@ -1,0 +1,78 @@
+/**
+ * Auth-aware fetch wrapper.
+ *
+ * Patches globalThis.fetch to automatically inject the Authorization header
+ * from the auth store and intercept 401 responses before ApiClient throws.
+ *
+ * This ensures all fetch calls (including those inside ApiClient.#request()
+ * and _uploadFormData()) automatically get auth headers.
+ */
+
+/** @type {{ authHeader: import('vue').ComputedRef<string|undefined>, markRequired: () => void }|null} */
+let store = null;
+
+/** @type {import('vue-router').Router|null} */
+let router = null;
+
+/** @type {typeof globalThis.fetch} */
+const originalFetch = globalThis.fetch;
+
+/**
+ * Get the current Authorization header value
+ * @returns {string|undefined}
+ */
+export function getAuthHeaderValue() {
+  return store?.authHeader?.value ?? undefined;
+}
+
+/**
+ * Get the current auth token (base64 encoded user:password)
+ * @returns {string|undefined}
+ */
+export function getAuthToken() {
+  return store?.authToken?.value ?? undefined;
+}
+
+/**
+ * Patched fetch that injects the Authorization header and intercepts 401s.
+ * @param  {...any} args - Arguments passed to fetch
+ * @returns {Promise<Response>}
+ */
+function patchedFetch(...args) {
+  const [input, init = {}] = args;
+
+  // Inject Authorization header if available
+  const authHeader = getAuthHeaderValue();
+  if (authHeader) {
+    init.headers = {
+      ...(init.headers || {}),
+      Authorization: authHeader,
+    };
+  }
+
+  return originalFetch(input, init).then((response) => {
+    // Intercept 401 before ApiClient throws
+    if (response.status === 401) {
+      if (store) {
+        store.markRequired();
+      }
+      if (router) {
+        router.push('/login');
+      }
+    }
+    return response;
+  });
+}
+
+/**
+ * Initialize the auth-aware fetch wrapper.
+ * Patches globalThis.fetch to inject Authorization headers and handle 401s.
+ *
+ * @param {{ authHeader: import('vue').ComputedRef<string|undefined>, authToken: import('vue').ComputedRef<string|undefined>, markRequired: () => void }} authStore
+ * @param {import('vue-router').Router} vueRouter
+ */
+export function initFetchAuth(authStore, vueRouter) {
+  store = authStore;
+  router = vueRouter;
+  globalThis.fetch = patchedFetch;
+}

--- a/packages/web/src/api/fetchWithAuth.js
+++ b/packages/web/src/api/fetchWithAuth.js
@@ -8,7 +8,7 @@
  * and _uploadFormData()) automatically get auth headers.
  */
 
-/** @type {{ authHeader: import('vue').ComputedRef<string|undefined>, markRequired: () => void }|null} */
+/** @type {{ authHeader: import('vue').ComputedRef<string|undefined>, authToken: import('vue').ComputedRef<string|undefined>, markRequired: () => void }|null} */
 let store = null;
 
 /** @type {import('vue-router').Router|null} */
@@ -16,6 +16,15 @@ let router = null;
 
 /** @type {typeof globalThis.fetch} */
 const originalFetch = globalThis.fetch;
+
+/**
+ * Get the original (unpatched) fetch function.
+ * Used by auth store's login() to avoid the auth header injection loop.
+ * @returns {typeof globalThis.fetch}
+ */
+export function getOriginalFetch() {
+  return originalFetch;
+}
 
 /**
  * Get the current Authorization header value
@@ -31,6 +40,19 @@ export function getAuthHeaderValue() {
  */
 export function getAuthToken() {
   return store?.authToken?.value ?? undefined;
+}
+
+/**
+ * Whether we've already handled a 401 and initiated a redirect to /login.
+ * Prevents duplicate redirects from concurrent 401 responses.
+ */
+let handled401 = false;
+
+/**
+ * Reset the 401 handled flag (called after successful login).
+ */
+export function reset401Handled() {
+  handled401 = false;
 }
 
 /**
@@ -51,8 +73,9 @@ function patchedFetch(...args) {
   }
 
   return originalFetch(input, init).then((response) => {
-    // Intercept 401 before ApiClient throws
-    if (response.status === 401) {
+    // Intercept 401 before ApiClient throws — only redirect once
+    if (response.status === 401 && !handled401) {
+      handled401 = true;
       if (store) {
         store.markRequired();
       }

--- a/packages/web/src/api/fetchWithAuth.test.js
+++ b/packages/web/src/api/fetchWithAuth.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for fetchWithAuth.
+ *
+ * The module captures globalThis.fetch at import time as `originalFetch`.
+ * To test the patched fetch behavior, we need to control what "original fetch"
+ * returns. We do this by setting up a mock on globalThis.fetch BEFORE
+ * the test module is imported (vi.hoisted or top-level vi.fn), then
+ * calling the patched fetch which calls through to our mock.
+ */
+
+// Capture the mock reference before the module is imported
+const mockOriginalFetch = vi.fn();
+
+// Replace global fetch before the module captures it
+const savedFetch = globalThis.fetch;
+globalThis.fetch = mockOriginalFetch;
+
+// Import after mock is set up so the module captures our mock as "original"
+const {
+  initFetchAuth,
+  getAuthHeaderValue,
+  getAuthToken,
+  getOriginalFetch,
+  reset401Handled,
+} = await import('./fetchWithAuth.js');
+
+describe('fetchWithAuth', () => {
+  let mockAuthStore;
+  let mockRouter;
+
+  beforeEach(() => {
+    mockAuthStore = {
+      authHeader: { value: undefined },
+      authToken: { value: undefined },
+      markRequired: vi.fn(),
+    };
+    mockRouter = {
+      push: vi.fn(),
+    };
+    mockOriginalFetch.mockReset();
+  });
+
+  afterEach(() => {
+    // Restore original fetch so we don't pollute other tests
+    globalThis.fetch = savedFetch;
+    reset401Handled();
+  });
+
+  describe('before initialization', () => {
+    it('getAuthHeaderValue returns undefined', () => {
+      expect(getAuthHeaderValue()).toBeUndefined();
+    });
+
+    it('getAuthToken returns undefined', () => {
+      expect(getAuthToken()).toBeUndefined();
+    });
+  });
+
+  describe('getOriginalFetch', () => {
+    it('returns the fetch that was captured at import time', () => {
+      expect(getOriginalFetch()).toBe(mockOriginalFetch);
+    });
+  });
+
+  describe('after initialization', () => {
+    beforeEach(() => {
+      initFetchAuth(mockAuthStore, mockRouter);
+    });
+
+    it('patches globalThis.fetch', () => {
+      expect(globalThis.fetch).not.toBe(mockOriginalFetch);
+    });
+
+    it('getOriginalFetch still returns the pre-init fetch', () => {
+      expect(getOriginalFetch()).toBe(mockOriginalFetch);
+    });
+
+    describe('auth header injection', () => {
+      it('does not add Authorization header when store has no credentials', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        await globalThis.fetch('/api/test');
+
+        expect(mockOriginalFetch).toHaveBeenCalledWith('/api/test', {});
+      });
+
+      it('injects Authorization header when store has credentials', async () => {
+        const token = btoa('admin:secret');
+        mockAuthStore.authHeader.value = `Basic ${token}`;
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        await globalThis.fetch('/api/test');
+
+        expect(mockOriginalFetch).toHaveBeenCalledWith('/api/test', {
+          headers: { Authorization: `Basic ${token}` },
+        });
+      });
+
+      it('merges with existing headers', async () => {
+        const token = btoa('admin:secret');
+        mockAuthStore.authHeader.value = `Basic ${token}`;
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        await globalThis.fetch('/api/test', {
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+        expect(mockOriginalFetch).toHaveBeenCalledWith('/api/test', {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Basic ${token}`,
+          },
+        });
+      });
+
+      it('passes through non-200 responses', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+        const response = await globalThis.fetch('/api/test');
+
+        expect(response.status).toBe(404);
+        expect(mockAuthStore.markRequired).not.toHaveBeenCalled();
+        expect(mockRouter.push).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('401 handling', () => {
+      it('calls markRequired on 401', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 401 }));
+
+        await globalThis.fetch('/api/test');
+
+        expect(mockAuthStore.markRequired).toHaveBeenCalled();
+      });
+
+      it('redirects to /login on 401', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 401 }));
+
+        await globalThis.fetch('/api/test');
+
+        expect(mockRouter.push).toHaveBeenCalledWith('/login');
+      });
+
+      it('still returns the 401 response to the caller', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 401 }));
+
+        const response = await globalThis.fetch('/api/test');
+
+        expect(response.status).toBe(401);
+      });
+
+      it('only redirects once for concurrent 401s', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 401 }));
+
+        // Fire multiple concurrent requests
+        await Promise.all([
+          globalThis.fetch('/api/test1'),
+          globalThis.fetch('/api/test2'),
+          globalThis.fetch('/api/test3'),
+        ]);
+
+        // markRequired may be called multiple times, but router.push should only be called once
+        expect(mockRouter.push).toHaveBeenCalledTimes(1);
+      });
+
+      it('allows redirect again after reset401Handled', async () => {
+        mockOriginalFetch.mockResolvedValue(new Response('{}', { status: 401 }));
+
+        await globalThis.fetch('/api/test1');
+        expect(mockRouter.push).toHaveBeenCalledTimes(1);
+
+        reset401Handled();
+
+        await globalThis.fetch('/api/test2');
+        expect(mockRouter.push).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('reset401Handled', () => {
+    it('does not throw', () => {
+      expect(() => reset401Handled()).not.toThrow();
+    });
+  });
+});

--- a/packages/web/src/composables/useWebSocket.js
+++ b/packages/web/src/composables/useWebSocket.js
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { WS_RECONNECT_BASE_DELAY, WS_RECONNECT_MAX_DELAY, parseMessage, createMessage, WS_MESSAGE_TYPES } from '@circuschief/shared';
 import { sessionSubscriptionCounts } from './useSessionSubscription.js';
 import { projectSubscriptionIds } from './useProjectSubscription.js';
+import { getAuthToken } from '../api/fetchWithAuth.js';
 
 let socket = null;
 let reconnectTimeout = null;
@@ -21,7 +22,9 @@ const reconnectCallbacks = new Set();
 
 function getWebSocketUrl() {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return `${protocol}//${window.location.host}/ws`;
+  const baseUrl = `${protocol}//${window.location.host}/ws`;
+  const token = getAuthToken();
+  return token ? `${baseUrl}?token=${token}` : baseUrl;
 }
 
 function connect() {
@@ -93,6 +96,22 @@ function connect() {
     console.log('WebSocket closed', event.code);
     isConnected.value = false;
     socket = null;
+
+    // Auth failure — don't reconnect, redirect to login
+    if (event.code === 4001) {
+      connectionStatus.value = 'disconnected';
+      // Import and use auth store to mark required and redirect
+      import('../stores/auth.js').then(({ useAuthStore }) => {
+        // Use the existing pinia instance — this works because pinia
+        // is already installed on the app
+        const authStore = useAuthStore();
+        authStore.markRequired();
+      });
+      import('../router.js').then(({ default: router }) => {
+        router.push('/login');
+      });
+      return;
+    }
 
     // Don't reconnect on clean close
     if (event.code === 1000) {
@@ -212,6 +231,25 @@ function off(type, callback) {
   if (typeListeners) {
     typeListeners.delete(callback);
   }
+}
+
+/**
+ * Reconnect the WebSocket (e.g., after login to pick up new auth token).
+ * Kills any existing socket and creates a fresh connection.
+ */
+export function reconnectWithAuth() {
+  if (socket) {
+    socket.onclose = null; // prevent reconnect loop
+    socket.close();
+    socket = null;
+  }
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout);
+    reconnectTimeout = null;
+  }
+  connectionStatus.value = 'reconnecting';
+  reconnectAttempt.value++;
+  connect();
 }
 
 /**

--- a/packages/web/src/composables/useWebSocket.test.js
+++ b/packages/web/src/composables/useWebSocket.test.js
@@ -1280,3 +1280,200 @@ describe('connectionStatus and reconnectAttempt refs', () => {
     expect(ws.reconnectAttempt.value).toBe(0);
   });
 });
+
+describe('WebSocket auth token in URL', () => {
+  let capturedUrl = null;
+
+  class UrlCapturingWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+
+    constructor(url) {
+      capturedUrl = url;
+      this.readyState = UrlCapturingWebSocket.OPEN;
+      this.onopen = null;
+      this.onmessage = null;
+      this.onclose = null;
+      this.onerror = null;
+      this.sentMessages = [];
+
+      setTimeout(() => {
+        if (this.onopen) this.onopen();
+      }, 0);
+    }
+
+    send(data) {
+      this.sentMessages.push(data);
+    }
+
+    close(code) {
+      this.readyState = UrlCapturingWebSocket.CLOSED;
+      if (this.onclose) this.onclose({ code });
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    capturedUrl = null;
+    globalThis.WebSocket = UrlCapturingWebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+  });
+
+  it('includes auth token as query parameter when available', async () => {
+    // Mock getAuthToken to return a token
+    vi.doMock('../api/fetchWithAuth.js', () => ({
+      getAuthToken: () => 'dXNlcjpwYXNz',
+    }));
+
+    const module = await import('./useWebSocket.js');
+    module.useWebSocket();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(capturedUrl).toContain('token=dXNlcjpwYXNz');
+  });
+
+  it('does not include token when getAuthToken returns undefined', async () => {
+    vi.doMock('../api/fetchWithAuth.js', () => ({
+      getAuthToken: () => undefined,
+    }));
+
+    const module = await import('./useWebSocket.js');
+    module.useWebSocket();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(capturedUrl).not.toContain('token=');
+  });
+});
+
+describe('WebSocket auth failure (code 4001)', () => {
+  let closeCode = null;
+
+  class AuthRejectingWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+
+    constructor(url) {
+      this.readyState = AuthRejectingWebSocket.OPEN;
+      this.onopen = null;
+      this.onmessage = null;
+      this.onclose = null;
+      this.onerror = null;
+
+      // Simulate immediate auth rejection
+      setTimeout(() => {
+        if (this.onclose) {
+          closeCode = 4001;
+          this.onclose({ code: 4001 });
+        }
+      }, 0);
+    }
+
+    send() {}
+    close() {}
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    closeCode = null;
+    globalThis.WebSocket = AuthRejectingWebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+  });
+
+  it('sets connectionStatus to disconnected on auth failure (code 4001)', async () => {
+    // Mock auth store to avoid pinia errors from dynamic import in close handler
+    const mockMarkRequired = vi.fn();
+    vi.doMock('../stores/auth.js', () => ({
+      useAuthStore: () => ({ markRequired: mockMarkRequired }),
+    }));
+    // Mock router to avoid errors
+    vi.doMock('../router.js', () => ({
+      default: { push: vi.fn() },
+    }));
+
+    const module = await import('./useWebSocket.js');
+    const ws = module.useWebSocket();
+
+    // Wait for close event and dynamic imports to resolve
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(ws.connectionStatus.value).toBe('disconnected');
+    expect(ws.isConnected.value).toBe(false);
+    expect(mockMarkRequired).toHaveBeenCalled();
+  });
+});
+
+describe('reconnectWithAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    globalThis.WebSocket = MockWebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+  });
+
+  it('is exported as a function', async () => {
+    const module = await import('./useWebSocket.js');
+    expect(typeof module.reconnectWithAuth).toBe('function');
+  });
+
+  it('creates a new connection after being called', async () => {
+    const module = await import('./useWebSocket.js');
+    const ws = module.useWebSocket();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Disconnect
+    ws.disconnect();
+    expect(ws.isConnected.value).toBe(false);
+
+    // Reconnect with auth
+    module.reconnectWithAuth();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ws.isConnected.value).toBe(true);
+    expect(ws.connectionStatus.value).toBe('connected');
+  });
+
+  it('sets connectionStatus to reconnecting before connecting', async () => {
+    const module = await import('./useWebSocket.js');
+    module.useWebSocket();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Use a delayed WebSocket to catch the reconnecting state
+    let resolveOpen;
+    class DelayedWebSocket {
+      static OPEN = 1;
+      static CLOSED = 3;
+      constructor(url) {
+        this.readyState = DelayedWebSocket.OPEN;
+        this.onopen = null;
+        this.onmessage = null;
+        this.onclose = null;
+        this.onerror = null;
+        resolveOpen = () => { if (this.onopen) this.onopen(); };
+      }
+      send() {}
+      close() {}
+    }
+    globalThis.WebSocket = DelayedWebSocket;
+
+    module.reconnectWithAuth();
+
+    // Should be reconnecting before onopen fires
+    expect(module.useWebSocket().connectionStatus.value).toBe('reconnecting');
+
+    // Now resolve
+    resolveOpen();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(module.useWebSocket().connectionStatus.value).toBe('connected');
+  });
+});

--- a/packages/web/src/main.js
+++ b/packages/web/src/main.js
@@ -2,17 +2,42 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from './router.js';
+import { useAuthStore } from './stores/auth.js';
+import { initFetchAuth } from './api/fetchWithAuth.js';
 import { initPostHog } from './plugins/posthog.js';
 import './assets/main.css';
 
-// Initialize PostHog before mounting the app.
-// The API key is baked in at build time via VITE_POSTHOG_KEY.
-// When empty (local dev, CI), analytics are silently disabled.
-// With defaults: '2026-01-30', SPA page views are tracked automatically
-// via the browser History API — no router.afterEach hook needed.
+// Initialization order:
+// 1. Create Pinia instance (needed for stores outside components)
+// 2. Create router
+// 3. Create auth store and wire up fetch wrapper (before any API calls)
+// 4. Make initial API calls (now patched with auth)
+// 5. Create and mount Vue app
+
 async function initializeApp() {
+  // 1. Create Pinia first
+  const pinia = createPinia();
+
+  // 2. Router is already imported as a singleton
+
+  // 3. Create auth store and wire fetch wrapper BEFORE any API calls
+  const authStore = useAuthStore(pinia);
+  initFetchAuth(authStore, router);
+
+  // Add navigation guard for auth
+  router.beforeEach((to) => {
+    // If going to login and already authenticated, redirect to home
+    if (to.name === 'Login' && authStore.isAuthenticated) {
+      return '/';
+    }
+    // If going to a non-public route and auth is required but not authenticated, redirect to login
+    if (!to.meta?.public && authStore.required && !authStore.isAuthenticated) {
+      return '/login';
+    }
+  });
+
+  // 4. Fetch general settings (now goes through patched fetch with auth handling)
   try {
-    // Fetch general settings before initializing PostHog
     const resp = await fetch('/api/settings/general');
     const { disableAnalytics } = await resp.json();
     initPostHog({ disableAnalytics });
@@ -22,8 +47,9 @@ async function initializeApp() {
     initPostHog();
   }
 
+  // 5. Create app, install plugins, mount
   const app = createApp(App);
-  app.use(createPinia());
+  app.use(pinia);
   app.use(router);
   app.mount('#app');
 }

--- a/packages/web/src/router.js
+++ b/packages/web/src/router.js
@@ -2,6 +2,12 @@ import { createRouter, createWebHistory } from 'vue-router';
 
 const routes = [
   {
+    path: '/login',
+    name: 'Login',
+    component: () => import('./views/LoginView.vue'),
+    meta: { public: true },
+  },
+  {
     path: '/',
     name: 'ProjectList',
     component: () => import('./views/ProjectListView.vue'),

--- a/packages/web/src/router.test.js
+++ b/packages/web/src/router.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { createRouter, createWebHistory } from 'vue-router';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRouter, createWebHistory, createMemoryHistory } from 'vue-router';
+import { createPinia, setActivePinia } from 'pinia';
 
 describe('Router Configuration', () => {
   it('should have command-button routes with projectId parameter', () => {
@@ -60,5 +61,110 @@ describe('Router Configuration', () => {
 
     // NOT this (the original bug):
     expect(mockRoute.params.id).toBeUndefined();
+  });
+});
+
+describe('auth navigation guard', () => {
+  let pinia;
+  let authStore;
+
+  // Replicate the exact guard from main.js for testing
+  function createAuthGuard(router, store) {
+    router.beforeEach((to) => {
+      if (to.name === 'Login' && store.isAuthenticated) {
+        return '/';
+      }
+      if (!to.meta?.public && store.required && !store.isAuthenticated) {
+        return '/login';
+      }
+    });
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  async function createTestRouter(guard = true) {
+    const { useAuthStore } = await import('./stores/auth.js');
+    authStore = useAuthStore(pinia);
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/login', name: 'Login', meta: { public: true }, component: { template: '<div>Login</div>' } },
+        { path: '/', name: 'Home', component: { template: '<div>Home</div>' } },
+        { path: '/projects', name: 'Projects', component: { template: '<div>Projects</div>' } },
+      ],
+    });
+
+    if (guard) {
+      createAuthGuard(router, authStore);
+    }
+
+    return router;
+  }
+
+  describe('when auth is not required', () => {
+    it('allows navigation to any route', async () => {
+      const router = await createTestRouter();
+      await router.push('/');
+      expect(router.currentRoute.value.path).toBe('/');
+
+      await router.push('/projects');
+      expect(router.currentRoute.value.path).toBe('/projects');
+    });
+
+    it('allows navigation to login', async () => {
+      const router = await createTestRouter();
+      await router.push('/login');
+      expect(router.currentRoute.value.path).toBe('/login');
+    });
+  });
+
+  describe('when auth is required but not authenticated', () => {
+    it('redirects to login for protected routes', async () => {
+      const router = await createTestRouter();
+      authStore.required = true;
+
+      await router.push('/projects');
+      expect(router.currentRoute.value.path).toBe('/login');
+    });
+
+    it('redirects to login for home route', async () => {
+      const router = await createTestRouter();
+      authStore.required = true;
+
+      await router.push('/');
+      expect(router.currentRoute.value.path).toBe('/login');
+    });
+
+    it('allows navigation to login page', async () => {
+      const router = await createTestRouter();
+      authStore.required = true;
+
+      await router.push('/login');
+      expect(router.currentRoute.value.path).toBe('/login');
+    });
+  });
+
+  describe('when authenticated', () => {
+    it('redirects away from login to home', async () => {
+      const router = await createTestRouter();
+      authStore.credentials = { username: 'admin', password: 'pass' };
+      authStore.required = true;
+
+      await router.push('/login');
+      expect(router.currentRoute.value.path).toBe('/');
+    });
+
+    it('allows navigation to protected routes', async () => {
+      const router = await createTestRouter();
+      authStore.credentials = { username: 'admin', password: 'pass' };
+      authStore.required = true;
+
+      await router.push('/projects');
+      expect(router.currentRoute.value.path).toBe('/projects');
+    });
   });
 });

--- a/packages/web/src/stores/auth.js
+++ b/packages/web/src/stores/auth.js
@@ -1,0 +1,77 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+
+export const useAuthStore = defineStore('auth', () => {
+  /** @type {import('vue').Ref<{ username: string, password: string }|null>} */
+  const credentials = ref(null);
+
+  /** @type {import('vue').Ref<boolean>} */
+  const required = ref(false);
+
+  /** @type {import('vue').ComputedRef<boolean>} */
+  const isAuthenticated = computed(() => credentials.value !== null);
+
+  /** @type {import('vue').ComputedRef<string|undefined>} */
+  const authHeader = computed(() => {
+    if (!credentials.value) return undefined;
+    const token = btoa(`${credentials.value.username}:${credentials.value.password}`);
+    return `Basic ${token}`;
+  });
+
+  /** @type {import('vue').ComputedRef<string|undefined>} */
+  const authToken = computed(() => {
+    if (!credentials.value) return undefined;
+    return btoa(`${credentials.value.username}:${credentials.value.password}`);
+  });
+
+  /**
+   * Mark that auth is required (called when a 401 is received)
+   */
+  function markRequired() {
+    required.value = true;
+  }
+
+  /**
+   * Attempt to log in by validating credentials against a protected endpoint.
+   * @param {string} username
+   * @param {string} password
+   * @returns {Promise<void>}
+   */
+  async function login(username, password) {
+    const token = btoa(`${username}:${password}`);
+    const response = await fetch('/api/settings/general', {
+      headers: {
+        Authorization: `Basic ${token}`,
+      },
+    });
+
+    if (response.status === 401) {
+      throw new Error('Invalid username or password');
+    }
+
+    if (!response.ok) {
+      throw new Error(`Login failed: ${response.statusText}`);
+    }
+
+    credentials.value = { username, password };
+    required.value = true;
+  }
+
+  /**
+   * Log out and clear credentials
+   */
+  function logout() {
+    credentials.value = null;
+  }
+
+  return {
+    credentials,
+    required,
+    isAuthenticated,
+    authHeader,
+    authToken,
+    markRequired,
+    login,
+    logout,
+  };
+});

--- a/packages/web/src/stores/auth.js
+++ b/packages/web/src/stores/auth.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
+import { getOriginalFetch, reset401Handled } from '../api/fetchWithAuth.js';
 
 export const useAuthStore = defineStore('auth', () => {
   /** @type {import('vue').Ref<{ username: string, password: string }|null>} */
@@ -33,13 +34,15 @@ export const useAuthStore = defineStore('auth', () => {
 
   /**
    * Attempt to log in by validating credentials against a protected endpoint.
+   * Uses the original (unpatched) fetch to avoid the auth header injection loop.
    * @param {string} username
    * @param {string} password
    * @returns {Promise<void>}
    */
   async function login(username, password) {
     const token = btoa(`${username}:${password}`);
-    const response = await fetch('/api/settings/general', {
+    const fetchFn = getOriginalFetch();
+    const response = await fetchFn('/api/settings/general', {
       headers: {
         Authorization: `Basic ${token}`,
       },
@@ -55,6 +58,7 @@ export const useAuthStore = defineStore('auth', () => {
 
     credentials.value = { username, password };
     required.value = true;
+    reset401Handled();
   }
 
   /**

--- a/packages/web/src/stores/auth.test.js
+++ b/packages/web/src/stores/auth.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useAuthStore } from './auth.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('Auth Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('has null credentials initially', () => {
+      const store = useAuthStore();
+      expect(store.credentials).toBeNull();
+    });
+
+    it('is not authenticated initially', () => {
+      const store = useAuthStore();
+      expect(store.isAuthenticated).toBe(false);
+    });
+
+    it('does not require auth initially', () => {
+      const store = useAuthStore();
+      expect(store.required).toBe(false);
+    });
+  });
+
+  describe('markRequired', () => {
+    it('sets required to true', () => {
+      const store = useAuthStore();
+      store.markRequired();
+      expect(store.required).toBe(true);
+    });
+  });
+
+  describe('isAuthenticated computed', () => {
+    it('returns true when credentials are set', () => {
+      const store = useAuthStore();
+      store.credentials = { username: 'admin', password: 'pass' };
+      expect(store.isAuthenticated).toBe(true);
+    });
+
+    it('returns false when credentials are null', () => {
+      const store = useAuthStore();
+      expect(store.isAuthenticated).toBe(false);
+    });
+  });
+
+  describe('authHeader computed', () => {
+    it('returns undefined when not authenticated', () => {
+      const store = useAuthStore();
+      expect(store.authHeader).toBeUndefined();
+    });
+
+    it('returns Basic header when authenticated', () => {
+      const store = useAuthStore();
+      store.credentials = { username: 'admin', password: 'secret' };
+      const expected = `Basic ${btoa('admin:secret')}`;
+      expect(store.authHeader).toBe(expected);
+    });
+  });
+
+  describe('authToken computed', () => {
+    it('returns undefined when not authenticated', () => {
+      const store = useAuthStore();
+      expect(store.authToken).toBeUndefined();
+    });
+
+    it('returns base64 token when authenticated', () => {
+      const store = useAuthStore();
+      store.credentials = { username: 'admin', password: 'secret' };
+      expect(store.authToken).toBe(btoa('admin:secret'));
+    });
+  });
+
+  describe('login', () => {
+    it('sets credentials on successful login', async () => {
+      const store = useAuthStore();
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      await store.login('admin', 'secret');
+
+      expect(store.credentials).toEqual({ username: 'admin', password: 'secret' });
+      expect(store.required).toBe(true);
+    });
+
+    it('throws on 401 response', async () => {
+      const store = useAuthStore();
+      mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' });
+
+      await expect(store.login('admin', 'wrong')).rejects.toThrow('Invalid username or password');
+      expect(store.credentials).toBeNull();
+    });
+
+    it('throws on non-ok response', async () => {
+      const store = useAuthStore();
+      mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' });
+
+      await expect(store.login('admin', 'secret')).rejects.toThrow('Login failed: Internal Server Error');
+    });
+
+    it('sends Authorization header with credentials', async () => {
+      const store = useAuthStore();
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      await store.login('admin', 'secret');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/settings/general', {
+        headers: {
+          Authorization: `Basic ${btoa('admin:secret')}`,
+        },
+      });
+    });
+  });
+
+  describe('logout', () => {
+    it('clears credentials', () => {
+      const store = useAuthStore();
+      store.credentials = { username: 'admin', password: 'secret' };
+      store.logout();
+      expect(store.credentials).toBeNull();
+      expect(store.isAuthenticated).toBe(false);
+    });
+  });
+});

--- a/packages/web/src/stores/auth.test.js
+++ b/packages/web/src/stores/auth.test.js
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useAuthStore } from './auth.js';
 
-// Mock global fetch
-const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
+// Mock getOriginalFetch from fetchWithAuth — login() uses this instead of global fetch
+const mockOriginalFetch = vi.fn();
+vi.mock('../api/fetchWithAuth.js', () => ({
+  getOriginalFetch: () => mockOriginalFetch,
+  reset401Handled: () => {},
+}));
 
 describe('Auth Store', () => {
   beforeEach(() => {
@@ -80,7 +83,7 @@ describe('Auth Store', () => {
   describe('login', () => {
     it('sets credentials on successful login', async () => {
       const store = useAuthStore();
-      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      mockOriginalFetch.mockResolvedValue({ ok: true, status: 200 });
 
       await store.login('admin', 'secret');
 
@@ -90,7 +93,7 @@ describe('Auth Store', () => {
 
     it('throws on 401 response', async () => {
       const store = useAuthStore();
-      mockFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' });
+      mockOriginalFetch.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized' });
 
       await expect(store.login('admin', 'wrong')).rejects.toThrow('Invalid username or password');
       expect(store.credentials).toBeNull();
@@ -98,18 +101,18 @@ describe('Auth Store', () => {
 
     it('throws on non-ok response', async () => {
       const store = useAuthStore();
-      mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' });
+      mockOriginalFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' });
 
       await expect(store.login('admin', 'secret')).rejects.toThrow('Login failed: Internal Server Error');
     });
 
     it('sends Authorization header with credentials', async () => {
       const store = useAuthStore();
-      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      mockOriginalFetch.mockResolvedValue({ ok: true, status: 200 });
 
       await store.login('admin', 'secret');
 
-      expect(mockFetch).toHaveBeenCalledWith('/api/settings/general', {
+      expect(mockOriginalFetch).toHaveBeenCalledWith('/api/settings/general', {
         headers: {
           Authorization: `Basic ${btoa('admin:secret')}`,
         },

--- a/packages/web/src/views/LoginView.test.js
+++ b/packages/web/src/views/LoginView.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import LoginView from './LoginView.vue';
+
+// Mock the auth store
+const mockLogin = vi.fn();
+vi.mock('../stores/auth.js', () => ({
+  useAuthStore: vi.fn(() => ({
+    login: mockLogin,
+    markRequired: vi.fn(),
+    isAuthenticated: false,
+    required: false,
+    credentials: null,
+  })),
+}));
+
+// Mock the reconnectWithAuth function — must use vi.hoisted for proper ordering
+const { mockReconnectWithAuth } = vi.hoisted(() => ({
+  mockReconnectWithAuth: vi.fn(),
+}));
+vi.mock('../composables/useWebSocket.js', () => ({
+  reconnectWithAuth: mockReconnectWithAuth,
+}));
+
+describe('LoginView', () => {
+  let pinia;
+  let router;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pinia = createPinia();
+    setActivePinia(pinia);
+
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'Home' },
+        { path: '/login', name: 'Login', component: LoginView },
+      ],
+    });
+  });
+
+  function mountLogin() {
+    return mount(LoginView, {
+      global: {
+        plugins: [pinia, router],
+      },
+    });
+  }
+
+  describe('rendering', () => {
+    it('renders username and password inputs', () => {
+      const wrapper = mountLogin();
+
+      expect(wrapper.find('#username').exists()).toBe(true);
+      expect(wrapper.find('#password').exists()).toBe(true);
+    });
+
+    it('renders a submit button', () => {
+      const wrapper = mountLogin();
+
+      const button = wrapper.find('button[type="submit"]');
+      expect(button.exists()).toBe(true);
+      expect(button.text()).toContain('Sign in');
+    });
+
+    it('has required attribute on inputs', () => {
+      const wrapper = mountLogin();
+
+      expect(wrapper.find('#username').attributes('required')).toBeDefined();
+      expect(wrapper.find('#password').attributes('required')).toBeDefined();
+    });
+
+    it('has correct autocomplete attributes', () => {
+      const wrapper = mountLogin();
+
+      expect(wrapper.find('#username').attributes('autocomplete')).toBe('username');
+      expect(wrapper.find('#password').attributes('autocomplete')).toBe('current-password');
+    });
+  });
+
+  describe('form submission', () => {
+    it('calls auth store login with username and password', async () => {
+      mockLogin.mockResolvedValue(undefined);
+      const wrapper = mountLogin();
+
+      await wrapper.find('#username').setValue('admin');
+      await wrapper.find('#password').setValue('secret123');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushPromises();
+
+      expect(mockLogin).toHaveBeenCalledWith('admin', 'secret123');
+    });
+
+    it('navigates to home on successful login', async () => {
+      mockLogin.mockResolvedValue(undefined);
+      const pushSpy = vi.spyOn(router, 'push');
+      const wrapper = mountLogin();
+
+      await wrapper.find('#username').setValue('admin');
+      await wrapper.find('#password').setValue('secret123');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushPromises();
+
+      expect(pushSpy).toHaveBeenCalledWith('/');
+    });
+
+    it('displays error message on login failure', async () => {
+      mockLogin.mockRejectedValue(new Error('Invalid username or password'));
+      const wrapper = mountLogin();
+
+      await wrapper.find('#username').setValue('admin');
+      await wrapper.find('#password').setValue('wrong');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushPromises();
+
+      expect(wrapper.find('.error-message').text()).toBe('Invalid username or password');
+    });
+
+    it('shows loading state during login', async () => {
+      let resolveLogin;
+      mockLogin.mockReturnValue(new Promise((resolve) => { resolveLogin = resolve; }));
+      const wrapper = mountLogin();
+
+      await wrapper.find('#username').setValue('admin');
+      await wrapper.find('#password').setValue('secret');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushPromises();
+
+      // Button should show loading text
+      expect(wrapper.find('button[type="submit"]').text()).toContain('Signing in...');
+      expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined();
+
+      // Inputs should be disabled
+      expect(wrapper.find('#username').attributes('disabled')).toBeDefined();
+      expect(wrapper.find('#password').attributes('disabled')).toBeDefined();
+
+      // Resolve the login
+      resolveLogin();
+      await flushPromises();
+
+      // Loading state should be cleared
+      expect(wrapper.find('button[type="submit"]').text()).toContain('Sign in');
+    });
+
+    it('clears error on new submission', async () => {
+      mockLogin.mockRejectedValueOnce(new Error('First error'));
+      mockLogin.mockResolvedValueOnce(undefined);
+      const wrapper = mountLogin();
+
+      // First submission fails
+      await wrapper.find('#username').setValue('admin');
+      await wrapper.find('#password').setValue('wrong');
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushPromises();
+      expect(wrapper.find('.error-message').exists()).toBe(true);
+
+      // Second submission succeeds
+      await wrapper.find('form').trigger('submit.prevent');
+      await flushPromises();
+      expect(wrapper.find('.error-message').exists()).toBe(false);
+    });
+  });
+});

--- a/packages/web/src/views/LoginView.vue
+++ b/packages/web/src/views/LoginView.vue
@@ -1,0 +1,205 @@
+<template>
+  <div class="login-container">
+    <div class="login-card">
+      <div class="login-header">
+        <h1 class="login-title">
+          Circus Chief
+        </h1>
+        <p class="login-subtitle">
+          Sign in to continue
+        </p>
+      </div>
+
+      <form @submit.prevent="handleSubmit">
+        <div class="form-group">
+          <label
+            class="form-label"
+            for="username"
+          >Username</label>
+          <input
+            id="username"
+            ref="usernameInput"
+            v-model="username"
+            type="text"
+            class="form-input"
+            autocomplete="username"
+            required
+            :disabled="loading"
+          >
+        </div>
+
+        <div class="form-group">
+          <label
+            class="form-label"
+            for="password"
+          >Password</label>
+          <input
+            id="password"
+            v-model="password"
+            type="password"
+            class="form-input"
+            autocomplete="current-password"
+            required
+            :disabled="loading"
+          >
+        </div>
+
+        <div
+          v-if="error"
+          class="error-message"
+        >
+          {{ error }}
+        </div>
+
+        <button
+          type="submit"
+          class="btn btn-primary login-btn"
+          :disabled="loading"
+        >
+          <span
+            v-if="loading"
+            class="loading-spinner"
+          />
+          {{ loading ? 'Signing in...' : 'Sign in' }}
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useAuthStore } from '../stores/auth.js';
+
+const router = useRouter();
+const authStore = useAuthStore();
+
+const username = ref('');
+const password = ref('');
+const loading = ref(false);
+const error = ref(null);
+const usernameInput = ref(null);
+
+onMounted(() => {
+  usernameInput.value?.focus();
+});
+
+async function handleSubmit() {
+  loading.value = true;
+  error.value = null;
+
+  try {
+    await authStore.login(username.value, password.value);
+    router.push('/');
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.login-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 380px;
+  padding: 2rem;
+  background: var(--color-bg-secondary, #1f2937);
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border, #374151);
+}
+
+.login-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.login-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text, #f3f4f6);
+  margin: 0;
+}
+
+.login-subtitle {
+  color: var(--color-text-muted, #9ca3af);
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-muted, #9ca3af);
+  margin-bottom: 0.375rem;
+}
+
+.form-input {
+  display: block;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: var(--color-bg-primary, #111827);
+  border: 1px solid var(--color-border, #374151);
+  border-radius: 0.375rem;
+  color: var(--color-text, #f3f4f6);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  box-sizing: border-box;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #06b6d4);
+  box-shadow: 0 0 0 1px var(--color-primary, #06b6d4);
+}
+
+.form-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error-message {
+  color: var(--color-error, #f87171);
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(248, 113, 113, 0.1);
+  border-radius: 0.375rem;
+}
+
+.login-btn {
+  width: 100%;
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.loading-spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/packages/web/src/views/LoginView.vue
+++ b/packages/web/src/views/LoginView.vue
@@ -71,6 +71,7 @@
 import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useAuthStore } from '../stores/auth.js';
+import { reconnectWithAuth } from '../composables/useWebSocket.js';
 
 const router = useRouter();
 const authStore = useAuthStore();
@@ -91,6 +92,7 @@ async function handleSubmit() {
 
   try {
     await authStore.login(username.value, password.value);
+    reconnectWithAuth();
     router.push('/');
   } catch (err) {
     error.value = err.message;


### PR DESCRIPTION
## Summary

This PR adds opt-in HTTP Basic Authentication to Circus Chief, controlled by a `--auth user:password` CLI flag (or `CC_AUTH` environment variable). When enabled, all HTTP API requests and WebSocket connections require valid credentials, while static files and the SPA fallback remain publicly accessible.

## Key Features

- **CLI flag**: `--auth user:password` with `CC_AUTH` env var fallback
- **API protection**: All `/api/*` routes require valid `Authorization: Basic ...` header
- **WebSocket authentication**: Credentials passed via `token` query parameter
- **Custom login page**: Styled Vue component with dark theme (no browser native auth dialog)
- **In-memory credentials**: Stored via Pinia, cleared on page reload
- **Opt-in design**: Disabled by default, maintains backward compatibility
- **CORS support**: Properly configured to allow `Authorization` header when auth is enabled

## Implementation Details

### Server Changes
- `packages/server/src/middleware/basicAuth.js` - Express middleware factory that validates Basic Auth headers
- `packages/server/src/middleware/basicAuth.test.js` - Comprehensive unit tests for middleware
- `packages/server/src/cli.js` - Add `--auth` flag with validation
- `packages/server/src/cli.test.js` - Updated tests for CLI flag parsing
- `packages/server/src/app.js` - Wire auth middleware and conditional CORS
- `packages/server/src/index.js` - Pass auth config through to app and WebSocket
- `packages/server/src/ws/WebSocketManager.js` - Validate auth token in WS connections
- `packages/server/src/ws/index.js` - Forward auth to WebSocketManager

### Frontend Changes
- `packages/web/src/stores/auth.js` - Pinia store for credential management
- `packages/web/src/stores/auth.test.js` - Unit tests for auth store
- `packages/web/src/api/fetchWithAuth.js` - Fetch wrapper that injects auth header and handles 401s
- `packages/web/src/views/LoginView.vue` - Styled login form component
- `packages/web/src/router.js` - Add login route and authentication guard
- `packages/web/src/main.js` - Fix initialization order to support auth before API calls
- `packages/web/src/composables/useWebSocket.js` - Send auth token in WS URL

### Authentication Flow

1. Server starts with `--auth admin:secret123`
2. Browser loads SPA (no auth required for static files)
3. Frontend makes API call → receives 401 with `WWW-Authenticate: xBasic`
4. Router redirects to `/login` (custom login page, not browser dialog)
5. User enters credentials → validated against `/api/settings/general`
6. On success, credentials stored in Pinia store
7. All subsequent fetch calls include `Authorization` header (via fetch wrapper)
8. WebSocket connects with `?token=<base64>` query parameter
9. Real-time updates work seamlessly

### Security Considerations

- Uses `xBasic` instead of `Basic` in `WWW-Authenticate` header to suppress browser's native auth dialog
- Credentials validated against configured `user:password` on every request
- WebSocket connections closed with code 4001 if auth fails
- Static files and SPA fallback remain public (they contain no sensitive data)
- Credentials stored in-memory only (not persisted)

## Test plan

- [ ] Run `yarn dev` without `--auth` → verify everything works as before (backward compatibility)
- [ ] Run `yarn dev --auth admin:secret123`:
  - [ ] `curl http://localhost:5000/api/server-info` → 401
  - [ ] `curl -u admin:secret123 http://localhost:5000/api/server-info` → 200
  - [ ] `curl http://localhost:5000/` → 200 (SPA loads)
  - [ ] Browser shows login form
  - [ ] Wrong credentials show error
  - [ ] Correct credentials redirect to app
  - [ ] WebSocket connects and real-time updates work
  - [ ] Logout clears credentials and redirects to login
- [ ] Run all unit tests: `yarn test`
- [ ] Test with password containing colon: `--auth admin:pass:word`
- [ ] Test env var: `CC_AUTH=admin:secret yarn dev`
- [ ] Verify CORS preflight requests succeed when auth is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)