### PR TITLE
Remove publish confirmation flag

### DIFF
--- a/docs/build-and-distribution.md
+++ b/docs/build-and-distribution.md
@@ -113,17 +113,12 @@ Regular `./scripts/pw.sh test` is still the fast path for normal development —
 Use `scripts/publish.sh`, which wraps the build and `npm publish`:
 
 ```bash
-# Usage: ./scripts/publish.sh [-y] [version] <otp>
+# Usage: ./scripts/publish.sh [version] <otp>
 
 # Examples:
 ./scripts/publish.sh 123456             # auto-bump minor, publish
 ./scripts/publish.sh 0.2.0 123456       # publish exactly 0.2.0
-./scripts/publish.sh -y 123456          # auto-bump without prompt
 ```
-
-Options:
-
-- `-y, --yes` — Skip confirmation prompt when auto-bumping version.
 
 Arguments:
 
@@ -133,7 +128,7 @@ Arguments:
 What the script does:
 
 1. Verifies you're logged in (`npm whoami`) and aborts with an error if not.
-2. If `version` is omitted, queries npm for the latest published version and auto-bumps the minor version (e.g. `1.4.2` → `1.5.0`). Prompts for confirmation unless `-y` is passed.
+2. If `version` is omitted, queries npm for the latest published version and auto-bumps the minor version (e.g. `1.4.2` → `1.5.0`).
 3. Runs `node scripts/build-package.js --version=$VERSION`.
 4. Runs `npm publish --otp=$OTP` from inside `dist-package/`.
 5. Prints install/run hints (`npx circuschief`, `npx circuschief@<version>`).

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -5,10 +5,7 @@ set -euo pipefail
 # Publish circuschief to npm.
 #
 # Usage:
-#   ./scripts/publish.sh [-y] [version] <otp>
-#
-# Options:
-#   -y, --yes   Skip confirmation prompt when auto-bumping version.
+#   ./scripts/publish.sh [version] <otp>
 #
 # Arguments:
 #   version     Optional. Semver to publish (e.g. 0.2.0). If omitted,
@@ -18,7 +15,6 @@ set -euo pipefail
 # Examples:
 #   ./scripts/publish.sh 123456             # auto-bump minor, publish
 #   ./scripts/publish.sh 0.2.0 123456       # publish exactly 0.2.0
-#   ./scripts/publish.sh -y 123456          # auto-bump without prompt
 ##
 
 # --- Guard for test harness sourcing ---
@@ -27,28 +23,11 @@ if [ "${PUBLISH_SH_TEST-}" = "1" ]; then
   return 0 2>/dev/null || true
 fi
 
