### PR TITLE
Stop pw.sh Playwright server after tests

### DIFF
--- a/packages/server/test/pwshReuse.test.js
+++ b/packages/server/test/pwshReuse.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import { spawn } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -49,10 +49,11 @@ describe('pw.sh server-reuse verification', () => {
     const parseFn = extract('parse_server_info_field');
     const verifyFn = extract('verify_server_isolation');
     const setupFn = extract('setup_isolated_test_db');
+    const cleanupFn = extract('cleanup_test_server');
 
     writeFileSync(
       helperScript,
-      `#!/bin/bash\nprint_error() { echo "ERROR: $1" >&2; }\nprint_info() { echo "INFO: $1" >&2; }\nprint_warning() { echo "WARN: $1" >&2; }\n${parseFn}\n${verifyFn}\n${setupFn}\n`,
+      `#!/bin/bash\nprint_error() { echo "ERROR: $1" >&2; }\nprint_info() { echo "INFO: $1" >&2; }\nprint_warning() { echo "WARN: $1" >&2; }\n${parseFn}\n${verifyFn}\n${setupFn}\n${cleanupFn}\n`,
       { mode: 0o755 },
     );
   });
@@ -264,7 +265,7 @@ describe('pw.sh server-reuse verification', () => {
       }
     });
 
