### PR TITLE
Remove Codex agent badge from session form

### DIFF
--- a/packages/web/src/components/SessionFormOptions.test.js
+++ b/packages/web/src/components/SessionFormOptions.test.js
@@ -166,13 +166,13 @@ describe('SessionFormOptions', () => {
     expect(effortSelect.element.disabled).toBe(true);
   });
 
-  it('shows an "Agent: Codex" badge only when a Codex model is selected', async () => {
+  it('does not render the Codex agent badge when a Codex model is selected', async () => {
     const wrapper = mountForm({ model: 'claude-sonnet-4-6' });
     await flushAll(wrapper);
     expect(wrapper.find('[data-agent-badge="codex"]').exists()).toBe(false);
 
     await wrapper.setProps({ model: 'gpt-4o' });
     await flushAll(wrapper);
-    expect(wrapper.find('[data-agent-badge="codex"]').exists()).toBe(true);
+    expect(wrapper.find('[data-agent-badge="codex"]').exists()).toBe(false);
   });
 });

--- a/packages/web/src/components/SessionFormOptions.vue
+++ b/packages/web/src/components/SessionFormOptions.vue
@@ -16,11 +16,6 @@
           @update:model-value="$emit('update:model', $event)"
           @update:provider-id="$emit('update:providerId', $event)"
         />
-        <span
-          v-if="isCodexModel"
-          class="agent-badge"
-          data-agent-badge="codex"
-        >Agent: Codex</span>
       </div>
 
       <div
@@ -192,17 +187,6 @@ const effortSelectorTitle = computed(() => (
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-
-.agent-badge {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--color-text-soft);
-  background-color: var(--color-background-mute);
-  border: 1px solid var(--color-border);
-  border-radius: 0.375rem;
-  padding: 0.125rem 0.375rem;
-  letter-spacing: 0.02em;
 }
 
 .option-disabled {


### PR DESCRIPTION
## Summary
- Remove the visible "Agent: Codex" badge from the create session form model selector area
- Keep the existing Codex model detection behavior for form control enablement
- Update the focused component test to assert the badge does not render for Codex models

## Tests
- yarn workspace @circuschief/web test SessionFormOptions.test.js