### PR TITLE
Prevent relinking cleared PR URLs

### DIFF
--- a/packages/server/src/api/sessions-patch.js
+++ b/packages/server/src/api/sessions-patch.js
@@ -158,6 +158,10 @@ function buildUpdateData(body) {
     updateData.manuallyNamed = true;
   }
 
+  if (body.prUrl !== undefined) {
+    updateData.prUrlAutoLinkDisabled = updateData.prUrl === null;
+  }
+
   return { updateData };
 }
 

--- a/packages/server/src/api/sessions.prUrl.test.js
+++ b/packages/server/src/api/sessions.prUrl.test.js
@@ -43,10 +43,12 @@ describe('Sessions API - PR URL Endpoint', () => {
         .expect(200);
 
       expect(response.body.prUrl).toBe(prUrl);
+      expect(response.body.prUrlAutoLinkDisabled).toBe(false);
 
       // Verify it was persisted
       const updated = sessions.getById(session.id);
       expect(updated.prUrl).toBe(prUrl);
+      expect(updated.prUrlAutoLinkDisabled).toBe(false);
     });
 
     it('updates prUrl with different valid PR URL', async () => {
@@ -80,10 +82,12 @@ describe('Sessions API - PR URL Endpoint', () => {
         .expect(200);
 
       expect(response.body.prUrl).toBeNull();
+      expect(response.body.prUrlAutoLinkDisabled).toBe(true);
 
       // Verify it was persisted
       const updated = sessions.getById(session.id);
       expect(updated.prUrl).toBeNull();
+      expect(updated.prUrlAutoLinkDisabled).toBe(true);
     });
 
     it('clears prUrl when set to empty string', async () => {
@@ -100,10 +104,55 @@ describe('Sessions API - PR URL Endpoint', () => {
         .expect(200);
 
       expect(response.body.prUrl).toBeNull();
+      expect(response.body.prUrlAutoLinkDisabled).toBe(true);
 
       // Verify it was persisted
       const updated = sessions.getById(session.id);
       expect(updated.prUrl).toBeNull();
+      expect(updated.prUrlAutoLinkDisabled).toBe(true);
+    });
+
+    it('defaults prUrlAutoLinkDisabled to false for new sessions', () => {
+      const created = sessions.getById(session.id);
+      expect(created.prUrlAutoLinkDisabled).toBe(false);
+    });
+
+    it('re-enables auto linking when manually setting a valid PR URL after clearing', async () => {
+      await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ prUrl: null })
+        .expect(200);
+
+      const prUrl = 'https://github.com/owner/repo/pull/456';
+      const response = await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ prUrl })
+        .expect(200);
+
+      expect(response.body.prUrl).toBe(prUrl);
+      expect(response.body.prUrlAutoLinkDisabled).toBe(false);
+
+      const updated = sessions.getById(session.id);
+      expect(updated.prUrl).toBe(prUrl);
+      expect(updated.prUrlAutoLinkDisabled).toBe(false);
+    });
+
+    it('does not modify prUrlAutoLinkDisabled when prUrl is not included in request', async () => {
+      await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ prUrl: null })
+        .expect(200);
+
+      const response = await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ thinkingEnabled: true })
+        .expect(200);
+
+      expect(response.body.prUrl).toBeNull();
+      expect(response.body.prUrlAutoLinkDisabled).toBe(true);
+
+      const updated = sessions.getById(session.id);
+      expect(updated.prUrlAutoLinkDisabled).toBe(true);
     });
 
     it('rejects invalid PR URL format', async () => {

--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -53,6 +53,7 @@ export class SessionRepository extends BaseRepository {
       gitBranch: row.git_branch,
       gitWorktree: row.git_worktree,
       prUrl: row.pr_url,
+      prUrlAutoLinkDisabled: Boolean(row.pr_url_auto_link_disabled),
       error: row.error,
       costUsd: row.cost_usd,
       claudeSessionId: row.claude_session_id,

--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -134,6 +134,7 @@ export const allMigrations = validateMigrations([
   s.get('sessions-add-archived'),
   s.get('sessions-add-starred'),
   s.get('sessions-add-manually_named'),
+  s.get('sessions-add-pr_url_auto_link_disabled'),
 
   // --- Project session defaults table ---
   p.get('project_session_defaults-create-table'),

--- a/packages/server/src/db/migrations/sessionsMigrations.js
+++ b/packages/server/src/db/migrations/sessionsMigrations.js
@@ -23,6 +23,7 @@ const SESSIONS_BASE_COLUMNS = `
     git_branch TEXT,
     git_worktree TEXT,
     pr_url TEXT,
+    pr_url_auto_link_disabled INTEGER NOT NULL DEFAULT 0,
     error TEXT,
     effort_level TEXT CHECK(effort_level IN ('low', 'medium', 'high', 'max', 'auto')),
     cost_usd REAL DEFAULT 0,
@@ -58,7 +59,7 @@ const SESSIONS_BASE_COLUMNS = `
  */
 const SESSIONS_ALL_COLUMNS = [
   'id', 'project_id', 'name', 'status', 'mode', 'thinking_enabled',
-  'git_branch', 'git_worktree', 'pr_url', 'error', 'effort_level',
+  'git_branch', 'git_worktree', 'pr_url', 'pr_url_auto_link_disabled', 'error', 'effort_level',
   'cost_usd', 'claude_session_id', 'model', 'next_template_id',
   'parent_session_id', 'input_tokens', 'output_tokens', 'thinking_tokens',
   'cache_read_input_tokens', 'cache_creation_input_tokens',
@@ -251,6 +252,10 @@ export const sessionsMigrations = [
   {
     name: 'sessions-add-manually_named',
     up(db) { addColumnIfMissing(db, TABLE_SESSIONS, 'manually_named', 'INTEGER NOT NULL DEFAULT 0'); },
+  },
+  {
+    name: 'sessions-add-pr_url_auto_link_disabled',
+    up(db) { addColumnIfMissing(db, TABLE_SESSIONS, 'pr_url_auto_link_disabled', 'INTEGER NOT NULL DEFAULT 0'); },
   },
 
   // --- Pending prompt / slash commands / pending model / auto send ---

--- a/packages/server/src/db/session-helpers.js
+++ b/packages/server/src/db/session-helpers.js
@@ -125,6 +125,7 @@ export const BOOLEAN_FIELD_MAP = {
   archived: 'archived',
   starred: 'starred',
   manuallyNamed: 'manually_named',
+  prUrlAutoLinkDisabled: 'pr_url_auto_link_disabled',
   autoRescheduleEnabled: 'auto_reschedule_enabled',
   rescheduleOnTokenLimit: 'reschedule_on_token_limit',
   rescheduleOnServiceError: 'reschedule_on_service_error',

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   git_branch TEXT,
   git_worktree TEXT,
   pr_url TEXT,
+  pr_url_auto_link_disabled INTEGER NOT NULL DEFAULT 0,
   error TEXT,
   effort_level TEXT CHECK(effort_level IN ('low', 'medium', 'high', 'max', 'auto')),
   cost_usd REAL DEFAULT 0,

--- a/packages/server/src/services/prUrlService.js
+++ b/packages/server/src/services/prUrlService.js
@@ -126,8 +126,8 @@ export async function extractPrUrlIfNeeded(sessionId) {
   const session = sessions.getById(sessionId);
   if (!session) return;
 
-  // Skip if session already has a PR URL
-  if (session.prUrl) return;
+  // Skip if session already has a PR URL or the user cleared automatic PR linking.
+  if (session.prUrl || session.prUrlAutoLinkDisabled) return;
 
   // Extract PR URL from messages
   const prUrl = extractPrUrlFromMessages(sessionId);
@@ -145,7 +145,7 @@ export async function extractPrUrlIfNeeded(sessionId) {
     if (session.parentSessionId) {
       const rootId = sessions.getRootSessionId(sessionId);
       const root = rootId && rootId !== sessionId ? sessions.getById(rootId) : null;
-      if (root && !root.prUrl) {
+      if (root && !root.prUrl && !root.prUrlAutoLinkDisabled) {
         sessions.update(root.id, { prUrl });
         console.log(`[PrUrlService] Propagated PR URL from session ${sessionId} to root ${root.id}: ${prUrl}`);
 

--- a/packages/server/src/services/prUrlService.test.js
+++ b/packages/server/src/services/prUrlService.test.js
@@ -212,6 +212,18 @@ describe('prUrlService', () => {
       expect(session.prUrl).toBe('https://github.com/user/repo/pull/1');
     });
 
+    it('does not extract when automatic PR linking is disabled', async () => {
+      sessions.update(sessionId, { prUrlAutoLinkDisabled: true });
+      messages.create(sessionId, 'assistant', 'PR: https://github.com/user/repo/pull/42');
+
+      await extractPrUrlIfNeeded(sessionId);
+
+      const session = sessions.getById(sessionId);
+      expect(session.prUrl).toBeNull();
+      expect(broadcastSessionUpdate).not.toHaveBeenCalled();
+      expect(ghService.getPrInfo).not.toHaveBeenCalled();
+    });
+
     it('does nothing for non-existent session', async () => {
       await extractPrUrlIfNeeded('non-existent');
       expect(broadcastSessionUpdate).not.toHaveBeenCalled();
@@ -254,6 +266,23 @@ describe('prUrlService', () => {
       // Verify root keeps the original PR URL (first wins)
       const rootAfter = sessions.getById(root.id);
       expect(rootAfter.prUrl).toBe(originalPrUrl);
+    });
+
+    it('does not propagate extracted PR URL to root when root automatic linking is disabled', async () => {
+      const root = sessions.create(projectId, 'Root Session', 'Root prompt');
+      sessions.update(root.id, { prUrlAutoLinkDisabled: true });
+
+      const child = sessions.create(projectId, 'Child Session', 'Child prompt', 'standard', false, null, root.id);
+      messages.create(child.id, 'assistant', 'Created PR: https://github.com/user/repo/pull/777');
+
+      await extractPrUrlIfNeeded(child.id);
+
+      const childAfter = sessions.getById(child.id);
+      expect(childAfter.prUrl).toBe('https://github.com/user/repo/pull/777');
+
+      const rootAfter = sessions.getById(root.id);
+      expect(rootAfter.prUrl).toBeNull();
+      expect(rootAfter.prUrlAutoLinkDisabled).toBe(true);
     });
   });
 

--- a/packages/server/src/services/summaryService.js
+++ b/packages/server/src/services/summaryService.js
@@ -200,18 +200,19 @@ function updateSessionFromSummary(sessionId, session, summaryData) {
   if (summaryData.sessionTitle || summaryData.prUrl) {
     const updateData = {};
     const freshSession = sessions.getById(sessionId);
+    const shouldApplySummaryPrUrl = summaryData.prUrl && !freshSession.prUrlAutoLinkDisabled;
 
     if (summaryData.sessionTitle && !freshSession.manuallyNamed) {
       updateData.name = summaryData.sessionTitle;
     }
 
-    if (summaryData.prUrl) {
+    if (shouldApplySummaryPrUrl) {
       updateData.prUrl = summaryData.prUrl;
     }
 
     const updatedSession = sessions.update(sessionId, updateData);
 
-    if (summaryData.prUrl) {
+    if (shouldApplySummaryPrUrl) {
       propagatePrUrlToParent(sessionId, summaryData.prUrl);
     }
 
@@ -521,7 +522,7 @@ export function propagatePrUrlToParent(sessionId, prUrl) {
   if (!rootId || rootId === sessionId) return;
 
   const root = sessions.getById(rootId);
-  if (!root || root.prUrl) return; // Don't overwrite existing PR URL
+  if (!root || root.prUrl || root.prUrlAutoLinkDisabled) return; // Don't overwrite existing or user-cleared PR URL
 
   sessions.update(root.id, { prUrl });
 
@@ -536,6 +537,7 @@ export {
   MAX_MESSAGES, MIN_MESSAGES_FOR_SUMMARY, MAX_RETRIES, DEFAULT_SESSION_TITLE_PROMPT,
   SUMMARY_SYSTEM_PROMPT, formatMessages, buildIncrementalPrompt, parseSummaryResponse,
   stripMarkdownCodeBlock as _stripMarkdownCodeBlock, trackMessageMetadata as _trackMessageMetadata,
+  updateSessionFromSummary as _updateSessionFromSummary,
 };
 export { callSummaryModel };
 export { callClaude } from './summaryClaudeClient.js';

--- a/packages/server/src/services/summaryService.test.js
+++ b/packages/server/src/services/summaryService.test.js
@@ -112,6 +112,7 @@ import {
   _stripMarkdownCodeBlock,
   _trackMessageMetadata,
   _enrichPrData,
+  _updateSessionFromSummary,
 } from './summaryService.js';
 
 describe('summaryService', () => {
@@ -2695,6 +2696,56 @@ describe('summaryService', () => {
     });
   });
 
+  describe('updateSessionFromSummary PR URL handling', () => {
+    it('does not apply summary PR URL when automatic linking is disabled', () => {
+      sessions.update(sessionId, { prUrlAutoLinkDisabled: true });
+      const session = sessions.getById(sessionId);
+      const prUrl = 'https://github.com/user/repo/pull/123';
+
+      _updateSessionFromSummary(sessionId, session, {
+        sessionTitle: null,
+        prUrl,
+      });
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.prUrl).toBeNull();
+      expect(updated.prUrlAutoLinkDisabled).toBe(true);
+    });
+
+    it('applies summary PR URL when automatic linking is enabled', () => {
+      const session = sessions.getById(sessionId);
+      const prUrl = 'https://github.com/user/repo/pull/456';
+
+      _updateSessionFromSummary(sessionId, session, {
+        sessionTitle: null,
+        prUrl,
+      });
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.prUrl).toBe(prUrl);
+      expect(updated.prUrlAutoLinkDisabled).toBe(false);
+    });
+
+    it('does not propagate child summary PR URL to a disabled root', () => {
+      const root = sessions.create(projectId, 'Root', 'Root prompt');
+      sessions.update(root.id, { prUrlAutoLinkDisabled: true });
+      const child = sessions.create(projectId, 'Child', 'Child prompt', 'standard', false, null, root.id);
+      const prUrl = 'https://github.com/user/repo/pull/789';
+
+      _updateSessionFromSummary(child.id, child, {
+        sessionTitle: null,
+        prUrl,
+      });
+
+      const childAfter = sessions.getById(child.id);
+      expect(childAfter.prUrl).toBe(prUrl);
+
+      const rootAfter = sessions.getById(root.id);
+      expect(rootAfter.prUrl).toBeNull();
+      expect(rootAfter.prUrlAutoLinkDisabled).toBe(true);
+    });
+  });
+
   describe('concurrency guard', () => {
     afterEach(() => {
       // Clean up concurrency state
@@ -2964,6 +3015,19 @@ describe('summaryService', () => {
 
       const rootAfter = sessions.getById(root.id);
       expect(rootAfter.prUrl).toBe(originalPrUrl);
+    });
+
+    it('does not set root PR URL when automatic linking is disabled', () => {
+      const root = sessions.create(projectId, 'Root', 'Root prompt');
+      sessions.update(root.id, { prUrlAutoLinkDisabled: true });
+      const child = sessions.create(projectId, 'Child', 'Child prompt', 'standard', false, null, root.id);
+      const prUrl = 'https://github.com/owner/repo/pull/222';
+
+      summaryService.propagatePrUrlToParent(child.id, prUrl);
+
+      const rootAfter = sessions.getById(root.id);
+      expect(rootAfter.prUrl).toBeNull();
+      expect(rootAfter.prUrlAutoLinkDisabled).toBe(true);
     });
 
     it('does nothing when session has no parent', () => {

--- a/packages/shared/src/contracts/sessions.js
+++ b/packages/shared/src/contracts/sessions.js
@@ -64,6 +64,7 @@ export const SessionResponse = z.object({
   gitBranch: z.string().nullable(),
   gitWorktree: z.string().nullable(),
   prUrl: z.string().nullable(),
+  prUrlAutoLinkDisabled: z.boolean(),
   manuallyNamed: z.boolean(),
   error: z.string().nullable(),
   nextTemplateId: z.string().uuid().nullable(),

--- a/packages/shared/src/contracts/sessions.test.js
+++ b/packages/shared/src/contracts/sessions.test.js
@@ -305,6 +305,7 @@ describe('SessionResponse', () => {
     gitBranch: null,
     gitWorktree: null,
     prUrl: null,
+    prUrlAutoLinkDisabled: false,
     manuallyNamed: false,
     error: null,
     nextTemplateId: null,
@@ -373,6 +374,21 @@ describe('SessionResponse', () => {
       manuallyNamed: false,
     });
     expect(result.success).toBe(true);
+  });
+
+  it('validates session with prUrlAutoLinkDisabled: true', () => {
+    const result = SessionResponse.safeParse({
+      ...validSession,
+      prUrlAutoLinkDisabled: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('requires prUrlAutoLinkDisabled', () => {
+    const { prUrlAutoLinkDisabled, ...sessionWithoutFlag } = validSession;
+    void prUrlAutoLinkDisabled;
+    const result = SessionResponse.safeParse(sessionWithoutFlag);
+    expect(result.success).toBe(false);
   });
 
   it('validates session with effortLevel set', () => {
@@ -466,6 +482,7 @@ describe('SessionListResponse', () => {
         gitBranch: null,
         gitWorktree: null,
         prUrl: null,
+        prUrlAutoLinkDisabled: false,
         manuallyNamed: false,
         error: null,
         nextTemplateId: null,

--- a/packages/shared/src/types.js
+++ b/packages/shared/src/types.js
@@ -47,6 +47,7 @@
  * @property {string|null} gitBranch
  * @property {string|null} gitWorktree
  * @property {string|null} prUrl
+ * @property {boolean} prUrlAutoLinkDisabled
  * @property {string|null} error
  * @property {number} createdAt
  * @property {number} updatedAt

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1302,7 +1302,7 @@ export async function cleanupProviders() {
  * session_summaries and must be seeded via seedSessionSummaryWithPR().
  */
 export async function updateSessionWithPR(sessionId: string, prData: {
-  prUrl?: string;
+  prUrl?: string | null;
   prState?: 'open' | 'merged' | 'closed' | 'draft';
   hasMergeConflicts?: boolean;
   ciStatus?: 'success' | 'failure' | 'pending';

--- a/tests/e2e/pr-propagation.spec.ts
+++ b/tests/e2e/pr-propagation.spec.ts
@@ -613,6 +613,55 @@ test.describe('PR URL Propagation', () => {
       const parentAfter = await getSession(parent.id);
       expect(parentAfter.prUrl).toBe(prUrl);
     });
+
+    test('clearing parent PR URL in the UI blocks later child propagation', async ({ page }) => {
+      const parent = await seedSession(project.id, {
+        prompt: 'Parent session',
+        name: 'Parent Session',
+        startImmediately: false,
+      });
+      await waitForSessionToExist(parent.id);
+
+      const child = await seedChildSession(project.id, parent.id, {
+        prompt: 'Child session',
+        name: 'Child Session',
+      });
+      await waitForSessionToExist(child.id);
+
+      const originalPrUrl = 'https://github.com/owner/repo/pull/123';
+      await updateSessionWithPR(parent.id, { prUrl: originalPrUrl });
+
+      await navigateAndWait(page, `/sessions/${parent.id}/summary`, {
+        waitFor: 'body',
+        timeout: 15000,
+      });
+
+      await expect(page.locator(`a[href="${originalPrUrl}"]`)).toBeVisible();
+      await page.locator('button[title="Edit PR URL"]').click();
+      await page.locator('button[title="Clear PR URL"]').click();
+
+      await expect.poll(async () => {
+        const updated = await getSession(parent.id);
+        return {
+          prUrl: updated.prUrl,
+          prUrlAutoLinkDisabled: updated.prUrlAutoLinkDisabled,
+        };
+      }).toEqual({
+        prUrl: null,
+        prUrlAutoLinkDisabled: true,
+      });
+
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator(`a[href="${originalPrUrl}"]`)).toHaveCount(0);
+
+      const childPrUrl = 'https://github.com/owner/repo/pull/456';
+      await updateSessionWithPR(child.id, { prUrl: childPrUrl });
+
+      const parentAfterChildPr = await getSession(parent.id);
+      expect(parentAfterChildPr.prUrl).toBeNull();
+      expect(parentAfterChildPr.prUrlAutoLinkDisabled).toBe(true);
+    });
   });
 
   // ============================================================


### PR DESCRIPTION
## Summary
- add persisted `prUrlAutoLinkDisabled` session state and expose it through repository mapping, API responses, shared contracts, and typedefs
- treat manual PR URL clearing as an opt-out from automatic relinking, while manually setting a valid PR URL re-enables automatic linking
- gate message extraction, summary PR URL application, and child-to-root PR propagation when auto-linking is disabled
- add server, shared contract, and Playwright regression coverage for the cleared-PR behavior

## Tests
- `yarn workspace @circuschief/server test src/api/sessions.prUrl.test.js src/services/prUrlService.test.js src/services/summaryService.test.js`
- `yarn workspace @circuschief/shared test src/contracts/sessions.test.js`
- `./scripts/pw.sh test tests/e2e/pr-propagation.spec.ts`

Session summary: Implemented canvas plan to add PR URL auto-link disable flag with full persistence, API, and e2e coverage.