### PR TITLE
docs: add --no-analytics CLI option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npx circuschief
 | Flag | Description |
 |------|-------------|
 | `-p, --port <number>` | Port to listen on (default: `5000`) |
+| `--no-analytics` | Disable anonymous usage analytics |
 | `-h, --help` | Show help message |
 | `-v, --version` | Show version number |
 


### PR DESCRIPTION
## Summary
- Adds the `--no-analytics` CLI flag to the Options table in README.md so users know they can disable anonymous usage analytics via the command line.

## Test plan
- [x] Verified the flag exists in `packages/server/src/cli.js`
- [x] README renders correctly with the new table row

🤖 Generated with [Claude Code](https://claude.com/claude-code)