### PR TITLE
Enable CLI-configured MCP servers for agents

### DIFF
--- a/packages/server/src/services/sessionExecution.js
+++ b/packages/server/src/services/sessionExecution.js
@@ -82,7 +82,9 @@ function buildClaudeCodeQueryParams({
       abortController: controller,
       includePartialMessages: true,
       permissionMode: getPermissionModeForSession(session.mode),
-      settingSources: ['project'],
+      // Match normal Claude Code CLI behavior: load user-level settings
+      // such as configured MCP servers, then project/local overrides.
+      settingSources: ['user', 'project', 'local'],
       ...(resumeSessionId && { resume: resumeSessionId }),
       env: sessionEnv,
       spawnClaudeCodeProcess: createClaudeCodeSpawner(),

--- a/packages/server/src/services/sessionExecution.test.js
+++ b/packages/server/src/services/sessionExecution.test.js
@@ -84,6 +84,11 @@ describe('buildQueryParams', () => {
     expect(result.options.resume).toBeUndefined();
   });
 
+  it('loads Claude user/project/local settings so CLI-configured MCP servers are available', () => {
+    const result = buildQueryParams(baseArgs());
+    expect(result.options.settingSources).toEqual(['user', 'project', 'local']);
+  });
+
   it('propagates effortLevel into Codex query options', () => {
     const args = {
       ...baseArgs(),
@@ -369,7 +374,7 @@ describe('buildQueryParams agent-aware', () => {
       model: 'claude-sonnet-4-20250514',
     };
     const result = buildQueryParams(args);
-    expect(result.options.settingSources).toEqual(['project']);
+    expect(result.options.settingSources).toEqual(['user', 'project', 'local']);
     expect(result.options.includePartialMessages).toBe(true);
     expect(typeof result.options.spawnClaudeCodeProcess).toBe('function');
     expect(result.options.permissionMode).toBeDefined();

--- a/packages/server/src/services/sessionProvider.js
+++ b/packages/server/src/services/sessionProvider.js
@@ -204,14 +204,12 @@ function stripAnthropicHostEnv(env) {
 
 function replaceWithCodexCliEnv(sessionEnv, providerEnv) {
   const target = sessionEnv;
-  const allowed = ['HOME', 'PATH', 'USER', 'LOGNAME', 'SHELL', 'TERM', 'LANG', 'LC_ALL', 'TMPDIR'];
-  const cleaned = {};
-  for (const key of allowed) {
-    if (target[key] !== undefined) cleaned[key] = target[key];
-  }
-  Object.assign(cleaned, providerEnv);
-  for (const key of Object.keys(target)) delete target[key];
-  Object.assign(target, cleaned);
+  delete target.OPENAI_API_KEY;
+  delete target.OPENAI_BASE_URL;
+  delete target.OPENAI_API_BASE;
+  delete target.OPENAI_ORG_ID;
+  delete target.OPENAI_PROJECT;
+  Object.assign(target, providerEnv);
 }
 
 function stripOpenAIBaseUrlUnlessProvided(sessionEnv, providerEnv) {

--- a/packages/server/src/services/sessionProvider.test.js
+++ b/packages/server/src/services/sessionProvider.test.js
@@ -518,22 +518,30 @@ describe('sessionProvider', () => {
       process.env.OPENAI_PROJECT = 'proj-should-be-stripped';
       const provider = { name: 'O', kind: 'openai' };
       const env = buildSessionEnv(provider, false, null);
-      // Whitelist strips all OPENAI_* vars
       expect(env.OPENAI_API_KEY).toBeUndefined();
       expect(env.OPENAI_BASE_URL).toBeUndefined();
       expect(env.OPENAI_ORG_ID).toBeUndefined();
       expect(env.OPENAI_PROJECT).toBeUndefined();
     });
 
-    it('openai provider with no authToken: whitelist preserves HOME and PATH', () => {
-      const provider = { name: 'O', kind: 'openai' };
-      const env = buildSessionEnv(provider, false, null);
-      expect(env.HOME).toBeDefined();
-      expect(env.PATH).toBeDefined();
-      expect(env.PATH).toContain('/mock-node-bin');
+    it('openai provider with no authToken: preserves CLI environment for Codex MCP servers', () => {
+      try {
+        process.env.GITHUB_TOKEN = 'github-token-for-mcp';
+        process.env.FIRECRAWL_API_KEY = 'firecrawl-token-for-mcp';
+        const provider = { name: 'O', kind: 'openai' };
+        const env = buildSessionEnv(provider, false, null);
+        expect(env.HOME).toBeDefined();
+        expect(env.PATH).toBeDefined();
+        expect(env.PATH).toContain('/mock-node-bin');
+        expect(env.GITHUB_TOKEN).toBe('github-token-for-mcp');
+        expect(env.FIRECRAWL_API_KEY).toBe('firecrawl-token-for-mcp');
+      } finally {
+        delete process.env.GITHUB_TOKEN;
+        delete process.env.FIRECRAWL_API_KEY;
+      }
     });
 
-    it('openai provider with no authToken: whitelist strips ANTHROPIC_* too', () => {
+    it('openai provider with no authToken: strips ANTHROPIC_* too', () => {
       process.env.ANTHROPIC_API_KEY = 'should-be-stripped';
       process.env.ANTHROPIC_BASE_URL = 'https://should-be-stripped';
       const provider = { name: 'O', kind: 'openai' };
@@ -579,7 +587,6 @@ describe('sessionProvider', () => {
     });
 
     it('openai provider with no config: strips host OPENAI_API_BASE (older alias)', () => {
-      // Whitelist strips everything except safe vars
       process.env.OPENAI_API_BASE = 'https://host-api-base';
       const provider = { name: 'O', kind: 'openai' };
       const env = buildSessionEnv(provider, false, null);


### PR DESCRIPTION
## Summary
- Load Claude Code user/project/local settings so CLI-configured MCP servers are available to app-launched Claude agents
- Preserve the Codex CLI environment while still stripping host OpenAI auth/base variables, allowing CLI-configured MCP servers to receive their required env
- Update regression coverage for Claude setting sources and Codex MCP env preservation

## Tests
- yarn workspace @circuschief/server test sessionExecution.test.js sessionProvider.test.js

Session summary endpoint returned only: "You've hit your limit · resets Apr 29, 10pm (America/Chicago)"