### PR TITLE
Rename 'Command Buttons' to 'Commands' in agent system prompt

### DIFF
--- a/docs/agent-system-prompt.md
+++ b/docs/agent-system-prompt.md
@@ -15,7 +15,7 @@ This document describes the system prompt injected into every agent session and 
 | 5 | Canvas write instructions | `buildCanvasWriteSystemPrompt()` | Yes |
 | 6 | Canvas read instructions | `buildCanvasReadSystemPrompt()` | Yes |
 | 7 | Session management API | `buildSessionApiInstructions()` | Yes |
-| 8 | Command buttons API | `buildCommandButtonApiInstructions()` (in `commandButtonPrompts.js`) | Only when project has command buttons |
+| 8 | Commands API | `buildCommandButtonApiInstructions()` (in `commandButtonPrompts.js`) | Only when project has commands |
 | 9 | Kanban board API | `buildKanbanApiInstructions()` | Only when project has kanban enabled |
 
 The base URL used in all endpoint examples is derived from `CIRCUSCHIEF_API_URL` env var, falling back to `http://localhost:{PORT}`.
@@ -69,14 +69,14 @@ The prompt provides the agent with its own session ID and project ID. All endpoi
 | GET | `/api/sessions/{sessionId}/summary?generate=true` | Get (and generate) a session summary |
 | POST | `/api/sessions/{sessionId}/summary` | Regenerate the session summary |
 
-### Command Buttons API (conditional)
+### Commands API (conditional)
 
