### PR TITLE
Show final agent errors in session messages

### DIFF
--- a/packages/server/src/services/sessionManager.broadcasts.test.js
+++ b/packages/server/src/services/sessionManager.broadcasts.test.js
@@ -1010,10 +1010,7 @@ describe('sessionManager broadcasts', () => {
       expect(clearedTemplateCall).toBeDefined();
     });
 
-    it('still triggers template after error result (session goes to waiting after loop)', async () => {
-      // Note: The current implementation triggers templates even after error results
-      // because the error is handled inside the event loop, but the template trigger
-      // happens after the loop completes (when status becomes 'waiting')
+    it('does not trigger template after error result', async () => {
       sessions.update(sessionId, { nextTemplateId: templateId });
 
       query.mockImplementation(async function* () {
@@ -1023,8 +1020,11 @@ describe('sessionManager broadcasts', () => {
 
       await runSession(sessionId, 'Test prompt', tempDir);
 
-      // Template IS triggered even on error because session transitions to 'waiting'
-      expect(checkAndTriggerNextTemplate).toHaveBeenCalledWith(sessionId);
+      expect(checkAndTriggerNextTemplate).not.toHaveBeenCalled();
+      expect(sessions.getById(sessionId)).toMatchObject({
+        status: 'error',
+        error: 'Something went wrong',
+      });
     });
   });
 

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -15,6 +15,68 @@ import {
 } from './streamEventHandler.js';
 
 /**
+ * Associate work logs with the last message and clean up tracking state.
+ * @param {string} sessionId
+ */
+function associateAndCleanupWorkLogs(sessionId) {
+  const lastMessageId = lastMessageIds.get(sessionId);
+  if (lastMessageId) {
+    associateAndBroadcastWorkLogs(sessionId, lastMessageId);
+    lastMessageIds.delete(sessionId);
+  }
+}
+
+/**
+ * Handle post-turn activities for a session that's ready for follow-up.
+ * @param {string} sessionId
+ * @param {string} workingDirectory
+ * @param {{ checkProactiveReschedule?: Function, handleAutoSendIfNeeded?: Function, handleTemplateTriggerIfNeeded?: Function }} callbacks
+ * @returns {Promise<boolean>} True if rescheduled, false otherwise
+ */
+async function handleActiveSessionCompletion(sessionId, workingDirectory, callbacks) {
+  sessions.update(sessionId, { status: 'waiting', error: null });
+  broadcastSessionStatus(sessionId, 'waiting');
+
+  // Check if session should be proactively rescheduled based on token threshold
+  const { checkProactiveReschedule } = callbacks;
+  if (checkProactiveReschedule) {
+    const wasRescheduled = await checkProactiveReschedule(sessionId);
+    if (wasRescheduled) {
+      return true; // Session was rescheduled, don't continue with normal completion
+    }
+  }
+
+  // Extract PR URL immediately (lightweight, no API call)
+  summaryService.extractPrUrlIfNeeded(sessionId);
+  // Trigger debounced summary generation on turn completion (not complete yet)
+  summaryService.onSessionActivity(sessionId);
+
+  // Broadcast changes update when turn completes (real-time indicator)
+  const currentSession = sessions.getById(sessionId);
+  if (currentSession) {
+    await broadcastChangesUpdate(sessionId, currentSession.projectId, workingDirectory);
+  }
+
+  // Handle kanban lane movements based on targetLaneId
+  await kanbanService.handleTurnCompletion(sessionId);
+
+  // Auto-send queued prompt if enabled (runs BEFORE template trigger)
+  const { handleAutoSendIfNeeded, handleTemplateTriggerIfNeeded } = callbacks;
+  let autoSendFired = false;
+  if (handleAutoSendIfNeeded) {
+    autoSendFired = await handleAutoSendIfNeeded(sessionId);
+  }
+
+  // Only trigger next template if auto-send did NOT fire
+  // (if auto-send fired, template will trigger after that turn completes)
+  if (!autoSendFired && handleTemplateTriggerIfNeeded) {
+    await handleTemplateTriggerIfNeeded(sessionId);
+  }
+
+  return false;
+}
+
+/**
  * Handle post-turn completion logic (after stream loop ends successfully)
  * Encapsulates the duplicated completion block from runSession/continueSession/continueSessionWithExistingMessage
  * @param {string} sessionId
@@ -22,14 +84,10 @@ import {
  * @param {{ handleTemplateTriggerIfNeeded?: Function, checkProactiveReschedule?: Function, handleAutoSendIfNeeded?: Function }} callbacks
  */
 export async function handleTurnCompletion(sessionId, workingDirectory, callbacks = {}) {
-  const { handleTemplateTriggerIfNeeded, checkProactiveReschedule: _checkProactiveReschedule, handleAutoSendIfNeeded } = callbacks;
   // Associate work logs with the last message now that the turn is complete
-  const lastMessageId = lastMessageIds.get(sessionId);
-  if (lastMessageId) {
-    associateAndBroadcastWorkLogs(sessionId, lastMessageId);
-    lastMessageIds.delete(sessionId);
-  }
+  associateAndCleanupWorkLogs(sessionId);
 
+  // Sessions with final errors should not transition to waiting
   if (finalErrorSessionIds.has(sessionId)) {
     finalErrorSessionIds.delete(sessionId);
     return false;
@@ -38,43 +96,9 @@ export async function handleTurnCompletion(sessionId, workingDirectory, callback
   // Session ready for follow-up - set to waiting instead of completed
   const activeSession = activeSessions.get(sessionId);
   if (activeSession && !activeSession.controller?.signal?.aborted) {
-    sessions.update(sessionId, { status: 'waiting', error: null });
-    broadcastSessionStatus(sessionId, 'waiting');
-
-    // Check if session should be proactively rescheduled based on token threshold
-    if (_checkProactiveReschedule) {
-      const wasRescheduled = await _checkProactiveReschedule(sessionId);
-      if (wasRescheduled) {
-        return true; // Session was rescheduled, don't continue with normal completion
-      }
-    }
-
-    // Extract PR URL immediately (lightweight, no API call)
-    summaryService.extractPrUrlIfNeeded(sessionId);
-    // Trigger debounced summary generation on turn completion (not complete yet)
-    summaryService.onSessionActivity(sessionId);
-
-    // Broadcast changes update when turn completes (real-time indicator)
-    const currentSession = sessions.getById(sessionId);
-    if (currentSession) {
-      await broadcastChangesUpdate(sessionId, currentSession.projectId, workingDirectory);
-    }
-
-    // Handle kanban lane movements based on targetLaneId
-    await kanbanService.handleTurnCompletion(sessionId);
-
-    // Auto-send queued prompt if enabled (runs BEFORE template trigger)
-    let autoSendFired = false;
-    if (handleAutoSendIfNeeded) {
-      autoSendFired = await handleAutoSendIfNeeded(sessionId);
-    }
-
-    // Only trigger next template if auto-send did NOT fire
-    // (if auto-send fired, template will trigger after that turn completes)
-    if (!autoSendFired && handleTemplateTriggerIfNeeded) {
-      await handleTemplateTriggerIfNeeded(sessionId);
-    }
+    return handleActiveSessionCompletion(sessionId, workingDirectory, callbacks);
   }
+
   return false;
 }
 

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -1,4 +1,4 @@
-import { sessions, conversations } from '../database.js';
+import { sessions, conversations, messages } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as summaryService from './summaryService.js';
@@ -31,7 +31,7 @@ export async function handleTurnCompletion(sessionId, workingDirectory, callback
   // Session ready for follow-up - set to waiting instead of completed
   const activeSession = activeSessions.get(sessionId);
   if (activeSession && !activeSession.controller?.signal?.aborted) {
-    sessions.update(sessionId, { status: 'waiting' });
+    sessions.update(sessionId, { status: 'waiting', error: null });
     broadcastSessionStatus(sessionId, 'waiting');
 
     // Check if session should be proactively rescheduled based on token threshold
@@ -124,6 +124,89 @@ async function safeTriggerTemplate(sessionId, handleTemplateTriggerIfNeeded) {
   }
 }
 
+function normalizeMessageContent(content) {
+  return (content || '').trim().replace(/\s+/g, ' ');
+}
+
+function buildVisibleErrorContent(agentType, errorMessage) {
+  if (agentType === 'codex') {
+    return `Codex failed before completing this turn:\n\n${errorMessage}`;
+  }
+  if (agentType === 'claude-code') {
+    return `Claude Code failed before completing this turn:\n\n${errorMessage}`;
+  }
+  return `The agent failed before completing this turn:\n\n${errorMessage}`;
+}
+
+function hasExistingVisibleFailure(conversationMessages, generatedContent, rawErrorMessage) {
+  const normalizedGenerated = normalizeMessageContent(generatedContent);
+  const normalizedError = normalizeMessageContent(rawErrorMessage);
+  const latestMessage = conversationMessages[conversationMessages.length - 1];
+
+  if (
+    latestMessage?.role === 'assistant' &&
+    normalizeMessageContent(latestMessage.content) === normalizedGenerated
+  ) {
+    return true;
+  }
+
+  let latestUserIndex = -1;
+  for (let i = conversationMessages.length - 1; i >= 0; i -= 1) {
+    if (conversationMessages[i].role === 'user') {
+      latestUserIndex = i;
+      break;
+    }
+  }
+
+  return conversationMessages
+    .slice(latestUserIndex + 1)
+    .some((message) => {
+      if (message.role !== 'assistant') {
+        return false;
+      }
+      const normalizedContent = normalizeMessageContent(message.content);
+      return normalizedContent === normalizedGenerated ||
+        (normalizedError && normalizedContent.includes(normalizedError));
+    });
+}
+
+function resolveErrorConversationId(sessionId) {
+  const activeConversationId = activeConversationIds.get(sessionId);
+  if (activeConversationId) {
+    return activeConversationId;
+  }
+  const activeConversation = conversations.ensureActiveConversation(sessionId);
+  if (activeConversation?.id) {
+    activeConversationIds.set(sessionId, activeConversation.id);
+    return activeConversation.id;
+  }
+  return null;
+}
+
+function createVisibleSessionErrorMessage(sessionId, error) {
+  const conversationId = resolveErrorConversationId(sessionId);
+  if (!conversationId) {
+    return null;
+  }
+
+  const session = sessions.getById(sessionId);
+  const errorMessage = error?.message || String(error);
+  const content = buildVisibleErrorContent(session?.agentType, errorMessage);
+  const conversationMessages = messages.getByConversationId(conversationId) || [];
+
+  if (hasExistingVisibleFailure(conversationMessages, content, errorMessage)) {
+    return null;
+  }
+
+  const message = messages.create(sessionId, 'assistant', content, { conversationId });
+  sessions.touch(sessionId);
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, {
+    message,
+    conversationId,
+  });
+  return message;
+}
+
 /**
  * Handle session error with optional rescheduling
  * Encapsulates the duplicated error handling block from runSession/continueSession/continueSessionWithExistingMessage
@@ -149,6 +232,7 @@ export async function handleSessionError(sessionId, error, options = {}) {
 
   // Normal error handling (no reschedule or reschedule limits reached)
   sessions.update(sessionId, { status: 'error', error: error.message });
+  createVisibleSessionErrorMessage(sessionId, error);
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
 
   // Optionally broadcast final conversation state (continueSession does this)

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -1,12 +1,14 @@
-import { sessions, conversations, messages } from '../database.js';
+import { sessions, conversations } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as summaryService from './summaryService.js';
 import * as kanbanService from './kanbanService.js';
+import { createVisibleFinalErrorMessage } from './visibleFinalErrorMessage.js';
 import {
   lastMessageIds,
   activeSessions,
   activeConversationIds,
+  finalErrorSessionIds,
   associateAndBroadcastWorkLogs,
   broadcastSessionStatus,
   broadcastChangesUpdate,
@@ -26,6 +28,11 @@ export async function handleTurnCompletion(sessionId, workingDirectory, callback
   if (lastMessageId) {
     associateAndBroadcastWorkLogs(sessionId, lastMessageId);
     lastMessageIds.delete(sessionId);
+  }
+
+  if (finalErrorSessionIds.has(sessionId)) {
+    finalErrorSessionIds.delete(sessionId);
+    return false;
   }
 
   // Session ready for follow-up - set to waiting instead of completed
@@ -124,89 +131,6 @@ async function safeTriggerTemplate(sessionId, handleTemplateTriggerIfNeeded) {
   }
 }
 
-function normalizeMessageContent(content) {
-  return (content || '').trim().replace(/\s+/g, ' ');
-}
-
-function buildVisibleErrorContent(agentType, errorMessage) {
-  if (agentType === 'codex') {
-    return `Codex failed before completing this turn:\n\n${errorMessage}`;
-  }
-  if (agentType === 'claude-code') {
-    return `Claude Code failed before completing this turn:\n\n${errorMessage}`;
-  }
-  return `The agent failed before completing this turn:\n\n${errorMessage}`;
-}
-
-function hasExistingVisibleFailure(conversationMessages, generatedContent, rawErrorMessage) {
-  const normalizedGenerated = normalizeMessageContent(generatedContent);
-  const normalizedError = normalizeMessageContent(rawErrorMessage);
-  const latestMessage = conversationMessages[conversationMessages.length - 1];
-
-  if (
-    latestMessage?.role === 'assistant' &&
-    normalizeMessageContent(latestMessage.content) === normalizedGenerated
-  ) {
-    return true;
-  }
-
-  let latestUserIndex = -1;
-  for (let i = conversationMessages.length - 1; i >= 0; i -= 1) {
-    if (conversationMessages[i].role === 'user') {
-      latestUserIndex = i;
-      break;
-    }
-  }
-
-  return conversationMessages
-    .slice(latestUserIndex + 1)
-    .some((message) => {
-      if (message.role !== 'assistant') {
-        return false;
-      }
-      const normalizedContent = normalizeMessageContent(message.content);
-      return normalizedContent === normalizedGenerated ||
-        (normalizedError && normalizedContent.includes(normalizedError));
-    });
-}
-
-function resolveErrorConversationId(sessionId) {
-  const activeConversationId = activeConversationIds.get(sessionId);
-  if (activeConversationId) {
-    return activeConversationId;
-  }
-  const activeConversation = conversations.ensureActiveConversation(sessionId);
-  if (activeConversation?.id) {
-    activeConversationIds.set(sessionId, activeConversation.id);
-    return activeConversation.id;
-  }
-  return null;
-}
-
-function createVisibleSessionErrorMessage(sessionId, error) {
-  const conversationId = resolveErrorConversationId(sessionId);
-  if (!conversationId) {
-    return null;
-  }
-
-  const session = sessions.getById(sessionId);
-  const errorMessage = error?.message || String(error);
-  const content = buildVisibleErrorContent(session?.agentType, errorMessage);
-  const conversationMessages = messages.getByConversationId(conversationId) || [];
-
-  if (hasExistingVisibleFailure(conversationMessages, content, errorMessage)) {
-    return null;
-  }
-
-  const message = messages.create(sessionId, 'assistant', content, { conversationId });
-  sessions.touch(sessionId);
-  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, {
-    message,
-    conversationId,
-  });
-  return message;
-}
-
 /**
  * Handle session error with optional rescheduling
  * Encapsulates the duplicated error handling block from runSession/continueSession/continueSessionWithExistingMessage
@@ -232,7 +156,7 @@ export async function handleSessionError(sessionId, error, options = {}) {
 
   // Normal error handling (no reschedule or reschedule limits reached)
   sessions.update(sessionId, { status: 'error', error: error.message });
-  createVisibleSessionErrorMessage(sessionId, error);
+  createVisibleFinalErrorMessage(sessionId, error, activeConversationIds);
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
 
   // Optionally broadcast final conversation state (continueSession does this)

--- a/packages/server/src/services/streamEventHandler.js
+++ b/packages/server/src/services/streamEventHandler.js
@@ -10,6 +10,10 @@ import {
   handleTextDelta as _handleTextDelta,
   handleResultUsage,
 } from './streamUsageHandler.js';
+import {
+  createVisibleFinalErrorMessage,
+  normalizeFinalErrorMessage,
+} from './visibleFinalErrorMessage.js';
 
 // ── Shared module-level state ──────────────────────────────────────────────
 
@@ -33,6 +37,9 @@ export const currentModels = new Map();
 
 /** @type {Map<string, Set<string>>} Track tool_use IDs that have already been logged per session */
 export const loggedToolUseIds = new Map();
+
+/** @type {Set<string>} Track sessions that received a final result.error event */
+export const finalErrorSessionIds = new Set();
 
 // ── Helper functions ───────────────────────────────────────────────────────
 
@@ -404,8 +411,11 @@ function handleResultEvent(sessionId, event) {
  * @param {Object} event
  */
 function handleResultError(sessionId, event) {
-  sessions.update(sessionId, { status: 'error', error: event.error });
-  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: event.error });
+  const errorMessage = normalizeFinalErrorMessage(event.error);
+  finalErrorSessionIds.add(sessionId);
+  sessions.update(sessionId, { status: 'error', error: errorMessage });
+  createVisibleFinalErrorMessage(sessionId, errorMessage, activeConversationIds);
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: errorMessage });
   // Broadcast error status to project subscribers for session list updates
   broadcastSessionStatus(sessionId, 'error');
   // Extract PR URL before generating summary (PR may have been created before error)
@@ -481,6 +491,7 @@ export function cleanupSessionState(sessionId, includeConversationId = false) {
   thinkingAccumulators.delete(sessionId);
   currentModels.delete(sessionId);
   loggedToolUseIds.delete(sessionId);
+  finalErrorSessionIds.delete(sessionId);
   activeSessions.delete(sessionId);
   if (includeConversationId) {
     activeConversationIds.delete(sessionId);

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -18,6 +18,7 @@ vi.mock('../database.js', () => ({
   },
   conversations: {
     getActiveBySessionId: vi.fn(),
+    ensureActiveConversation: vi.fn(),
     getById: vi.fn(),
     update: vi.fn(),
     updateUsage: vi.fn(),
@@ -95,6 +96,14 @@ describe('streamEventHandler', () => {
     activeConversationIds.clear();
     currentModels.clear();
     loggedToolUseIds.clear();
+    messages.getByConversationId.mockReturnValue([]);
+    messages.create.mockImplementation((sessionId, role, content, options = {}) => ({
+      id: `msg-${role}`,
+      sessionId,
+      conversationId: options.conversationId ?? null,
+      role,
+      content,
+    }));
   });
 
   // ── createWorkLog ─────────────────────────────────────────────────────
@@ -352,7 +361,21 @@ describe('streamEventHandler', () => {
 
       await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
 
-      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting' });
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
+    });
+
+    it('clears stale error when transitioning to waiting status', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
     });
 
     it('checks proactive reschedule', async () => {
@@ -594,8 +617,12 @@ describe('streamEventHandler', () => {
     it('falls through to error handling when reschedule fails', async () => {
       const controller = { signal: { aborted: false } };
       const error = new Error('token limit exceeded');
-      const mockSession = { autoRescheduleEnabled: true, rescheduleOnTokenLimit: true };
+      const mockSession = { agentType: 'codex', autoRescheduleEnabled: true, rescheduleOnTokenLimit: true };
       sessions.getById.mockReturnValue(mockSession);
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+      ]);
 
       const mockShouldReschedule = vi.fn().mockReturnValue(true);
       const mockScheduler = { rescheduleSession: vi.fn().mockResolvedValue(false) };
@@ -604,6 +631,12 @@ describe('streamEventHandler', () => {
 
       expect(result).toBe(false);
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'error', error: error.message });
+      expect(messages.create).toHaveBeenCalledWith(
+        'sess-1',
+        'assistant',
+        expect.stringContaining('Codex failed before completing this turn'),
+        { conversationId: 'conv-1' }
+      );
       expect(broadcastToSession).toHaveBeenCalledWith(
         'sess-1',
         WS_MESSAGE_TYPES.SESSION_ERROR,
@@ -614,7 +647,11 @@ describe('streamEventHandler', () => {
     it('sets error status when not reschedulable', async () => {
       const controller = { signal: { aborted: false } };
       const error = new Error('Unexpected error');
-      sessions.getById.mockReturnValue({ autoRescheduleEnabled: false });
+      sessions.getById.mockReturnValue({ agentType: 'codex', autoRescheduleEnabled: false });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'start' },
+      ]);
 
       const mockShouldReschedule = vi.fn().mockReturnValue(false);
       const mockScheduler = { rescheduleSession: vi.fn() };
@@ -622,10 +659,77 @@ describe('streamEventHandler', () => {
       await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
 
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'error', error: 'Unexpected error' });
+      expect(messages.create).toHaveBeenCalledWith(
+        'sess-1',
+        'assistant',
+        expect.stringContaining('Unexpected error'),
+        { conversationId: 'conv-1' }
+      );
       expect(broadcastToSession).toHaveBeenCalledWith(
         'sess-1',
         WS_MESSAGE_TYPES.SESSION_ERROR,
         { sessionId: 'sess-1', error: 'Unexpected error' }
+      );
+    });
+
+    it('creates and broadcasts Codex final error messages before SESSION_ERROR', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('usage limit reached');
+      sessions.getById.mockReturnValue({ agentType: 'codex', autoRescheduleEnabled: false });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'Implement the plan' },
+      ]);
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(messages.create).toHaveBeenCalledWith(
+        'sess-1',
+        'assistant',
+        expect.stringContaining('Codex failed before completing this turn'),
+        { conversationId: 'conv-1' }
+      );
+      expect(messages.create.mock.calls[0][2]).toContain('usage limit reached');
+
+      const sessionMessageCallIndex = broadcastToSession.mock.calls.findIndex(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_MESSAGE
+      );
+      const sessionErrorCallIndex = broadcastToSession.mock.calls.findIndex(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_ERROR
+      );
+      expect(sessionMessageCallIndex).toBeGreaterThanOrEqual(0);
+      expect(sessionErrorCallIndex).toBeGreaterThanOrEqual(0);
+      expect(sessionMessageCallIndex).toBeLessThan(sessionErrorCallIndex);
+    });
+
+    it('creates final error messages with an ensured conversation when no active conversation ID exists', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('adapter startup failed');
+      sessions.getById.mockReturnValue({ agentType: 'codex', autoRescheduleEnabled: false });
+      conversations.ensureActiveConversation.mockReturnValue({ id: 'conv-created' });
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(conversations.ensureActiveConversation).toHaveBeenCalledWith('sess-1');
+      expect(messages.create).toHaveBeenCalledWith(
+        'sess-1',
+        'assistant',
+        expect.stringContaining('Codex failed before completing this turn'),
+        { conversationId: 'conv-created' }
+      );
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        'sess-1',
+        WS_MESSAGE_TYPES.SESSION_MESSAGE,
+        {
+          message: expect.objectContaining({ conversationId: 'conv-created', role: 'assistant' }),
+          conversationId: 'conv-created',
+        }
       );
     });
 
@@ -639,7 +743,98 @@ describe('streamEventHandler', () => {
 
       expect(result).toBe(false);
       expect(sessions.update).not.toHaveBeenCalled();
+      expect(messages.create).not.toHaveBeenCalled();
       expect(broadcastToSession).not.toHaveBeenCalled();
+    });
+
+    it('does not create or broadcast visible messages for rescheduled errors', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('token limit exceeded');
+      const mockSession = { agentType: 'codex', autoRescheduleEnabled: true, rescheduleOnTokenLimit: true };
+      sessions.getById.mockReturnValue(mockSession);
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(true);
+      const mockScheduler = { rescheduleSession: vi.fn().mockResolvedValue(true) };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(messages.create).not.toHaveBeenCalled();
+      expect(broadcastToSession.mock.calls.some((call) => call[1] === WS_MESSAGE_TYPES.SESSION_MESSAGE)).toBe(false);
+      expect(broadcastToSession.mock.calls.some((call) => call[1] === WS_MESSAGE_TYPES.SESSION_ERROR)).toBe(false);
+    });
+
+    it('does not duplicate the same generated assistant failure message', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('usage limit reached');
+      const generatedContent = 'Codex failed before completing this turn:\n\nusage limit reached';
+      sessions.getById.mockReturnValue({ agentType: 'codex', autoRescheduleEnabled: false });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+        { id: 'msg-assistant', sessionId: 'sess-1', conversationId: 'conv-1', role: 'assistant', content: generatedContent },
+      ]);
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(messages.create).not.toHaveBeenCalled();
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        'sess-1',
+        WS_MESSAGE_TYPES.SESSION_ERROR,
+        { sessionId: 'sess-1', error: 'usage limit reached' }
+      );
+    });
+
+    it('does not duplicate an assistant failure after the latest user when it contains the raw error', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('context window exceeded');
+      sessions.getById.mockReturnValue({ agentType: 'codex', autoRescheduleEnabled: false });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+        { id: 'msg-assistant', sessionId: 'sess-1', conversationId: 'conv-1', role: 'assistant', content: 'Run failed: context window exceeded' },
+      ]);
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(messages.create).not.toHaveBeenCalled();
+    });
+
+    it('does not duplicate a Claude Code visible error containing the raw error', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('process exited with code 1');
+      sessions.getById.mockReturnValue({ agentType: 'claude-code', autoRescheduleEnabled: false });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+        { id: 'msg-assistant', sessionId: 'sess-1', conversationId: 'conv-1', role: 'assistant', content: 'Claude reported: process exited with code 1' },
+      ]);
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(messages.create).not.toHaveBeenCalled();
+    });
+
+    it('uses fallback wording for unknown adapter types', async () => {
+      const controller = { signal: { aborted: false } };
+      const error = new Error('adapter failed');
+      sessions.getById.mockReturnValue({ agentType: 'other-agent', autoRescheduleEnabled: false });
+      activeConversationIds.set('sess-1', 'conv-1');
+
+      const mockShouldReschedule = vi.fn().mockReturnValue(false);
+      const mockScheduler = { rescheduleSession: vi.fn() };
+
+      await handleSessionError('sess-1', error, { controller, shouldRescheduleOnError: mockShouldReschedule, schedulerService: mockScheduler });
+
+      expect(messages.create.mock.calls[0][2]).toMatch(/^The agent failed before completing this turn/);
     });
 
     it('broadcasts conversation state when broadcastConversationState option is true', async () => {

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -83,6 +83,7 @@ import {
   activeConversationIds,
   currentModels,
   loggedToolUseIds,
+  finalErrorSessionIds,
 } from './streamEventHandler.js';
 
 describe('streamEventHandler', () => {
@@ -96,6 +97,7 @@ describe('streamEventHandler', () => {
     activeConversationIds.clear();
     currentModels.clear();
     loggedToolUseIds.clear();
+    finalErrorSessionIds.clear();
     messages.getByConversationId.mockReturnValue([]);
     messages.create.mockImplementation((sessionId, role, content, options = {}) => ({
       id: `msg-${role}`,
@@ -292,6 +294,7 @@ describe('streamEventHandler', () => {
       currentModels.set('sess-1', 'claude-3');
       loggedToolUseIds.set('sess-1', new Set(['tu-1']));
       activeSessions.set('sess-1', { controller: new AbortController() });
+      finalErrorSessionIds.add('sess-1');
 
       cleanupSessionState('sess-1');
 
@@ -299,6 +302,7 @@ describe('streamEventHandler', () => {
       expect(thinkingAccumulators.has('sess-1')).toBe(false);
       expect(currentModels.has('sess-1')).toBe(false);
       expect(loggedToolUseIds.has('sess-1')).toBe(false);
+      expect(finalErrorSessionIds.has('sess-1')).toBe(false);
       expect(activeSessions.has('sess-1')).toBe(false);
     });
 
@@ -592,6 +596,53 @@ describe('streamEventHandler', () => {
 
       expect(mockAutoSend).not.toHaveBeenCalled();
       expect(mockHandleTemplate).not.toHaveBeenCalled();
+    });
+
+    it('preserves error state after a final result error', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      activeConversationIds.set('sess-1', 'conv-1');
+      lastMessageIds.set('sess-1', 'msg-last');
+      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+      ]);
+      workLogs.associatePendingLogs.mockReturnValue(1);
+
+      await handleStreamEvent('sess-1', {
+        type: 'result',
+        subtype: 'error',
+        error: 'usage limit reached',
+      });
+
+      vi.clearAllMocks();
+      workLogs.associatePendingLogs.mockReturnValue(1);
+      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+      const mockAutoSend = vi.fn().mockResolvedValue(false);
+
+      const result = await handleTurnCompletion('sess-1', '/workspace', {
+        handleTemplateTriggerIfNeeded: mockHandleTemplate,
+        checkProactiveReschedule: mockCheckReschedule,
+        handleAutoSendIfNeeded: mockAutoSend,
+      });
+
+      expect(result).toBe(false);
+      expect(workLogs.associatePendingLogs).toHaveBeenCalledWith('sess-1', 'msg-last');
+      expect(lastMessageIds.has('sess-1')).toBe(false);
+      expect(sessions.update).not.toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
+      expect(broadcastToSession.mock.calls.some(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_STATUS && call[2]?.status === 'waiting'
+      )).toBe(false);
+      expect(summaryService.onSessionActivity).not.toHaveBeenCalled();
+      expect(summaryService.extractPrUrlIfNeeded).not.toHaveBeenCalled();
+      expect(diffService.getChanges).not.toHaveBeenCalled();
+      expect(kanbanService.handleTurnCompletion).not.toHaveBeenCalled();
+      expect(mockCheckReschedule).not.toHaveBeenCalled();
+      expect(mockAutoSend).not.toHaveBeenCalled();
+      expect(mockHandleTemplate).not.toHaveBeenCalled();
+      expect(finalErrorSessionIds.has('sess-1')).toBe(false);
     });
   });
 
@@ -1158,6 +1209,10 @@ describe('streamEventHandler', () => {
     it('exports loggedToolUseIds as a Map', () => {
       expect(loggedToolUseIds).toBeInstanceOf(Map);
     });
+
+    it('exports finalErrorSessionIds as a Set', () => {
+      expect(finalErrorSessionIds).toBeInstanceOf(Set);
+    });
   });
 
   // ── handleStreamEvent ─────────────────────────────────────────────────────
@@ -1219,6 +1274,102 @@ describe('streamEventHandler', () => {
 
       expect(messages.create).not.toHaveBeenCalled();
       expect(sessions.touch).not.toHaveBeenCalled();
+    });
+
+    it('creates and broadcasts visible assistant messages for final result errors', async () => {
+      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+      ]);
+
+      await handleStreamEvent('sess-1', {
+        type: 'result',
+        subtype: 'error',
+        error: 'usage limit reached',
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'error', error: 'usage limit reached' });
+      expect(messages.create).toHaveBeenCalledWith(
+        'sess-1',
+        'assistant',
+        expect.stringContaining('Codex failed before completing this turn'),
+        { conversationId: 'conv-1' }
+      );
+      expect(messages.create.mock.calls[0][2]).toContain('usage limit reached');
+
+      const sessionMessageCallIndex = broadcastToSession.mock.calls.findIndex(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_MESSAGE
+      );
+      const sessionErrorCallIndex = broadcastToSession.mock.calls.findIndex(
+        (call) => call[1] === WS_MESSAGE_TYPES.SESSION_ERROR
+      );
+      expect(sessionMessageCallIndex).toBeGreaterThanOrEqual(0);
+      expect(sessionErrorCallIndex).toBeGreaterThanOrEqual(0);
+      expect(sessionMessageCallIndex).toBeLessThan(sessionErrorCallIndex);
+      expect(finalErrorSessionIds.has('sess-1')).toBe(true);
+    });
+
+    it('uses an ensured conversation for final result errors when none is active', async () => {
+      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      conversations.ensureActiveConversation.mockReturnValue({ id: 'conv-created' });
+
+      await handleStreamEvent('sess-1', {
+        type: 'result',
+        subtype: 'error',
+        error: 'adapter failed',
+      });
+
+      expect(conversations.ensureActiveConversation).toHaveBeenCalledWith('sess-1');
+      expect(messages.create).toHaveBeenCalledWith(
+        'sess-1',
+        'assistant',
+        expect.stringContaining('adapter failed'),
+        { conversationId: 'conv-created' }
+      );
+      expect(activeConversationIds.get('sess-1')).toBe('conv-created');
+    });
+
+    it('normalizes object-shaped final result errors', async () => {
+      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      activeConversationIds.set('sess-1', 'conv-1');
+
+      await handleStreamEvent('sess-1', {
+        type: 'result',
+        subtype: 'error',
+        error: { message: 'object shaped failure' },
+      });
+
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'error', error: 'object shaped failure' });
+      expect(messages.create.mock.calls[0][2]).toContain('object shaped failure');
+      expect(messages.create.mock.calls[0][2]).not.toContain('[object Object]');
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        'sess-1',
+        WS_MESSAGE_TYPES.SESSION_ERROR,
+        { sessionId: 'sess-1', error: 'object shaped failure' }
+      );
+    });
+
+    it('does not duplicate final result error messages containing the raw error after the latest user', async () => {
+      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      activeConversationIds.set('sess-1', 'conv-1');
+      messages.getByConversationId.mockReturnValue([
+        { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
+        { id: 'msg-assistant', sessionId: 'sess-1', conversationId: 'conv-1', role: 'assistant', content: 'Run failed: usage limit reached' },
+      ]);
+
+      await handleStreamEvent('sess-1', {
+        type: 'result',
+        subtype: 'error',
+        error: 'usage limit reached',
+      });
+
+      expect(messages.create).not.toHaveBeenCalled();
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        'sess-1',
+        WS_MESSAGE_TYPES.SESSION_ERROR,
+        { sessionId: 'sess-1', error: 'usage limit reached' }
+      );
     });
   });
 });

