### PR TITLE
Fix iPhone session chat overlay blur regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ temp/
 .claude/plans/
 .claude-plans/
 .plan/
+
+# Session attachments (temporary artifacts)
+.attachments/

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -8,20 +8,17 @@ import sessionChatOverlaySource from './SessionChatOverlay.vue?raw';
 import { api } from '../composables/useApi.js';
 import { generateWorktreeBranch } from '@circuschief/shared';
 
-const mockRequestVisualViewportUpdate = vi.hoisted(() => vi.fn());
-const mockRequestVisualViewportSettle = vi.hoisted(() => vi.fn());
-
-vi.mock('../composables/useVisualViewport.js', () => ({
-  requestVisualViewportSettle: mockRequestVisualViewportSettle,
-  requestVisualViewportUpdate: mockRequestVisualViewportUpdate,
-}));
-
-// jsdom has no scrollIntoView. Several overlay code paths call it after
-// focus transitions fire; stub it globally so blur-recovery tests can
-// exercise the real focusin/focusout listeners without throwing.
+// jsdom has no scrollIntoView. Several descendant overlay code paths can call
+// it after focus transitions fire; stub it globally for mounted tests.
 if (!HTMLElement.prototype.scrollIntoView) {
   HTMLElement.prototype.scrollIntoView = function scrollIntoViewStub() {};
 }
