### PR TITLE
Replace standalone quick responses with template-backed system

### DIFF
--- a/.circuschief-hooks/commit-msg
+++ b/.circuschief-hooks/commit-msg
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+msg_file="$1"
+trailer="${CIRCUSCHIEF_COMMIT_ATTRIBUTION:-}"
+
+[ -n "$trailer" ] || exit 0
+[ -n "$(printf '%s' "$trailer" | tr -d '[:space:]')" ] || exit 0
+
+if printf '%s' "$trailer" | grep '[[:cntrl:]]' >/dev/null 2>&1; then
+  echo "CIRCUSCHIEF_COMMIT_ATTRIBUTION must be a canonical Co-authored-by: Name <email> trailer." >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$trailer" | grep -E '^Co-authored-by: [^<>[:space:]][^<>]* <[^[:space:]<>@]+@[^[:space:]<>@]+\.[^[:space:]<>@]+>$' >/dev/null 2>&1; then
+  echo "CIRCUSCHIEF_COMMIT_ATTRIBUTION must be a canonical Co-authored-by: Name <email> trailer." >&2
+  exit 1
+fi
+
+if grep -F -x -i -- "$trailer" "$msg_file" >/dev/null 2>&1; then
+  exit 0
+fi
+
+git interpret-trailers --trailer "$trailer" --in-place "$msg_file"

--- a/packages/server/src/db/SessionTemplateRepository.js
+++ b/packages/server/src/db/SessionTemplateRepository.js
@@ -23,6 +23,10 @@ export class SessionTemplateRepository extends BaseRepository {
       mode: row.mode || null,
       effortLevel: row.effort_level ?? null,
       targetLaneId: row.target_lane_id || null,
+      showInQuickResponses: Boolean(row.show_in_quick_responses),
+      quickResponseAutoSubmit: Boolean(row.quick_response_auto_submit),
+      quickResponseSortOrder: row.quick_response_sort_order ?? 0,
+      legacyQuickResponseId: row.legacy_quick_response_id || null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -51,13 +55,22 @@ export class SessionTemplateRepository extends BaseRepository {
     return value ? 1 : 0;
   }
 
+  static #normalizeBoolean(value) {
+    return value ? 1 : 0;
+  }
+
   create(data) {
     const id = databaseManager.generateId();
     const now = Date.now();
     this.db
       .prepare(
-        `INSERT INTO session_templates (id, project_id, name, prompt, next_template_id, thinking_enabled, git_branch, git_mode, model, mode, effort_level, target_lane_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO session_templates (
+          id, project_id, name, prompt, next_template_id, thinking_enabled,
+          git_branch, git_mode, model, mode, effort_level, target_lane_id,
+          show_in_quick_responses, quick_response_auto_submit,
+          quick_response_sort_order, legacy_quick_response_id,
+          created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         id,
@@ -72,6 +85,10 @@ export class SessionTemplateRepository extends BaseRepository {
         data.mode !== undefined && data.mode !== null ? data.mode : null,
         data.effortLevel ?? null,
         data.targetLaneId || null,
+        SessionTemplateRepository.#normalizeBoolean(data.showInQuickResponses),
+        SessionTemplateRepository.#normalizeBoolean(data.quickResponseAutoSubmit),
+        data.quickResponseSortOrder ?? 0,
+        data.legacyQuickResponseId || null,
         now,
         now
       );
@@ -93,6 +110,10 @@ export class SessionTemplateRepository extends BaseRepository {
     mode: { column: 'mode', transform: (v) => v },
     effortLevel: { column: 'effort_level', transform: (v) => v },
     targetLaneId: { column: 'target_lane_id', transform: (v) => v },
+    showInQuickResponses: { column: 'show_in_quick_responses', transform: (v) => v ? 1 : 0 },
+    quickResponseAutoSubmit: { column: 'quick_response_auto_submit', transform: (v) => v ? 1 : 0 },
+    quickResponseSortOrder: { column: 'quick_response_sort_order', transform: (v) => v },
+    legacyQuickResponseId: { column: 'legacy_quick_response_id', transform: (v) => v || null },
   };
 
   /**

--- a/packages/server/src/db/SessionTemplateRepository.test.js
+++ b/packages/server/src/db/SessionTemplateRepository.test.js
@@ -160,6 +160,36 @@ describe('SessionTemplateRepository', () => {
       });
       expect(template.effortLevel).toBeNull();
     });
+
+    it('defaults quick response fields when not provided', () => {
+      const template = repo.create({
+        projectId: null,
+        name: 'No Quick Response',
+        prompt: 'Prompt',
+      });
+
+      expect(template.showInQuickResponses).toBe(false);
+      expect(template.quickResponseAutoSubmit).toBe(false);
+      expect(template.quickResponseSortOrder).toBe(0);
+      expect(template.legacyQuickResponseId).toBeNull();
+    });
+
+    it('creates template with quick response fields', () => {
+      const template = repo.create({
+        projectId: null,
+        name: 'Quick Response',
+        prompt: 'Prompt',
+        showInQuickResponses: true,
+        quickResponseAutoSubmit: true,
+        quickResponseSortOrder: 4,
+        legacyQuickResponseId: 'legacy-response-id',
+      });
+
+      expect(template.showInQuickResponses).toBe(true);
+      expect(template.quickResponseAutoSubmit).toBe(true);
+      expect(template.quickResponseSortOrder).toBe(4);
+      expect(template.legacyQuickResponseId).toBe('legacy-response-id');
+    });
   });
 
   describe('getById', () => {
@@ -382,6 +412,36 @@ describe('SessionTemplateRepository', () => {
       const template = repo.create({ projectId: null, name: 'Test', prompt: 'Prompt', effortLevel: 'high' });
       const updated = repo.update(template.id, { effortLevel: null });
       expect(updated.effortLevel).toBeNull();
+    });
+
+    it('updates quick response fields', () => {
+      const template = repo.create({ projectId: null, name: 'Test', prompt: 'Prompt' });
+      const updated = repo.update(template.id, {
+        showInQuickResponses: true,
+        quickResponseAutoSubmit: true,
+        quickResponseSortOrder: 9,
+      });
+
+      expect(updated.showInQuickResponses).toBe(true);
+      expect(updated.quickResponseAutoSubmit).toBe(true);
+      expect(updated.quickResponseSortOrder).toBe(9);
+    });
+
+    it('toggles quick response booleans off', () => {
+      const template = repo.create({
+        projectId: null,
+        name: 'Test',
+        prompt: 'Prompt',
+        showInQuickResponses: true,
+        quickResponseAutoSubmit: true,
+      });
+      const updated = repo.update(template.id, {
+        showInQuickResponses: false,
+        quickResponseAutoSubmit: false,
+      });
+
+      expect(updated.showInQuickResponses).toBe(false);
+      expect(updated.quickResponseAutoSubmit).toBe(false);
     });
 
     it('updates multiple fields at once', () => {

--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -163,6 +163,7 @@ export const allMigrations = validateMigrations([
   m.get('session_templates-add-model'),
   m.get('session_templates-add-mode'),
   m.get('session_templates-add-effort_level'),
+  m.get('session_templates-add-quick-response-fields'),
 
   // --- Conversation messages model ---
   c.get('conversation_messages-add-model'),
@@ -211,6 +212,9 @@ export const allMigrations = validateMigrations([
 
   // --- Seed default global quick responses ---
   m.get('quick_responses-seed-defaults'),
+
+  // --- Convert legacy quick responses into template-backed quick responses ---
+  m.get('session_templates-convert-quick-responses'),
 
   // --- Seed default global session templates ---
   m.get('session_templates-seed-defaults'),

--- a/packages/server/src/db/migrations/miscMigrations.js
+++ b/packages/server/src/db/migrations/miscMigrations.js
@@ -30,7 +30,10 @@ Create a draft pr and ensure all changes are committed and pushed.`,
  */
 function seedDefaultSessionTemplates(db) {
   const count = db.prepare(
-    'SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL'
+    `SELECT COUNT(*) AS cnt
+     FROM session_templates
+     WHERE project_id IS NULL
+       AND legacy_quick_response_id IS NULL`
   ).get().cnt;
   if (count > 0) return;
 
@@ -45,8 +48,10 @@ function seedDefaultSessionTemplates(db) {
       id, project_id, name, prompt,
       next_template_id, thinking_enabled,
       git_branch, git_mode, model, mode, effort_level, target_lane_id,
+      show_in_quick_responses, quick_response_auto_submit,
+      quick_response_sort_order, legacy_quick_response_id,
       created_at, updated_at
-    ) VALUES (?, NULL, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, ?, ?)
+    ) VALUES (?, NULL, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, 0, 0, 0, NULL, ?, ?)
   `);
 
   const now = Date.now();
@@ -88,6 +93,38 @@ function seedDefaultQuickResponses(db) {
   }
 }
 
+function convertQuickResponsesToTemplates(db) {
+  const rows = db.prepare('SELECT * FROM quick_responses ORDER BY sort_order ASC, created_at ASC').all();
+  const exists = db.prepare(
+    'SELECT 1 FROM session_templates WHERE legacy_quick_response_id = ? LIMIT 1'
+  );
+  const insert = db.prepare(`
+    INSERT INTO session_templates (
+      id, project_id, name, prompt,
+      next_template_id, thinking_enabled,
+      git_branch, git_mode, model, mode, effort_level, target_lane_id,
+      show_in_quick_responses, quick_response_auto_submit,
+      quick_response_sort_order, legacy_quick_response_id,
+      created_at, updated_at
+    ) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, ?, ?, ?, ?, ?)
+  `);
+
+  for (const row of rows) {
+    if (exists.get(row.id)) continue;
+    insert.run(
+      randomUUID(),
+      row.project_id || null,
+      row.label,
+      row.content,
+      row.auto_submit ? 1 : 0,
+      row.sort_order ?? 0,
+      row.id,
+      row.created_at,
+      row.updated_at
+    );
+  }
+}
+
 /** @type {Array<{name: string, up: (db: import('better-sqlite3').Database) => void}>} */
 export const miscMigrations = [
   // --- Command buttons ---
@@ -119,6 +156,20 @@ export const miscMigrations = [
         db, 'session_templates', 'effort_level',
         "TEXT CHECK(effort_level IN ('low', 'medium', 'high', 'max', 'auto'))"
       );
+    },
+  },
+  {
+    name: 'session_templates-add-quick-response-fields',
+    up(db) {
+      addColumnIfMissing(db, 'session_templates', 'show_in_quick_responses', 'INTEGER NOT NULL DEFAULT 0');
+      addColumnIfMissing(db, 'session_templates', 'quick_response_auto_submit', 'INTEGER NOT NULL DEFAULT 0');
+      addColumnIfMissing(db, 'session_templates', 'quick_response_sort_order', 'INTEGER NOT NULL DEFAULT 0');
+      addColumnIfMissing(db, 'session_templates', 'legacy_quick_response_id', 'TEXT');
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_session_templates_legacy_quick_response_id
+        ON session_templates(legacy_quick_response_id)
+        WHERE legacy_quick_response_id IS NOT NULL
+      `);
     },
   },
 
