### PR TITLE
Fix session chat overlay viewport handling

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -382,7 +382,7 @@ pre {
   position: fixed;
   top: 1rem;
   right: 1rem;
-  z-index: 1100;
+  z-index: 1300;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;

--- a/packages/web/src/components/AutoRescheduleModal.vue
+++ b/packages/web/src/components/AutoRescheduleModal.vue
@@ -260,7 +260,7 @@ watch(
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 1250;
 }
 
 .modal-content {

--- a/packages/web/src/components/QuickResponseDialog.vue
+++ b/packages/web/src/components/QuickResponseDialog.vue
@@ -319,7 +319,7 @@ async function handleSubmit() {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1015;
+  z-index: 1260;
 }
 
 .dialog {

--- a/packages/web/src/components/QuickResponseSettings.vue
+++ b/packages/web/src/components/QuickResponseSettings.vue
@@ -332,7 +332,7 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1010;
+  z-index: 1250;
 }
 
 .settings-panel {
@@ -540,7 +540,7 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1020;
+  z-index: 1260;
 }
 
 .confirm-dialog {

--- a/packages/web/src/components/ScheduleSessionModal.vue
+++ b/packages/web/src/components/ScheduleSessionModal.vue
@@ -140,7 +140,7 @@ watch(
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 1250;
 }
 
 .modal-content {

--- a/packages/web/src/components/SchedulingEditModal.vue
+++ b/packages/web/src/components/SchedulingEditModal.vue
@@ -382,7 +382,7 @@ watch(
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 1250;
 }
 
 .modal-content {

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1567,14 +1567,21 @@ describe('SessionChatOverlay', () => {
       wrapper.unmount();
     });
 
-    it('backdrop stylesheet uses browser-owned full viewport geometry', () => {
+    it('backdrop stylesheet uses fixed viewport geometry by default', () => {
       const block = getStyleBlock('.overlay-backdrop');
       expect(block).toMatch(/position:\s*fixed/);
       expect(block).toMatch(/inset:\s*0/);
+      expect(block).toMatch(/z-index:\s*1200/);
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
       expect(block).not.toMatch(/top:\s*var\(/);
       expect(block).not.toMatch(/height:\s*var\(/);
+    });
+
+    it('backdrop stylesheet opts tablet-sized viewports into visual viewport geometry', () => {
+      expect(sessionChatOverlaySource).toMatch(
+        /@media\s*\(min-width:\s*700px\)\s*and\s*\(min-height:\s*700px\)\s*\{[\s\S]*?\.overlay-backdrop\s*\{[\s\S]*?top:\s*var\(--viewport-offset-top,\s*0px\);[\s\S]*?height:\s*var\(--visual-viewport-height,\s*100dvh\);/
+      );
     });
 
     it('panel-wrapper stylesheet is child geometry inside the backdrop', () => {
@@ -1586,12 +1593,11 @@ describe('SessionChatOverlay', () => {
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
       expect(block).not.toMatch(/top:\s*var\(/);
-      expect(block).not.toMatch(/height:\s*var\(/);
       expect(block).not.toMatch(/min-height:\s*100vh/);
       expect(block).not.toMatch(/min-height:\s*100dvh/);
     });
 
-    it('overlay shell stylesheet ignores stale visual viewport variables', () => {
+    it('overlay shell keeps visual viewport variables out of phone-sized default geometry', () => {
       const shellBlocks = [
         getStyleBlock('.overlay-backdrop'),
         getStyleBlock('.overlay-panel-wrapper'),
@@ -1609,18 +1615,15 @@ describe('SessionChatOverlay', () => {
       }
     });
 
-    it('source no longer references visual viewport APIs', () => {
-      // Viewport reads stay centralized in useVisualViewport.js for app-level chrome.
+    it('source keeps visual viewport reads centralized in the composable', () => {
+      // SessionChatOverlay may request viewport refreshes, but direct viewport
+      // reads stay centralized in useVisualViewport.js.
       expect(sessionChatOverlaySource).not.toMatch(/window\.visualViewport/);
-      expect(sessionChatOverlaySource).not.toMatch(/requestVisualViewportSettle/);
-      expect(sessionChatOverlaySource).not.toMatch(/useVisualViewport\.js/);
       expect(sessionChatOverlaySource).not.toMatch(/syncToVisualViewport/);
       expect(sessionChatOverlaySource).not.toMatch(/markRecentBlur/);
       expect(sessionChatOverlaySource).not.toMatch(/applyLayoutViewport/);
-      expect(sessionChatOverlaySource).not.toMatch(/overlayBackdropRef/);
       expect(sessionChatOverlaySource).not.toMatch(/inputFocused/);
       expect(sessionChatOverlaySource).not.toMatch(/focusOutRaf/);
-      expect(sessionChatOverlaySource).not.toMatch(/handleOverlayFocus(?:in|out)/);
     });
 
     it('lockBodyScroll does not call window.scrollTo(0, 0) at mount time', async () => {

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -74,7 +74,7 @@
                       type="text"
                       class="name-edit-input"
                       placeholder="Session name"
-                      @keyup.enter="saveSessionName"
+                      @keydown.enter.prevent="saveSessionName"
                       @keyup.escape="cancelEditName"
                     >
                     <button

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -10,6 +10,8 @@
         class="overlay-backdrop"
         data-testid="session-chat-overlay"
         @click.self="close"
+        @focusin="handleOverlayFocusin"
+        @focusout="handleOverlayFocusout"
       >
         <div
           class="overlay-panel-wrapper"
@@ -367,6 +369,10 @@ import { api } from '../composables/useApi.js';
 import { createOverlaySessionsStore } from '../stores/createOverlaySessionsStore.js';
 import { createOverlayTodosStore } from '../stores/createOverlayTodosStore.js';
 import { SESSIONS_STORE_KEY, TODOS_STORE_KEY } from '../composables/useOverlayStore.js';
+import {
+  requestVisualViewportSettle,
+  requestVisualViewportUpdate,
+} from '../composables/useVisualViewport.js';
 
 import ConversationTab from './ConversationTab.vue';
 import SessionChatPicker from './SessionChatPicker.vue';
@@ -799,6 +805,14 @@ function handleHeaderTouchmove(event) {
   event.preventDefault();
 }
 
+function handleOverlayFocusin() {
+  requestVisualViewportUpdate();
+}
+
+function handleOverlayFocusout() {
+  requestVisualViewportSettle();
+}
+
 // Body scroll lock — iOS-compatible "fixed wrapper" pattern.
 // On iOS Safari, `overflow: hidden` alone is insufficient: it doesn't reset
 // the existing scroll offset and touch gestures can still move the body.
@@ -852,6 +866,8 @@ function unlockBodyScroll() {
 // Lifecycle
 onMounted(async () => {
   lockBodyScroll();
+  requestVisualViewportUpdate();
+  requestVisualViewportSettle();
   document.addEventListener('keydown', handleEscape);
   document.addEventListener('click', handleClickOutsidePicker, true);
   window.addEventListener('resize', checkMobile);
@@ -964,12 +980,22 @@ defineExpose({
 .overlay-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: 1200;
   background: rgb(17, 24, 39);
   display: block;
   overflow: hidden;
   overflow-y: hidden;
   overscroll-behavior: none;
+}
+
+@media (min-width: 700px) and (min-height: 700px) {
+  .overlay-backdrop {
+    top: var(--viewport-offset-top, 0px);
+    right: 0;
+    bottom: auto;
+    left: 0;
+    height: var(--visual-viewport-height, 100dvh);
+  }
 }
 
 .overlay-panel-wrapper {

--- a/packages/web/src/components/SlashCommandWizard.vue
+++ b/packages/web/src/components/SlashCommandWizard.vue
@@ -248,7 +248,7 @@ function buildInsertString(command, args) {
   justify-content: center;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(2px);
-  z-index: 1000;
+  z-index: 1250;
 }
 
 .wizard-modal {

--- a/packages/web/src/components/modalZIndex.test.js
+++ b/packages/web/src/components/modalZIndex.test.js
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readComponent(name) {
+  return readFileSync(resolve(__dirname, name), 'utf8');
+}
+
+function getRuleZIndex(source, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`${escaped}\\s*\\{[\\s\\S]*?z-index:\\s*(\\d+)`));
+  expect(match, `${selector} should define a z-index`).toBeTruthy();
+  return Number(match[1]);
+}
+
+describe('Overlay modal z-index regression guard', () => {
+  it('modals opened from the session overlay render above the overlay backdrop', () => {
+    const overlayZ = getRuleZIndex(readComponent('SessionChatOverlay.vue'), '.overlay-backdrop');
+    const modalLayers = [
+      ['AutoRescheduleModal.vue', '.modal-backdrop'],
+      ['SchedulingEditModal.vue', '.modal-backdrop'],
+      ['ScheduleSessionModal.vue', '.modal-backdrop'],
+      ['SlashCommandWizard.vue', '.wizard-overlay'],
+      ['QuickResponseSettings.vue', '.settings-overlay'],
+    ];
+
+    for (const [fileName, selector] of modalLayers) {
+      const modalZ = getRuleZIndex(readComponent(fileName), selector);
+      expect(modalZ, `${fileName} ${selector}`).toBeGreaterThan(overlayZ);
+    }
+  });
+
+  it('quick response dialog renders above quick response settings', () => {
+    const settingsZ = getRuleZIndex(readComponent('QuickResponseSettings.vue'), '.settings-overlay');
+    const dialogZ = getRuleZIndex(readComponent('QuickResponseDialog.vue'), '.dialog-overlay');
+    const confirmZ = getRuleZIndex(readComponent('QuickResponseSettings.vue'), '.confirm-overlay');
+
+    expect(dialogZ).toBeGreaterThan(settingsZ);
+    expect(confirmZ).toBeGreaterThan(settingsZ);
+  });
+});

--- a/scripts/seed-messages-batch.mjs
+++ b/scripts/seed-messages-batch.mjs
@@ -56,9 +56,8 @@ const insertStmt = db.prepare(
 
 const selectStmt = db.prepare('SELECT * FROM conversation_messages WHERE id = ?');
 
-const results = [];
-
 const insertAll = db.transaction(() => {
+  const results = [];
   let now = Date.now();
   for (const msg of messages) {
     const id = randomUUID();
@@ -82,16 +81,22 @@ const insertAll = db.transaction(() => {
     // Increment timestamp so messages have distinct ordering
     now++;
   }
+  return results;
 });
 
-// Retry the transaction in case of transient SQLITE_BUSY errors
-const MAX_RETRIES = 3;
+function isTransientBusyError(err) {
+  return err?.code === 'SQLITE_BUSY' || err?.code === 'SQLITE_BUSY_SNAPSHOT';
+}
+
+// Retry the transaction in case of transient SQLite lock/snapshot errors.
+const MAX_RETRIES = 5;
+let results;
 for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
   try {
-    insertAll();
+    results = insertAll();
     break;
   } catch (err) {
-    if (err.code === 'SQLITE_BUSY' && attempt < MAX_RETRIES) {
+    if (isTransientBusyError(err) && attempt < MAX_RETRIES) {
       // Wait with exponential backoff before retrying
       const delay = 1000 * attempt;
       await new Promise(resolve => setTimeout(resolve, delay));

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -1,12 +1,10 @@
 /**
  * SessionChatOverlay layout regression coverage.
  *
- * This spec replaces `session-chat-overlay-blur.spec.ts`. The overlay no
- * longer uses JS-written visual viewport CSS variables for its shell.
- * Geometry is owned by browser CSS (`position: fixed; inset: 0` on the
- * backdrop, child geometry for the panel). These tests verify that stale
- * root CSS variables do not affect the shell and that no inline geometry
- * is written by the component.
+ * The overlay is teleported to body and scroll locking is applied to #app,
+ * while tablet-sized layouts align the fixed backdrop to the visual viewport CSS variables.
+ * This keeps the overlay out of the fixed app wrapper without losing the
+ * iPadOS browser-chrome offset and height corrections.
  *
  * HONEST SCOPE of the mobile projects (iphone-14, ipad-pro):
  * Playwright's mobile devices run chromium with only viewport size + UA
@@ -97,7 +95,7 @@ test.describe('SessionChatOverlay layout', () => {
     expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
   });
 
-  test('backdrop uses position: fixed at the viewport origin', async ({ page }) => {
+  test('backdrop uses position: fixed at the viewport origin by default', async ({ page }) => {
     await navigateToSession(page);
     await openOverlay(page);
 
@@ -118,16 +116,56 @@ test.describe('SessionChatOverlay layout', () => {
     expect(computed.left).toBe('0px');
   });
 
-  test('stale visual viewport CSS variables do not move or shrink the shell', async ({ page }) => {
+  test('narrow phone-sized layouts ignore stale visual viewport CSS variables', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
     await navigateToSession(page);
+    await openOverlay(page);
+
     await page.evaluate(() => {
       document.documentElement.style.setProperty('--viewport-offset-top', '260px');
       document.documentElement.style.setProperty('--visual-viewport-height', '420px');
     });
+    await page.waitForTimeout(50);
 
     try {
-      await openOverlay(page);
+      const result = await page.evaluate(() => {
+        const el = document.querySelector(
+          '[data-testid="session-chat-overlay"]'
+        ) as HTMLElement;
+        const r = el.getBoundingClientRect();
+        return {
+          top: r.top,
+          bottom: r.bottom,
+          left: r.left,
+          right: r.right,
+          inner: { w: window.innerWidth, h: window.innerHeight },
+        };
+      });
 
+      expect(result.top).toBeLessThanOrEqual(1);
+      expect(result.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.left).toBeLessThanOrEqual(1);
+      expect(result.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+    } finally {
+      await page.evaluate(() => {
+        document.documentElement.style.removeProperty('--viewport-offset-top');
+        document.documentElement.style.removeProperty('--visual-viewport-height');
+      });
+    }
+  });
+
+  test('tablet-sized layouts let visual viewport CSS variables move and size the shell', async ({ page }) => {
+    await page.setViewportSize({ width: 744, height: 1000 });
+    await navigateToSession(page);
+    await openOverlay(page);
+
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--viewport-offset-top', '260px');
+      document.documentElement.style.setProperty('--visual-viewport-height', '420px');
+    });
+    await page.waitForTimeout(50);
+
+    try {
       const result = await page.evaluate(() => {
         const rectFor = (selector: string) => {
           const el = document.querySelector(selector) as HTMLElement;
@@ -149,19 +187,23 @@ test.describe('SessionChatOverlay layout', () => {
         };
       });
 
-      expect(result.backdrop.top).toBeLessThanOrEqual(1);
-      expect(result.backdrop.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.backdrop.top).toBeGreaterThanOrEqual(259);
+      expect(result.backdrop.top).toBeLessThanOrEqual(261);
+      expect(result.backdrop.bottom).toBeGreaterThanOrEqual(679);
+      expect(result.backdrop.bottom).toBeLessThanOrEqual(681);
       expect(result.backdrop.left).toBeLessThanOrEqual(1);
       expect(result.backdrop.right).toBeGreaterThanOrEqual(result.inner.w - 1);
 
-      expect(result.panel.top).toBeLessThanOrEqual(1);
-      expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.panel.top).toBeGreaterThanOrEqual(259);
+      expect(result.panel.top).toBeLessThanOrEqual(261);
+      expect(result.panel.bottom).toBeGreaterThanOrEqual(679);
+      expect(result.panel.bottom).toBeLessThanOrEqual(681);
       expect(result.panel.right).toBeGreaterThanOrEqual(result.inner.w - 1);
       expect(result.panel.right).toBeLessThanOrEqual(result.inner.w + 1);
       expect(result.panel.width).toBeLessThanOrEqual(Math.min(result.inner.w, 900) + 1);
 
-      expect(result.header.top).toBeLessThanOrEqual(1);
-      expect(result.header.top).toBeLessThan(260);
+      expect(result.header.top).toBeGreaterThanOrEqual(259);
+      expect(result.header.top).toBeLessThanOrEqual(261);
     } finally {
       await page.evaluate(() => {
         document.documentElement.style.removeProperty('--viewport-offset-top');
@@ -172,9 +214,9 @@ test.describe('SessionChatOverlay layout', () => {
 
   test('covers viewport after SessionDetailView scroll', async ({ page }) => {
     await navigateToSession(page);
-    // Scroll SessionDetailView before opening the overlay. Previously the
-    // JS sync relied on visualViewport events to anchor the backdrop; now
-    // `position: fixed` + the scroll-lock on #app handles this.
+    // Scroll SessionDetailView before opening the overlay. The app scroll
+    // lock is applied to #app, while the teleported backdrop remains fixed
+    // against the viewport.
     await page.evaluate(() => window.scrollTo(0, 400));
     await openOverlay(page);
 


### PR DESCRIPTION
## Summary
- keep the body-teleported session chat overlay above app chrome
- preserve plain fixed overlay geometry on narrow iPhone layouts
- apply visual viewport offset/height only on tablet-sized layouts to address iPad Safari browser chrome
- update unit and e2e coverage for phone, tablet, and toast layering behavior

## Verification
- yarn workspace @circuschief/web vitest run src/components/SessionChatOverlay.test.js src/components/toastZIndex.test.js
- yarn test:e2e tests/e2e/session-chat-overlay-layout.spec.ts

## Notes
- Session summary API was stale and only reflected the initial close-handle diagnosis; this PR body is based on the final committed diff and successful test runs.