### PR TITLE
Fix blank model dropdown for hidden provider defaults

### DIFF
--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -763,6 +763,41 @@ describe('ModelSelector', () => {
       expect(wrapper.find('option').element.value).toBe(optionValue('custom-openai', 'gpt-5.5'));
     });
 
+    it('falls back to a visible duplicate option when the requested provider is hidden', async () => {
+      const localProvidersStore = useProvidersStore();
+      localProvidersStore.providers = [
+        {
+          id: 'openai-default',
+          name: 'OpenAI (Official)',
+          isBuiltIn: true,
+          kind: 'openai',
+          models: [
+            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+          ],
+        },
+        {
+          id: 'custom-openai',
+          name: 'Custom OpenAI',
+          isBuiltIn: false,
+          kind: 'openai',
+          models: [
+            { id: 'custom-gpt-5-5', modelId: 'gpt-5.5', displayName: 'Custom GPT-5.5', tier: 'custom' },
+          ],
+        },
+      ];
+
+      const wrapper = mountComponent({
+        modelValue: 'gpt-5.5',
+        providerId: 'openai-default',
+      });
+      await flushAll(wrapper);
+
+      const select = wrapper.find('select');
+      expect(select.element.value).toBe(optionValue('custom-openai', 'gpt-5.5'));
+      expect(wrapper.attributes('data-model')).toBe('gpt-5.5');
+      expect(wrapper.attributes('data-provider-id')).toBe('custom-openai');
+    });
+
     it('shows duplicate built-in and custom options when requested', async () => {
       const localProvidersStore = useProvidersStore();
       localProvidersStore.providers = [

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -370,7 +370,9 @@ function findVisibleOption(modelId, providerId = null) {
     const model = provider.models?.find((entry) => entry.modelId === modelId);
     if (model) return { provider, model };
   }
-  if (providerId) return null;
+  // If the requested provider is not visible, still select a visible option for
+  // the requested model. This can happen when built-in duplicate models are
+  // hidden in favor of a custom provider.
   for (const provider of visibleProviders.value) {
     const model = provider.models?.find((entry) => entry.modelId === modelId);
     if (model) return { provider, model };


### PR DESCRIPTION
## Summary
- fall back to a visible duplicate model option when the requested provider is hidden
- keep the selected model/provider emitted from `ModelSelector` consistent with the visible option
- add regression coverage for project defaults pointing at a hidden duplicate provider

## Test
- `yarn vitest src/components/ModelSelector.test.js --run`