-# --- Argument parsing ---
-SKIP_CONFIRM=0
-ARGS=()
-
-for arg in "$@"; do
-  if [ "$arg" = "-y" ] || [ "$arg" = "--yes" ]; then
-    if [ ${#ARGS[@]} -gt 0 ]; then
-      echo "ERROR: -y/--yes flag must be the first argument."
-      exit 1
-    fi
-    SKIP_CONFIRM=1
-  else
-    ARGS+=("$arg")
-  fi
-done
-
-NUM_ARGS=${#ARGS[@]}
+NUM_ARGS=$#
 
 if [ "$NUM_ARGS" -eq 0 ]; then
-  echo "Usage: $0 [-y] [version] <otp>"
+  echo "Usage: $0 [version] <otp>"
   echo ""
-  echo "  -y, --yes  Skip confirmation prompt when auto-bumping."
   echo "  version    Optional. Semver to publish (e.g. 0.2.0). If omitted,"
   echo "             the script bumps the minor of the latest npm version."
   echo "  otp        Required. npm one-time password (6 digits)."
@@ -56,7 +35,6 @@ if [ "$NUM_ARGS" -eq 0 ]; then
   echo "Examples:"
   echo "  $0 123456             # auto-bump minor, publish"
   echo "  $0 0.2.0 123456       # publish exactly 0.2.0"
-  echo "  $0 -y 123456          # auto-bump without prompt"
   exit 1
 fi
 
@@ -66,16 +44,16 @@ AUTO_BUMP=0
 
 if [ "$NUM_ARGS" -eq 2 ]; then
   # Two positional args: <version> <otp>
-  VERSION="${ARGS[0]}"
-  OTP="${ARGS[1]}"
+  VERSION="$1"
+  OTP="$2"
 elif [ "$NUM_ARGS" -eq 1 ]; then
   # Single arg: disambiguate by shape
-  SINGLE_ARG="${ARGS[0]}"
+  SINGLE_ARG="$1"
 
   if [[ "$SINGLE_ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
     # Looks like a version — OTP is missing
     echo "ERROR: OTP is required. Got version '$SINGLE_ARG' but no OTP."
-    echo "Usage: $0 [-y] [version] <otp>"
+    echo "Usage: $0 [version] <otp>"
     exit 1
   elif [[ "$SINGLE_ARG" =~ ^[0-9]{6}$ ]]; then
     # Looks like an OTP — auto-bump
@@ -86,6 +64,12 @@ elif [ "$NUM_ARGS" -eq 1 ]; then
     echo "Expected a version (e.g. 0.2.0) or an OTP (6 digits)."
     exit 1
   fi
+fi
+
+# --- Validate explicit version shape ---
+if [ -n "$VERSION" ] && ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+  echo "ERROR: version must be semver (e.g. 0.2.0), got '$VERSION'."
+  exit 1
 fi
 
 # --- Validate OTP shape ---
@@ -123,14 +107,6 @@ if [ "$AUTO_BUMP" -eq 1 ]; then
   echo "No version specified. Latest on npm: ${CURRENT:-(none)} → Next: $VERSION"
   echo ""
 
-  # Confirmation prompt (skip if -y or non-interactive stdin)
-  if [ "$SKIP_CONFIRM" -eq 0 ] && [ -t 0 ]; then
-    read -r -p "Proceed? [y/N] " RESPONSE
-    if [ "$RESPONSE" != "y" ] && [ "$RESPONSE" != "Y" ]; then
-      echo "Aborted."
-      exit 1
-    fi
-  fi
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/publish.test.sh
+++ b/scripts/publish.test.sh
@@ -157,26 +157,26 @@ assert_output_includes "OTP is required" "$OUTPUT" "one-arg version mentions mis
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 4: One arg (OTP 123456) → auto-bump minor"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_VIEW" -y 123456 2>&1) && RC=$? || RC=$?
-assert_exit 0 "$RC" "auto-bump with -y succeeds past confirmation"
+OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_VIEW" 123456 2>&1) && RC=$? || RC=$?
+assert_exit 0 "$RC" "auto-bump succeeds"
 assert_output_includes "Next: 1.5.0" "$OUTPUT" "auto-bump from 1.4.2 → 1.5.0"
 assert_output_includes "Publishing circuschief v1.5.0" "$OUTPUT" "VERSION set to 1.5.0"
 
 # --------------------------------------------------------------------------------
-# Test 5: -y mid-args should fail
+# Test 5: -y is not supported
 # --------------------------------------------------------------------------------
 echo ""
-echo "Test 5: -y mid-args (123456 -y) → error"
-OUTPUT=$(bash "$SCRIPT" 123456 -y 2>&1) && RC=$? || RC=$?
-assert_exit 1 "$RC" "-y mid-args exits 1"
-assert_output_includes "must be the first argument" "$OUTPUT" "-y mid-args error message"
+echo "Test 5: -y 123456 → error"
+OUTPUT=$(bash "$SCRIPT" -y 123456 2>&1) && RC=$? || RC=$?
+assert_exit 1 "$RC" "-y exits 1"
+assert_output_includes "version must be semver" "$OUTPUT" "-y rejected"
 
 # --------------------------------------------------------------------------------
 # Test 6: Pre-release latest → error
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 6: Pre-release latest → error"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_PRERELEASE" -y 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_PRERELEASE" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 1 "$RC" "pre-release latest exits 1"
 assert_output_includes "pre-release" "$OUTPUT" "pre-release error message"
 
@@ -185,7 +185,7 @@ assert_output_includes "pre-release" "$OUTPUT" "pre-release error message"
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 7: Never published → 0.1.0"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_EMPTY" -y 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_EMPTY" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 0 "$RC" "never-published succeeds"
 assert_output_includes "Next: 0.1.0" "$OUTPUT" "never-published starts at 0.1.0"
 assert_output_includes "Publishing circuschief v0.1.0" "$OUTPUT" "VERSION set to 0.1.0"
@@ -195,7 +195,7 @@ assert_output_includes "Publishing circuschief v0.1.0" "$OUTPUT" "VERSION set to
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 8: Unparseable npm output → error"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_GARBAGE" -y 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_GARBAGE" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 1 "$RC" "unparseable npm output exits 1"
 assert_output_includes "could not parse" "$OUTPUT" "unparseable error message"
 
@@ -209,14 +209,23 @@ assert_exit 1 "$RC" "invalid OTP exits 1"
 assert_output_includes "Unrecognized" "$OUTPUT" "invalid OTP rejected"
 
 # --------------------------------------------------------------------------------
-# Test 10: -y with explicit version and OTP (no prompt expected)
+# Test 10: --yes is not supported
 # --------------------------------------------------------------------------------
 echo ""
-echo "Test 10: -y with explicit version (9.9.9 000000) → no prompt, fails at whoami"
-OUTPUT=$(run_with_mock "$MOCK_NOT_LOGGED_IN" -y 9.9.9 000000 2>&1) && RC=$? || RC=$?
-assert_exit 1 "$RC" "-y explicit version fails at whoami"
-assert_output_includes "Publishing circuschief v9.9.9" "$OUTPUT" "version set correctly"
-assert_output_not_includes "Proceed?" "$OUTPUT" "no confirmation prompt"
+echo "Test 10: --yes 123456 → error"
+OUTPUT=$(bash "$SCRIPT" --yes 123456 2>&1) && RC=$? || RC=$?
+assert_exit 1 "$RC" "--yes exits 1"
+assert_output_includes "version must be semver" "$OUTPUT" "--yes rejected"
+
+# --------------------------------------------------------------------------------
+# Test 11: Auto-bump does not prompt
+# --------------------------------------------------------------------------------
+echo ""
+echo "Test 11: One arg (OTP 123456) → auto-bump without prompt"
+OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_VIEW" 123456 2>&1) && RC=$? || RC=$?
+assert_exit 0 "$RC" "auto-bump succeeds"
+assert_output_includes "Next: 1.5.0" "$OUTPUT" "auto-bump still calculates next version"
+assert_output_not_includes "Proceed?" "$OUTPUT" "auto-bump does not prompt"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary
- Remove the publish script auto-bump confirmation prompt
- Drop the legacy `-y/--yes` flag entirely
- Validate explicit versions as semver before npm work
- Update publish docs and tests for the positional-only interface

## Verification
- `bash scripts/publish.test.sh` (`27 passed, 0 failed`)

Session summary: Removed legacy `-y/--yes` flag entirely from publish script.