### PR TITLE
Normalize workflow session routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ npx circuschief -p 8080
 
 - [Development Guide](docs/development.md) — Quick start, commands, testing, environment variables
 - [Build & Distribution](docs/build-and-distribution.md) — How the npm package is built, published, and run
+- [Agent System Prompt & REST API Reference](docs/agent-system-prompt.md) — The REST API exposed to agents via the system prompt

--- a/docs/agent-system-prompt.md
+++ b/docs/agent-system-prompt.md
@@ -1,0 +1,104 @@
+# Agent System Prompt & REST API Reference
+
+This document describes the system prompt injected into every agent session and the REST API endpoints exposed to agents. The system prompt is assembled at runtime by `packages/server/src/services/sessionPrompts.js` and teaches the agent how to interact with Circus Chief's canvas, session management, and project APIs.
+
+## Prompt Assembly
+
+`buildSystemPromptConfig(sessionId, projectId, customSystemPrompt, mode)` assembles the full system prompt from these parts, joined with double newlines (empty parts are filtered out):
+
+| # | Section | Builder Function | Always Included? |
+|---|---------|-----------------|-----------------|
+| 1 | Plan mode instructions | `PLAN_MODE_PROMPT` | Only when mode = `plan` |
+| 2 | Base prompt | `customSystemPrompt` or `DEFAULT_SYSTEM_PROMPT` | Yes |
+| 3 | Git worktree context | `buildWorktreeContext()` | Only when session uses a git worktree |
+| 4 | Session attached files | `getSessionAttachmentsContext()` | Only when files are attached to the session |
+| 5 | Canvas write instructions | `buildCanvasWriteSystemPrompt()` | Yes |
+| 6 | Canvas read instructions | `buildCanvasReadSystemPrompt()` | Yes |
+| 7 | Session management API | `buildSessionApiInstructions()` | Yes |
+| 8 | Command buttons API | `buildCommandButtonApiInstructions()` (in `commandButtonPrompts.js`) | Only when project has command buttons |
+| 9 | Kanban board API | `buildKanbanApiInstructions()` | Only when project has kanban enabled |
+
+The base URL used in all endpoint examples is derived from `CIRCUSCHIEF_API_URL` env var, falling back to `http://localhost:{PORT}`.
+
+## REST API Endpoints Exposed to Agents
+
+### Canvas API (always included)
+
+Agents can post artifacts to the canvas and read them back.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/sessions/{sessionId}/canvas` | Add a file to the canvas. Body: `{"filePath": "/path/to/file"}`. File type auto-detected from extension. |
+| GET | `/api/sessions/{sessionId}/canvas` | List all files on the canvas |
+| GET | `/api/sessions/{sessionId}/canvas/file/{filename}` | Get metadata for a canvas file. Response: `{ filePath, type, mimeType, createdAt, version, totalVersions }` |
+| GET | `/api/sessions/{sessionId}/canvas/file/{filename}/history/{version}` | Get a historical version of a canvas file. Version 1 = oldest. |
+
+**Supported file formats:** Images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`), PDFs (`.pdf`), Markdown (`.md`, `.mdx`), Code (`.js`, `.ts`, `.py`, `.go`, `.rs`, `.java`, etc.), JSON (`.json`), Text (`.txt`, `.log`, `.csv`).
+
+### Session Management API (always included)
+
+The prompt provides the agent with its own session ID and project ID. All endpoints use `curl` examples.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/projects/{projectId}/sessions` | Create a new session. Required body field: `prompt`. See optional fields below. |
+| POST | `/api/sessions/{session_id}/message` | Send a follow-up message. Body: `{"content": "..."}` |
+| GET | `/api/sessions` | List all active sessions |
+| GET | `/api/sessions/{session_id}` | Get session details |
+| GET | `/api/sessions/{session_id}/messages` | Get session messages |
+| POST | `/api/sessions/{session_id}/stop` | Stop a session |
+| POST | `/api/sessions/{session_id}/restart` | Restart a session |
+| DELETE | `/api/sessions/{session_id}` | Delete a session |
+| PATCH | `/api/sessions/{session_id}` | Update session settings. Example body: `{"thinkingEnabled": true, "effortLevel": "high"}` |
+
+**Optional fields for session creation:** `name`, `mode`, `thinkingEnabled` (boolean), `effortLevel` (low/medium/high/max/auto), `model`, `providerId`, `gitBranch`, `gitMode`, `templateId`, `nextTemplateId`, `parentSessionId` (to create a related follow-up session from the current session), `startImmediately`, `scheduledAt`, `autoRescheduleEnabled`, `rescheduleDelayMinutes`, `rescheduleOnTokenLimit`, `rescheduleOnServiceError`, `maxRescheduleCount`, `maxTotalTokens`, `rescheduleAtTokenCount`.
+
+### Project Operations (always included)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/projects` | List all projects |
+| GET | `/api/projects/{project_id}` | Get project details |
+| GET | `/api/projects/{project_id}/sessions` | List project sessions |
+| POST | `/api/projects` | Create a project. Required body: `{"name": "...", "workingDirectory": "..."}`. Optional: `systemPrompt` |
+
+### Workflow Summary (always included)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/sessions/{sessionId}/summary?generate=true` | Get (and generate) a session summary |
+| POST | `/api/sessions/{sessionId}/summary` | Regenerate the session summary |
+
+### Command Buttons API (conditional)
+
+Included only when the project has command buttons configured. Built in `packages/server/src/services/commandButtonPrompts.js`.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/sessions/{sessionId}/command-buttons` | List available buttons |
+| POST | `/api/sessions/{sessionId}/command-buttons/{button_id}/run` | Run a button. Response: `{ runId, buttonId, status: "running", output: "" }` |
+| GET | `/api/sessions/{sessionId}/command-buttons/runs/{run_id}` | Check run status & output. Response: `{ runId, buttonId, status, exitCode, output, startedAt, completedAt }` |
+| GET | `/api/sessions/{sessionId}/command-buttons/runs` | List all command runs |
+| POST | `/api/sessions/{sessionId}/command-buttons/runs/{run_id}/kill` | Kill a running command |
+
+### Kanban Board API (conditional)
+
+Included only when the project has kanban enabled. Also includes a dynamically populated list of available lanes with names and IDs.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/projects/{projectId}/kanban` | Get board with all lanes and cards |
+| POST | `/api/projects/{projectId}/kanban/cards` | Add session to board. Body: `{"sessionId": "...", "laneId": "..."}` |
+| PATCH | `/api/projects/{projectId}/kanban/cards/{card_id}/move` | Move card to a different lane. Body: `{"targetLaneId": "..."}` |
+| DELETE | `/api/projects/{projectId}/kanban/cards/{card_id}` | Remove a card |
+| POST | `/api/projects/{projectId}/kanban/lanes` | Create a new lane. Body: `{"name": "..."}` |
+| PATCH | `/api/projects/{projectId}/kanban/lanes/{lane_id}` | Update a lane. Body: `{"name": "..."}` |
+| DELETE | `/api/projects/{projectId}/kanban/lanes/{lane_id}` | Delete a lane |
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `packages/server/src/services/sessionPrompts.js` | Main prompt assembly and canvas/session/kanban endpoint documentation |
+| `packages/server/src/services/commandButtonPrompts.js` | Command button endpoint documentation |
+| `packages/shared/src/constants.js` | `DEFAULT_SYSTEM_PROMPT` fallback |

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,6 +93,10 @@ These variables are resolved during `yarn build` (specifically `vite build`). Th
 | `BROWSER` | `chromium` | Browser to use |
 | `HEADLESS` | `true` | Run headless |
 