-Included only when the project has command buttons configured. Built in `packages/server/src/services/commandButtonPrompts.js`.
+Included only when the project has commands configured. Built in `packages/server/src/services/commandButtonPrompts.js`.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/sessions/{sessionId}/command-buttons` | List available buttons |
-| POST | `/api/sessions/{sessionId}/command-buttons/{button_id}/run` | Run a button. Response: `{ runId, buttonId, status: "running", output: "" }` |
+| GET | `/api/sessions/{sessionId}/command-buttons` | List available commands |
+| POST | `/api/sessions/{sessionId}/command-buttons/{button_id}/run` | Run a command. Response: `{ runId, buttonId, status: "running", output: "" }` |
 | GET | `/api/sessions/{sessionId}/command-buttons/runs/{run_id}` | Check run status & output. Response: `{ runId, buttonId, status, exitCode, output, startedAt, completedAt }` |
 | GET | `/api/sessions/{sessionId}/command-buttons/runs` | List all command runs |
 | POST | `/api/sessions/{sessionId}/command-buttons/runs/{run_id}/kill` | Kill a running command |
@@ -100,5 +100,5 @@ Included only when the project has kanban enabled. Also includes a dynamically p
 | File | Purpose |
 |------|---------|
 | `packages/server/src/services/sessionPrompts.js` | Main prompt assembly and canvas/session/kanban endpoint documentation |
-| `packages/server/src/services/commandButtonPrompts.js` | Command button endpoint documentation |
+| `packages/server/src/services/commandButtonPrompts.js` | Command endpoint documentation |
 | `packages/shared/src/constants.js` | `DEFAULT_SYSTEM_PROMPT` fallback |

--- a/packages/server/src/services/commandButtonPrompts.js
+++ b/packages/server/src/services/commandButtonPrompts.js
@@ -1,11 +1,11 @@
 import { commandButtons } from '../database.js';
 
 /**
- * Build Command Button API instructions for system prompt if the project has command buttons.
+ * Build Command API instructions for system prompt if the project has commands.
  * @param {string} apiUrl - Base API URL
  * @param {string} sessionId - Current session ID
  * @param {string} projectId - Current project ID
- * @returns {string} Command button instructions or empty string if no buttons configured
+ * @returns {string} Command instructions or empty string if no commands configured
  */
 export function buildCommandButtonApiInstructions(apiUrl, sessionId, projectId) {
   const buttons = commandButtons.getByProjectId(projectId);
@@ -13,16 +13,16 @@ export function buildCommandButtonApiInstructions(apiUrl, sessionId, projectId) 
     return '';
   }
 
-  return `## Command Buttons API
+  return `## Commands API
 
-This project has command buttons configured - reusable shell commands you can execute. Use the Bash tool to run these curl commands.
+This project has commands configured - reusable shell commands you can execute. Use the Bash tool to run these curl commands.
 
-### List Available Buttons
+### List Available Commands
 \`\`\`bash
 curl ${apiUrl}/api/sessions/${sessionId}/command-buttons
 \`\`\`
 
-### Run a Button
+### Run a Command
 \`\`\`bash
 curl -X POST ${apiUrl}/api/sessions/${sessionId}/command-buttons/<button_id>/run
 \`\`\`

--- a/packages/server/src/services/sessionPrompts.test.js
+++ b/packages/server/src/services/sessionPrompts.test.js
@@ -560,25 +560,25 @@ describe('sessionPrompts', () => {
       expect(result).toContain('Delete a Lane');
     });
 
-    describe('command button API instructions', () => {
-      it('includes section when buttons exist', () => {
+    describe('command API instructions', () => {
+      it('includes section when commands exist', () => {
         commandButtons.getByProjectId.mockReturnValue([{ id: 'btn-1', name: 'Build' }]);
 
         const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
-        expect(result).toContain('## Command Buttons API');
+        expect(result).toContain('## Commands API');
         expect(result).toContain('/command-buttons');
         expect(result).toContain('/runs');
         expect(result).toContain('/run');
         expect(result).toContain('/kill');
       });
 
-      it('excludes section when no buttons exist', () => {
+      it('excludes section when no commands exist', () => {
         commandButtons.getByProjectId.mockReturnValue([]);
 
         const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
-        expect(result).not.toContain('## Command Buttons API');
+        expect(result).not.toContain('## Commands API');
       });
 
       it('section appears between Session Management and Kanban', () => {
@@ -590,14 +590,14 @@ describe('sessionPrompts', () => {
         const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');
 
         const sessionApiIdx = result.indexOf('## Session Management API');
-        const commandBtnIdx = result.indexOf('## Command Buttons API');
+        const commandIdx = result.indexOf('## Commands API');
         const kanbanIdx = result.indexOf('## Kanban Board API');
 
         expect(sessionApiIdx).toBeGreaterThanOrEqual(0);
-        expect(commandBtnIdx).toBeGreaterThanOrEqual(0);
+        expect(commandIdx).toBeGreaterThanOrEqual(0);
         expect(kanbanIdx).toBeGreaterThanOrEqual(0);
-        expect(commandBtnIdx).toBeGreaterThan(sessionApiIdx);
-        expect(commandBtnIdx).toBeLessThan(kanbanIdx);
+        expect(commandIdx).toBeGreaterThan(sessionApiIdx);
+        expect(commandIdx).toBeLessThan(kanbanIdx);
       });
 
       it('kill endpoint is documented', () => {
@@ -608,7 +608,7 @@ describe('sessionPrompts', () => {
         expect(result).toContain(`/api/sessions/${sessionId}/command-buttons/runs/<run_id>/kill`);
       });
 
-      it('uses session-scoped command button routes without tree traversal terms', () => {
+      it('uses session-scoped command routes without tree traversal terms', () => {
         commandButtons.getByProjectId.mockReturnValue([{ id: 'btn-1', name: 'Build' }]);
 
         const result = buildSystemPromptConfig(sessionId, projectId, null, 'standard');


### PR DESCRIPTION
## Summary
- Updates the system prompt sent to AI agents so that "command buttons" is referred to as just "commands"
- Changes the section heading from "Command Buttons API" → "Commands API", "List Available Buttons" → "List Available Commands", "Run a Button" → "Run a Command", etc.
- Only the agent-facing display text changes — API URL paths (`/command-buttons/...`) remain unchanged

## Files changed
- `packages/server/src/services/commandButtonPrompts.js` — prompt text headings and labels
- `packages/server/src/services/sessionPrompts.test.js` — test assertions updated to match
- `docs/agent-system-prompt.md` — documentation table and section headings updated

## Test plan
- [x] All 60 existing tests pass (`yarn workspace @circuschief/server test src/services/sessionPrompts.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)