### PR TITLE
Add date stamp to conversation messages from prior days

### DIFF
--- a/packages/web/src/components/MessageItem.test.js
+++ b/packages/web/src/components/MessageItem.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { reactive, h } from 'vue';
@@ -52,6 +52,10 @@ describe('MessageItem', () => {
     setActivePinia(createPinia());
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('rendering', () => {
     it('should render with correct data-testid for user messages', () => {
       const wrapper = mountComponent();
@@ -94,6 +98,43 @@ describe('MessageItem', () => {
     it('should render message timestamp', () => {
       const wrapper = mountComponent();
       expect(wrapper.find('.message-time').text()).toBeTruthy();
+    });
+
+    it('should not render message date for messages from today', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 4, 1, 12, 0));
+
+      const wrapper = mountComponent({
+        message: createMessage({ timestamp: new Date(2026, 4, 1, 9, 30) }),
+      });
+
+      expect(wrapper.find('.message-time').text()).toBeTruthy();
+      expect(wrapper.find('.message-date').exists()).toBe(false);
+    });
+
+    it('should render message date above time for prior-day messages', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 4, 1, 12, 0));
+
+      const wrapper = mountComponent({
+        message: createMessage({ timestamp: new Date(2026, 3, 30, 23, 59) }),
+      });
+
+      expect(wrapper.find('.message-date').exists()).toBe(true);
+      expect(wrapper.find('.message-date').text()).toContain('2026');
+      expect(wrapper.find('.message-time').text()).toBeTruthy();
+    });
+
+    it('should not render message date for missing timestamps', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 4, 1, 12, 0));
+
+      const wrapper = mountComponent({
+        message: createMessage({ timestamp: null }),
+      });
+
+      expect(wrapper.find('.message-date').exists()).toBe(false);
+      expect(wrapper.find('.message-time').text()).toBe('');
     });
   });
 

--- a/packages/web/src/components/MessageItem.vue
+++ b/packages/web/src/components/MessageItem.vue
@@ -13,7 +13,15 @@
       >
         {{ formatModelName(message.model) }}
       </span>
-      <span class="message-time">{{ formatTime(message.timestamp) }}</span>
+      <span class="message-timestamp">
+        <span
+          v-if="isBeforeToday(message.timestamp)"
+          class="message-date"
+        >
+          {{ formatMessageDate(message.timestamp) }}
+        </span>
+        <span class="message-time">{{ formatTime(message.timestamp) }}</span>
+      </span>
     </div>
     <div class="message-content">
       <MarkdownViewer
@@ -69,7 +77,14 @@ const props = defineProps({
   workLogs: { type: Array, default: () => [] },
 });
 
-const { formatTime, formatModelName, formatFileSize, getAttachmentIcon } = useMessageFormatting();
+const {
+  formatTime,
+  formatMessageDate,
+  isBeforeToday,
+  formatModelName,
+  formatFileSize,
+  getAttachmentIcon,
+} = useMessageFormatting();
 </script>
 
 <style scoped>
@@ -108,8 +123,16 @@ const { formatTime, formatModelName, formatFileSize, getAttachmentIcon } = useMe
   text-transform: capitalize;
 }
 