-    it('preserves a caller-provided DB_PATH on the dev-server path', async () => {
+    it('overrides a caller-provided DB_PATH on the dev-server path', async () => {
       const fakeRoot = mkdtempSync(join(tmpdir(), 'cc-setup-test-'));
       try {
         const result = await runSetup({
@@ -273,7 +274,8 @@ describe('pw.sh server-reuse verification', () => {
           DB_PATH: '/some/caller/path.db',
         });
         expect(result.status).toBe(0);
-        expect(result.stdout).toContain('DB_PATH=/some/caller/path.db');
+        expect(result.stdout).toContain(`DB_PATH=${fakeRoot}/.circuschief-test.db`);
+        expect(result.stdout).not.toContain('/some/caller/path.db');
       } finally {
         rmSync(fakeRoot, { recursive: true, force: true });
       }
@@ -293,6 +295,69 @@ describe('pw.sh server-reuse verification', () => {
         expect(result.stdout).toContain('DB_PATH=UNSET');
         expect(result.stdout).not.toContain('/stale/value.db');
         expect(result.stdout).not.toContain('.circuschief-test.db');
+      } finally {
+        rmSync(fakeRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('cleanup_test_server', () => {
+    const runCleanup = (port, fakeRoot, extraEnv = {}) =>
+      new Promise((resolve) => {
+        const child = spawn(
+          'bash',
+          ['-c', `source "${helperScript}"; PROJECT_ROOT="${fakeRoot}" cleanup_test_server "${port}"`],
+          { stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, ...extraEnv } },
+        );
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d) => (stdout += d.toString()));
+        child.stderr.on('data', (d) => (stderr += d.toString()));
+        child.on('exit', (status) => resolve({ status, stdout, stderr }));
+      });
+
+    it('removes worktree marker files after stopping a non-5000 test server', async () => {
+      const fakeRoot = mkdtempSync(join(tmpdir(), 'cc-cleanup-test-'));
+      try {
+        const fakeBin = join(fakeRoot, 'bin');
+        mkdirSync(fakeBin);
+        writeFileSync(
+          join(fakeBin, 'lsof'),
+          '#!/bin/bash\nif [ "$1" = "-t" ]; then echo 12345; exit 0; fi\nexit 1\n',
+          { mode: 0o755 },
+        );
+
+        const serverPort = 51234;
+        writeFileSync(join(fakeRoot, '.server-port'), String(serverPort));
+        writeFileSync(join(fakeRoot, '.vcr-mode'), 'replay');
+        writeFileSync(join(fakeRoot, '.db-path'), join(fakeRoot, '.circuschief-test.db'));
+
+        const result = await runCleanup(serverPort, fakeRoot, {
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        });
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain(`Stopping Playwright test server on port ${serverPort}`);
+        expect(existsSync(join(fakeRoot, '.server-port'))).toBe(false);
+        expect(existsSync(join(fakeRoot, '.vcr-mode'))).toBe(false);
+        expect(existsSync(join(fakeRoot, '.db-path'))).toBe(false);
+      } finally {
+        rmSync(fakeRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('does not remove marker files or kill protected port 5000', async () => {
+      const fakeRoot = mkdtempSync(join(tmpdir(), 'cc-cleanup-test-'));
+      try {
+        writeFileSync(join(fakeRoot, '.server-port'), '5000');
+        writeFileSync(join(fakeRoot, '.vcr-mode'), 'replay');
+        writeFileSync(join(fakeRoot, '.db-path'), join(fakeRoot, '.circuschief-test.db'));
+
+        const result = await runCleanup(5000, fakeRoot);
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain('protected');
+        expect(existsSync(join(fakeRoot, '.server-port'))).toBe(true);
+        expect(existsSync(join(fakeRoot, '.vcr-mode'))).toBe(true);
+        expect(existsSync(join(fakeRoot, '.db-path'))).toBe(true);
       } finally {
         rmSync(fakeRoot, { recursive: true, force: true });
       }

--- a/scripts/pw.sh
+++ b/scripts/pw.sh
@@ -106,7 +106,7 @@ verify_server_isolation() {
     return 0
 }
 
-# Before we touch the server, set DB_PATH to a worktree-local file and wipe
+# Before we touch the server, force DB_PATH to a worktree-local file and wipe
 # any leftover DB from earlier runs so each pw.sh run starts clean. The rm
 # is guarded to files inside PROJECT_ROOT.
 #
@@ -123,9 +123,7 @@ setup_isolated_test_db() {
         return 0
     fi
 
-    if [ -z "${DB_PATH:-}" ]; then
-        export DB_PATH="$PROJECT_ROOT/.circuschief-test.db"
-    fi
+    export DB_PATH="$PROJECT_ROOT/.circuschief-test.db"
 
     case "$DB_PATH" in
         "$PROJECT_ROOT"/*)
@@ -155,6 +153,45 @@ wait_for_server() {
 
     print_error "Server did not respond after ${timeout}s"
     return 1
+}
+
+# Stop a server started for a pw.sh test/debug run.
+#
+# detect_or_start_server always restarts any reusable non-5000 worktree server
+# before returning a port, so cmd_test/cmd_debug can safely tear down the
+# returned non-5000 listener after Playwright finishes. Port 5000 is still
+# protected because it may be the user's main development server.
+cleanup_test_server() {
+    local port="${1:-}"
+
+    if [ -z "$port" ]; then
+        return 0
+    fi
+
+    if [ "$port" = "5000" ]; then
+        print_warning "Leaving protected server on port 5000 running"
+        return 0
+    fi
+
+    local server_pid
+    server_pid=$(lsof -t -i:"$port" 2>/dev/null || true)
+    if [ -n "$server_pid" ]; then
+        print_info "Stopping Playwright test server on port $port..."
+        kill $server_pid 2>/dev/null || true
+
+        local wait_count=0
+        while lsof -i:"$port" >/dev/null 2>&1 && [ $wait_count -lt 10 ]; do
+            sleep 1
+            ((wait_count+=1))
+        done
+
+        if lsof -i:"$port" >/dev/null 2>&1; then
+            print_warning "Test server on port $port did not stop after SIGTERM; forcing shutdown"
+            kill -9 $server_pid 2>/dev/null || true
+        fi
+    fi
+
+    rm -f "$PROJECT_ROOT/.server-port" "$PROJECT_ROOT/.vcr-mode" "$PROJECT_ROOT/.db-path"
 }
 
 # Detect or start server
@@ -400,12 +437,16 @@ cmd_test() {
     export BASE_URL="http://localhost:$TEST_SERVER_PORT"
 
     if ! verify_server_isolation "$TEST_SERVER_PORT"; then
+        cleanup_test_server "$TEST_SERVER_PORT"
         exit 1
     fi
+
+    trap 'cleanup_test_server "$TEST_SERVER_PORT"' EXIT INT TERM
 
     print_info "Running Playwright tests on port: $TEST_SERVER_PORT"
 
     local exit_code
+    set +e
     if [ "$USE_DOCKER" = true ]; then
         # Use -T to disable pseudo-TTY allocation in docker
         # This prevents conflicts with the PTY wrapper used by command buttons
@@ -417,6 +458,10 @@ cmd_test() {
         cd "$PROJECT_ROOT" && npx playwright test "$@"
         exit_code=$?
     fi
+    set -e
+
+    cleanup_test_server "$TEST_SERVER_PORT"
+    trap - EXIT INT TERM
 
     # Explicitly return the exit code
     return $exit_code
@@ -542,12 +587,16 @@ cmd_debug() {
     export BASE_URL="http://localhost:$TEST_SERVER_PORT"
 
     if ! verify_server_isolation "$TEST_SERVER_PORT"; then
+        cleanup_test_server "$TEST_SERVER_PORT"
         exit 1
     fi
+
+    trap 'cleanup_test_server "$TEST_SERVER_PORT"' EXIT INT TERM
 
     print_info "Running tests in debug mode (headed browser) on port: $TEST_SERVER_PORT"
 
     local exit_code
+    set +e
     if [ "$USE_DOCKER" = true ]; then
         # Use -T for output streaming (headed mode still works with X11 forwarding)
         docker compose -f "$COMPOSE_FILE" --profile headed run --rm -T playwright-headed test "$@"
@@ -557,6 +606,10 @@ cmd_debug() {
         cd "$PROJECT_ROOT" && npx playwright test --headed "$@"
         exit_code=$?
     fi
+    set -e
+
+    cleanup_test_server "$TEST_SERVER_PORT"
+    trap - EXIT INT TERM
 
     return $exit_code
 }


### PR DESCRIPTION
## Summary
- force pw.sh dev Playwright runs to use a worktree-local test database
- stop non-5000 Playwright test/debug servers after completion, failure, or interruption
- add regression coverage for cleanup behavior and DB_PATH overriding

## Testing
- bash -n scripts/pw.sh
- yarn workspace @circuschief/server vitest run test/pwshReuse.test.js

Note: the generated session summary only contained an account-limit message, so this PR description is based on the code diff and verified test output.