@@ -177,6 +228,11 @@ export const miscMigrations = [
   {
     name: 'quick_responses-seed-defaults',
     up(db) { seedDefaultQuickResponses(db); },
+  },
+
+  {
+    name: 'session_templates-convert-quick-responses',
+    up(db) { convertQuickResponsesToTemplates(db); },
   },
 
   // --- Seed default global session templates ---

--- a/packages/server/src/db/migrations/miscMigrations.test.js
+++ b/packages/server/src/db/migrations/miscMigrations.test.js
@@ -7,6 +7,7 @@ import { OPENAI_MODELS } from '@circuschief/shared';
 
 const seedMigration = miscMigrations.find(m => m.name === 'quick_responses-seed-defaults');
 const seedTemplatesMigration = miscMigrations.find(m => m.name === 'session_templates-seed-defaults');
+const convertQuickResponsesMigration = miscMigrations.find(m => m.name === 'session_templates-convert-quick-responses');
 
 const expectedDefaults = [
   { label: 'Put a plan on the canvas', content: 'Put a plan on the canvas to get this done', autoSubmit: false, sortOrder: 0 },
@@ -103,6 +104,81 @@ describe('quick_responses-seed-defaults migration', () => {
   });
 });
 
+describe('session_templates-convert-quick-responses migration', () => {
+  it('converts legacy quick responses into quick response templates', () => {
+    const db = getDatabase();
+    db.prepare('DELETE FROM session_templates').run();
+    db.prepare('DELETE FROM quick_responses').run();
+
+    const projectRepo = new ProjectRepository();
+    const project = projectRepo.create('Quick Response Project', '/tmp/quick-response-project');
+    const now = Date.now();
+
+    db.prepare(
+      `INSERT INTO quick_responses (id, project_id, label, content, auto_submit, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, NULL, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'project-quick-response',
+      project.id,
+      'Project Response',
+      'Project content',
+      1,
+      7,
+      now - 2,
+      now - 1,
+      'global-quick-response',
+      'Global Response',
+      'Global content',
+      0,
+      2,
+      now - 4,
+      now - 3
+    );
+
+    convertQuickResponsesMigration.up(db);
+
+    const rows = db
+      .prepare('SELECT * FROM session_templates ORDER BY quick_response_sort_order')
+      .all();
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      project_id: null,
+      name: 'Global Response',
+      prompt: 'Global content',
+      show_in_quick_responses: 1,
+      quick_response_auto_submit: 0,
+      quick_response_sort_order: 2,
+      legacy_quick_response_id: 'global-quick-response',
+      thinking_enabled: null,
+      mode: null,
+    });
+    expect(rows[1]).toMatchObject({
+      project_id: project.id,
+      name: 'Project Response',
+      prompt: 'Project content',
+      show_in_quick_responses: 1,
+      quick_response_auto_submit: 1,
+      quick_response_sort_order: 7,
+      legacy_quick_response_id: 'project-quick-response',
+      next_template_id: null,
+    });
+
+    const legacyCount = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
+    expect(legacyCount).toBe(2);
+  });
+
+  it('is idempotent when rerun', () => {
+    const db = getDatabase();
+    const countBefore = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
+
+    convertQuickResponsesMigration.up(db);
+
+    const countAfter = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
+    expect(countAfter).toBe(countBefore);
+  });
+});
+
 const expectedSessionTemplateNames = [
   'Review the plan',
   'Implement the plan on the canvas',
@@ -119,7 +195,7 @@ describe('session_templates-seed-defaults migration', () => {
   it('seeds exactly 3 global session templates on a fresh DB', () => {
     const db = getDatabase();
     const rows = db
-      .prepare('SELECT * FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT * FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .all();
 
     expect(rows).toHaveLength(3);
@@ -131,7 +207,7 @@ describe('session_templates-seed-defaults migration', () => {
   it('stores each prompt verbatim (golden strings)', () => {
     const db = getDatabase();
     const rows = db
-      .prepare('SELECT name, prompt FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT name, prompt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .all();
 
     for (const row of rows) {
@@ -142,7 +218,7 @@ describe('session_templates-seed-defaults migration', () => {
   it('uses the expected default column values on every seeded row', () => {
     const db = getDatabase();
     const rows = db
-      .prepare('SELECT * FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT * FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .all();
 
     for (const row of rows) {
@@ -155,13 +231,17 @@ describe('session_templates-seed-defaults migration', () => {
       expect(row.model).toBeNull();
       expect(row.effort_level).toBeNull();
       expect(row.target_lane_id).toBeNull();
+      expect(row.show_in_quick_responses).toBe(0);
+      expect(row.quick_response_auto_submit).toBe(0);
+      expect(row.quick_response_sort_order).toBe(0);
+      expect(row.legacy_quick_response_id).toBeNull();
     }
   });
 
   it('populates created_at and updated_at as numeric timestamps near now', () => {
     const db = getDatabase();
     const rows = db
-      .prepare('SELECT created_at, updated_at FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT created_at, updated_at FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .all();
     const now = Date.now();
 
@@ -176,7 +256,7 @@ describe('session_templates-seed-defaults migration', () => {
   it('assigns non-null, distinct string IDs to each seeded row', () => {
     const db = getDatabase();
     const rows = db
-      .prepare('SELECT id FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT id FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .all();
 
     expect(rows).toHaveLength(3);
@@ -191,14 +271,14 @@ describe('session_templates-seed-defaults migration', () => {
   it('is idempotent when re-run on an already-seeded DB', () => {
     const db = getDatabase();
     const countBefore = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .get().cnt;
     expect(countBefore).toBe(3);
 
     seedTemplatesMigration.up(db);
 
     const countAfter = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .get().cnt;
     expect(countAfter).toBe(3);
   });
@@ -248,7 +328,7 @@ describe('session_templates-seed-defaults migration', () => {
 
     const total = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
     const globals = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .get().cnt;
     const scoped = db
       .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NOT NULL')
@@ -265,7 +345,7 @@ describe('session_templates-seed-defaults migration', () => {
     // having to invoke seedTemplatesMigration manually.
     const db = getDatabase();
     const count = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL')
+      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
       .get().cnt;
     expect(count).toBe(3);
   });
@@ -277,6 +357,8 @@ describe('session_templates-seed-defaults migration', () => {
       'id', 'project_id', 'name', 'prompt',
       'next_template_id', 'thinking_enabled',
       'git_branch', 'git_mode', 'model', 'mode', 'effort_level', 'target_lane_id',
+      'show_in_quick_responses', 'quick_response_auto_submit',
+      'quick_response_sort_order', 'legacy_quick_response_id',
       'created_at', 'updated_at',
     ]);
 

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -26,6 +26,10 @@ CREATE TABLE IF NOT EXISTS session_templates (
   model TEXT,
   mode TEXT DEFAULT 'yolo' CHECK(mode IN ('plan', 'standard', 'yolo')),
   effort_level TEXT CHECK(effort_level IN ('low', 'medium', 'high', 'max', 'auto')),
+  show_in_quick_responses INTEGER NOT NULL DEFAULT 0,
+  quick_response_auto_submit INTEGER NOT NULL DEFAULT 0,
+  quick_response_sort_order INTEGER NOT NULL DEFAULT 0,
+  legacy_quick_response_id TEXT UNIQUE,
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/shared/src/contracts/templates.js
+++ b/packages/shared/src/contracts/templates.js
@@ -11,6 +11,9 @@ export const CreateSessionTemplateRequest = z.object({
   mode: z.enum(['plan', 'standard', 'yolo']).nullable().optional(),
   effortLevel: z.enum(['low', 'medium', 'high', 'max', 'auto']).nullable().optional(),
   targetLaneId: z.string().uuid().nullable().optional(), // Lane to place session in when created from this template
+  showInQuickResponses: z.boolean().optional(),
+  quickResponseAutoSubmit: z.boolean().optional(),
+  quickResponseSortOrder: z.number().int().optional(),
 });
 
 export const UpdateSessionTemplateRequest = z.object({
@@ -24,6 +27,9 @@ export const UpdateSessionTemplateRequest = z.object({
   mode: z.enum(['plan', 'standard', 'yolo']).nullable().optional(),
   effortLevel: z.enum(['low', 'medium', 'high', 'max', 'auto']).nullable().optional(),
   targetLaneId: z.string().uuid().nullable().optional(),
+  showInQuickResponses: z.boolean().optional(),
+  quickResponseAutoSubmit: z.boolean().optional(),
+  quickResponseSortOrder: z.number().int().optional(),
 });
 
 export const SessionTemplateResponse = z.object({
@@ -39,6 +45,10 @@ export const SessionTemplateResponse = z.object({
   mode: z.string().nullable(),
   effortLevel: z.enum(['low', 'medium', 'high', 'max', 'auto']).nullable(),
   targetLaneId: z.string().uuid().nullable(),
+  showInQuickResponses: z.boolean(),
+  quickResponseAutoSubmit: z.boolean(),
+  quickResponseSortOrder: z.number(),
+  legacyQuickResponseId: z.string().nullable(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/packages/shared/src/contracts/templates.test.js
+++ b/packages/shared/src/contracts/templates.test.js
@@ -26,6 +26,9 @@ describe('CreateSessionTemplateRequest', () => {
       gitMode: 'worktree',
       model: 'claude-sonnet-4-20250514',
       mode: 'plan',
+      showInQuickResponses: true,
+      quickResponseAutoSubmit: true,
+      quickResponseSortOrder: 3,
     });
     expect(result.success).toBe(true);
   });
@@ -201,6 +204,28 @@ describe('CreateSessionTemplateRequest', () => {
     expect(result.success).toBe(true);
     expect(result.data.targetLaneId).toBeUndefined();
   });
+
+  it('validates quick response options', () => {
+    const result = CreateSessionTemplateRequest.safeParse({
+      name: 'Quick Template',
+      prompt: 'Prompt',
+      showInQuickResponses: true,
+      quickResponseAutoSubmit: true,
+      quickResponseSortOrder: 2,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid quick response option types', () => {
+    const result = CreateSessionTemplateRequest.safeParse({
+      name: 'Quick Template',
+      prompt: 'Prompt',
+      showInQuickResponses: 'true',
+      quickResponseAutoSubmit: 1,
+      quickResponseSortOrder: '2',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('UpdateSessionTemplateRequest', () => {
@@ -306,13 +331,9 @@ describe('UpdateSessionTemplateRequest', () => {
 
   it('validates effortLevel enum in update', () => {
     for (const level of ['low', 'medium', 'high', 'max', 'auto']) {
-      expect(
-        UpdateSessionTemplateRequest.safeParse({ effortLevel: level }).success
-      ).toBe(true);
+      expect(UpdateSessionTemplateRequest.safeParse({ effortLevel: level }).success).toBe(true);
     }
-    expect(
-      UpdateSessionTemplateRequest.safeParse({ effortLevel: 'invalid' }).success
-    ).toBe(false);
+    expect(UpdateSessionTemplateRequest.safeParse({ effortLevel: 'invalid' }).success).toBe(false);
   });
 
   it('allows null effortLevel in update', () => {
@@ -342,6 +363,15 @@ describe('UpdateSessionTemplateRequest', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('validates quick response option updates', () => {
+    const result = UpdateSessionTemplateRequest.safeParse({
+      showInQuickResponses: true,
+      quickResponseAutoSubmit: false,
+      quickResponseSortOrder: 8,
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('SessionTemplateResponse', () => {
@@ -358,6 +388,10 @@ describe('SessionTemplateResponse', () => {
     mode: null,
     effortLevel: null,
     targetLaneId: null,
+    showInQuickResponses: false,
+    quickResponseAutoSubmit: false,
+    quickResponseSortOrder: 0,
+    legacyQuickResponseId: null,
     createdAt: Date.now(),
     updatedAt: Date.now(),
   };
@@ -481,6 +515,10 @@ describe('SessionTemplateListResponse', () => {
         mode: null,
         effortLevel: null,
         targetLaneId: null,
+        showInQuickResponses: false,
+        quickResponseAutoSubmit: false,
+        quickResponseSortOrder: 0,
+        legacyQuickResponseId: null,
         createdAt: Date.now(),
         updatedAt: Date.now(),
       },
@@ -497,6 +535,10 @@ describe('SessionTemplateListResponse', () => {
         mode: 'plan',
         effortLevel: 'high',
         targetLaneId: null,
+        showInQuickResponses: false,
+        quickResponseAutoSubmit: false,
+        quickResponseSortOrder: 0,
+        legacyQuickResponseId: null,
         createdAt: Date.now(),
         updatedAt: Date.now(),
       },
@@ -530,6 +572,10 @@ describe('AvailableTemplatesResponse', () => {
           mode: null,
           effortLevel: null,
           targetLaneId: null,
+          showInQuickResponses: false,
+          quickResponseAutoSubmit: false,
+          quickResponseSortOrder: 0,
+          legacyQuickResponseId: null,
           createdAt: Date.now(),
           updatedAt: Date.now(),
         },
@@ -556,6 +602,10 @@ describe('AvailableTemplatesResponse', () => {
           mode: null,
           effortLevel: null,
           targetLaneId: null,
+          showInQuickResponses: false,
+          quickResponseAutoSubmit: false,
+          quickResponseSortOrder: 0,
+          legacyQuickResponseId: null,
           createdAt: Date.now(),
           updatedAt: Date.now(),
         },
@@ -578,6 +628,10 @@ describe('AvailableTemplatesResponse', () => {
       mode: null,
       effortLevel: null,
       targetLaneId: null,
+      showInQuickResponses: false,
+      quickResponseAutoSubmit: false,
+      quickResponseSortOrder: 0,
+      legacyQuickResponseId: null,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -69,7 +69,6 @@
       @auto-send-toggle="handleAutoSendToggle"
       @input="handleInput"
       @quick-response-insert="handleQuickResponseInsert"
-      @open-quick-response-settings="quickResponseSettingsOpen = true"
       @update:attached-files="attachedFiles = $event"
       @open-slash-command="showSlashCommandWizard = true"
       @thinking-toggle="handleThinkingToggle"
@@ -82,13 +81,6 @@
     <SchedulingInfo
       v-if="sessionsStore.currentSession"
       :session="sessionsStore.currentSession"
-    />
-
-    <!-- Quick Response Settings Modal -->
-    <QuickResponseSettings
-      :is-open="quickResponseSettingsOpen"
-      :project-id="sessionsStore.currentSession?.projectId"
-      @close="quickResponseSettingsOpen = false"
     />
 
     <!-- Schedule Session Modal -->
@@ -133,13 +125,11 @@ import ConversationPanel from './ConversationPanel.vue';
 import ConversationMessages from './ConversationMessages.vue';
 import InputForm from './InputForm.vue';
 import RunningState from './RunningState.vue';
-import QuickResponseSettings from './QuickResponseSettings.vue';
 import ScheduleSessionModal from './ScheduleSessionModal.vue';
 import AutoRescheduleModal from './AutoRescheduleModal.vue';
 import SchedulingInfo from './SchedulingInfo.vue';
 import SlashCommandWizard from './SlashCommandWizard.vue';
 import StaleBadge from './StaleBadge.vue';
-import { useQuickResponsesStore } from '../stores/quickResponses.js';
 import { useProjectsStore } from '../stores/projects.js';
 
 const props = defineProps({
@@ -163,7 +153,6 @@ const sessionsStore = useInjectedSessionsStore();
 const uiStore = useUiStore();
 const templatesStore = useTemplatesStore();
 const defaultsStore = useProjectDefaultsStore();
-const quickResponsesStore = useQuickResponsesStore();
 const projectsStore = useProjectsStore();
 const { getModelDisplayName } = useModelInfo();
 const { isStale } = useConnectionStatus();
@@ -179,7 +168,6 @@ const {
 
 // Local state
 const input = ref('');
-const quickResponseSettingsOpen = ref(false);
 const showScheduleModal = ref(false);
 const showAutoRescheduleModal = ref(false);
 const showSlashCommandWizard = ref(false);
@@ -336,7 +324,7 @@ onMounted(async () => {
 
   if (sessionsStore.currentSession?.projectId) {
     const projectId = sessionsStore.currentSession.projectId;
-    quickResponsesStore.fetchForProject(projectId);
+    templatesStore.fetchProjectTemplates(projectId);
 
     try {
       await projectsStore.fetchProject(projectId);

--- a/packages/web/src/components/InputForm.vue
+++ b/packages/web/src/components/InputForm.vue
@@ -18,8 +18,8 @@
     <QuickResponsesPanel
       v-if="(canSendMessage || isDraft) && !isScheduledForFuture"
       :show-empty="true"
+      :project-id="projectId"
       @insert="$emit('quickResponseInsert', $event)"
-      @open-settings="$emit('openQuickResponseSettings')"
     />
 
     <!-- Auto-send checkbox - only during running with content -->
@@ -176,7 +176,6 @@ const emit = defineEmits([
   'submit',
   'input',
   'quickResponseInsert',
-  'openQuickResponseSettings',
   'update:attachedFiles',
   'openSlashCommand',
   'thinkingToggle',

--- a/packages/web/src/components/QuickResponsesPanel.test.js
+++ b/packages/web/src/components/QuickResponsesPanel.test.js
@@ -4,7 +4,13 @@ import { createPinia, setActivePinia } from 'pinia';
 import { nextTick } from 'vue';
 
 import QuickResponsesPanel from './QuickResponsesPanel.vue';
-import { useQuickResponsesStore } from '../stores/quickResponses.js';
+import { useTemplatesStore } from '../stores/templates.js';
+
+const pushMock = vi.fn();
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
 
 describe('QuickResponsesPanel', () => {
   let store;
@@ -13,13 +19,27 @@ describe('QuickResponsesPanel', () => {
   beforeEach(() => {
     pinia = createPinia();
     setActivePinia(pinia);
-    store = useQuickResponsesStore();
+    store = useTemplatesStore();
     // Clear the store state
-    store.projectResponses = [];
-    store.globalResponses = [];
+    store.projectTemplates = [];
+    store.globalTemplates = [];
     store.loading = false;
     store.error = null;
+    pushMock.mockClear();
   });
+
+  function template(overrides = {}) {
+    return {
+      id: '1',
+      name: 'Test',
+      prompt: 'test content',
+      showInQuickResponses: true,
+      quickResponseAutoSubmit: false,
+      quickResponseSortOrder: 0,
+      createdAt: 1,
+      ...overrides,
+    };
+  }
 
   function mountComponent(props = {}) {
     return mount(QuickResponsesPanel, {
@@ -58,7 +78,7 @@ describe('QuickResponsesPanel', () => {
   });
 
   describe('store integration', () => {
-    it('uses the quick responses store', () => {
+    it('uses the templates store', () => {
       const wrapper = mountComponent();
       expect(wrapper.vm).toBeDefined();
       // The component successfully mounts, which means it uses the store
@@ -66,7 +86,7 @@ describe('QuickResponsesPanel', () => {
   });
 
   describe('events', () => {
-    it('defines insert and openSettings events', () => {
+    it('defines insert events', () => {
       const wrapper = mountComponent();
       expect(wrapper.emitted()).toBeDefined();
     });
@@ -79,22 +99,22 @@ describe('QuickResponsesPanel', () => {
       expect(store.loading).toBe(true);
     });
 
-    it('reads projectResponses from store', () => {
-      store.projectResponses = [{ id: '1', label: 'Test' }];
+    it('reads project quick response templates from store', () => {
+      store.projectTemplates = [template()];
       mountComponent();
-      expect(store.projectResponses).toHaveLength(1);
+      expect(store.quickResponseTemplates.project).toHaveLength(1);
     });
 
-    it('reads globalResponses from store', () => {
-      store.globalResponses = [{ id: '2', label: 'Global' }];
+    it('reads global quick response templates from store', () => {
+      store.globalTemplates = [template({ id: '2', name: 'Global' })];
       mountComponent();
-      expect(store.globalResponses).toHaveLength(1);
+      expect(store.quickResponseTemplates.global).toHaveLength(1);
     });
 
-    it('reads hasResponses from store', () => {
-      store.projectResponses = [{ id: '1', label: 'Test' }];
+    it('reads hasQuickResponseTemplates from store', () => {
+      store.projectTemplates = [template()];
       mountComponent();
-      expect(store.hasResponses).toBe(true);
+      expect(store.hasQuickResponseTemplates).toBe(true);
     });
   });
 
@@ -110,7 +130,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('shows panel when there are responses regardless of showEmpty', () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent({ showEmpty: false });
       expect(wrapper.find('.quick-responses-panel').exists()).toBe(true);
     });
@@ -120,20 +140,20 @@ describe('QuickResponsesPanel', () => {
       // Expand the panel
       await triggerClick(wrapper, '.toggle-button');
       expect(wrapper.find('.empty-state').exists()).toBe(true);
-      expect(wrapper.find('.empty-text').text()).toBe('No quick responses yet');
+      expect(wrapper.find('.empty-text').text()).toBe('No quick response templates yet');
     });
   });
 
   describe('collapsible behavior', () => {
     it('starts in collapsed state', () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
       // Empty state should not be visible in collapsed state
       expect(wrapper.find('.responses-content').exists()).toBe(false);
     });
 
     it('expands when toggle button is clicked', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Initially collapsed
@@ -145,7 +165,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('collapses when toggle button is clicked again', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Expand
@@ -158,7 +178,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('sets aria-expanded attribute correctly', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
       const toggleButton = wrapper.find('.toggle-button');
 
@@ -171,9 +191,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('auto-collapses after clicking a quick response', async () => {
-      store.projectResponses = [
-        { id: '1', label: 'Test', content: 'test content', autoSubmit: false }
-      ];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Expand panel
@@ -189,12 +207,14 @@ describe('QuickResponsesPanel', () => {
 
     it('handles response click with correct data structure', async () => {
       const testResponse = {
-        id: '1',
-        label: 'Test Response',
-        content: 'test content here',
-        autoSubmit: true
+        ...template({
+          id: '1',
+          name: 'Test Response',
+          prompt: 'test content here',
+          quickResponseAutoSubmit: true,
+        }),
       };
-      store.projectResponses = [testResponse];
+      store.projectTemplates = [testResponse];
       const wrapper = mountComponent();
 
       // Expand panel
@@ -211,7 +231,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('chevron icon rotates when expanded', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
       const toggleButton = wrapper.find('.toggle-button');
 
@@ -224,7 +244,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('header is always visible when panel is shown', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Panel header and toggle button should always be visible
@@ -234,8 +254,18 @@ describe('QuickResponsesPanel', () => {
       expect(wrapper.find('.settings-button').exists()).toBe(false);
     });
 
+    it('navigates to project templates from the settings button', async () => {
+      store.projectTemplates = [template()];
+      const wrapper = mountComponent({ projectId: 'project-123' });
+
+      await triggerClick(wrapper, '.toggle-button');
+      await triggerClick(wrapper, '.settings-button');
+
+      expect(pushMock).toHaveBeenCalledWith('/projects/project-123/templates');
+    });
+
     it('uses v-if to remove content from DOM when collapsed', () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // When collapsed, .responses-content element should NOT be in DOM
@@ -244,7 +274,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('expands when clicking on the panel itself (not just the toggle button)', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Initially collapsed
@@ -256,7 +286,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('has cursor-pointer class to indicate panel is clickable', () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       const panel = wrapper.find('.quick-responses-panel');
@@ -264,7 +294,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('collapses when clicking on the panel while already expanded', async () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Expand via toggle button
@@ -277,7 +307,7 @@ describe('QuickResponsesPanel', () => {
     });
 
     it('toggle button has @click.stop to prevent panel toggle', () => {
-      store.projectResponses = [{ id: '1', label: 'Test', content: 'test content' }];
+      store.projectTemplates = [template()];
       const wrapper = mountComponent();
 
       // Verify toggle button exists

--- a/packages/web/src/components/QuickResponsesPanel.vue
+++ b/packages/web/src/components/QuickResponsesPanel.vue
@@ -31,12 +31,12 @@
         <span class="panel-title">Quick Responses</span>
       </div>
       <button
-        v-if="isExpanded"
+        v-if="isExpanded && projectId"
         type="button"
         class="settings-button"
-        title="Manage quick responses"
-        aria-label="Manage quick responses"
-        @click.stop="$emit('openSettings')"
+        title="Manage templates"
+        aria-label="Manage templates"
+        @click.stop="openTemplates"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -66,7 +66,7 @@
       v-else-if="!hasResponses && isExpanded"
       class="empty-state"
     >
-      <span class="empty-text">No quick responses yet</span>
+      <span class="empty-text">No quick response templates yet</span>
     </div>
 
     <!-- Responses content (collapsible) -->
@@ -86,13 +86,13 @@
             :key="response.id"
             type="button"
             class="response-button project-response"
-            :class="{ 'auto-submit': response.autoSubmit }"
-            :title="response.content"
+            :class="{ 'auto-submit': response.quickResponseAutoSubmit }"
+            :title="response.prompt"
             @click.stop="handleClick(response)"
           >
-            <span class="button-label">{{ response.label }}</span>
+            <span class="button-label">{{ response.name }}</span>
             <span
-              v-if="response.autoSubmit"
+              v-if="response.quickResponseAutoSubmit"
               class="auto-icon"
               title="Auto-submit"
             >&#9889;</span>
@@ -112,13 +112,13 @@
             :key="response.id"
             type="button"
             class="response-button global-response"
-            :class="{ 'auto-submit': response.autoSubmit }"
-            :title="response.content"
+            :class="{ 'auto-submit': response.quickResponseAutoSubmit }"
+            :title="response.prompt"
             @click.stop="handleClick(response)"
           >
-            <span class="button-label">{{ response.label }}</span>
+            <span class="button-label">{{ response.name }}</span>
             <span
-              v-if="response.autoSubmit"
+              v-if="response.quickResponseAutoSubmit"
               class="auto-icon"
               title="Auto-submit"
             >&#9889;</span>
@@ -131,7 +131,8 @@
 
 <script setup>
 import { ref, computed, defineOptions } from 'vue';
-import { useQuickResponsesStore } from '../stores/quickResponses.js';
+import { useRouter } from 'vue-router';
+import { useTemplatesStore } from '../stores/templates.js';
 
 defineOptions({
   name: 'QuickResponsesPanel',
@@ -142,17 +143,22 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  projectId: {
+    type: String,
+    default: null,
+  },
 });
 
-const emit = defineEmits(['insert', 'openSettings']);
+const emit = defineEmits(['insert']);
 
-const store = useQuickResponsesStore();
+const router = useRouter();
+const store = useTemplatesStore();
 const isExpanded = ref(false);
 
 const loading = computed(() => store.loading);
-const projectResponses = computed(() => store.projectResponses);
-const globalResponses = computed(() => store.globalResponses);
-const hasResponses = computed(() => store.hasResponses);
+const projectResponses = computed(() => store.quickResponseTemplates.project);
+const globalResponses = computed(() => store.quickResponseTemplates.global);
+const hasResponses = computed(() => store.hasQuickResponseTemplates);
 
 function toggle() {
   isExpanded.value = !isExpanded.value;
@@ -160,11 +166,16 @@ function toggle() {
 
 function handleClick(response) {
   emit('insert', {
-    content: response.content,
-    autoSubmit: response.autoSubmit,
+    content: response.prompt,
+    autoSubmit: response.quickResponseAutoSubmit,
   });
   // Auto-collapse panel after selecting a response
   isExpanded.value = false;
+}
+
+function openTemplates() {
+  if (!props.projectId) return;
+  router.push(`/projects/${props.projectId}/templates`);
 }
 </script>
 

--- a/packages/web/src/components/TemplatesPanel.vue
+++ b/packages/web/src/components/TemplatesPanel.vue
@@ -149,6 +149,27 @@
           >
         </div>
 
+        <div class="form-group">
+          <label class="form-check">
+            <input
+              v-model="formData.showInQuickResponses"
+              type="checkbox"
+            >
+            <span>Show in Quick Responses</span>
+          </label>
+        </div>
+
+        <div class="form-group">
+          <label class="form-check">
+            <input
+              v-model="formData.quickResponseAutoSubmit"
+              type="checkbox"
+              :disabled="!formData.showInQuickResponses"
+            >
+            <span>Auto-submit from Quick Responses</span>
+          </label>
+        </div>
+
         <div class="form-actions">
           <button
             type="button"
@@ -232,6 +253,14 @@
               >
                 Chains to: {{ getTemplateName(template.nextTemplateId) }}
               </span>
+              <span
+                v-if="template.showInQuickResponses"
+                class="meta-badge"
+              >Quick Response</span>
+              <span
+                v-if="template.quickResponseAutoSubmit"
+                class="meta-badge"
+              >Auto-submit</span>
             </div>
           </router-link>
         </div>
@@ -285,6 +314,14 @@
               >
                 Chains to: {{ getTemplateName(template.nextTemplateId) }}
               </span>
+              <span
+                v-if="template.showInQuickResponses"
+                class="meta-badge"
+              >Quick Response</span>
+              <span
+                v-if="template.quickResponseAutoSubmit"
+                class="meta-badge"
+              >Auto-submit</span>
             </div>
           </router-link>
         </div>
@@ -336,6 +373,8 @@ const formData = ref({
   gitBranch: '',
   model: null,
   mode: null,
+  showInQuickResponses: false,
+  quickResponseAutoSubmit: false,
 });
 
 const loading = computed(() => templatesStore.loading);
@@ -393,6 +432,8 @@ function resetForm() {
     gitBranch: '',
     model: null,
     mode: null,
+    showInQuickResponses: false,
+    quickResponseAutoSubmit: false,
   };
 }
 
@@ -418,6 +459,10 @@ async function handleSubmit() {
       gitBranch: formData.value.gitBranch || undefined,
       model: formData.value.model,                      // null = inherit
       mode: formData.value.mode,                        // null = inherit
+      showInQuickResponses: formData.value.showInQuickResponses,
+      quickResponseAutoSubmit: formData.value.showInQuickResponses
+        ? formData.value.quickResponseAutoSubmit
+        : false,
     };
 
     if (formData.value.isGlobal) {
@@ -435,6 +480,15 @@ async function handleSubmit() {
     saving.value = false;
   }
 }
+
+watch(
+  () => formData.value.showInQuickResponses,
+  (showInQuickResponses) => {
+    if (!showInQuickResponses) {
+      formData.value.quickResponseAutoSubmit = false;
+    }
+  }
+);
 
 // Expose for testing
 defineExpose({

--- a/packages/web/src/stores/templates.js
+++ b/packages/web/src/stores/templates.js
@@ -5,6 +5,7 @@ export const useTemplatesStore = defineStore('templates', {
   state: () => ({
     projectTemplates: [],
     globalTemplates: [],
+    currentProjectId: null,
     loading: false,
     error: null,
   }),
@@ -15,6 +16,25 @@ export const useTemplatesStore = defineStore('templates', {
         state.projectTemplates.find((t) => t.id === id) ||
         state.globalTemplates.find((t) => t.id === id)
       ),
+    quickResponseTemplates: (state) => {
+      const sortTemplates = (templates) => templates
+        .filter((template) => template.showInQuickResponses)
+        .slice()
+        .sort((a, b) => (
+          (a.quickResponseSortOrder ?? 0) - (b.quickResponseSortOrder ?? 0) ||
+          (a.createdAt ?? 0) - (b.createdAt ?? 0) ||
+          a.name.localeCompare(b.name)
+        ));
+
+      return {
+        project: sortTemplates(state.projectTemplates),
+        global: sortTemplates(state.globalTemplates),
+      };
+    },
+    hasQuickResponseTemplates() {
+      return this.quickResponseTemplates.project.length > 0 ||
+        this.quickResponseTemplates.global.length > 0;
+    },
   },
 
   actions: {
@@ -25,6 +45,7 @@ export const useTemplatesStore = defineStore('templates', {
         const result = await api.getProjectTemplates(projectId);
         this.projectTemplates = result.project || [];
         this.globalTemplates = result.global || [];
+        this.currentProjectId = projectId;
       } catch (err) {
         this.error = err.message;
       } finally {

--- a/packages/web/src/stores/templates.test.js
+++ b/packages/web/src/stores/templates.test.js
@@ -92,6 +92,46 @@ describe('Templates Store', () => {
         expect(template.name).toBe('Project Version');
       });
     });
+
+    describe('quickResponseTemplates', () => {
+      it('filters templates not shown in quick responses and preserves groups', () => {
+        const store = useTemplatesStore();
+        store.projectTemplates = [
+          { id: 'hidden-project', name: 'Hidden', showInQuickResponses: false },
+          { id: 'shown-project', name: 'Shown Project', showInQuickResponses: true, quickResponseSortOrder: 0, createdAt: 1 },
+        ];
+        store.globalTemplates = [
+          { id: 'shown-global', name: 'Shown Global', showInQuickResponses: true, quickResponseSortOrder: 0, createdAt: 1 },
+        ];
+
+        expect(store.quickResponseTemplates.project.map(t => t.id)).toEqual(['shown-project']);
+        expect(store.quickResponseTemplates.global.map(t => t.id)).toEqual(['shown-global']);
+      });
+
+      it('sorts by quick response sort order, createdAt, then name', () => {
+        const store = useTemplatesStore();
+        store.projectTemplates = [
+          { id: 'c', name: 'Charlie', showInQuickResponses: true, quickResponseSortOrder: 2, createdAt: 1 },
+          { id: 'b', name: 'Beta', showInQuickResponses: true, quickResponseSortOrder: 1, createdAt: 2 },
+          { id: 'a', name: 'Alpha', showInQuickResponses: true, quickResponseSortOrder: 1, createdAt: 2 },
+          { id: 'd', name: 'Delta', showInQuickResponses: true, quickResponseSortOrder: 1, createdAt: 1 },
+        ];
+
+        expect(store.quickResponseTemplates.project.map(t => t.id)).toEqual(['d', 'a', 'b', 'c']);
+      });
+
+      it('hasQuickResponseTemplates reflects filtered templates', () => {
+        const store = useTemplatesStore();
+        expect(store.hasQuickResponseTemplates).toBe(false);
+
+        store.globalTemplates = [
+          { id: 'hidden', name: 'Hidden', showInQuickResponses: false },
+          { id: 'shown', name: 'Shown', showInQuickResponses: true, quickResponseSortOrder: 0, createdAt: 1 },
+        ];
+
+        expect(store.hasQuickResponseTemplates).toBe(true);
+      });
+    });
   });
 
   describe('actions', () => {
@@ -109,6 +149,7 @@ describe('Templates Store', () => {
         expect(api.getProjectTemplates).toHaveBeenCalledWith('proj-123');
         expect(store.projectTemplates).toEqual(mockResult.project);
         expect(store.globalTemplates).toEqual(mockResult.global);
+        expect(store.currentProjectId).toBe('proj-123');
         expect(store.loading).toBe(false);
         expect(store.error).toBeNull();
       });

--- a/packages/web/src/views/NewSessionView.vue
+++ b/packages/web/src/views/NewSessionView.vue
@@ -84,8 +84,8 @@
       <!-- Quick Responses Panel -->
       <QuickResponsesPanel
         :show-empty="true"
+        :project-id="route.params.id"
         @insert="handleQuickResponseInsert"
-        @open-settings="quickResponseSettingsOpen = true"
       />
 
       <SessionFormOptions
@@ -246,12 +246,6 @@
       @insert="handleSlashCommandInsert"
     />
 
-    <!-- Quick Response Settings Modal -->
-    <QuickResponseSettings
-      :is-open="quickResponseSettingsOpen"
-      :project-id="route.params.id"
-      @close="quickResponseSettingsOpen = false"
-    />
   </div>
 </template>
 
@@ -279,9 +273,7 @@ import ResizableTextarea from '../components/ResizableTextarea.vue';
 import SlashCommandButton from '../components/SlashCommandButton.vue';
 import SlashCommandWizard from '../components/SlashCommandWizard.vue';
 import { useProjectsStore } from '../stores/projects.js';
-import { useQuickResponsesStore } from '../stores/quickResponses.js';
 import QuickResponsesPanel from '../components/QuickResponsesPanel.vue';
-import QuickResponseSettings from '../components/QuickResponseSettings.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -307,7 +299,6 @@ let debounceTimer = null;
 let branchDebounceTimer = null;
 const loading = ref(false);
 const showSlashCommandWizard = ref(false);
-const quickResponseSettingsOpen = ref(false);
 
 // Rec 9: Responsive textarea min height
 const textareaMinHeight = computed(() => window.innerWidth <= 480 ? 80 : 120);
@@ -436,8 +427,6 @@ onMounted(async () => {
   }
 
   templatesStore.fetchProjectTemplates(projectId);
-  const quickResponsesStore = useQuickResponsesStore();
-  quickResponsesStore.fetchForProject(projectId);
   if (route.query.parentSessionId) parentSessionId.value = route.query.parentSessionId;
 });
 

--- a/packages/web/src/views/TemplateDetailView.vue
+++ b/packages/web/src/views/TemplateDetailView.vue
@@ -150,6 +150,27 @@
           >
         </div>
 
+        <div class="form-group">
+          <label class="form-check">
+            <input
+              v-model="formData.showInQuickResponses"
+              type="checkbox"
+            >
+            <span>Show in Quick Responses</span>
+          </label>
+        </div>
+
+        <div class="form-group">
+          <label class="form-check">
+            <input
+              v-model="formData.quickResponseAutoSubmit"
+              type="checkbox"
+              :disabled="!formData.showInQuickResponses"
+            >
+            <span>Auto-submit from Quick Responses</span>
+          </label>
+        </div>
+
         <!-- Form Actions -->
         <div class="form-actions">
           <button
@@ -223,7 +244,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { useTemplatesStore } from '../stores/templates.js';
 import { useUiStore } from '../stores/ui.js';
@@ -254,6 +275,8 @@ const formData = ref({
   model: null,
   mode: null,
   effortLevel: null,
+  showInQuickResponses: false,
+  quickResponseAutoSubmit: false,
 });
 
 const projectId = computed(() => route.params.projectId);
@@ -282,6 +305,8 @@ const loadTemplate = async () => {
         model: template.model,                      // Preserve null (inherit) or model ID
         mode: template.mode,                        // Preserve null (inherit), 'plan', 'standard', or 'yolo'
         effortLevel: template.effortLevel ?? null,
+        showInQuickResponses: template.showInQuickResponses,
+        quickResponseAutoSubmit: template.quickResponseAutoSubmit,
       };
     }
   } catch (err) {
@@ -305,6 +330,10 @@ const onSubmit = async () => {
       model: formData.value.model,                      // null = inherit
       mode: formData.value.mode,                        // null = inherit
       effortLevel: formData.value.effortLevel,          // null = inherit
+      showInQuickResponses: formData.value.showInQuickResponses,
+      quickResponseAutoSubmit: formData.value.showInQuickResponses
+        ? formData.value.quickResponseAutoSubmit
+        : false,
     };
 
     await templatesStore.updateTemplate(templateId.value, data);
@@ -318,6 +347,15 @@ const onSubmit = async () => {
     isSaving.value = false;
   }
 };
+
+watch(
+  () => formData.value.showInQuickResponses,
+  (showInQuickResponses) => {
+    if (!showInQuickResponses) {
+      formData.value.quickResponseAutoSubmit = false;
+    }
+  }
+);
 
 const onCancel = () => {
   router.back();
@@ -472,6 +510,19 @@ onMounted(async () => {
   height: 18px;
   cursor: pointer;
   accent-color: var(--color-primary);
+}
+
+.form-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.form-check input {
+  cursor: pointer;
 }
 
 .form-error-message {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -703,7 +703,7 @@ export async function updateSessionFields(sessionId: string, fields: Record<stri
 
 export async function seedProjectTemplate(
   projectId: string,
-  data: { name: string; prompt: string; nextTemplateId?: string; thinkingEnabled?: boolean | null; gitBranch?: string; model?: string; mode?: string | null; gitMode?: string; effortLevel?: string | null }
+  data: { name: string; prompt: string; nextTemplateId?: string; thinkingEnabled?: boolean | null; gitBranch?: string; model?: string; mode?: string | null; gitMode?: string; effortLevel?: string | null; showInQuickResponses?: boolean; quickResponseAutoSubmit?: boolean; quickResponseSortOrder?: number }
 ) {
   const response = await fetch(`${API_URL}/api/projects/${projectId}/templates`, {
     method: 'POST',
@@ -724,6 +724,9 @@ export async function seedGlobalTemplate(data: {
   mode?: string | null;
   gitMode?: string;
   effortLevel?: string | null;
+  showInQuickResponses?: boolean;
+  quickResponseAutoSubmit?: boolean;
+  quickResponseSortOrder?: number;
 }) {
   const response = await fetch(`${API_URL}/api/templates`, {
     method: 'POST',
@@ -1883,6 +1886,9 @@ export async function updateTemplate(
     model?: string | null;
     mode?: string | null;
     effortLevel?: string | null;
+    showInQuickResponses?: boolean;
+    quickResponseAutoSubmit?: boolean;
+    quickResponseSortOrder?: number;
   }
 ): Promise<any> {
   const response = await fetch(`${API_URL}/api/templates/${id}`, {

--- a/tests/e2e/quick-responses.spec.ts
+++ b/tests/e2e/quick-responses.spec.ts
@@ -6,6 +6,10 @@ import {
   getQuickResponses,
   deleteQuickResponse,
   reorderQuickResponses,
+  seedProjectTemplate,
+  seedGlobalTemplate,
+  deleteTemplate,
+  updateTemplate,
   cleanupCreatedResources,
   navigateAndWait,
   waitForPageReady,
@@ -20,9 +24,14 @@ const API_URL = getAPIURL();
  * We only delete OUR global QRs to avoid interfering with parallel tests.
  */
 const createdGlobalQRIds: string[] = [];
+const createdGlobalTemplateIds: string[] = [];
 
 function trackGlobalQR(id: string) {
   createdGlobalQRIds.push(id);
+}
+
+function trackGlobalTemplate(id: string) {
+  createdGlobalTemplateIds.push(id);
 }
 
 async function cleanupTrackedGlobalQRs() {
@@ -34,6 +43,44 @@ async function cleanupTrackedGlobalQRs() {
       // Already deleted (e.g., by cascade or prior cleanup) — ignore
     }
   }
+}
+
+async function cleanupTrackedGlobalTemplates() {
+  while (createdGlobalTemplateIds.length > 0) {
+    const id = createdGlobalTemplateIds.pop()!;
+    try {
+      await deleteTemplate(id);
+    } catch {
+      // Already deleted — ignore
+    }
+  }
+}
+
+async function seedQuickResponseTemplate(
+  projectId: string,
+  data: {
+    label: string;
+    content: string;
+    autoSubmit?: boolean;
+    sortOrder?: number;
+    isGlobal?: boolean;
+  }
+) {
+  const templateData = {
+    name: data.label,
+    prompt: data.content,
+    showInQuickResponses: true,
+    quickResponseAutoSubmit: data.autoSubmit ?? false,
+    quickResponseSortOrder: data.sortOrder ?? 0,
+  };
+
+  if (data.isGlobal) {
+    const template = await seedGlobalTemplate(templateData);
+    trackGlobalTemplate(template.id);
+    return template;
+  }
+
+  return seedProjectTemplate(projectId, templateData);
 }
 
 // ============================================================
@@ -78,24 +125,24 @@ async function openAddDialog(page, section: 'project' | 'global') {
 
 // ============================================================
 // Helper: Navigate to session detail conversation view and expand panel.
-// Wait for the store to finish loading quick responses before returning.
+// Wait for the store to finish loading templates before returning.
 // ============================================================
 async function navigateToSessionAndExpandPanel(page, sessionId: string) {
-  // Set up the quick-responses API response listener BEFORE navigating.
-  // The quick-responses fetch happens late in the page lifecycle:
+  // Set up the templates API response listener BEFORE navigating.
+  // The templates fetch happens late in the page lifecycle:
   //   1. SessionDetailView.initializeSession() fetches session + conversations
   //   2. Vue re-renders, ConversationTab mounts
-  //   3. ConversationTab.onMounted fires fetchForProject() (without await)
-  // We need to catch the quick-responses response whenever it arrives.
+  //   3. ConversationTab.onMounted fires fetchProjectTemplates() (without await)
+  // We need to catch the templates response whenever it arrives.
   const apiDone = page.waitForResponse(
-    (resp) => resp.url().includes('/quick-responses') && resp.status() === 200,
+    (resp) => resp.url().includes('/templates') && resp.status() === 200,
     { timeout: 30000 }
   );
 
   await page.goto(`/sessions/${sessionId}/summary`);
   await openSessionOverlay(page);
 
-  // Wait for the quick-responses API call to complete.
+  // Wait for the templates API call to complete.
   await apiDone;
 
   // Wait for the panel to render.
@@ -119,11 +166,13 @@ async function navigateToSessionAndExpandPanel(page, sessionId: string) {
 test.beforeEach(async () => {
   await cleanupCreatedResources();
   await cleanupTrackedGlobalQRs();
+  await cleanupTrackedGlobalTemplates();
 });
 
 test.afterEach(async () => {
   await cleanupCreatedResources();
   await cleanupTrackedGlobalQRs();
+  await cleanupTrackedGlobalTemplates();
 });
 
 // ============================================================
@@ -300,14 +349,8 @@ test.describe('Category 1: Quick Response CRUD via Settings Modal', () => {
 test.describe('Category 2: Quick Response Panel in Conversation View', () => {
   test('panel displays project and global responses with correct styling', async ({ page }) => {
     const project = await seedProject('QR Panel Styling', '/tmp/qr-panel-1');
-    await seedQuickResponse(project.id, { label: 'Project Response', content: 'Project content' });
-    const globalQR1 = await seedQuickResponse(project.id, { label: 'Global Response', content: 'Global content', isGlobal: true });
-    trackGlobalQR(globalQR1.id);
-
-    // Verify via API that both responses are available before navigating
-    const available = await getQuickResponses(project.id);
-    expect(available.project.map((r: any) => r.label)).toContain('Project Response');
-    expect(available.global.map((r: any) => r.label)).toContain('Global Response');
+    await seedQuickResponseTemplate(project.id, { label: 'Project Response', content: 'Project content' });
+    await seedQuickResponseTemplate(project.id, { label: 'Global Response', content: 'Global content', isGlobal: true });
 
     const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
     await navigateToSessionAndExpandPanel(page, session.id);
@@ -324,7 +367,7 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
 
   test('clicking a response inserts content into textarea', async ({ page }) => {
     const project = await seedProject('QR Panel Insert', '/tmp/qr-panel-2');
-    await seedQuickResponse(project.id, { label: 'Insert Me', content: 'Inserted content here' });
+    await seedQuickResponseTemplate(project.id, { label: 'Insert Me', content: 'Inserted content here' });
 
     const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
     await navigateToSessionAndExpandPanel(page, session.id);
@@ -345,7 +388,7 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
 
   test('auto-submit response shows lightning bolt indicator', async ({ page }) => {
     const project = await seedProject('QR Panel AutoSubmit', '/tmp/qr-panel-3');
-    await seedQuickResponse(project.id, {
+    await seedQuickResponseTemplate(project.id, {
       label: 'Auto Response',
       content: 'Auto content',
       autoSubmit: true,
@@ -365,7 +408,7 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
 
   test('panel collapse and expand toggle works', async ({ page }) => {
     const project = await seedProject('QR Panel Toggle', '/tmp/qr-panel-5');
-    await seedQuickResponse(project.id, { label: 'Toggle Test', content: 'Toggle content' });
+    await seedQuickResponseTemplate(project.id, { label: 'Toggle Test', content: 'Toggle content' });
 
     const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
 
@@ -388,52 +431,34 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
     await expect(page.locator('.responses-content')).not.toBeVisible({ timeout: 3000 });
   });
 
-  test('settings gear opens settings modal from conversation view', async ({ page }) => {
+  test('settings gear opens template list from conversation view', async ({ page }) => {
     const project = await seedProject('QR Panel Settings', '/tmp/qr-panel-6');
-    await seedQuickResponse(project.id, { label: 'Gear Test', content: 'Gear content' });
+    await seedQuickResponseTemplate(project.id, { label: 'Gear Test', content: 'Gear content' });
 
     const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
     await navigateToSessionAndExpandPanel(page, session.id);
 
     // Click the settings gear button
-    const settingsBtn = page.locator('button[aria-label="Manage quick responses"]');
+    const settingsBtn = page.locator('button[aria-label="Manage templates"]');
     await expect(settingsBtn).toBeVisible({ timeout: 5000 });
     await settingsBtn.click();
 
-    // Verify settings modal opens
-    const settingsModal = page.locator('.settings-panel[role="dialog"]');
-    await expect(settingsModal).toBeVisible({ timeout: 5000 });
-    await expect(settingsModal.locator('.settings-title')).toContainText('Quick Responses');
-
-    // Close the modal to prove it was interactable (not obscured by session overlay)
-    await page.locator('.close-button').click();
-    await expect(settingsModal).not.toBeVisible({ timeout: 3000 });
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/templates`), { timeout: 5000 });
   });
 
-  test('settings modal is interactable from session overlay', async ({ page }) => {
+  test('template list is reachable from session overlay', async ({ page }) => {
     const project = await seedProject('QR Overlay Interact', '/tmp/qr-overlay-interact');
-    await seedQuickResponse(project.id, { label: 'Interact Test', content: 'Test content' });
+    await seedQuickResponseTemplate(project.id, { label: 'Interact Test', content: 'Test content' });
 
     const session = await seedSession(project.id, { prompt: 'Test prompt', startImmediately: false });
     await navigateToSessionAndExpandPanel(page, session.id);
 
     // Click the settings gear button
-    const settingsBtn = page.locator('button[aria-label="Manage quick responses"]');
+    const settingsBtn = page.locator('button[aria-label="Manage templates"]');
     await expect(settingsBtn).toBeVisible({ timeout: 5000 });
     await settingsBtn.click();
 
-    // Verify settings modal opens
-    const settingsModal = page.locator('.settings-panel[role="dialog"]');
-    await expect(settingsModal).toBeVisible({ timeout: 5000 });
-
-    // Click the "+ Add" button inside the settings modal — this proves the modal
-    // is interactable (not obscured by the session overlay behind it)
-    const addBtn = settingsModal.locator('.add-button').first();
-    await addBtn.click();
-
-    // Assert the Add Quick Response dialog opens
-    const dialog = page.locator('.dialog-overlay .dialog');
-    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/templates`), { timeout: 5000 });
   });
 });
 
@@ -444,7 +469,7 @@ test.describe('Category 2: Quick Response Panel in Conversation View', () => {
 test.describe('Category 3: Quick Response Panel in New Session View', () => {
   test('panel displays responses in new session view', async ({ page }) => {
     const project = await seedProject('QR NewSession Display', '/tmp/qr-new-1');
-    await seedQuickResponse(project.id, { label: 'New Session QR', content: 'New session content' });
+    await seedQuickResponseTemplate(project.id, { label: 'New Session QR', content: 'New session content' });
 
     await page.goto(`/projects/${project.id}/sessions/new`);
     await waitForPageReady(page);
@@ -462,7 +487,7 @@ test.describe('Category 3: Quick Response Panel in New Session View', () => {
 
   test('clicking response inserts content into prompt textarea', async ({ page }) => {
     const project = await seedProject('QR NewSession Insert', '/tmp/qr-new-2');
-    await seedQuickResponse(project.id, { label: 'Insert Prompt', content: 'Prompt content here' });
+    await seedQuickResponseTemplate(project.id, { label: 'Insert Prompt', content: 'Prompt content here' });
 
     await page.goto(`/projects/${project.id}/sessions/new`);
     await waitForPageReady(page);
@@ -482,7 +507,7 @@ test.describe('Category 3: Quick Response Panel in New Session View', () => {
 
   test('auto-submit response triggers form submission in new session', async ({ page }) => {
     const project = await seedProject('QR NewSession AutoSubmit', '/tmp/qr-new-3');
-    await seedQuickResponse(project.id, {
+    await seedQuickResponseTemplate(project.id, {
       label: 'Auto Create',
       content: 'Auto-create this session',
       autoSubmit: true,
@@ -503,12 +528,12 @@ test.describe('Category 3: Quick Response Panel in New Session View', () => {
     await expect(page).not.toHaveURL(/\/sessions\/new/, { timeout: 10000 });
   });
 
-  test('settings gear opens settings modal from new session view', async ({ page }) => {
+  test('settings gear opens template list from new session view', async ({ page }) => {
     const project = await seedProject('QR NewSession Settings', '/tmp/qr-new-settings');
-    await seedQuickResponse(project.id, { label: 'Settings Test', content: 'Settings content' });
+    await seedQuickResponseTemplate(project.id, { label: 'Settings Test', content: 'Settings content' });
 
     const apiDone = page.waitForResponse(
-      (resp) => resp.url().includes('/quick-responses') && resp.status() === 200,
+      (resp) => resp.url().includes('/templates') && resp.status() === 200,
       { timeout: 30000 }
     );
 
@@ -525,18 +550,11 @@ test.describe('Category 3: Quick Response Panel in New Session View', () => {
     ).toBeVisible({ timeout: 5000 });
 
     // Click the settings gear button
-    const settingsBtn = page.locator('button[aria-label="Manage quick responses"]');
+    const settingsBtn = page.locator('button[aria-label="Manage templates"]');
     await expect(settingsBtn).toBeVisible({ timeout: 5000 });
     await settingsBtn.click();
 
-    // Verify settings modal opens
-    const settingsModal = page.locator('.settings-panel[role="dialog"]');
-    await expect(settingsModal).toBeVisible({ timeout: 5000 });
-    await expect(settingsModal.locator('.settings-title')).toContainText('Quick Responses');
-
-    // Verify modal can be closed
-    await page.locator('.close-button').click();
-    await expect(settingsModal).not.toBeVisible({ timeout: 3000 });
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/templates`), { timeout: 5000 });
   });
 });
 