+## Agent System Prompt & REST API
+
+The system prompt injected into every agent session includes documentation for a REST API that agents can use to create sessions, manage the canvas, and interact with project resources. For a full reference, see [Agent System Prompt & REST API Reference](./agent-system-prompt.md).
+
 ## Project Structure
 
 ```

--- a/packages/server/src/api/canvas.js
+++ b/packages/server/src/api/canvas.js
@@ -2,10 +2,11 @@ import { Router } from 'express';
 import { readFileSync, existsSync, statSync } from 'fs';
 import { mkdir } from 'fs/promises';
 import { extname, join, basename } from 'path';
-import { sessions, canvasItems } from '../database.js';
+import { canvasItems } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES, UpdateCanvasItemRequest } from '@circuschief/shared';
 import { upload, handleUploadError } from '../middleware/upload.js';
+import { requireRootSessionAndProject } from '../middleware/sessionLookup.js';
 import {
   isBinaryContent,
   getTypeFromExtension,
@@ -19,8 +20,6 @@ import {
 import trashRoutes from './canvas-trash-routes.js';
 
 // Error message constants
-const ERR_SESSION_NOT_FOUND = 'Session not found';
-
 /**
  * Process multipart file upload (Mode 1)
  * @param {Express.Multer.File} file - The uploaded file from multer
@@ -84,12 +83,7 @@ router.use('/', trashRoutes);
 // 1. Multipart mode: FormData with 'file' field - from browser file uploads
 // 2. File mode: { filePath } - reads file from disk
 // 3. Inline mode: { type, content, filename } - uses provided content directly
-router.post('/:id/canvas', upload.single('file'), handleUploadError, (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) {
-    return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-  }
-
+router.post('/:id/canvas', requireRootSessionAndProject, upload.single('file'), handleUploadError, (req, res) => {
   const { filePath, type, content, filename } = req.body;
   let result;
 
@@ -110,21 +104,16 @@ router.post('/:id/canvas', upload.single('file'), handleUploadError, (req, res) 
     return res.status(400).json({ error: result.error });
   }
 
-  const item = canvasItems.create(req.params.id, result.itemData);
+  const item = canvasItems.create(req.rootSessionId, result.itemData);
 
   // Broadcast to session subscribers
-  broadcastCanvasUpdate(req.params.id, item);
+  broadcastCanvasUpdate(req.rootSessionId, item);
 
   res.status(201).json(item);
 });
 
 // PUT /api/sessions/:id/canvas/:itemId - Update canvas item content in-place
-router.put('/:id/canvas/:itemId', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) {
-    return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-  }
-
+router.put('/:id/canvas/:itemId', requireRootSessionAndProject, (req, res) => {
   const parsed = UpdateCanvasItemRequest.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: 'Invalid request body', details: parsed.error.issues });
@@ -135,7 +124,7 @@ router.put('/:id/canvas/:itemId', (req, res) => {
     return res.status(404).json({ error: 'Canvas item not found' });
   }
 
-  if (item.sessionId !== req.params.id) {
+  if (item.sessionId !== req.rootSessionId) {
     return res.status(400).json({ error: 'Canvas item does not belong to this session' });
   }
 
@@ -144,20 +133,15 @@ router.put('/:id/canvas/:itemId', (req, res) => {
   }
 
   const updatedItem = canvasItems.updateContent(req.params.itemId, parsed.data.content);
-  broadcastToSession(req.params.id, WS_MESSAGE_TYPES.CANVAS_UPDATE, { item: updatedItem });
+  broadcastToSession(req.rootSessionId, WS_MESSAGE_TYPES.CANVAS_UPDATE, { item: updatedItem });
   res.json(updatedItem);
 });
 
 // GET /api/sessions/:id/canvas - List canvas items
 // Returns only latest version of each file (no version metadata exposed)
-router.get('/:id/canvas', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) {
-    return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-  }
-
+router.get('/:id/canvas', requireRootSessionAndProject, (req, res) => {
   // Get only latest versions (one per filename)
-  const items = canvasItems.getLatestVersionsBySessionId(req.params.id);
+  const items = canvasItems.getLatestVersionsBySessionId(req.rootSessionId);
 
   // Strip content/data from list responses to reduce payload size.
   // Clients should use GET /canvas/file/:filename/content for inline content.
@@ -166,14 +150,9 @@ router.get('/:id/canvas', (req, res) => {
 
 // GET /api/sessions/:id/canvas/all - List ALL canvas items (including all versions)
 // Returns all versions of each file for the frontend UI
-router.get('/:id/canvas/all', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) {
-    return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-  }
-
+router.get('/:id/canvas/all', requireRootSessionAndProject, (req, res) => {
   // Get ALL versions (not just latest)
-  const items = canvasItems.getBySessionId(req.params.id);
+  const items = canvasItems.getBySessionId(req.rootSessionId);
 
   // Strip content/data from list responses to reduce payload size.
   res.json(items.map(({ content: _content, data: _data, ...meta }) => meta));
@@ -182,14 +161,10 @@ router.get('/:id/canvas/all', (req, res) => {
 // GET /api/sessions/:id/canvas/file/:filename/history/:version - Get historical version of canvas file
 // Uses standard versioning: version 1 = oldest, version N = latest (where N = totalVersions)
 // NOTE: This route must be defined BEFORE the main file route to match correctly
-router.get('/:id/canvas/file/:filename/history/:version', async (req, res) => {
-  const { id: sessionId, filename, version } = req.params;
+router.get('/:id/canvas/file/:filename/history/:version', requireRootSessionAndProject, async (req, res) => {
+  const { filename, version } = req.params;
+  const sessionId = req.rootSessionId;
   const versionNum = parseInt(version, 10);
-
-  const session = sessions.getById(sessionId);
-  if (!session) {
-    return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-  }
 
   // Get all versions of this file (newest first)
   const allVersions = canvasItems.getAllVersionsByFilename(sessionId, filename);
@@ -247,11 +222,8 @@ router.get('/:id/canvas/file/:filename/history/:version', async (req, res) => {
 // GET /api/sessions/:id/canvas/file/:filename/content - Get canvas file content inline
 // Returns content/data inline in JSON for browser consumption (unlike the temp-file endpoint below)
 // Supports ?version=N query param (1-based, 1 = oldest)
-router.get('/:id/canvas/file/:filename/content', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-
-  const allVersions = canvasItems.getAllVersionsByFilename(req.params.id, req.params.filename);
+router.get('/:id/canvas/file/:filename/content', requireRootSessionAndProject, (req, res) => {
+  const allVersions = canvasItems.getAllVersionsByFilename(req.rootSessionId, req.params.filename);
   if (allVersions.length === 0) return res.status(404).json({ error: 'File not found' });
 
   // Support ?version=N (1-based, 1 = oldest)
@@ -280,13 +252,10 @@ router.get('/:id/canvas/file/:filename/content', (req, res) => {
 });
 
 // GET /api/sessions/:id/canvas/:itemId/content - Get one canvas item content inline
-router.get('/:id/canvas/:itemId/content', (req, res) => {
-  const session = sessions.getById(req.params.id);
-  if (!session) return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-
+router.get('/:id/canvas/:itemId/content', requireRootSessionAndProject, (req, res) => {
   const item = canvasItems.getById(req.params.itemId);
   if (!item) return res.status(404).json({ error: 'Canvas item not found' });
-  if (item.sessionId !== req.params.id) {
+  if (item.sessionId !== req.rootSessionId) {
     return res.status(400).json({ error: 'Canvas item does not belong to this session' });
   }
 
@@ -302,13 +271,9 @@ router.get('/:id/canvas/:itemId/content', (req, res) => {
 // GET /api/sessions/:id/canvas/file/:filename - Get canvas file by filename
 // Writes the file to /tmp and returns the file path for Claude's Read tool
 // Always returns the latest version
-router.get('/:id/canvas/file/:filename', async (req, res) => {
-  const { id: sessionId, filename } = req.params;
-
-  const session = sessions.getById(sessionId);
-  if (!session) {
-    return res.status(404).json({ error: ERR_SESSION_NOT_FOUND });
-  }
+router.get('/:id/canvas/file/:filename', requireRootSessionAndProject, async (req, res) => {
+  const { filename } = req.params;
+  const sessionId = req.rootSessionId;
 
   // Get all versions of this file (newest first)
   const allVersions = canvasItems.getAllVersionsByFilename(sessionId, filename);

--- a/packages/server/src/api/canvas.test.js
+++ b/packages/server/src/api/canvas.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { canvasItems, projects } from '../database.js';
+import { canvasItems, projects, sessions } from '../database.js';
 import { databaseManager } from '../db/DatabaseManager.js';
 import { existsSync, rmSync, readFileSync } from 'fs';
 import canvasRouter, { isBinaryContent, getTypeFromExtension } from './canvas.js';
@@ -1298,6 +1298,44 @@ describe('Canvas API', () => {
         expect(res.body.content).toBe('Hello, World!');
         expect(res.body.filename).toBe('output.txt');
         expect(res.body.mimeType).toBe('text/plain');
+      });
+
+      it('creates canvas items on the workflow root through a child session', async () => {
+        const child = sessions.create(projectId, 'Child Session', 'Child prompt', {
+          mode: 'standard',
+          parentSessionId: sessionId,
+        });
+
+        const res = await request(app)
+          .post(`/api/sessions/${child.id}/canvas`)
+          .send({
+            type: 'text',
+            content: 'Shared workflow content',
+            filename: 'workflow.txt',
+          });
+
+        expect(res.status).toBe(201);
+        expect(res.body.sessionId).toBe(sessionId);
+        expect(canvasItems.getLatestVersionsBySessionId(sessionId)).toHaveLength(1);
+        expect(canvasItems.getLatestVersionsBySessionId(child.id)).toHaveLength(0);
+      });
+
+      it('lists and reads root canvas files through a child session', async () => {
+        const child = sessions.create(projectId, 'Child Session', 'Child prompt', {
+          mode: 'standard',
+          parentSessionId: sessionId,
+        });
+        canvasItems.create(sessionId, { type: 'text', content: 'Version 1', filename: 'workflow.txt' });
+        canvasItems.create(sessionId, { type: 'text', content: 'Version 2', filename: 'workflow.txt' });
+
+        const listRes = await request(app).get(`/api/sessions/${child.id}/canvas`);
+        expect(listRes.status).toBe(200);
+        expect(listRes.body).toHaveLength(1);
+        expect(listRes.body[0].sessionId).toBe(sessionId);
+
+        const contentRes = await request(app).get(`/api/sessions/${child.id}/canvas/file/workflow.txt/content?version=1`);
+        expect(contentRes.status).toBe(200);
+        expect(contentRes.body.content).toBe('Version 1');
       });
 
       it('creates canvas item from inline markdown content', async () => {

--- a/packages/server/src/api/canvas.test.js
+++ b/packages/server/src/api/canvas.test.js
@@ -1338,6 +1338,21 @@ describe('Canvas API', () => {
         expect(contentRes.body.content).toBe('Version 1');
       });
 
+      it('rejects a child session whose parent chain crosses projects', async () => {
+        const otherProject = projects.create('Other Project', '/tmp/other');
+        const otherRoot = sessions.create(otherProject.id, 'Other Root', 'Other prompt');
+        const child = sessions.create(projectId, 'Cross Project Child', 'Child prompt', {
+          mode: 'standard',
+          parentSessionId: otherRoot.id,
+        });
+        canvasItems.create(otherRoot.id, { type: 'text', content: 'Do not leak', filename: 'secret.txt' });
+
+        const res = await request(app).get(`/api/sessions/${child.id}/canvas`);
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('Session parent chain crosses projects');
+      });
+
       it('creates canvas item from inline markdown content', async () => {
         const res = await request(app)
           .post(`/api/sessions/${sessionId}/canvas`)

--- a/packages/server/src/api/commandButtons.test.js
+++ b/packages/server/src/api/commandButtons.test.js
@@ -692,6 +692,9 @@ describe('Command Buttons API', () => {
 
   describe('POST /api/sessions/:sessionId/command-buttons/runs/:runId/kill', () => {
     it('kills running command', async () => {
+      commandRunner.getRunsBySession.mockReturnValue([
+        { runId: 'run-123', buttonId, status: 'running' },
+      ]);
       commandRunner.kill.mockReturnValue(true);
 
       const res = await request(app).post(

--- a/packages/server/src/api/kanban.js
+++ b/packages/server/src/api/kanban.js
@@ -11,6 +11,7 @@ import {
   ReorderKanbanCardsRequest,
 } from '@circuschief/shared/contracts/kanban';
 import { moveCard as moveCardService } from '../services/kanbanService.js';
+import { resolveBodyRootSessionForProject } from '../middleware/sessionLookup.js';
 
 const router = Router({ mergeParams: true });
 
@@ -215,7 +216,7 @@ router.put('/lanes/reorder', (req, res) => {
  * POST /api/projects/:projectId/kanban/cards
  * Add a session to the board (create card in a lane)
  */
-router.post('/cards', (req, res) => {
+router.post('/cards', resolveBodyRootSessionForProject('projectId'), (req, res) => {
   const { projectId } = req.params;
 
   const result = CreateKanbanCardRequest.safeParse(req.body);
@@ -223,7 +224,8 @@ router.post('/cards', (req, res) => {
     return res.status(400).json({ error: result.error.issues[0].message });
   }
 
-  const { sessionId, laneId } = result.data;
+  const { laneId } = result.data;
+  const sessionId = req.bodyRootSessionId;
 
   // Check if session already has a card
   const existingCard = kanbanCards.getBySessionId(sessionId);

--- a/packages/server/src/api/kanban.test.js
+++ b/packages/server/src/api/kanban.test.js
@@ -305,6 +305,58 @@ describe('Kanban API', () => {
       expect(res.body.sessions[0].id).toBe(session.id);
     });
 
+    it('creates a card for the workflow root when body session is a child', async () => {
+      setupBoard();
+      const root = createSession('Root Session');
+      const child = sessions.create(projectId, 'Child Session', 'Child prompt', {
+        mode: 'standard',
+        parentSessionId: root.id,
+      });
+
+      const res = await request(app)
+        .post(`/api/projects/${projectId}/kanban/cards`)
+        .send({ sessionId: child.id, laneId: lanes[0].id });
+
+      expect(res.status).toBe(201);
+      expect(res.body.sessions[0].id).toBe(root.id);
+      expect(kanbanCards.getBySessionId(root.id)).toBeTruthy();
+      expect(kanbanCards.getBySessionId(child.id)).toBeNull();
+    });
+
+    it('detects duplicate cards by workflow root session ID', async () => {
+      setupBoard();
+      const root = createSession('Root Session');
+      const child = sessions.create(projectId, 'Child Session', 'Child prompt', {
+        mode: 'standard',
+        parentSessionId: root.id,
+      });
+      kanbanCards.create(lanes[0].id, root.id);
+
+      const res = await request(app)
+        .post(`/api/projects/${projectId}/kanban/cards`)
+        .send({ sessionId: child.id, laneId: lanes[1].id });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('Session already has a card on the board');
+    });
+
+    it('rejects child sessions whose workflow root belongs to another project', async () => {
+      setupBoard();
+      const otherProject = projects.create('Other Project', '/tmp/other', null, { kanbanEnabled: true });
+      const root = sessions.create(otherProject.id, 'Other Root', 'Prompt');
+      const child = sessions.create(otherProject.id, 'Other Child', 'Prompt', {
+        mode: 'standard',
+        parentSessionId: root.id,
+      });
+
+      const res = await request(app)
+        .post(`/api/projects/${projectId}/kanban/cards`)
+        .send({ sessionId: child.id, laneId: lanes[0].id });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Session does not belong to this project');
+    });
+
     it('broadcasts KANBAN_CARD_ADDED', async () => {
       setupBoard();
       const session = createSession();

--- a/packages/server/src/api/kanban.test.js
+++ b/packages/server/src/api/kanban.test.js
@@ -357,6 +357,24 @@ describe('Kanban API', () => {
       expect(res.body.error).toBe('Session does not belong to this project');
     });
 
+    it('rejects a provided session that belongs to another project even if root is in this project', async () => {
+      setupBoard();
+      const otherProject = projects.create('Other Project', '/tmp/other', null, { kanbanEnabled: true });
+      // root lives in our project, child lives in otherProject
+      const root = createSession('Root in This Project');
+      const child = sessions.create(otherProject.id, 'Child in Other Project', 'Prompt', {
+        mode: 'standard',
+        parentSessionId: root.id,
+      });
+
+      const res = await request(app)
+        .post(`/api/projects/${projectId}/kanban/cards`)
+        .send({ sessionId: child.id, laneId: lanes[0].id });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Session does not belong to this project');
+    });
+
     it('broadcasts KANBAN_CARD_ADDED', async () => {
       setupBoard();
       const session = createSession();

--- a/packages/server/src/api/projects-session-helpers.test.js
+++ b/packages/server/src/api/projects-session-helpers.test.js
@@ -285,12 +285,58 @@ describe('prepareSessionConfig', () => {
   });
 
   it('uses project defaults when body fields not provided', () => {
-    const projectDefs = { mode: 'plan', model: 'haiku', providerId: 'project-provider', thinkingEnabled: false };
+    const projectDefs = {
+      mode: 'plan',
+      model: 'haiku',
+      providerId: 'project-provider',
+      thinkingEnabled: false,
+      effortLevel: 'high',
+      gitMode: 'worktree',
+      gitBranch: 'feature/default',
+      startImmediately: false,
+    };
     const config = prepareSessionConfig({ prompt: 'test' }, projectDefs, systemDefaults);
     expect(config.mode).toBe('plan');
     expect(config.model).toBe('haiku');
     expect(config.providerId).toBe('project-provider');
     expect(config.thinkingEnabled).toBe(false);
+    expect(config.effortLevel).toBe('high');
+    expect(config.gitMode).toBe('worktree');
+    expect(config.gitBranch).toBe('feature/default');
+    expect(config.startImmediately).toBe(false);
+  });
+
+  it('uses explicit body overrides before project defaults', () => {
+    const projectDefs = {
+      mode: 'plan',
+      model: 'haiku',
+      providerId: 'project-provider',
+      thinkingEnabled: false,
+      effortLevel: 'high',
+      gitMode: 'worktree',
+      gitBranch: 'feature/default',
+      startImmediately: false,
+    };
+    const config = prepareSessionConfig({
+      prompt: 'test',
+      mode: 'standard',
+      model: 'opus',
+      providerId: 'body-provider',
+      thinkingEnabled: true,
+      effortLevel: 'low',
+      gitMode: 'branch',
+      gitBranch: 'feature/body',
+      startImmediately: true,
+    }, projectDefs, systemDefaults);
+
+    expect(config.mode).toBe('standard');
+    expect(config.model).toBe('opus');
+    expect(config.providerId).toBe('body-provider');
+    expect(config.thinkingEnabled).toBe(true);
+    expect(config.effortLevel).toBe('low');
+    expect(config.gitMode).toBe('branch');
+    expect(config.gitBranch).toBe('feature/body');
+    expect(config.startImmediately).toBe(true);
   });
 
   it('normalizes empty providerId to null', () => {

--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -212,6 +212,16 @@ async function validateAndPrepareSessionConfig(reqBody, reqFiles, projectId, pro
     return { error: 'Prompt is required', status: 400 };
   }
 
+  if (config.parentSessionId) {
+    const parentSession = sessions.getById(config.parentSessionId);
+    if (!parentSession) {
+      return { error: 'Parent session not found', status: 404 };
+    }
+    if (parentSession.projectId !== projectId) {
+      return { error: 'Parent session does not belong to this project', status: 400 };
+    }
+  }
+
   // Apply template overrides and resolve nextTemplateId
   applyTemplateOverrides(config);
   const { nextTemplateId, error: nextTemplateError } = resolveNextTemplateId(reqBody, config.nextTemplateId || null);

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -161,6 +161,33 @@ describe('Projects API', () => {
       expect(res.status).toBe(400);
     });
 
+    it('returns 404 when parentSessionId references a missing session', async () => {
+      const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+        prompt: 'Child prompt',
+        parentSessionId: 'missing-parent-session',
+      });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Parent session not found');
+      expect(setupGitForSession).not.toHaveBeenCalled();
+      expect(sessions.getByProjectId(projectId)).toHaveLength(0);
+    });
+
+    it('rejects parentSessionId from another project', async () => {
+      const otherProject = projects.create('Other Project', tempDir);
+      const otherParent = sessions.create(otherProject.id, 'Other Parent', 'Parent prompt');
+
+      const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+        prompt: 'Child prompt',
+        parentSessionId: otherParent.id,
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Parent session does not belong to this project');
+      expect(setupGitForSession).not.toHaveBeenCalled();
+      expect(sessions.getByProjectId(projectId)).toHaveLength(0);
+    });
+
     it('persists providerId for JSON session creation', async () => {
       const provider = modelProviders.create({
         name: 'OpenAI Test',

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -1059,6 +1059,82 @@ describe('Projects API', () => {
   });
 
   describe('Session creation with project defaults', () => {
+    it('creates a session from prompt only and resolves project defaults', async () => {
+      const provider = modelProviders.create({
+        name: 'Prompt Only Provider',
+        kind: 'openai',
+        baseUrl: 'https://api.openai.test',
+        apiKey: 'test-key',
+      });
+
+      await request(app).post(`/api/projects/${projectId}/session-defaults`).send({
+        mode: 'plan',
+        thinkingEnabled: true,
+        model: 'gpt-4o',
+        providerId: provider.id,
+        effortLevel: 'high',
+        startImmediately: false,
+      });
+
+      const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+        prompt: 'Prompt only creation',
+      });
+
+      expect(res.status).toBe(201);
+
+      const session = sessions.getById(res.body.id);
+      expect(session.mode).toBe('plan');
+      expect(session.thinkingEnabled).toBe(true);
+      expect(session.model).toBe('gpt-4o');
+      expect(session.providerId).toBe(provider.id);
+      expect(session.effortLevel).toBe('high');
+      expect(session.status).toBe('waiting');
+    });
+
+    it('uses request body overrides before project defaults', async () => {
+      const defaultProvider = modelProviders.create({
+        name: 'Default Provider',
+        kind: 'openai',
+        baseUrl: 'https://api.default.test',
+        apiKey: 'test-key',
+      });
+      const overrideProvider = modelProviders.create({
+        name: 'Override Provider',
+        kind: 'openai',
+        baseUrl: 'https://api.override.test',
+        apiKey: 'test-key',
+      });
+
+      await request(app).post(`/api/projects/${projectId}/session-defaults`).send({
+        mode: 'plan',
+        thinkingEnabled: false,
+        model: 'default-model',
+        providerId: defaultProvider.id,
+        effortLevel: 'low',
+        startImmediately: false,
+      });
+
+      const res = await request(app).post(`/api/projects/${projectId}/sessions`).send({
+        prompt: 'Override defaults',
+        mode: 'standard',
+        thinkingEnabled: true,
+        model: 'override-model',
+        providerId: overrideProvider.id,
+        effortLevel: 'max',
+        startImmediately: true,
+      });
+
+      expect(res.status).toBe(201);
+
+      const session = sessions.getById(res.body.id);
+      expect(session.mode).toBe('standard');
+      expect(session.thinkingEnabled).toBe(true);
+      expect(session.model).toBe('override-model');
+      expect(session.providerId).toBe(overrideProvider.id);
+      expect(session.effortLevel).toBe('max');
+      expect(session.status).toBe('starting');
+    });
+
     it('applies project mode default when no param provided', async () => {
       // Set project defaults
       await request(app).post(`/api/projects/${projectId}/session-defaults`).send({

--- a/packages/server/src/api/sessions-commands.js
+++ b/packages/server/src/api/sessions-commands.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { commandButtons, commandRuns } from '../database.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
-import { requireSession, requireSessionAndProject } from '../middleware/sessionLookup.js';
+import { requireRootSessionAndProject } from '../middleware/sessionLookup.js';
 import { commandRunner } from '../services/commandRunner.js';
 import { databaseManager } from '../db/DatabaseManager.js';
 
@@ -46,15 +46,23 @@ function broadcastCommandError(ctx, errorMessage) {
   broadcastToProject(projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, { projectId, sessionId, runId, buttonId, error: errorMessage });
 }
 
+// GET /api/sessions/:id/command-buttons - List command buttons for the workflow project
+router.get('/:id/command-buttons', requireRootSessionAndProject, (req, res) => {
+  res.json(commandButtons.getByProjectId(req.rootSession_.projectId));
+});
+
 // POST /api/sessions/:id/command-buttons/:buttonId/run - Execute button command
-router.post('/:id/command-buttons/:buttonId/run', requireSessionAndProject, (req, res) => {
-  const sessionId = req.params.id;
+router.post('/:id/command-buttons/:buttonId/run', requireRootSessionAndProject, (req, res) => {
+  const sessionId = req.rootSessionId;
   const buttonId = req.params.buttonId;
 
   console.log(`[RUN] Starting command for buttonId: ${buttonId}, sessionId: ${sessionId}`);
 
   const button = commandButtons.getById(buttonId);
   if (!button) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
+  if (button.projectId !== req.rootSession_.projectId) {
     return res.status(404).json({ error: 'Command button not found' });
   }
 
@@ -67,8 +75,8 @@ router.post('/:id/command-buttons/:buttonId/run', requireSessionAndProject, (req
   res.json({ runId, buttonId, status: 'running', output: '' });
 
   // Capture middleware values for use in async callbacks
-  const projectId = req.session_.projectId;
-  const workingDirectory = req.workingDirectory;
+  const projectId = req.rootSession_.projectId;
+  const workingDirectory = req.rootWorkingDirectory;
   const ctx = { sessionId, projectId, runId, buttonId };
 
   // Broadcast initial "running" status immediately so session list can show the running indicator
@@ -98,16 +106,17 @@ router.post('/:id/command-buttons/:buttonId/run', requireSessionAndProject, (req
 });
 
 // GET /api/sessions/:id/command-buttons/runs - Get active runs for session
-router.get('/:id/command-buttons/runs', requireSession, (req, res) => {
-  const sessionId = req.params.id;
+router.get('/:id/command-buttons/runs', requireRootSessionAndProject, (req, res) => {
+  const sessionId = req.rootSessionId;
 
   const activeRuns = commandRunner.getRunsBySession(sessionId);
   res.json(activeRuns);
 });
 
 // GET /api/sessions/:id/command-buttons/runs/:runId - Get single run by ID
-router.get('/:id/command-buttons/runs/:runId', requireSession, (req, res) => {
-  const { id: sessionId, runId } = req.params;
+router.get('/:id/command-buttons/runs/:runId', requireRootSessionAndProject, (req, res) => {
+  const { runId } = req.params;
+  const sessionId = req.rootSessionId;
 
   // Check if run is currently running (in memory)
   if (commandRunner.isRunning(runId)) {
@@ -136,8 +145,8 @@ router.get('/:id/command-buttons/runs/:runId', requireSession, (req, res) => {
 });
 
 // DELETE /api/sessions/:id/command-buttons/runs/:runId - Delete a command run record
-router.delete('/:id/command-buttons/runs/:runId', requireSessionAndProject, (req, res) => {
-  const sessionId = req.params.id;
+router.delete('/:id/command-buttons/runs/:runId', requireRootSessionAndProject, (req, res) => {
+  const sessionId = req.rootSessionId;
   const { runId } = req.params;
 
   const run = commandRuns.getById(runId);
@@ -151,7 +160,7 @@ router.delete('/:id/command-buttons/runs/:runId', requireSessionAndProject, (req
 
   commandRuns.deleteById(runId);
 
-  const projectId = req.session_.projectId;
+  const projectId = req.rootSession_.projectId;
 
   // Broadcast deletion to session and project subscribers
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.COMMAND_RUN_DELETED, {
@@ -170,18 +179,21 @@ router.delete('/:id/command-buttons/runs/:runId', requireSessionAndProject, (req
 });
 
 // DELETE /api/sessions/:id/command-buttons/:buttonId/runs/all - Delete all runs for a button in a session
-router.delete('/:id/command-buttons/:buttonId/runs/all', requireSessionAndProject, (req, res) => {
-  const sessionId = req.params.id;
+router.delete('/:id/command-buttons/:buttonId/runs/all', requireRootSessionAndProject, (req, res) => {
+  const sessionId = req.rootSessionId;
   const { buttonId } = req.params;
 
   const button = commandButtons.getById(buttonId);
   if (!button) {
     return res.status(404).json({ error: 'Command button not found' });
   }
+  if (button.projectId !== req.rootSession_.projectId) {
+    return res.status(404).json({ error: 'Command button not found' });
+  }
 
   const { deletedRuns } = commandRuns.deleteByButtonAndSession(buttonId, sessionId);
 
-  const projectId = req.session_.projectId;
+  const projectId = req.rootSession_.projectId;
 
   // Broadcast individual COMMAND_RUN_DELETED events for each deleted run
   for (const run of deletedRuns) {
@@ -202,11 +214,17 @@ router.delete('/:id/command-buttons/:buttonId/runs/all', requireSessionAndProjec
 });
 
 // POST /api/sessions/:id/command-buttons/runs/:runId/kill - Kill running command
-router.post('/:id/command-buttons/runs/:runId/kill', requireSession, (req, res) => {
-  const sessionId = req.params.id;
+router.post('/:id/command-buttons/runs/:runId/kill', requireRootSessionAndProject, (req, res) => {
+  const sessionId = req.rootSessionId;
   const runId = req.params.runId;
 
   console.log(`[KILL] Kill request for runId: ${runId}, sessionId: ${sessionId}`);
+
+  const activeRuns = commandRunner.getRunsBySession(sessionId);
+  const activeRun = activeRuns.find((run) => run.runId === runId);
+  if (!activeRun) {
+    return res.status(404).json({ error: 'Run not found or already completed' });
+  }
 
   const killed = commandRunner.kill(runId);
   console.log(`[KILL] Kill result: ${killed} for runId: ${runId}`);

--- a/packages/server/src/api/sessions-commands.test.js
+++ b/packages/server/src/api/sessions-commands.test.js
@@ -353,6 +353,18 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       expect(commandRunner.kill).toHaveBeenCalledWith('root-active');
     });
 
+    it('returns 404 when run does not belong to the root session', async () => {
+      const child = createChildSession();
+      commandRunner.getRunsBySession.mockReturnValue([]); // no active runs for root
+
+      const res = await request(app)
+        .post(`/api/sessions/${child.id}/command-buttons/runs/unknown-run/kill`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Run not found or already completed');
+      expect(commandRunner.kill).not.toHaveBeenCalled();
+    });
+
     it('returns 404 when run not found or already completed', async () => {
       commandRunner.kill.mockReturnValue(false);
 

--- a/packages/server/src/api/sessions-commands.test.js
+++ b/packages/server/src/api/sessions-commands.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { projects, sessions, commandButtons } from '../database.js';
+import { projects, sessions, commandButtons, commandRuns } from '../database.js';
 
 // Mock websocket before importing the router
 vi.mock('../websocket.js', () => ({
@@ -39,6 +39,7 @@ vi.mock('../services/commandRunner.js', () => ({
 // Import after mocks are set up
 import sessionsRouter from './sessions.js';
 import { commandRunner } from '../services/commandRunner.js';
+import { broadcastToProject, broadcastToSession } from '../websocket.js';
 
 describe('Sessions API - Command Routes (sessions-commands.js)', () => {
   let app;
@@ -55,6 +56,27 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
     project = projects.create('Test Project', '/tmp/test');
     session = sessions.create(project.id, 'Test Session', 'Initial prompt', 'standard');
     sessions.update(session.id, { status: 'waiting' });
+  });
+
+  function createChildSession(parent = session) {
+    return sessions.create(project.id, 'Child Session', 'Child prompt', {
+      mode: 'standard',
+      parentSessionId: parent.id,
+    });
+  }
+
+  describe('GET /api/sessions/:id/command-buttons', () => {
+    it('returns buttons for the workflow root project through a child session', async () => {
+      const child = createChildSession();
+      const button = commandButtons.create({ projectId: project.id, label: 'Test Button', command: 'echo hello' });
+
+      const res = await request(app)
+        .get(`/api/sessions/${child.id}/command-buttons`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].id).toBe(button.id);
+    });
   });
 
   describe('POST /api/sessions/:id/command-buttons/:buttonId/run', () => {
@@ -78,6 +100,36 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       expect(res.body.status).toBe('running');
     });
 
+    it('runs commands against workflow root metadata and working directory through a child session', async () => {
+      session = sessions.update(session.id, { gitWorktree: '/tmp/root-worktree' });
+      const child = createChildSession();
+      const button = commandButtons.create({ projectId: project.id, label: 'Test Button', command: 'echo hello' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${child.id}/command-buttons/${button.id}/run`);
+
+      expect(res.status).toBe(200);
+      expect(commandRunner.run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'echo hello',
+          workingDirectory: '/tmp/root-worktree',
+        }),
+        expect.any(Object),
+        { sessionId: session.id, buttonId: button.id }
+      );
+    });
+
+    it('returns 404 when the button belongs to another project', async () => {
+      const otherProject = projects.create('Other Project', '/tmp/other');
+      const button = commandButtons.create({ projectId: otherProject.id, label: 'Other Button', command: 'echo no' });
+
+      const res = await request(app)
+        .post(`/api/sessions/${session.id}/command-buttons/${button.id}/run`);
+
+      expect(res.status).toBe(404);
+      expect(commandRunner.run).not.toHaveBeenCalled();
+    });
+
     it('returns 404 for non-existent session', async () => {
       const res = await request(app)
         .post('/api/sessions/non-existent/command-buttons/btn-1/run');
@@ -98,6 +150,20 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(1);
       expect(res.body[0].runId).toBe('r1');
+    });
+
+    it('returns active runs for the workflow root through a child session', async () => {
+      const child = createChildSession();
+      commandRunner.getRunsBySession.mockReturnValue([
+        { runId: 'root-run', buttonId: 'b1', status: 'running' },
+      ]);
+
+      const res = await request(app)
+        .get(`/api/sessions/${child.id}/command-buttons/runs`);
+
+      expect(res.status).toBe(200);
+      expect(commandRunner.getRunsBySession).toHaveBeenCalledWith(session.id);
+      expect(res.body[0].runId).toBe('root-run');
     });
 
     it('returns empty array when no runs exist', async () => {
@@ -133,6 +199,33 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       expect(res.body.status).toBe('running');
     });
 