--- a/packages/server/src/services/visibleFinalErrorMessage.js
+++ b/packages/server/src/services/visibleFinalErrorMessage.js
@@ -1,0 +1,99 @@
+import { sessions, conversations, messages } from '../database.js';
+import { broadcastToSession } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+
+export function normalizeFinalErrorMessage(error) {
+  if (error?.message) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error == null) {
+    return 'Unknown error';
+  }
+  return String(error);
+}
+
+function normalizeMessageContent(content) {
+  return (content || '').trim().replace(/\s+/g, ' ');
+}
+
+function buildVisibleErrorContent(agentType, errorMessage) {
+  if (agentType === 'codex') {
+    return `Codex failed before completing this turn:\n\n${errorMessage}`;
+  }
+  if (agentType === 'claude-code') {
+    return `Claude Code failed before completing this turn:\n\n${errorMessage}`;
+  }
+  return `The agent failed before completing this turn:\n\n${errorMessage}`;
+}
+
+function hasExistingVisibleFailure(conversationMessages, generatedContent, rawErrorMessage) {
+  const normalizedGenerated = normalizeMessageContent(generatedContent);
+  const normalizedError = normalizeMessageContent(rawErrorMessage);
+  const latestMessage = conversationMessages[conversationMessages.length - 1];
+
+  if (
+    latestMessage?.role === 'assistant' &&
+    normalizeMessageContent(latestMessage.content) === normalizedGenerated
+  ) {
+    return true;
+  }
+
+  let latestUserIndex = -1;
+  for (let i = conversationMessages.length - 1; i >= 0; i -= 1) {
+    if (conversationMessages[i].role === 'user') {
+      latestUserIndex = i;
+      break;
+    }
+  }
+
+  return conversationMessages
+    .slice(latestUserIndex + 1)
+    .some((message) => {
+      if (message.role !== 'assistant') {
+        return false;
+      }
+      const normalizedContent = normalizeMessageContent(message.content);
+      return normalizedContent === normalizedGenerated ||
+        (normalizedError && normalizedContent.includes(normalizedError));
+    });
+}
+
+function resolveErrorConversationId(sessionId, activeConversationIds) {
+  const activeConversationId = activeConversationIds.get(sessionId);
+  if (activeConversationId) {
+    return activeConversationId;
+  }
+  const activeConversation = conversations.ensureActiveConversation(sessionId);
+  if (activeConversation?.id) {
+    activeConversationIds.set(sessionId, activeConversation.id);
+    return activeConversation.id;
+  }
+  return null;
+}
+
+export function createVisibleFinalErrorMessage(sessionId, error, activeConversationIds) {
+  const conversationId = resolveErrorConversationId(sessionId, activeConversationIds);
+  if (!conversationId) {
+    return null;
+  }
+
+  const session = sessions.getById(sessionId);
+  const errorMessage = normalizeFinalErrorMessage(error);
+  const content = buildVisibleErrorContent(session?.agentType, errorMessage);
+  const conversationMessages = messages.getByConversationId(conversationId) || [];
+
+  if (hasExistingVisibleFailure(conversationMessages, content, errorMessage)) {
+    return null;
+  }
+
+  const message = messages.create(sessionId, 'assistant', content, { conversationId });
+  sessions.touch(sessionId);
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_MESSAGE, {
+    message,
+    conversationId,
+  });
+  return message;
+}