@@ -549,7 +567,7 @@ test.describe('Category 4: Scope Isolation', () => {
     const projectA = await seedProject('QR Scope A', '/tmp/qr-scope-a');
     const projectB = await seedProject('QR Scope B', '/tmp/qr-scope-b');
 
-    await seedQuickResponse(projectA.id, { label: 'Only In A', content: 'Project A content' });
+    await seedQuickResponseTemplate(projectA.id, { label: 'Only In A', content: 'Project A content' });
 
     const sessionA = await seedSession(projectA.id, { prompt: 'Test A', startImmediately: false });
     const sessionB = await seedSession(projectB.id, { prompt: 'Test B', startImmediately: false });
@@ -626,9 +644,9 @@ test.describe('Category 5: Sort Ordering and Reordering', () => {
     const project = await seedProject('QR Sort Display', '/tmp/qr-sort-1');
 
     // Seed 3 responses with explicit sort orders (not in display order)
-    await seedQuickResponse(project.id, { label: 'Third', content: 'C', sortOrder: 2 });
-    await seedQuickResponse(project.id, { label: 'First', content: 'A', sortOrder: 0 });
-    await seedQuickResponse(project.id, { label: 'Second', content: 'B', sortOrder: 1 });
+    await seedQuickResponseTemplate(project.id, { label: 'Third', content: 'C', sortOrder: 2 });
+    await seedQuickResponseTemplate(project.id, { label: 'First', content: 'A', sortOrder: 0 });
+    await seedQuickResponseTemplate(project.id, { label: 'Second', content: 'B', sortOrder: 1 });
 
     const session = await seedSession(project.id, { prompt: 'Test sort', startImmediately: false });
     await navigateToSessionAndExpandPanel(page, session.id);
@@ -664,16 +682,14 @@ test.describe('Category 5: Sort Ordering and Reordering', () => {
   test('reordered responses display in new order in panel', async ({ page }) => {
     const project = await seedProject('QR Reorder Panel', '/tmp/qr-sort-3');
 
-    const r1 = await seedQuickResponse(project.id, { label: 'Uno', content: 'A', sortOrder: 0 });
-    const r2 = await seedQuickResponse(project.id, { label: 'Dos', content: 'B', sortOrder: 1 });
-    const r3 = await seedQuickResponse(project.id, { label: 'Tres', content: 'C', sortOrder: 2 });
+    const r1 = await seedQuickResponseTemplate(project.id, { label: 'Uno', content: 'A', sortOrder: 0 });
+    const r2 = await seedQuickResponseTemplate(project.id, { label: 'Dos', content: 'B', sortOrder: 1 });
+    const r3 = await seedQuickResponseTemplate(project.id, { label: 'Tres', content: 'C', sortOrder: 2 });
 
-    // Reverse order via API
-    await reorderQuickResponses(project.id, [
-      { id: r1.id, sortOrder: 2 },
-      { id: r2.id, sortOrder: 1 },
-      { id: r3.id, sortOrder: 0 },
-    ]);
+    // Reverse order via template API
+    await updateTemplate(r1.id, { quickResponseSortOrder: 2 });
+    await updateTemplate(r2.id, { quickResponseSortOrder: 1 });
+    await updateTemplate(r3.id, { quickResponseSortOrder: 0 });
 
     const session = await seedSession(project.id, { prompt: 'Test reorder', startImmediately: false });
     await navigateToSessionAndExpandPanel(page, session.id);


### PR DESCRIPTION
## Summary

This PR replaces the standalone quick response system with a template-backed implementation. Quick responses are now stored as session templates with additional metadata, consolidating the data model while preserving the existing UX.

**Key changes:**

- **Database schema**: Added quick response metadata to `session_templates` table:
  - `show_in_quick_responses` - flag to show template in quick responses panel
  - `quick_response_auto_submit` - flag to auto-submit when clicked
  - `quick_response_sort_order` - ordering for quick responses panel
  - `legacy_quick_response_id` - idempotent migration tracking

- **Migration**: Idempotent conversion of existing `quick_responses` to templates:
  - Converts label → name, content → prompt
  - Preserves auto_submit and sort_order
  - Handles both project and global scope
  - Leaves legacy rows intact for future cleanup

- **Backend updates**:
  - `SessionTemplateRepository` handles new quick response fields
  - Template contracts support new optional fields
  - API responses include quick response metadata

- **Frontend updates**:
  - Template create/edit forms have quick response controls
  - Templates panel shows quick response badges
  - `QuickResponsesPanel` now reads from templates store
  - Cog navigation goes to template list instead of settings modal
  - Conversation tab fetches templates instead of quick responses

- **Preserved behavior**:
  - Quick response buttons still insert prompt text into composer
  - Auto-submit still works when enabled
  - Project/global grouping maintained
  - Ordering preserved via sort_order

## Test plan

- [x] All unit tests pass (shared contracts, server repositories, web components)
- [x] E2E tests updated and passing for template-backed quick responses
- [x] Migration is idempotent (can be run multiple times safely)
- [x] Existing quick responses convert to templates correctly
- [x] New templates can be created with quick response settings
- [x] Quick response panel shows template-backed buttons
- [x] Cog navigation opens template list
- [x] Auto-submit behavior preserved

## Verification commands

```bash
# Run all relevant tests
yarn workspace @circuschief/shared test
yarn workspace @circuschief/server test
yarn workspace @circuschief/web test
./scripts/pw.sh test tests/e2e/quick-responses.spec.ts
```

## Follow-up items

- Remove legacy `quick_responses` table/routes/store after migration soak
- Consider adding manual ordering UI for quick response templates
- Decide whether quick response templates should apply model/mode/thinking metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)