-.message-time {
+.message-timestamp {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   margin-left: auto;
+  line-height: 1.2;
+}
+
+.message-date,
+.message-time {
   font-size: 0.75rem;
   color: var(--color-text-soft);
 }

--- a/packages/web/src/composables/useMessageFormatting.js
+++ b/packages/web/src/composables/useMessageFormatting.js
@@ -13,6 +13,49 @@ export function useMessageFormatting() {
     return new Date(timestamp).toLocaleTimeString();
   }
 
+  function parseValidDate(timestamp) {
+    if (!timestamp) return null;
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  /**
+   * Format a timestamp date for display in message headers.
+   * @param {string|number|Date} timestamp - The timestamp to format
+   * @returns {string} Formatted date string
+   */
+  function formatMessageDate(timestamp) {
+    const date = parseValidDate(timestamp);
+    if (!date) return '';
+
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  /**
+   * Check whether a timestamp is before today's local calendar date.
+   * @param {string|number|Date} timestamp - The timestamp to compare
+   * @param {Date} now - The date to compare against
+   * @returns {boolean} True when timestamp is before today's local date
+   */
+  function isBeforeToday(timestamp, now = new Date()) {
+    const date = parseValidDate(timestamp);
+    const comparisonDate = parseValidDate(now);
+    if (!date || !comparisonDate) return false;
+
+    const messageDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const today = new Date(
+      comparisonDate.getFullYear(),
+      comparisonDate.getMonth(),
+      comparisonDate.getDate()
+    );
+
+    return messageDay < today;
+  }
+
   /**
    * Format model name for display.
    * Converts "claude-3-5-sonnet-20241022" to "claude-3.5-sonnet"
@@ -54,6 +97,8 @@ export function useMessageFormatting() {
 
   return {
     formatTime,
+    formatMessageDate,
+    isBeforeToday,
     formatModelName,
     formatFileSize,
     getAttachmentIcon,

--- a/packages/web/src/composables/useMessageFormatting.test.js
+++ b/packages/web/src/composables/useMessageFormatting.test.js
@@ -2,7 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { useMessageFormatting } from './useMessageFormatting.js';
 
 describe('useMessageFormatting', () => {
-  const { formatTime, formatModelName, formatFileSize, getAttachmentIcon } = useMessageFormatting();
+  const {
+    formatTime,
+    formatMessageDate,
+    isBeforeToday,
+    formatModelName,
+    formatFileSize,
+    getAttachmentIcon,
+  } = useMessageFormatting();
 
   describe('formatTime', () => {
     it('should format an ISO timestamp to locale time string', () => {
@@ -36,6 +43,71 @@ describe('useMessageFormatting', () => {
 
     it('should return empty string for empty string input', () => {
       expect(formatTime('')).toBe('');
+    });
+  });
+
+  describe('formatMessageDate', () => {
+    it('should format a timestamp as a compact local date', () => {
+      const result = formatMessageDate(new Date(2026, 3, 30, 14, 30));
+
+      expect(result).toContain('2026');
+      expect(result).toMatch(/Apr|4/);
+      expect(result).toContain('30');
+    });
+
+    it('should return empty string for null input', () => {
+      expect(formatMessageDate(null)).toBe('');
+    });
+
+    it('should return empty string for undefined input', () => {
+      expect(formatMessageDate(undefined)).toBe('');
+    });
+
+    it('should return empty string for empty string input', () => {
+      expect(formatMessageDate('')).toBe('');
+    });
+
+    it('should return empty string for invalid dates', () => {
+      expect(formatMessageDate('not-a-date')).toBe('');
+    });
+  });
+
+  describe('isBeforeToday', () => {
+    it('should return false for a timestamp on the same local calendar day', () => {
+      const now = new Date(2026, 4, 1, 22, 0);
+      const timestamp = new Date(2026, 4, 1, 8, 0);
+
+      expect(isBeforeToday(timestamp, now)).toBe(false);
+    });
+
+    it('should return true for a timestamp from the prior local calendar day', () => {
+      const now = new Date(2026, 4, 1, 12, 0);
+      const timestamp = new Date(2026, 3, 30, 12, 0);
+
+      expect(isBeforeToday(timestamp, now)).toBe(true);
+    });
+
+    it('should compare local calendar days instead of elapsed hours', () => {
+      const now = new Date(2026, 4, 1, 0, 1);
+      const timestamp = new Date(2026, 3, 30, 23, 59);
+
+      expect(isBeforeToday(timestamp, now)).toBe(true);
+    });
+
+    it('should return false for null input', () => {
+      expect(isBeforeToday(null, new Date(2026, 4, 1))).toBe(false);
+    });
+
+    it('should return false for undefined input', () => {
+      expect(isBeforeToday(undefined, new Date(2026, 4, 1))).toBe(false);
+    });
+
+    it('should return false for empty string input', () => {
+      expect(isBeforeToday('', new Date(2026, 4, 1))).toBe(false);
+    });
+
+    it('should return false for invalid dates', () => {
+      expect(isBeforeToday('not-a-date', new Date(2026, 4, 1))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds date display above timestamp for conversation messages from prior local calendar days
- Messages from today retain existing time-only display for cleaner UI
- Date comparison uses local calendar day boundaries (not 24-hour elapsed time)

## Implementation Details

**Component Changes (`MessageItem.vue`):**
- Replaced single `.message-time` span with `.message-timestamp` wrapper
- Conditionally renders `.message-date` for messages before today
- Preserves existing `.message-time` for all messages
- Updated styles to right-align timestamp wrapper with proper spacing

**Composable Changes (`useMessageFormatting.js`):**
- Added `formatMessageDate(timestamp)`: Returns compact local date string (e.g., "Apr 30, 2026")
- Added `isBeforeToday(timestamp, now)`: Compares local calendar days using midnight boundaries
- Both helpers return empty string for falsy/invalid inputs
- Existing `formatTime()` unchanged for backward compatibility

**Test Coverage:**
- Unit tests for `isBeforeToday()` with boundary cases (midnight transitions, invalid inputs)
- Unit tests for `formatMessageDate()` with various timestamps
- Component tests using Vitest fake timers for deterministic date assertions
- Tests verify today messages show no date, prior-day messages show date above time

## Test Plan
✅ All existing tests pass
✅ New unit tests in `useMessageFormatting.test.js` cover date formatting and comparison logic
✅ New component tests in `MessageItem.test.js` verify conditional date rendering
✅ Tests are deterministic using mocked system clock

## Files Changed
- `packages/web/src/components/MessageItem.vue` - Updated timestamp markup and styles
- `packages/web/src/components/MessageItem.test.js` - Added date rendering tests
- `packages/web/src/composables/useMessageFormatting.js` - Added date formatting helpers
- `packages/web/src/composables/useMessageFormatting.test.js` - Added date logic unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)