--- a/packages/server/src/services/visibleFinalErrorMessage.js
+++ b/packages/server/src/services/visibleFinalErrorMessage.js
@@ -29,11 +29,33 @@ function buildVisibleErrorContent(agentType, errorMessage) {
   return `The agent failed before completing this turn:\n\n${errorMessage}`;
 }
 
+/**
+ * Check if a visible error message already exists to prevent duplicates.
+ *
+ * Uses two strategies to detect existing failures:
+ *
+ * Strategy 1: Exact match with generated content
+ * - Checks if the latest message is an assistant message with content exactly matching
+ *   what we would generate (e.g., "Codex failed before completing this turn:\n\nerror")
+ * - This catches cases where we already created the formatted error message
+ *
+ * Strategy 2: Raw error in messages after latest user message
+ * - Finds the latest user message, then checks all subsequent assistant messages
+ * - Returns true if any assistant message contains the raw error text
+ * - This catches cases where the agent itself already reported the error
+ *   (e.g., "Run failed: usage limit reached" contains "usage limit reached")
+ *
+ * @param {Array} conversationMessages - All messages in the conversation
+ * @param {string} generatedContent - The formatted error content we would create
+ * @param {string} rawErrorMessage - The raw error message text
+ * @returns {boolean} True if a duplicate error message already exists
+ */
 function hasExistingVisibleFailure(conversationMessages, generatedContent, rawErrorMessage) {
   const normalizedGenerated = normalizeMessageContent(generatedContent);
   const normalizedError = normalizeMessageContent(rawErrorMessage);
   const latestMessage = conversationMessages[conversationMessages.length - 1];
 
+  // Strategy 1: Check if the latest message is an exact match with our generated content
   if (
     latestMessage?.role === 'assistant' &&
     normalizeMessageContent(latestMessage.content) === normalizedGenerated
@@ -41,6 +63,7 @@ function hasExistingVisibleFailure(conversationMessages, generatedContent, rawEr
     return true;
   }
 
+  // Find the index of the latest user message
   let latestUserIndex = -1;
   for (let i = conversationMessages.length - 1; i >= 0; i -= 1) {
     if (conversationMessages[i].role === 'user') {
@@ -49,6 +72,7 @@ function hasExistingVisibleFailure(conversationMessages, generatedContent, rawEr
     }
   }
 
+  // Strategy 2: Check if any assistant message after the latest user message contains the raw error
   return conversationMessages
     .slice(latestUserIndex + 1)
     .some((message) => {

--- a/tests/e2e/codex-provider.spec.ts
+++ b/tests/e2e/codex-provider.spec.ts
@@ -81,7 +81,7 @@ test.describe('Codex provider flow', () => {
     expect(hasCodexOption).toBe(true);
 
     await page.locator('#model-select').selectOption('gpt-4o');
-    await expect(page.locator('[data-agent-badge="codex"]')).toBeVisible();
+    await expect(page.locator('[data-agent-badge="codex"]')).toHaveCount(0);
     await expect(
       page.locator('.thinking-toggle').filter({ hasText: 'Enable Thinking' }).locator('input')
     ).toBeDisabled();


### PR DESCRIPTION
## Summary
- persist a visible assistant message when a final Claude Code/Codex adapter error ends a turn
- ensure an active conversation exists for those visible errors and avoid duplicate failure messages
- clear stale session errors when a turn completes successfully
- add unit coverage for broadcast ordering, abort/reschedule behavior, duplicate suppression, adapter wording, and stale error clearing

## Verification
- yarn workspace @circuschief/server test src/services/streamEventHandler.test.js
- yarn workspace @circuschief/server test