+
+Object.defineProperty(window, 'scrollTo', {
+  configurable: true,
+  writable: true,
+  value: vi.fn(),
+});
 
 // Mock @circuschief/shared
 vi.mock('@circuschief/shared', () => ({
@@ -262,6 +259,14 @@ describe('SessionChatOverlay', () => {
       },
       attachTo: document.body,
     });
+  }
+
+  function getStyleBlock(selector) {
+    const start = sessionChatOverlaySource.indexOf(`${selector} {`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = sessionChatOverlaySource.indexOf('\n}', start);
+    expect(end).toBeGreaterThan(start);
+    return sessionChatOverlaySource.slice(start, end + 2);
   }
 
   async function waitForTransition() {
@@ -1549,7 +1554,7 @@ describe('SessionChatOverlay', () => {
     });
   });
 
-  describe('CSS-owned geometry (no JS viewport sync)', () => {
+  describe('fullscreen shell CSS contract', () => {
     it('does not write inline geometry on the backdrop', async () => {
       const wrapper = mountOverlay();
       await nextTick();
@@ -1562,42 +1567,60 @@ describe('SessionChatOverlay', () => {
       wrapper.unmount();
     });
 
-    it('backdrop stylesheet uses fixed viewport-offset geometry', () => {
-      // Assert against the SFC source text (imported as raw via Vite `?raw`).
-      // jsdom does not reliably attach Vue <style scoped> blocks to
-      // document.styleSheets, so source-text inspection is the check used
-      // elsewhere in this file (see removed panel-wrapper stylesheet test).
-      const blockMatch = sessionChatOverlaySource.match(/\.overlay-backdrop\s*\{[^}]*\}/);
-      expect(blockMatch).toBeTruthy();
-      const block = blockMatch[0];
+    it('backdrop stylesheet uses browser-owned full viewport geometry', () => {
+      const block = getStyleBlock('.overlay-backdrop');
       expect(block).toMatch(/position:\s*fixed/);
-      expect(block).toMatch(/top:\s*var\(--viewport-offset-top,\s*0px\)/);
-      expect(block).toMatch(/right:\s*0/);
-      expect(block).toMatch(/left:\s*0/);
-      expect(block).toMatch(/height:\s*var\(--visual-viewport-height,\s*100dvh\)/);
-      expect(block).not.toMatch(/bottom:\s*0/);
+      expect(block).toMatch(/inset:\s*0/);
+      expect(block).not.toMatch(/--viewport-offset-top/);
+      expect(block).not.toMatch(/--visual-viewport-height/);
+      expect(block).not.toMatch(/top:\s*var\(/);
+      expect(block).not.toMatch(/height:\s*var\(/);
     });
 
-    it('panel-wrapper stylesheet uses fixed visual viewport geometry', () => {
-      const blockMatch = sessionChatOverlaySource.match(/\.overlay-panel-wrapper\s*\{[^}]*\}/);
-      expect(blockMatch).toBeTruthy();
-      const block = blockMatch[0];
-      expect(block).toMatch(/position:\s*fixed/);
-      expect(block).toMatch(/top:\s*var\(--viewport-offset-top,\s*0px\)/);
-      expect(block).toMatch(/right:\s*0/);
-      expect(block).toMatch(/height:\s*var\(--visual-viewport-height,\s*100dvh\)/);
-      expect(block).not.toMatch(/bottom:\s*0/);
+    it('panel-wrapper stylesheet is child geometry inside the backdrop', () => {
+      const block = getStyleBlock('.overlay-panel-wrapper');
+      expect(block).toMatch(/position:\s*absolute/);
+      expect(block).toMatch(/inset:\s*0 0 0 auto/);
+      expect(block).toMatch(/height:\s*100%/);
+      expect(block).not.toMatch(/position:\s*fixed/);
+      expect(block).not.toMatch(/--viewport-offset-top/);
+      expect(block).not.toMatch(/--visual-viewport-height/);
+      expect(block).not.toMatch(/top:\s*var\(/);
+      expect(block).not.toMatch(/height:\s*var\(/);
       expect(block).not.toMatch(/min-height:\s*100vh/);
       expect(block).not.toMatch(/min-height:\s*100dvh/);
     });
 
-    it('source no longer references window.visualViewport', () => {
-      // Viewport reads stay centralized in useVisualViewport.js.
+    it('overlay shell stylesheet ignores stale visual viewport variables', () => {
+      const shellBlocks = [
+        getStyleBlock('.overlay-backdrop'),
+        getStyleBlock('.overlay-panel-wrapper'),
+      ].join('\n');
+      expect(shellBlocks).not.toMatch(/--viewport-offset-top/);
+      expect(shellBlocks).not.toMatch(/--visual-viewport-height/);
+    });
+
+    it('content, header, and body declare solid backgrounds', () => {
+      for (const selector of ['.overlay-content', '.overlay-header', '.overlay-body']) {
+        const block = getStyleBlock(selector);
+        const declaration = block.match(/background(?:-color)?:\s*([^;]+);/);
+        expect(declaration).toBeTruthy();
+        expect(declaration[1]).not.toMatch(/\btransparent\b|rgba\(/);
+      }
+    });
+
+    it('source no longer references visual viewport APIs', () => {
+      // Viewport reads stay centralized in useVisualViewport.js for app-level chrome.
       expect(sessionChatOverlaySource).not.toMatch(/window\.visualViewport/);
+      expect(sessionChatOverlaySource).not.toMatch(/requestVisualViewportSettle/);
+      expect(sessionChatOverlaySource).not.toMatch(/useVisualViewport\.js/);
       expect(sessionChatOverlaySource).not.toMatch(/syncToVisualViewport/);
       expect(sessionChatOverlaySource).not.toMatch(/markRecentBlur/);
       expect(sessionChatOverlaySource).not.toMatch(/applyLayoutViewport/);
       expect(sessionChatOverlaySource).not.toMatch(/overlayBackdropRef/);
+      expect(sessionChatOverlaySource).not.toMatch(/inputFocused/);
+      expect(sessionChatOverlaySource).not.toMatch(/focusOutRaf/);
+      expect(sessionChatOverlaySource).not.toMatch(/handleOverlayFocus(?:in|out)/);
     });
 
     it('lockBodyScroll does not call window.scrollTo(0, 0) at mount time', async () => {
@@ -1616,36 +1639,50 @@ describe('SessionChatOverlay', () => {
       wrapper.unmount();
     });
 
-    it('inputFocused toggles via focusin/focusout and requests viewport settle on blur', async () => {
-      setViewportWidth(390);
+    it('locks body scroll and pins #app while mounted', async () => {
+      const app = document.createElement('div');
+      app.id = 'app';
+      document.body.appendChild(app);
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        value: 123,
+      });
+      const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
       const wrapper = mountOverlay();
       await nextTick();
 
-      expect(wrapper.vm.inputFocused).toBe(false);
+      expect(document.body.style.overflow).toBe('hidden');
+      expect(app.style.position).toBe('fixed');
+      expect(app.style.top).toBe('-123px');
+      expect(app.style.left).toBe('0px');
+      expect(app.style.right).toBe('0px');
+      expect(app.style.width).toBe('100%');
 
-      // Append a real textarea into .overlay-body so the delegated
-      // focusin/focusout handlers fire.
-      const body = wrapper.vm.overlayBodyRef;
-      expect(body).toBeTruthy();
-      const textarea = document.createElement('textarea');
-      body.appendChild(textarea);
+      wrapper.unmount();
+      expect(document.body.style.overflow).toBe('');
+      expect(app.style.position).toBe('');
+      expect(app.style.top).toBe('');
+      expect(app.style.left).toBe('');
+      expect(app.style.right).toBe('');
+      expect(app.style.width).toBe('');
+      expect(scrollToSpy).toHaveBeenCalledWith(0, 123);
 
-      textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      scrollToSpy.mockRestore();
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        value: 0,
+      });
+      app.remove();
+    });
+
+    it('does not expose dead focus or visual viewport settling state', async () => {
+      const wrapper = mountOverlay();
       await nextTick();
-      expect(wrapper.vm.inputFocused).toBe(true);
-      expect(document.querySelector('.overlay-header')?.classList.contains('header-compact')).toBe(false);
-
-      mockRequestVisualViewportSettle.mockClear();
-      textarea.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
-      expect(mockRequestVisualViewportSettle).toHaveBeenCalledTimes(1);
-      // focusout is rAF-debounced; flush one frame.
-      await new Promise((r) => requestAnimationFrame(() => r()));
-      await nextTick();
-      expect(mockRequestVisualViewportSettle).toHaveBeenCalledTimes(1);
-      expect(mockRequestVisualViewportUpdate).not.toHaveBeenCalled();
-      expect(wrapper.vm.inputFocused).toBe(false);
-
-      body.removeChild(textarea);
+      expect(wrapper.vm.inputFocused).toBeUndefined();
+      expect(wrapper.vm.handleOverlayFocusin).toBeUndefined();
+      expect(wrapper.vm.handleOverlayFocusout).toBeUndefined();
+      expect(wrapper.vm.requestVisualViewportSettle).toBeUndefined();
       wrapper.unmount();
     });
 

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -364,7 +364,6 @@ import { useUiStore } from '../stores/ui.js';
 import { useSessionSubscription } from '../composables/useSessionSubscription.js';
 import { useSessionPolling } from '../composables/useSessionPolling.js';
 import { api } from '../composables/useApi.js';
-import { requestVisualViewportSettle } from '../composables/useVisualViewport.js';
 import { createOverlaySessionsStore } from '../stores/createOverlaySessionsStore.js';
 import { createOverlayTodosStore } from '../stores/createOverlayTodosStore.js';
 import { SESSIONS_STORE_KEY, TODOS_STORE_KEY } from '../composables/useOverlayStore.js';
@@ -423,10 +422,6 @@ const switchingSession = ref(true);
 
 // Overlay body ref for scroll container override
 const overlayBodyRef = ref(null);
-
-// Track whether a text input is focused so blur can coordinate viewport settling.
-const inputFocused = ref(false);
-let focusOutRaf = null;
 
 // Template ref to the ConversationTab for flushing drafts before session switch
 const conversationTabRef = ref(null);
@@ -791,57 +786,6 @@ function handleEscape(event) {
 }
 
 /**
- * Handle focusin on the overlay body — detect when the prompt textarea gains focus.
- * Uses event delegation from .overlay-body so we catch the bubbling event from
- * InputForm → ResizableTextarea's <textarea>. Browser-native scroll-on-focus
- * handles bringing the focused field into the `.overlay-body` scroll viewport.
- */
-function handleOverlayFocusin(e) {
-  // Symmetric with handleOverlayFocusout: both TEXTAREA and text-typed INPUT
-  // can open the iOS keyboard. Keeping scopes identical ensures inputFocused
-  // transitions are balanced (focus→blur pairs on text inputs toggle it
-  // consistently).
-  const tag = e.target.tagName;
-  const isText =
-    tag === 'TEXTAREA' ||
-    (tag === 'INPUT' && /^(text|search|url|email|number|tel|password)$/i
-      .test(e.target.type || 'text'));
-  if (!isText) return;
-
-  // Cancel any pending focusout that would have cleared inputFocused
-  if (focusOutRaf) {
-    cancelAnimationFrame(focusOutRaf);
-    focusOutRaf = null;
-  }
-  inputFocused.value = true;
-}
-
-/**
- * Handle focusout on the overlay body — detect when the prompt textarea /
- * text input loses focus. Uses requestAnimationFrame delay to avoid flashing
- * the header when focus moves from textarea to another element (e.g. Send
- * button).
- */
-function handleOverlayFocusout(e) {
-  // Expanded scope: both TEXTAREA and text INPUT elements can open the iOS
-  // keyboard. Exclude non-text inputs (checkbox, radio, button, etc.) since
-  // they don't trigger the keyboard.
-  const tag = e.target.tagName;
-  const isText =
-    tag === 'TEXTAREA' ||
-    (tag === 'INPUT' && /^(text|search|url|email|number|tel|password)$/i
-      .test(e.target.type || 'text'));
-  if (!isText) return;
-
-  if (focusOutRaf) cancelAnimationFrame(focusOutRaf);
-  requestVisualViewportSettle();
-  focusOutRaf = requestAnimationFrame(() => {
-    focusOutRaf = null;
-    inputFocused.value = false;
-  });
-}
-
-/**
  * Prevent touch-drag on the overlay header from scrolling the overlay,
  * while allowing touch-move inside interactive children that need it:
  * - SessionChatPicker dropdown (scrollable list)
@@ -911,15 +855,6 @@ onMounted(async () => {
   window.addEventListener('resize', checkMobile);
   checkMobile();
 
-  // Register focusin/focusout BEFORE the await so they're ready immediately.
-  // overlayBodyRef is a template ref on .overlay-body which is always rendered
-  // (it does not depend on switchingSession), so it is available at mount time.
-  const body = overlayBodyRef.value;
-  if (body) {
-    body.addEventListener('focusin', handleOverlayFocusin);
-    body.addEventListener('focusout', handleOverlayFocusout);
-  }
-
   // Load data for the active session, then reveal ConversationTab.
   // switchingSession starts as true, so ConversationTab won't mount until
   // currentSession is set to the correct overlay session.
@@ -936,12 +871,6 @@ onUnmounted(() => {
   document.removeEventListener('keydown', handleEscape);
   document.removeEventListener('click', handleClickOutsidePicker, true);
   window.removeEventListener('resize', checkMobile);
-  const body = overlayBodyRef.value;
-  if (body) {
-    body.removeEventListener('focusin', handleOverlayFocusin);
-    body.removeEventListener('focusout', handleOverlayFocusout);
-  }
-  if (focusOutRaf) cancelAnimationFrame(focusOutRaf);
   cleanupSubscription();
   // Clean up overlay stores: dispose subscriptions AND remove from Pinia registry
   // to prevent state leaks on every overlay open/close cycle.
@@ -960,9 +889,6 @@ defineExpose({
   switchingSession,
   pickerOpen,
   handlePickerSelect,
-  inputFocused,
-  // DOM refs needed by tests that append real elements (textarea/input)
-  // into the overlay body to exercise focusin/focusout flows:
   overlayBodyRef,
 });
 </script>
@@ -1035,10 +961,7 @@ defineExpose({
 <style scoped>
 .overlay-backdrop {
   position: fixed;
-  top: var(--viewport-offset-top, 0px);
-  right: 0;
-  left: 0;
-  height: var(--visual-viewport-height, 100dvh);
+  inset: 0;
   z-index: 1000;
   background: rgb(17, 24, 39);
   display: block;
@@ -1048,10 +971,9 @@ defineExpose({
 }
 
 .overlay-panel-wrapper {
-  position: fixed;
-  top: var(--viewport-offset-top, 0px);
-  right: 0;
-  height: var(--visual-viewport-height, 100dvh);
+  position: absolute;
+  inset: 0 0 0 auto;
+  height: 100%;
   display: flex;
   min-height: 0;
   max-width: 900px;
@@ -1128,6 +1050,7 @@ defineExpose({
   padding: 0;
   box-shadow: -4px 0 20px rgba(0, 0, 0, 0.5);
   position: relative;
+  background: rgb(17, 24, 39);
 }
 
 .overlay-body {
@@ -1141,6 +1064,7 @@ defineExpose({
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  background: rgb(17, 24, 39);
 }
 
 .overlay-header {

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -2,10 +2,11 @@
  * SessionChatOverlay layout regression coverage.
  *
  * This spec replaces `session-chat-overlay-blur.spec.ts`. The overlay no
- * longer synchronises to `window.visualViewport` in JavaScript — geometry
- * is owned by CSS (`position: fixed; inset: 0` + `align-items: stretch`).
- * These tests verify the CSS contract and that no inline geometry is
- * written by the component.
+ * longer uses JS-written visual viewport CSS variables for its shell.
+ * Geometry is owned by browser CSS (`position: fixed; inset: 0` on the
+ * backdrop, child geometry for the panel). These tests verify that stale
+ * root CSS variables do not affect the shell and that no inline geometry
+ * is written by the component.
  *
  * HONEST SCOPE of the mobile projects (iphone-14, ipad-pro):
  * Playwright's mobile devices run chromium with only viewport size + UA
@@ -96,7 +97,7 @@ test.describe('SessionChatOverlay layout', () => {
     expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
   });
 
-  test('backdrop uses position: fixed and viewport-offset top', async ({ page }) => {
+  test('backdrop uses position: fixed at the viewport origin', async ({ page }) => {
     await navigateToSession(page);
     await openOverlay(page);
 
@@ -117,36 +118,56 @@ test.describe('SessionChatOverlay layout', () => {
     expect(computed.left).toBe('0px');
   });
 
-  test('panel honors visual viewport top offset', async ({ page }) => {
+  test('stale visual viewport CSS variables do not move or shrink the shell', async ({ page }) => {
     await navigateToSession(page);
     await page.evaluate(() => {
-      document.documentElement.style.setProperty('--viewport-offset-top', '48px');
-    });
-    await openOverlay(page);
-
-    const result = await page.evaluate(() => {
-      const backdrop = document.querySelector(
-        '[data-testid="session-chat-overlay"]'
-      ) as HTMLElement;
-      const panel = document.querySelector('.overlay-panel-wrapper') as HTMLElement;
-      const header = document.querySelector('.overlay-header') as HTMLElement;
-      return {
-        backdropTop: backdrop.getBoundingClientRect().top,
-        panelTop: panel.getBoundingClientRect().top,
-        headerTop: header.getBoundingClientRect().top,
-      };
+      document.documentElement.style.setProperty('--viewport-offset-top', '260px');
+      document.documentElement.style.setProperty('--visual-viewport-height', '420px');
     });
 
-    expect(result.backdropTop).toBeGreaterThanOrEqual(47);
-    expect(result.backdropTop).toBeLessThanOrEqual(49);
-    expect(result.panelTop).toBeGreaterThanOrEqual(47);
-    expect(result.panelTop).toBeLessThanOrEqual(49);
-    expect(result.headerTop).toBeGreaterThanOrEqual(47);
-    expect(result.headerTop).toBeLessThanOrEqual(49);
+    try {
+      await openOverlay(page);
 
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty('--viewport-offset-top', '0px');
-    });
+      const result = await page.evaluate(() => {
+        const rectFor = (selector: string) => {
+          const el = document.querySelector(selector) as HTMLElement;
+          const r = el.getBoundingClientRect();
+          return {
+            top: r.top,
+            bottom: r.bottom,
+            left: r.left,
+            right: r.right,
+            width: r.width,
+          };
+        };
+
+        return {
+          backdrop: rectFor('[data-testid="session-chat-overlay"]'),
+          panel: rectFor('.overlay-panel-wrapper'),
+          header: rectFor('.overlay-header'),
+          inner: { w: window.innerWidth, h: window.innerHeight },
+        };
+      });
+
+      expect(result.backdrop.top).toBeLessThanOrEqual(1);
+      expect(result.backdrop.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.backdrop.left).toBeLessThanOrEqual(1);
+      expect(result.backdrop.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+
+      expect(result.panel.top).toBeLessThanOrEqual(1);
+      expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.panel.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+      expect(result.panel.right).toBeLessThanOrEqual(result.inner.w + 1);
+      expect(result.panel.width).toBeLessThanOrEqual(Math.min(result.inner.w, 900) + 1);
+
+      expect(result.header.top).toBeLessThanOrEqual(1);
+      expect(result.header.top).toBeLessThan(260);
+    } finally {
+      await page.evaluate(() => {
+        document.documentElement.style.removeProperty('--viewport-offset-top');
+        document.documentElement.style.removeProperty('--visual-viewport-height');
+      });
+    }
   });
 
   test('covers viewport after SessionDetailView scroll', async ({ page }) => {

--- a/tests/e2e/session-chat-overlay-scroll.spec.ts
+++ b/tests/e2e/session-chat-overlay-scroll.spec.ts
@@ -326,7 +326,9 @@ test.describe('Session Chat Overlay Scroll Behavior', () => {
       expect(overlapsHoriz && overlapsVert).toBe(false);
     }
 
-    // Functional click.
+    // Functional click from a known non-target scroll position.
+    await overlay.locator('.overlay-body').evaluate((el) => { (el as HTMLElement).scrollTop = 0; });
+    await expect(scrollBtn).toBeVisible();
     const beforeScroll = await overlay.locator('.overlay-body').evaluate((el) => (el as HTMLElement).scrollTop);
     await scrollBtn.click();
     await expect.poll(


### PR DESCRIPTION
## Summary
- Fixes iPhone Safari bug where the session chat overlay was visually shifted down after keyboard blur
- Makes overlay shell invariant to stale visual viewport CSS variables
- Removes dead visual viewport settling logic from overlay component

## Problem
On real iPhone Safari devices, the session chat overlay exhibited a critical visual regression:

1. After focusing the prompt textarea (which shows the iOS keyboard) and then blurring it (dismissing the keyboard), the overlay shell was visually shifted down
2. The bottom of the overlay exposed the underlying session page behind it
3. The overlay used JS-written root CSS variables (`--viewport-offset-top`, `--visual-viewport-height`) that could become stale during iOS keyboard dismissal
4. When these variables preserved keyboard-sized values after blur, the entire modal shell moved and shrunk, no longer covering the full visible web area

## Root Cause
The overlay shell (`.overlay-backdrop` and `.overlay-panel-wrapper`) was coupled to mutable root CSS variables that are managed by a global `useVisualViewport()` composable. During iOS keyboard dismissal, Safari can temporarily report or preserve keyboard-sized viewport dimensions, causing the overlay to adopt incorrect geometry.

## Solution
Make the full-screen overlay root independent from visual viewport variables:

### CSS Changes
- `.overlay-backdrop`: Now uses browser-owned `position: fixed; inset: 0` instead of `top: var(--viewport-offset-top)` and `height: var(--visual-viewport-height)`
- `.overlay-panel-wrapper`: Changed from independently fixed layer to child geometry `position: absolute; inset: 0 0 0 auto; height: 100%` inside the backdrop
- Added solid backgrounds to `.overlay-content`, `.overlay-header`, and `.overlay-body` to prevent page transparency if descendant layout issues occur

### Component Changes
- Removed `requestVisualViewportSettle()` import and calls from blur handling
- Removed `inputFocused` state tracking (no longer used)
- Removed `handleOverlayFocusin` and `handleOverlayFocusout` event handlers
- Overlay no longer imports `useVisualViewport.js` or references `window.visualViewport`

### Test Updates
- **Unit tests**: Updated to assert new CSS contract, source-level checks for removed viewport API references, and solid backgrounds on content/header/body
- **E2E tests**: Replaced "panel honors visual viewport top offset" with regression test that sets stale CSS variables and verifies shell remains correctly positioned

## Test Plan
- [x] Unit tests pass: `yarn workspace @circuschief/web test src/components/SessionChatOverlay.test.js`
- [x] E2E tests pass: `./scripts/pw.sh test tests/e2e/session-chat-overlay-layout.spec.ts --project=chromium`
- [ ] Manual iPhone Safari QA required (automated tests cannot prove this bug is fixed):
  - Open session detail page, scroll, then open chat overlay
  - Tap prompt textarea to show keyboard
  - Dismiss keyboard by tapping overlay body, "Done", or Send
  - Verify no session page content shows through after blur
  - Verify overlay top remains pinned to viewport top
  - Verify overlay bottom does not expose gaps
  - Test with Safari toolbar visible, collapsed chrome, and after scrolling overlay body

## Note on Manual QA
Real iPhone Safari testing is required for signoff because Playwright's mobile projects run Chromium with only viewport size + UA string emulation. They cannot reproduce iOS Safari's actual keyboard or browser chrome behavior.

The automated tests verify that:
1. The overlay shell CSS doesn't reference visual viewport variables
2. Stale root CSS variables don't affect the shell geometry
3. No inline geometry is written by the component

But only a real device can confirm the visual regression is fixed.

## Files Changed
- `packages/web/src/components/SessionChatOverlay.vue` - New CSS contract, removed viewport coupling
- `packages/web/src/components/SessionChatOverlay.test.js` - Updated tests for new contract
- `tests/e2e/session-chat-overlay-layout.spec.ts` - Regression test for stale CSS variables
- `.gitignore` - Added `.attachments/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)