+    it('returns persisted root-owned run through a child session', async () => {
+      const child = createChildSession();
+      const button = commandButtons.create({ projectId: project.id, label: 'Done Button', command: 'echo done' });
+      commandRuns.create({ id: 'root-complete', sessionId: session.id, buttonId: button.id });
+      commandRuns.complete('root-complete', 0, 'done');
+
+      const res = await request(app)
+        .get(`/api/sessions/${child.id}/command-buttons/runs/root-complete`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.runId).toBe('root-complete');
+      expect(res.body.output).toBe('done');
+    });
+
+    it('does not return child-owned persisted runs through a child session', async () => {
+      const child = createChildSession();
+      const button = commandButtons.create({ projectId: project.id, label: 'Done Button', command: 'echo done' });
+      commandRuns.create({ id: 'child-complete', sessionId: child.id, buttonId: button.id });
+      commandRuns.complete('child-complete', 0, 'done');
+
+      const res = await request(app)
+        .get(`/api/sessions/${child.id}/command-buttons/runs/child-complete`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Run not found');
+    });
+
     it('returns 404 when run not found in memory or database', async () => {
       commandRunner.isRunning.mockReturnValue(false);
 
@@ -146,7 +239,6 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
 
   describe('DELETE /api/sessions/:id/command-buttons/runs/:runId', () => {
     it('returns 204 when run is deleted successfully', async () => {
-      const { commandRuns } = await import('../database.js');
       const button = commandButtons.create({ projectId: project.id, label: 'Del Button', command: 'echo del' });
       commandRuns.create({ id: 'run-del', sessionId: session.id, buttonId: button.id });
       commandRuns.complete('run-del', 0, 'output');
@@ -167,7 +259,6 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
     });
 
     it('returns 409 when run is still running', async () => {
-      const { commandRuns } = await import('../database.js');
       const button = commandButtons.create({ projectId: project.id, label: 'Running Button', command: 'sleep 10' });
       commandRuns.create({ id: 'run-active', sessionId: session.id, buttonId: button.id });
 
@@ -180,6 +271,30 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       expect(res.body.error).toBe('Cannot delete a running command. Kill it first.');
     });
 
+    it('deletes root-owned completed runs and broadcasts root IDs through a child session', async () => {
+      const child = createChildSession();
+      const button = commandButtons.create({ projectId: project.id, label: 'Del Button', command: 'echo del' });
+      commandRuns.create({ id: 'root-del', sessionId: session.id, buttonId: button.id });
+      commandRuns.complete('root-del', 0, 'output');
+      commandRunner.isRunning.mockReturnValue(false);
+
+      const res = await request(app)
+        .delete(`/api/sessions/${child.id}/command-buttons/runs/root-del`);
+
+      expect(res.status).toBe(204);
+      expect(commandRuns.getById('root-del')).toBeNull();
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        session.id,
+        expect.any(String),
+        expect.objectContaining({ runId: 'root-del', sessionId: session.id })
+      );
+      expect(broadcastToProject).toHaveBeenCalledWith(
+        project.id,
+        expect.any(String),
+        expect.objectContaining({ runId: 'root-del', sessionId: session.id, projectId: project.id })
+      );
+    });
+
     it('returns 404 for non-existent session', async () => {
       const res = await request(app)
         .delete('/api/sessions/non-existent/command-buttons/runs/run-1');
@@ -188,8 +303,31 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
     });
   });
 
+  describe('DELETE /api/sessions/:id/command-buttons/:buttonId/runs/all', () => {
+    it('deletes only completed root-session runs for a button through a child session', async () => {
+      const child = createChildSession();
+      const button = commandButtons.create({ projectId: project.id, label: 'Bulk Button', command: 'echo bulk' });
+      commandRuns.create({ id: 'root-1', sessionId: session.id, buttonId: button.id });
+      commandRuns.complete('root-1', 0, 'one');
+      commandRuns.create({ id: 'root-running', sessionId: session.id, buttonId: button.id });
+      commandRuns.create({ id: 'child-1', sessionId: child.id, buttonId: button.id });
+      commandRuns.complete('child-1', 0, 'child');
+
+      const res = await request(app)
+        .delete(`/api/sessions/${child.id}/command-buttons/${button.id}/runs/all`);
+
+      expect(res.status).toBe(204);
+      expect(commandRuns.getById('root-1')).toBeNull();
+      expect(commandRuns.getById('root-running')).toBeTruthy();
+      expect(commandRuns.getById('child-1')).toBeTruthy();
+    });
+  });
+
   describe('POST /api/sessions/:id/command-buttons/runs/:runId/kill', () => {
     it('kills a running command', async () => {
+      commandRunner.getRunsBySession.mockReturnValue([
+        { runId: 'r1', buttonId: 'b1', status: 'running' },
+      ]);
       commandRunner.kill.mockReturnValue(true);
 
       const res = await request(app)
@@ -198,6 +336,21 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
       expect(res.body.runId).toBe('r1');
+    });
+
+    it('kills a root active run through a child session', async () => {
+      const child = createChildSession();
+      commandRunner.getRunsBySession.mockReturnValue([
+        { runId: 'root-active', buttonId: 'b1', status: 'running' },
+      ]);
+      commandRunner.kill.mockReturnValue(true);
+
+      const res = await request(app)
+        .post(`/api/sessions/${child.id}/command-buttons/runs/root-active/kill`);
+
+      expect(res.status).toBe(200);
+      expect(commandRunner.getRunsBySession).toHaveBeenCalledWith(session.id);
+      expect(commandRunner.kill).toHaveBeenCalledWith('root-active');
     });
 
     it('returns 404 when run not found or already completed', async () => {

--- a/packages/server/src/api/sessions-lifecycle.js
+++ b/packages/server/src/api/sessions-lifecycle.js
@@ -6,19 +6,19 @@ import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as gitService from '../services/gitService.js';
 import * as summaryService from '../services/summaryService.js';
 import { executeHookAsync } from '../services/hookService.js';
-import { requireSession, requireSessionAndProject } from '../middleware/sessionLookup.js';
+import { requireRootSessionAndProject, requireSession, requireSessionAndProject } from '../middleware/sessionLookup.js';
 import { duplicateSession } from '../services/sessionDuplicator.js';
 import { configureSchedule, ScheduleError } from '../services/scheduleService.js';
 
 const router = Router();
 
-// GET /api/sessions/:id/summary - Get session summary
-router.get('/:id/summary', requireSession, async (req, res) => {
+// GET /api/sessions/:id/summary - Get workflow summary
+router.get('/:id/summary', requireRootSessionAndProject, async (req, res) => {
   // Check if generateIfMissing query param is set
   const generateIfMissing = req.query.generate === 'true';
 
   try {
-    const summary = await summaryService.getSummary(req.params.id, generateIfMissing);
+    const summary = await summaryService.getSummary(req.rootSessionId, generateIfMissing);
     if (!summary) {
       return res.status(404).json({ error: 'Summary not found' });
     }
@@ -28,10 +28,10 @@ router.get('/:id/summary', requireSession, async (req, res) => {
   }
 });
 
-// POST /api/sessions/:id/summary - Generate/regenerate session summary
-router.post('/:id/summary', requireSession, async (req, res) => {
+// POST /api/sessions/:id/summary - Generate/regenerate workflow summary
+router.post('/:id/summary', requireRootSessionAndProject, async (req, res) => {
   try {
-    const summary = await summaryService.regenerateSummary(req.params.id);
+    const summary = await summaryService.regenerateSummary(req.rootSessionId);
     if (!summary) {
       return res.status(500).json({ error: 'Failed to generate summary' });
     }
@@ -41,10 +41,10 @@ router.post('/:id/summary', requireSession, async (req, res) => {
   }
 });
 
-// PUT /api/sessions/:id/summary - Directly set summary data (for testing/seeding)
-router.put('/:id/summary', requireSession, async (req, res) => {
+// PUT /api/sessions/:id/summary - Directly set workflow summary data (for testing/seeding)
+router.put('/:id/summary', requireRootSessionAndProject, async (req, res) => {
   try {
-    const summary = sessionSummaries.upsert(req.params.id, req.body);
+    const summary = sessionSummaries.upsert(req.rootSessionId, req.body);
     res.json(summary);
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/packages/server/src/api/sessions-notes.js
+++ b/packages/server/src/api/sessions-notes.js
@@ -1,30 +1,30 @@
 import { Router } from 'express';
 import { sessionNotes } from '../database.js';
-import { requireSession } from '../middleware/sessionLookup.js';
+import { requireRootSessionAndProject } from '../middleware/sessionLookup.js';
 
 const router = Router();
 
-// GET /api/sessions/:id/notes - Get session notes
-router.get('/:id/notes', requireSession, (req, res) => {
-  const notes = sessionNotes.getBySessionId(req.params.id);
+// GET /api/sessions/:id/notes - Get workflow notes
+router.get('/:id/notes', requireRootSessionAndProject, (req, res) => {
+  const notes = sessionNotes.getBySessionId(req.rootSessionId);
   res.json(notes);
 });
 
-// POST /api/sessions/:id/notes - Create session note
-router.post('/:id/notes', requireSession, (req, res) => {
+// POST /api/sessions/:id/notes - Create workflow note
+router.post('/:id/notes', requireRootSessionAndProject, (req, res) => {
   const { content } = req.body;
   if (!content) {
     return res.status(400).json({ error: 'Content is required' });
   }
 
-  const note = sessionNotes.create(req.params.id, content);
+  const note = sessionNotes.create(req.rootSessionId, content);
   res.status(201).json(note);
 });
 
-// PUT /api/sessions/:id/notes/:noteId - Update session note
-router.put('/:id/notes/:noteId', (req, res) => {
+// PUT /api/sessions/:id/notes/:noteId - Update workflow note
+router.put('/:id/notes/:noteId', requireRootSessionAndProject, (req, res) => {
   const note = sessionNotes.getById(req.params.noteId);
-  if (!note || note.sessionId !== req.params.id) {
+  if (!note || note.sessionId !== req.rootSessionId) {
     return res.status(404).json({ error: 'Note not found' });
   }
 
@@ -37,10 +37,10 @@ router.put('/:id/notes/:noteId', (req, res) => {
   res.json(updated);
 });
 
-// DELETE /api/sessions/:id/notes/:noteId - Delete session note
-router.delete('/:id/notes/:noteId', (req, res) => {
+// DELETE /api/sessions/:id/notes/:noteId - Delete workflow note
+router.delete('/:id/notes/:noteId', requireRootSessionAndProject, (req, res) => {
   const note = sessionNotes.getById(req.params.noteId);
-  if (!note || note.sessionId !== req.params.id) {
+  if (!note || note.sessionId !== req.rootSessionId) {
     return res.status(404).json({ error: 'Note not found' });
   }
 

--- a/packages/server/src/api/sessions-notes.test.js
+++ b/packages/server/src/api/sessions-notes.test.js
@@ -42,6 +42,13 @@ describe('Sessions API - Notes Routes (sessions-notes.js)', () => {
     sessions.update(session.id, { status: 'waiting' });
   });
 
+  function createChildSession(parent = session) {
+    return sessions.create(project.id, 'Child Session', 'Child prompt', {
+      mode: 'standard',
+      parentSessionId: parent.id,
+    });
+  }
+
   describe('GET /api/sessions/:id/notes', () => {
     it('returns empty array when no notes exist', async () => {
       const res = await request(app).get(`/api/sessions/${session.id}/notes`);
@@ -61,6 +68,17 @@ describe('Sessions API - Notes Routes (sessions-notes.js)', () => {
       expect(contents).toContain('Second note');
     });
 
+    it('lists workflow root notes through a child session', async () => {
+      const child = createChildSession();
+      sessionNotes.create(session.id, 'Root note');
+      sessionNotes.create(child.id, 'Child-only note');
+
+      const res = await request(app).get(`/api/sessions/${child.id}/notes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.map(n => n.content)).toEqual(['Root note']);
+    });
+
     it('returns 404 for non-existent session', async () => {
       const res = await request(app).get('/api/sessions/non-existent/notes');
       expect(res.status).toBe(404);
@@ -77,6 +95,19 @@ describe('Sessions API - Notes Routes (sessions-notes.js)', () => {
       expect(res.body.content).toBe('My new note');
       expect(res.body.sessionId).toBe(session.id);
       expect(res.body.id).toBeDefined();
+    });
+
+    it('creates notes on the workflow root through a child session', async () => {
+      const child = createChildSession();
+
+      const res = await request(app)
+        .post(`/api/sessions/${child.id}/notes`)
+        .send({ content: 'Root workflow note' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.sessionId).toBe(session.id);
+      expect(sessionNotes.getBySessionId(session.id)).toHaveLength(1);
+      expect(sessionNotes.getBySessionId(child.id)).toHaveLength(0);
     });
 
     it('returns 400 when content is missing', async () => {
@@ -107,6 +138,18 @@ describe('Sessions API - Notes Routes (sessions-notes.js)', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.content).toBe('Updated content');
+    });
+
+    it('updates a root-owned note through a child session', async () => {
+      const child = createChildSession();
+      const note = sessionNotes.create(session.id, 'Original content');
+
+      const res = await request(app)
+        .put(`/api/sessions/${child.id}/notes/${note.id}`)
+        .send({ content: 'Updated through child' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe('Updated through child');
     });
 
     it('returns 404 when note does not exist', async () => {
@@ -154,6 +197,17 @@ describe('Sessions API - Notes Routes (sessions-notes.js)', () => {
       // Verify note is gone
       const remaining = sessionNotes.getBySessionId(session.id);
       expect(remaining).toHaveLength(0);
+    });
+
+    it('deletes a root-owned note through a child session', async () => {
+      const child = createChildSession();
+      const note = sessionNotes.create(session.id, 'To be deleted');
+
+      const res = await request(app)
+        .delete(`/api/sessions/${child.id}/notes/${note.id}`);
+
+      expect(res.status).toBe(204);
+      expect(sessionNotes.getBySessionId(session.id)).toHaveLength(0);
     });
 
     it('returns 404 when note does not exist', async () => {

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -108,11 +108,14 @@ router.get('/:id', requireSession, (req, res) => {
   const allMessages = messages.getBySessionId(req.params.id);
   const hasResponses = allMessages.some(msg => msg.role === 'assistant');
 
-  // Get command run statuses (latest run per button for this session)
+  // Session details are for the requested session; command runs are workflow-root scoped.
+  const commandRunSessionId = sessions.getRootSessionId(req.params.id) || req.params.id;
+
+  // Get command run statuses (latest run per button for this workflow)
   // Completed runs from DB
-  const dbRuns = commandRuns.getLatestRunsForSession(req.params.id);
+  const dbRuns = commandRuns.getLatestRunsForSession(commandRunSessionId);
   // Currently running commands from memory - filter all runs for this session
-  const allRunning = commandRunner.getRunsBySession(req.params.id);
+  const allRunning = commandRunner.getRunsBySession(commandRunSessionId);
   const runningRuns = allRunning.filter(run => run.status === 'running');
 
   // Build map of buttonId -> run data

--- a/packages/server/src/api/sessions.test.js
+++ b/packages/server/src/api/sessions.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { projects, sessions } from '../database.js';
+import { projects, sessions, commandButtons, commandRuns, sessionSummaries } from '../database.js';
 
 // Mock websocket before importing the router
 vi.mock('../websocket.js', () => ({
@@ -74,6 +74,7 @@ vi.mock('../middleware/upload.js', () => ({
 }));
 
 import sessionsRouter from './sessions.js';
+import * as summaryService from '../services/summaryService.js';
 
 describe('Sessions API - PATCH effortLevel', () => {
   let app;
@@ -185,5 +186,97 @@ describe('Sessions API - PATCH effortLevel', () => {
     expect(res.body.effortLevel).toBe('max');
     expect(res.body.thinkingEnabled).toBe(true);
     expect(res.body.name).toBe('Updated Session');
+  });
+});
+
+describe('Sessions API - workflow-root command metadata', () => {
+  let app;
+  let project;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    project = projects.create('Test Project', '/tmp/test');
+  });
+
+  it('returns requested child session details with latestCommandRuns from the workflow root', async () => {
+    const root = sessions.create(project.id, 'Root Session', 'root prompt');
+    const child = sessions.create(project.id, 'Child Session', 'child prompt', {
+      mode: 'standard',
+      parentSessionId: root.id,
+    });
+    const button = commandButtons.create({ projectId: project.id, label: 'Build', command: 'echo build' });
+    commandRuns.create({ id: 'root-run', sessionId: root.id, buttonId: button.id });
+    commandRuns.complete('root-run', 0, 'done');
+
+    const res = await request(app).get(`/api/sessions/${child.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(child.id);
+    expect(res.body.parentSessionId).toBe(root.id);
+    expect(res.body.latestCommandRuns).toEqual([
+      expect.objectContaining({
+        buttonId: button.id,
+        runId: 'root-run',
+        output: 'done',
+      }),
+    ]);
+  });
+});
+
+describe('Sessions API - workflow summary routes', () => {
+  let app;
+  let project;
+  let root;
+  let child;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    project = projects.create('Test Project', '/tmp/test');
+    root = sessions.create(project.id, 'Root Session', 'root prompt');
+    child = sessions.create(project.id, 'Child Session', 'child prompt', {
+      mode: 'standard',
+      parentSessionId: root.id,
+    });
+  });
+
+  it('gets workflow root summary through a child session', async () => {
+    summaryService.getSummary.mockResolvedValueOnce({ sessionId: root.id, summary: 'root summary' });
+
+    const res = await request(app).get(`/api/sessions/${child.id}/summary?generate=true`);
+
+    expect(res.status).toBe(200);
+    expect(summaryService.getSummary).toHaveBeenCalledWith(root.id, true);
+    expect(res.body.sessionId).toBe(root.id);
+  });
+
+  it('regenerates workflow root summary through a child session', async () => {
+    summaryService.regenerateSummary.mockResolvedValueOnce({ sessionId: root.id, summary: 'new summary' });
+
+    const res = await request(app).post(`/api/sessions/${child.id}/summary`);
+
+    expect(res.status).toBe(201);
+    expect(summaryService.regenerateSummary).toHaveBeenCalledWith(root.id);
+    expect(res.body.sessionId).toBe(root.id);
+  });
+
+  it('updates workflow root summary through a child session', async () => {
+    const res = await request(app)
+      .put(`/api/sessions/${child.id}/summary`)
+      .send({ shortSummary: 'Manual', fullSummary: 'manual summary' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.sessionId).toBe(root.id);
+    expect(sessionSummaries.getBySessionId(root.id).fullSummary).toBe('manual summary');
+    expect(sessionSummaries.getBySessionId(child.id)).toBeNull();
   });
 });

--- a/packages/server/src/middleware/sessionLookup.js
+++ b/packages/server/src/middleware/sessionLookup.js
@@ -72,6 +72,10 @@ export function requireRootSessionAndProject(req, res, next) {
     return res.status(404).json({ error: 'Session not found' });
   }
 
+  if (providedSession.projectId !== rootSession.projectId) {
+    return res.status(400).json({ error: 'Session parent chain crosses projects' });
+  }
+
   const rootProject = projects.getById(rootSession.projectId);
   if (!rootProject) {
     return res.status(404).json({ error: 'Project not found' });

--- a/packages/server/src/middleware/sessionLookup.js
+++ b/packages/server/src/middleware/sessionLookup.js
@@ -15,11 +15,6 @@ export function requireSession(req, res, next) {
 }
 
 /**
- * Middleware: Look up session AND its project. Attaches req.session_ and req.project.
- * Returns 404 if either is not found.
- * Also resolves req.workingDirectory (gitWorktree || project.workingDirectory).
- */
-/**
  * Middleware factory: Validates that req.session_.status is one of the allowed statuses.
  * Must be used AFTER requireSession or requireSessionAndProject middleware.
  * @param {string[]} allowedStatuses - Array of allowed status strings
@@ -39,6 +34,11 @@ export function requireSessionStatus(allowedStatuses, errorMessage) {
   };
 }
 
+/**
+ * Middleware: Look up session AND its project. Attaches req.session_ and req.project.
+ * Returns 404 if either is not found.
+ * Also resolves req.workingDirectory (gitWorktree || project.workingDirectory).
+ */
 export function requireSessionAndProject(req, res, next) {
   const session = sessions.getById(req.params.id);
   if (!session) {
@@ -103,6 +103,10 @@ export function resolveBodyRootSessionForProject(projectParam = 'projectId') {
     const providedSession = sessions.getById(providedSessionId);
     if (!providedSession) {
       return res.status(404).json({ error: 'Session not found' });
+    }
+
+    if (providedSession.projectId !== req.params[projectParam]) {
+      return res.status(400).json({ error: 'Session does not belong to this project' });
     }
 
     const rootSessionId = sessions.getRootSessionId(providedSession.id) || providedSession.id;

--- a/packages/server/src/middleware/sessionLookup.js
+++ b/packages/server/src/middleware/sessionLookup.js
@@ -55,3 +55,64 @@ export function requireSessionAndProject(req, res, next) {
   req.workingDirectory = session.gitWorktree || project.workingDirectory;
   next();
 }
+
+/**
+ * Middleware: Look up the provided session ID, then attach the workflow root
+ * session/project for resources shared across a session tree.
+ */
+export function requireRootSessionAndProject(req, res, next) {
+  const providedSession = sessions.getById(req.params.id);
+  if (!providedSession) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const rootSessionId = sessions.getRootSessionId(providedSession.id) || providedSession.id;
+  const rootSession = sessions.getById(rootSessionId);
+  if (!rootSession) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+
+  const rootProject = projects.getById(rootSession.projectId);
+  if (!rootProject) {
+    return res.status(404).json({ error: 'Project not found' });
+  }
+
+  req.providedSession_ = providedSession;
+  req.rootSession_ = rootSession;
+  req.rootSessionId = rootSessionId;
+  req.rootProject = rootProject;
+  req.rootWorkingDirectory = rootSession.gitWorktree || rootProject.workingDirectory;
+  next();
+}
+
+/**
+ * Middleware factory for project-scoped endpoints that receive a sessionId in
+ * the JSON body and should operate on that session tree's root.
+ */
+export function resolveBodyRootSessionForProject(projectParam = 'projectId') {
+  return (req, res, next) => {
+    const providedSessionId = req.body?.sessionId;
+    if (!providedSessionId) {
+      return res.status(400).json({ error: 'sessionId is required' });
+    }
+
+    const providedSession = sessions.getById(providedSessionId);
+    if (!providedSession) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+
+    const rootSessionId = sessions.getRootSessionId(providedSession.id) || providedSession.id;
+    const rootSession = sessions.getById(rootSessionId);
+    if (!rootSession) {
+      return res.status(404).json({ error: 'Session not found' });
+    }
+
+    if (rootSession.projectId !== req.params[projectParam]) {
+      return res.status(400).json({ error: 'Session does not belong to this project' });
+    }
+
+    req.bodyRootSession_ = rootSession;
+    req.bodyRootSessionId = rootSessionId;
+    next();
+  };
+}

--- a/packages/server/src/middleware/sessionLookup.js
+++ b/packages/server/src/middleware/sessionLookup.js
@@ -1,5 +1,9 @@
 import { sessions, projects } from '../database.js';
 
+const SESSION_NOT_FOUND = 'Session not found';
+const PROJECT_NOT_FOUND = 'Project not found';
+const SESSION_NOT_IN_PROJECT = 'Session does not belong to this project';
+
 /**
  * Middleware: Look up a session by req.params.id and attach to req.session_.
  * Returns 404 if session not found.
@@ -8,7 +12,7 @@ import { sessions, projects } from '../database.js';
 export function requireSession(req, res, next) {
   const session = sessions.getById(req.params.id);
   if (!session) {
-    return res.status(404).json({ error: 'Session not found' });
+    return res.status(404).json({ error: SESSION_NOT_FOUND });
   }
   req.session_ = session;
   next();
@@ -42,12 +46,12 @@ export function requireSessionStatus(allowedStatuses, errorMessage) {
 export function requireSessionAndProject(req, res, next) {
   const session = sessions.getById(req.params.id);
   if (!session) {
-    return res.status(404).json({ error: 'Session not found' });
+    return res.status(404).json({ error: SESSION_NOT_FOUND });
   }
 
   const project = projects.getById(session.projectId);
   if (!project) {
-    return res.status(404).json({ error: 'Project not found' });
+    return res.status(404).json({ error: PROJECT_NOT_FOUND });
   }
 
   req.session_ = session;
@@ -63,13 +67,13 @@ export function requireSessionAndProject(req, res, next) {
 export function requireRootSessionAndProject(req, res, next) {
   const providedSession = sessions.getById(req.params.id);
   if (!providedSession) {
-    return res.status(404).json({ error: 'Session not found' });
+    return res.status(404).json({ error: SESSION_NOT_FOUND });
   }
 
   const rootSessionId = sessions.getRootSessionId(providedSession.id) || providedSession.id;
   const rootSession = sessions.getById(rootSessionId);
   if (!rootSession) {
-    return res.status(404).json({ error: 'Session not found' });
+    return res.status(404).json({ error: SESSION_NOT_FOUND });
   }
 
   if (providedSession.projectId !== rootSession.projectId) {
@@ -78,7 +82,7 @@ export function requireRootSessionAndProject(req, res, next) {
 
   const rootProject = projects.getById(rootSession.projectId);
   if (!rootProject) {
-    return res.status(404).json({ error: 'Project not found' });
+    return res.status(404).json({ error: PROJECT_NOT_FOUND });
   }
 
   req.providedSession_ = providedSession;
@@ -102,21 +106,21 @@ export function resolveBodyRootSessionForProject(projectParam = 'projectId') {
 
     const providedSession = sessions.getById(providedSessionId);
     if (!providedSession) {
-      return res.status(404).json({ error: 'Session not found' });
+      return res.status(404).json({ error: SESSION_NOT_FOUND });
     }
 
     if (providedSession.projectId !== req.params[projectParam]) {
-      return res.status(400).json({ error: 'Session does not belong to this project' });
+      return res.status(400).json({ error: SESSION_NOT_IN_PROJECT });
     }
 
     const rootSessionId = sessions.getRootSessionId(providedSession.id) || providedSession.id;
     const rootSession = sessions.getById(rootSessionId);
     if (!rootSession) {
-      return res.status(404).json({ error: 'Session not found' });
+      return res.status(404).json({ error: SESSION_NOT_FOUND });
     }
 
     if (rootSession.projectId !== req.params[projectParam]) {
-      return res.status(400).json({ error: 'Session does not belong to this project' });
+      return res.status(400).json({ error: SESSION_NOT_IN_PROJECT });
     }
 
     req.bodyRootSession_ = rootSession;

--- a/packages/server/src/services/commandButtonPrompts.js
+++ b/packages/server/src/services/commandButtonPrompts.js
@@ -16,7 +16,6 @@ export function buildCommandButtonApiInstructions(apiUrl, sessionId, projectId) 
   return `## Command Buttons API
 
 This project has command buttons configured - reusable shell commands you can execute. Use the Bash tool to run these curl commands.
-Command-button runs are workflow-scoped and resolved automatically by the API.
 
 ### List Available Buttons
 \`\`\`bash

--- a/packages/server/src/services/commandButtonPrompts.js
+++ b/packages/server/src/services/commandButtonPrompts.js
@@ -16,10 +16,11 @@ export function buildCommandButtonApiInstructions(apiUrl, sessionId, projectId) 
   return `## Command Buttons API
 
 This project has command buttons configured - reusable shell commands you can execute. Use the Bash tool to run these curl commands.
+Command-button runs are workflow-scoped and resolved automatically by the API.
 
 ### List Available Buttons
 \`\`\`bash
-curl ${apiUrl}/api/projects/${projectId}/command-buttons
+curl ${apiUrl}/api/sessions/${sessionId}/command-buttons
 \`\`\`
 
 ### Run a Button
@@ -36,7 +37,7 @@ curl ${apiUrl}/api/sessions/${sessionId}/command-buttons/runs/<run_id>
 
 Response: { runId, buttonId, status, exitCode, output, startedAt, completedAt }
 
-### List All Runs for This Session
+### List Command Runs
 \`\`\`bash
 curl ${apiUrl}/api/sessions/${sessionId}/command-buttons/runs
 \`\`\`

--- a/packages/server/src/services/sessionPrompts.js
+++ b/packages/server/src/services/sessionPrompts.js
@@ -162,10 +162,7 @@ CRITICAL: Do NOT start coding until you have presented a plan and received appro
  */
 function buildCanvasWriteSystemPrompt(session) {
   const apiUrl = getApiBaseUrl();
-  // Use root session ID, fall back to session.id if getRootSessionId returns null, fall back to 'unknown-session' if session is null
-  const sessionId = session
-    ? (sessions.getRootSessionId(session.id) || session.id)
-    : 'unknown-session';
+  const sessionId = session?.id || 'unknown-session';
   return `When you generate artifacts that should be displayed on the canvas (images, markdown documents, code snippets, data visualizations, PDFs), POST them to:
 
 POST ${apiUrl}/api/sessions/${sessionId}/canvas
@@ -187,10 +184,7 @@ The file type is automatically detected from the file extension. Supported forma
  */
 function buildCanvasReadSystemPrompt(session) {
   const apiUrl = getApiBaseUrl();
-  // Use root session ID, fall back to session.id if getRootSessionId returns null, fall back to 'unknown-session' if session is null
-  const sessionId = session
-    ? (sessions.getRootSessionId(session.id) || session.id)
-    : 'unknown-session';
+  const sessionId = session?.id || 'unknown-session';
   return `## Reading from Canvas
 
 To list all files on the canvas:
@@ -225,9 +219,10 @@ function buildSessionCrudOps(apiUrl, projectId) {
 \`\`\`bash
 curl -X POST ${apiUrl}/api/projects/${projectId}/sessions \\
   -H "Content-Type: application/json" \\
-  -d '{"prompt": "Your task description here", "name": "Optional session name"}'
+  -d '{"prompt": "Your task description here"}'
 \`\`\`
-Optional fields: \`name\`, \`mode\`, \`thinkingEnabled\` (boolean), \`effortLevel\` (low/medium/high/max/auto), \`gitBranch\`, \`gitMode\`, \`parentSessionId\` (to create a child session)
+Only \`prompt\` is required. Omitted settings are automatically derived from the project's session defaults, then system defaults, matching UI behavior.
+Optional override fields: \`name\`, \`mode\`, \`thinkingEnabled\` (boolean), \`effortLevel\` (low/medium/high/max/auto), \`model\`, \`providerId\`, \`gitBranch\`, \`gitMode\`, \`templateId\`, \`nextTemplateId\`, \`parentSessionId\` (to create a related follow-up session from the current session), \`startImmediately\`, \`scheduledAt\`, \`autoRescheduleEnabled\`, \`rescheduleDelayMinutes\`, \`rescheduleOnTokenLimit\`, \`rescheduleOnServiceError\`, \`maxRescheduleCount\`, \`maxTotalTokens\`, and \`rescheduleAtTokenCount\`.
 
 ### Send a Follow-up Message
 \`\`\`bash
@@ -259,7 +254,7 @@ curl -X PATCH ${apiUrl}/api/sessions/<session_id> \\
 }
 
 /** Build project, notes, and summary operations section */
-function buildProjectNotesOps(apiUrl) {
+function buildProjectNotesOps(apiUrl, sessionId) {
   return `### Project Operations
 \`\`\`bash
 curl ${apiUrl}/api/projects                          # List all projects
@@ -271,18 +266,18 @@ curl -X POST ${apiUrl}/api/projects \\
 \`\`\`
 Optional field: \`systemPrompt\`
 
-### Session Notes
+### Workflow Notes
 \`\`\`bash
-curl ${apiUrl}/api/sessions/<session_id>/notes       # Get notes
-curl -X POST ${apiUrl}/api/sessions/<session_id>/notes \\
+curl ${apiUrl}/api/sessions/${sessionId}/notes       # Get notes
+curl -X POST ${apiUrl}/api/sessions/${sessionId}/notes \\
   -H "Content-Type: application/json" \\
   -d '{"content": "Note content"}'
 \`\`\`
 
-### Session Summary
+### Workflow Summary
 \`\`\`bash
-curl "${apiUrl}/api/sessions/<session_id>/summary?generate=true"
-curl -X POST ${apiUrl}/api/sessions/<session_id>/summary  # Regenerate
+curl "${apiUrl}/api/sessions/${sessionId}/summary?generate=true"
+curl -X POST ${apiUrl}/api/sessions/${sessionId}/summary  # Regenerate
 \`\`\``;
 }
 
@@ -297,9 +292,11 @@ You can create and modify sessions in this system using curl or similar HTTP too
 **Current Session ID:** ${sessionId}
 **Current Project ID:** ${projectId}
 
+Use the current session ID for documented workflow API calls; shared workflow resources are resolved automatically by the API.
+
 ${buildSessionCrudOps(apiUrl, projectId)}
 
-${buildProjectNotesOps(apiUrl)}`;
+${buildProjectNotesOps(apiUrl, sessionId)}`;
 }
 
 /**
@@ -336,7 +333,7 @@ ${laneContext}
 curl ${apiUrl}/api/projects/${projectId}/kanban
 \`\`\`
 
-### Add This Session to the Board
+### Add Current Workflow to the Board
 \`\`\`bash
 curl -X POST ${apiUrl}/api/projects/${projectId}/kanban/cards \\
   -H "Content-Type: application/json" \\
@@ -395,26 +392,6 @@ CRITICAL: Do NOT use \`cd\` to navigate to the main repository. Your working dir
 }
 
 /**
- * Build child session context for system prompt
- * @param {Object} session - Session object
- * @returns {string} Child session context or empty string
- */
-function buildChildSessionContext(session) {
-  if (!session || !session.parentSessionId) {
-    return '';
-  }
-
-  // Get root session ID using existing method
-  const rootSessionId = sessions.getRootSessionId(session.id);
-
-  return `## Child Session
-
-This session is part of a multi-session workflow:
-- Parent Session ID: ${session.parentSessionId}
-- Root Session ID: ${rootSessionId}`;
-}
-
-/**
  * Build the full system prompt configuration
  * @param {string} sessionId
  * @param {string} projectId
@@ -432,7 +409,6 @@ export function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt
   const kanbanApiInstructions = buildKanbanApiInstructions(sessionId, projectId);
   const attachmentsContext = getSessionAttachmentsContext(sessionId);
   const worktreeContext = buildWorktreeContext(session);
-  const childSessionContext = buildChildSessionContext(session);
   const basePrompt = customSystemPrompt || DEFAULT_SYSTEM_PROMPT;
 
   // Prepend plan mode instructions if in plan mode
@@ -442,7 +418,6 @@ export function buildSystemPromptConfig(sessionId, projectId, customSystemPrompt
   const parts = [
     modePrompt,
     basePrompt,
-    childSessionContext,
     worktreeContext,
     attachmentsContext,
     canvasWriteInstructions,

--- a/packages/server/src/services/sessionPrompts.js
+++ b/packages/server/src/services/sessionPrompts.js
@@ -253,8 +253,8 @@ curl -X PATCH ${apiUrl}/api/sessions/<session_id> \\
 \`\`\``;
 }
 
-/** Build project, notes, and summary operations section */
-function buildProjectNotesOps(apiUrl, sessionId) {
+/** Build project and summary operations section */
+function buildProjectOps(apiUrl, sessionId) {
   return `### Project Operations
 \`\`\`bash
 curl ${apiUrl}/api/projects                          # List all projects
@@ -265,14 +265,6 @@ curl -X POST ${apiUrl}/api/projects \\
   -d '{"name": "Project Name", "workingDirectory": "/path/to/directory"}'
 \`\`\`
 Optional field: \`systemPrompt\`
-
-### Workflow Notes
-\`\`\`bash
-curl ${apiUrl}/api/sessions/${sessionId}/notes       # Get notes
-curl -X POST ${apiUrl}/api/sessions/${sessionId}/notes \\
-  -H "Content-Type: application/json" \\
-  -d '{"content": "Note content"}'
-\`\`\`
 
 ### Workflow Summary
 \`\`\`bash
@@ -292,11 +284,9 @@ You can create and modify sessions in this system using curl or similar HTTP too
 **Current Session ID:** ${sessionId}
 **Current Project ID:** ${projectId}
 
-Use the current session ID for documented workflow API calls; shared workflow resources are resolved automatically by the API.
-
 ${buildSessionCrudOps(apiUrl, projectId)}
 
-${buildProjectNotesOps(apiUrl, sessionId)}`;
+${buildProjectOps(apiUrl, sessionId)}`;
 }
 
 /**

--- a/packages/server/src/services/sessionPrompts.test.js
+++ b/packages/server/src/services/sessionPrompts.test.js
@@ -282,10 +282,10 @@ describe('sessionPrompts', () => {
       const result = buildSystemPromptConfig('root-123', projectId, null, 'standard');
       expect(result).toContain('/api/sessions/root-123/canvas');
       expect(result).toContain('POST');
-      expect(sessions.getRootSessionId).toHaveBeenCalledWith('root-123');
+      expect(sessions.getRootSessionId).not.toHaveBeenCalled();
     });
 
-    it('includes canvas write instructions for child session (uses root ID)', () => {
+    it('includes canvas write instructions for child session using current session ID', () => {
       sessions.getById.mockReturnValue({
         id: 'child-456',
         parentSessionId: 'parent-789',
@@ -295,9 +295,9 @@ describe('sessionPrompts', () => {
       sessions.getRootSessionId = vi.fn().mockReturnValue('root-123');
 
       const result = buildSystemPromptConfig('child-456', projectId, null, 'standard');
-      expect(result).toContain('/api/sessions/root-123/canvas');
-      expect(result).not.toContain('/api/sessions/child-456/canvas');
-      expect(sessions.getRootSessionId).toHaveBeenCalledWith('child-456');
+      expect(result).toContain('/api/sessions/child-456/canvas');
+      expect(result).not.toContain('/api/sessions/root-123/canvas');
+      expect(sessions.getRootSessionId).not.toHaveBeenCalled();
     });
 
     it('includes canvas read instructions', () => {
@@ -315,7 +315,7 @@ describe('sessionPrompts', () => {
       expect(sessions.getRootSessionId).not.toHaveBeenCalled();
     });
 
-    it('uses root session ID for all canvas endpoints including history', () => {
+    it('uses current session ID for all canvas endpoints including history', () => {
       sessions.getById.mockReturnValue({
         id: 'child-456',
         parentSessionId: 'parent-789',
@@ -325,12 +325,12 @@ describe('sessionPrompts', () => {
       sessions.getRootSessionId = vi.fn().mockReturnValue('root-123');
 
       const result = buildSystemPromptConfig('child-456', projectId, null, 'standard');
-      expect(result).toContain('/api/sessions/root-123/canvas/file/');
+      expect(result).toContain('/api/sessions/child-456/canvas/file/');
       expect(result).toContain('/history/');
-      expect(result).not.toMatch(/\/api\/sessions\/child-456\/canvas\/file\/.*\/history\//);
+      expect(result).not.toMatch(/\/api\/sessions\/root-123\/canvas\/file\/.*\/history\//);
     });
 
-    it('falls back to session.id when getRootSessionId returns null', () => {
+    it('uses session.id without resolving root session IDs', () => {
       sessions.getById.mockReturnValue({
         id: 'orphan-123',
         parentSessionId: 'nonexistent-parent',
@@ -343,9 +343,10 @@ describe('sessionPrompts', () => {
       expect(result).toContain('/api/sessions/orphan-123/canvas');
       expect(result).toBeDefined();
       expect(result).not.toContain('/api/sessions/null/canvas');
+      expect(sessions.getRootSessionId).not.toHaveBeenCalled();
     });
 
-    it('maintains correct prompt ordering with child session context', () => {
+    it('maintains correct prompt ordering without exposing child session context', () => {
       sessions.getById.mockReturnValue({
         id: 'child-456',
         parentSessionId: 'parent-789',
@@ -359,8 +360,8 @@ describe('sessionPrompts', () => {
       const canvasWriteIdx = result.indexOf('When you generate artifacts');
       const canvasReadIdx = result.indexOf('## Reading from Canvas');
 
-      expect(childCtxIdx).toBeGreaterThanOrEqual(0);
-      expect(canvasWriteIdx).toBeGreaterThan(childCtxIdx);
+      expect(childCtxIdx).toBe(-1);
+      expect(canvasWriteIdx).toBeGreaterThanOrEqual(0);
       expect(canvasReadIdx).toBeGreaterThan(canvasWriteIdx);
     });
 
@@ -369,6 +370,27 @@ describe('sessionPrompts', () => {
       expect(result).toContain('Session Management API');
       expect(result).toContain(sessionId);
       expect(result).toContain(projectId);
+    });
+
+    it('documents prompt-only session creation and optional overrides', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+      expect(result).toContain('-d \'{"prompt": "Your task description here"}\'');
+      expect(result).toContain('Only `prompt` is required');
+      expect(result).toContain('Optional override fields');
+      expect(result).toContain('`model`');
+      expect(result).toContain('`providerId`');
+      expect(result).toContain('`startImmediately`');
+      expect(result).not.toContain('"name": "Optional session name"');
+    });
+
+    it('uses current session ID for workflow notes and summary examples', () => {
+      const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+      expect(result).toContain(`/api/sessions/${sessionId}/notes`);
+      expect(result).toContain(`/api/sessions/${sessionId}/summary?generate=true`);
+      expect(result).not.toContain('/api/sessions/<session_id>/notes');
+      expect(result).not.toContain('/api/sessions/<session_id>/summary');
     });
 
     it('includes worktree context when session has gitWorktree', () => {
@@ -405,7 +427,7 @@ describe('sessionPrompts', () => {
     });
 
     describe('child session context', () => {
-      it('includes child session context when session has parentSessionId', () => {
+      it('does not include child session context when session has parentSessionId', () => {
         sessions.getById.mockReturnValue({
           id: 'child-789',
           gitWorktree: null,
@@ -417,10 +439,10 @@ describe('sessionPrompts', () => {
 
         const result = buildSystemPromptConfig('child-789', 'proj-xyz', null, 'standard');
 
-        expect(result).toContain('## Child Session');
-        expect(result).toContain('Parent Session ID: parent-123');
-        expect(result).toContain('Root Session ID: root-456');
-        expect(sessions.getRootSessionId).toHaveBeenCalledWith('child-789');
+        expect(result).not.toContain('## Child Session');
+        expect(result).not.toContain('Parent Session ID');
+        expect(result).not.toContain('Root Session ID');
+        expect(sessions.getRootSessionId).not.toHaveBeenCalled();
       });
 
       it('excludes child session context when session has no parentSessionId', () => {
@@ -444,7 +466,7 @@ describe('sessionPrompts', () => {
         expect(result).not.toContain('## Child Session');
       });
 
-      it('places child context after base prompt and before worktree context', () => {
+      it('places worktree context after base prompt without child context', () => {
         sessions.getById.mockReturnValue({
           id: 'child-789',
           gitWorktree: '/path/to/worktree',
@@ -460,10 +482,9 @@ describe('sessionPrompts', () => {
         const worktreeIdx = result.indexOf('## Git Worktree Session');
 
         expect(basePromptIdx).toBeGreaterThanOrEqual(0);
-        expect(childCtxIdx).toBeGreaterThanOrEqual(0);
+        expect(childCtxIdx).toBe(-1);
         expect(worktreeIdx).toBeGreaterThanOrEqual(0);
-        expect(basePromptIdx).toBeLessThan(childCtxIdx);
-        expect(childCtxIdx).toBeLessThan(worktreeIdx);
+        expect(basePromptIdx).toBeLessThan(worktreeIdx);
       });
     });
 
@@ -533,7 +554,7 @@ describe('sessionPrompts', () => {
       const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
       expect(result).toContain('Get Board with All Lanes and Cards');
-      expect(result).toContain('Add This Session to the Board');
+      expect(result).toContain('Add Current Workflow to the Board');
       expect(result).toContain('Move a Card to a Different Lane');
       expect(result).toContain('Remove a Card from the Board');
       expect(result).toContain('Create a New Lane');
@@ -587,6 +608,18 @@ describe('sessionPrompts', () => {
         const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
         expect(result).toContain(`/api/sessions/${sessionId}/command-buttons/runs/<run_id>/kill`);
+      });
+
+      it('uses session-scoped command button routes without tree traversal terms', () => {
+        commandButtons.getByProjectId.mockReturnValue([{ id: 'btn-1', name: 'Build' }]);
+
+        const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
+
+        expect(result).toContain(`curl http://localhost:5000/api/sessions/${sessionId}/command-buttons`);
+        expect(result).toContain('Command-button runs are workflow-scoped');
+        expect(result).not.toContain(`/api/projects/${projectId}/command-buttons`);
+        expect(result).not.toContain('Root Session ID');
+        expect(result).not.toContain('Parent Session ID');
       });
 
       it('run response shape is documented', () => {

--- a/packages/server/src/services/sessionPrompts.test.js
+++ b/packages/server/src/services/sessionPrompts.test.js
@@ -384,12 +384,10 @@ describe('sessionPrompts', () => {
       expect(result).not.toContain('"name": "Optional session name"');
     });
 
-    it('uses current session ID for workflow notes and summary examples', () => {
+    it('uses current session ID for workflow summary examples', () => {
       const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
-      expect(result).toContain(`/api/sessions/${sessionId}/notes`);
       expect(result).toContain(`/api/sessions/${sessionId}/summary?generate=true`);
-      expect(result).not.toContain('/api/sessions/<session_id>/notes');
       expect(result).not.toContain('/api/sessions/<session_id>/summary');
     });
 
@@ -616,7 +614,6 @@ describe('sessionPrompts', () => {
         const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
         expect(result).toContain(`curl http://localhost:5000/api/sessions/${sessionId}/command-buttons`);
-        expect(result).toContain('Command-button runs are workflow-scoped');
         expect(result).not.toContain(`/api/projects/${projectId}/command-buttons`);
         expect(result).not.toContain('Root Session ID');
         expect(result).not.toContain('Parent Session ID');


### PR DESCRIPTION
## Summary
- Add workflow-root session resolution middleware and apply it to canvas, notes, summary, command-button session routes, session-detail command metadata, and kanban card creation.
- Update agent prompt/API behavior so session creation only requires `prompt`, command buttons use session-scoped routes, workflow resources use the current session ID, and parent/root session details stay hidden.
- Add regression coverage for prompt-only session creation/default cascading, workflow-root resources, command runs, summaries, kanban cards, and prompt output.

## Tests
- Targeted plan suite: `529 passed`
- Full server suite: `4207 passed | 19 skipped`

## Notes
- `.circuschief-hooks/` was already untracked in the worktree and is intentionally not included.