### PR TITLE
Fix session-defaults persistence bug in project settings

### DIFF
--- a/packages/web/src/components/ConversationTab.model-init.test.js
+++ b/packages/web/src/components/ConversationTab.model-init.test.js
@@ -451,11 +451,12 @@ describe('ConversationTab - Model Initialization Bug', () => {
       await flushAll(wrapper);
 
       // startSession should receive the dropdown model ('opus'), not the stale pendingModel ('sonnet')
+      // ModelSelector now resolves the provider when the model is selected
       expect(mockSessionsStore.startSession).toHaveBeenCalledWith(
         'sess-123',
         'Test prompt',
         'opus',
-        null
+        'anthropic'
       );
     });
   });

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -798,6 +798,35 @@ describe('ModelSelector', () => {
       expect(wrapper.attributes('data-provider-id')).toBe('custom-openai');
     });
 
+    it('emits the resolved provider when mounted with a model but no provider', async () => {
+      const localProvidersStore = useProvidersStore();
+      localProvidersStore.providers = [
+        {
+          id: 'openai-default',
+          name: 'OpenAI (Official)',
+          isBuiltIn: true,
+          kind: 'openai',
+          models: [
+            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+          ],
+        },
+      ];
+
+      const onUpdateProviderId = vi.fn();
+      const wrapper = mountComponent(
+        {
+          modelValue: 'gpt-5.5',
+          providerId: null,
+          allowEmpty: true,
+        },
+        { 'onUpdate:providerId': onUpdateProviderId }
+      );
+      await flushAll(wrapper);
+
+      expect(wrapper.find('select').element.value).toBe(optionValue('openai-default', 'gpt-5.5'));
+      expect(onUpdateProviderId).toHaveBeenCalledWith('openai-default');
+    });
+
     it('shows duplicate built-in and custom options when requested', async () => {
       const localProvidersStore = useProvidersStore();
       localProvidersStore.providers = [

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -301,12 +301,22 @@ function syncSelectionFromProviders() {
 }
 
 function applyResolvedModel(resolvedModel) {
-  if (selectedModel.value === resolvedModel) return;
+  const resolvedProviderId = findVisibleOption(resolvedModel, props.providerId)?.provider.id || null;
+  if (selectedModel.value === resolvedModel) {
+    if (selectedProviderId.value !== resolvedProviderId) {
+      selectedProviderId.value = resolvedProviderId;
+      emit('update:providerId', resolvedProviderId);
+    }
+    return;
+  }
   selectedModel.value = resolvedModel;
-  selectedProviderId.value = findVisibleOption(resolvedModel, props.providerId)?.provider.id || null;
+  selectedProviderId.value = resolvedProviderId;
   // Emit the resolved value back to parent if it changed
   if (resolvedModel !== props.modelValue) {
     emit('update:modelValue', resolvedModel);
+  }
+  if (resolvedProviderId !== props.providerId) {
+    emit('update:providerId', resolvedProviderId);
   }
 }
 

--- a/packages/web/src/components/ProjectSessionDefaults.vue
+++ b/packages/web/src/components/ProjectSessionDefaults.vue
@@ -202,21 +202,16 @@ watch(() => defaultsStore.getDefaultsForProject(props.projectId), (defaults) => 
 }, { immediate: true });
 
 function collectNonDefaultValues() {
-  const data = {};
-  if (defaultMode.value) data.mode = defaultMode.value;
-  if (defaultThinkingEnabled.value) data.thinkingEnabled = true;
-  if (defaultEffortLevel.value) data.effortLevel = defaultEffortLevel.value;
-  if (!defaultStartImmediately.value) data.startImmediately = false;
-  if (defaultGitMode.value) data.gitMode = defaultGitMode.value;
-  if (defaultGitBranch.value) data.gitBranch = defaultGitBranch.value;
-  if (defaultModel.value) {
-    data.model = defaultModel.value;
-    data.providerId = defaultProviderId.value || null;
-  } else {
-    data.model = null;
-    data.providerId = null;
-  }
-  return data;
+  return {
+    mode: defaultMode.value || null,
+    thinkingEnabled: defaultThinkingEnabled.value,
+    effortLevel: defaultEffortLevel.value || null,
+    startImmediately: defaultStartImmediately.value,
+    gitMode: defaultGitMode.value || null,
+    gitBranch: defaultGitBranch.value || null,
+    model: defaultModel.value || null,
+    providerId: defaultModel.value ? (defaultProviderId.value || null) : null,
+  };
 }
 
 async function handleResetDefaults() {

--- a/packages/web/src/views/ProjectEditView.test.js
+++ b/packages/web/src/views/ProjectEditView.test.js
@@ -496,7 +496,7 @@ describe('ProjectEditView with Session Defaults', () => {
       }
     });
 
-    it('only sends non-empty defaults to API', async () => {
+    it('sends the full defaults snapshot to API', async () => {
       // Set up project and defaults BEFORE mounting
       projectsStore.currentProject = {
         id: 'proj-1',
@@ -533,12 +533,18 @@ describe('ProjectEditView with Session Defaults', () => {
       await form.trigger('submit');
       await flushAll(wrapper);
 
-      // Should only send mode in the defaults (or skip if form submission didn't work)
+      // The edit form represents the complete defaults state, including false
+      // and null values that must overwrite previous values on the server.
       const calls = defaultsStore.updateDefaults.mock.calls;
       if (calls.length > 0) {
         const callArgs = calls[0];
         expect(callArgs[1]).toEqual({
           mode: 'plan',
+          thinkingEnabled: false,
+          effortLevel: null,
+          startImmediately: true,
+          gitMode: null,
+          gitBranch: null,
           model: null,
           providerId: null,
         });
@@ -589,6 +595,12 @@ describe('ProjectEditView with Session Defaults', () => {
       if (calls.length > 0) {
         const callArgs = calls[0];
         expect(callArgs[1]).toEqual({
+          mode: null,
+          thinkingEnabled: false,
+          effortLevel: null,
+          startImmediately: true,
+          gitMode: null,
+          gitBranch: null,
           model: 'claude-sonnet-4-6',
           providerId: 'anthropic-provider',
         });

--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -300,6 +300,10 @@ async function handleSubmit() {
   error.value = null;
 
   try {
+    // Capture child form state before updateProject toggles loading and
+    // temporarily unmounts the form via the view-level loading state.
+    const defaultsData = sessionDefaultsRef.value?.collectNonDefaultValues();
+
     // Update project
     // Save null if value equals default (to avoid storing redundant data)
     await projectsStore.updateProject(route.params.id, {
@@ -313,8 +317,7 @@ async function handleSubmit() {
       kanbanEnabled: kanbanEnabled.value,
     });
 
-    // Update defaults - collect non-default values from child component
-    const defaultsData = sessionDefaultsRef.value?.collectNonDefaultValues();
+    // Update defaults collected from child component
     if (defaultsData && Object.keys(defaultsData).length > 0) {
       await defaultsStore.updateDefaults(route.params.id, defaultsData);
     }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -788,6 +788,7 @@ export async function setProjectSessionDefaults(
     gitMode?: string | null;
     gitBranch?: string | null;
     model?: string | null;
+    providerId?: string | null;
     effortLevel?: string | null;
   }
 ) {

--- a/tests/e2e/sessionDefaults.spec.ts
+++ b/tests/e2e/sessionDefaults.spec.ts
@@ -33,6 +33,85 @@ test.describe('Project Session Defaults - Phase 5 E2E Tests', () => {
   });
 
   // ============================================================
+  // Test Suite 0: Project Edit UI Persistence
+  // ============================================================
+
+  test.describe('Project Edit UI Persistence', () => {
+    test('saves and reloads every session default from the edit screen', async ({ page }) => {
+      const project = await seedProject('UI Defaults Persistence Test', '/tmp/ui-defaults-persistence');
+      const defaultsPosts: string[] = [];
+      page.on('request', (request) => {
+        if (request.method() === 'POST' && request.url().includes(`/api/projects/${project.id}/session-defaults`)) {
+          defaultsPosts.push(request.postData() || '');
+        }
+      });
+
+      await page.goto(`/projects/${project.id}/edit`);
+      await page.getByText('Session Defaults').click();
+
+      await page.locator('#defaultMode').selectOption('plan');
+      await page.getByLabel('Enable thinking (extended thinking) by default').check();
+      await page.locator('#defaultEffortLevel').selectOption('high');
+      await page.getByLabel('Start sessions immediately').uncheck();
+      await page.locator('#defaultGitMode').selectOption('worktree');
+      await page.locator('#defaultGitBranch').fill('feature/e2e-defaults');
+
+      const modelSelect = page.locator('#model-select');
+      const modelOption = modelSelect.locator(`option[data-model-id="${TEST_MODEL}"]`).first();
+      await expect(modelOption).toBeAttached({ timeout: 15000 });
+      const modelOptionValue = await modelOption.getAttribute('value');
+      const providerId = await modelOption.getAttribute('data-provider-id');
+      expect(modelOptionValue).toBeTruthy();
+      expect(providerId).toBeTruthy();
+
+      await modelSelect.selectOption(modelOptionValue!);
+      await expect(modelSelect).toHaveValue(modelOptionValue!);
+
+      await expect(page.locator('#defaultMode')).toHaveValue('plan');
+      await expect(page.getByLabel('Enable thinking (extended thinking) by default')).toBeChecked();
+      await expect(page.locator('#defaultEffortLevel')).toHaveValue('high');
+      await expect(page.getByLabel('Start sessions immediately')).not.toBeChecked();
+      await expect(page.locator('#defaultGitMode')).toHaveValue('worktree');
+      await expect(page.locator('#defaultGitBranch')).toHaveValue('feature/e2e-defaults');
+
+      await page.locator('button.btn-primary:has-text("Save")').click();
+      await expect(page).toHaveURL(`/projects/${project.id}/sessions`);
+
+      expect(defaultsPosts).toHaveLength(1);
+      expect(JSON.parse(defaultsPosts[0])).toMatchObject({
+        mode: 'plan',
+        thinkingEnabled: true,
+        effortLevel: 'high',
+        startImmediately: false,
+        gitMode: 'worktree',
+        gitBranch: 'feature/e2e-defaults',
+        model: TEST_MODEL,
+        providerId,
+      });
+      const defaults = await getProjectSessionDefaults(project.id);
+      expect(defaults.mode).toBe('plan');
+      expect(defaults.thinkingEnabled).toBe(true);
+      expect(defaults.effortLevel).toBe('high');
+      expect(defaults.startImmediately).toBe(false);
+      expect(defaults.gitMode).toBe('worktree');
+      expect(defaults.gitBranch).toBe('feature/e2e-defaults');
+      expect(defaults.model).toBe(TEST_MODEL);
+      expect(defaults.providerId).toBe(providerId);
+
+      await page.goto(`/projects/${project.id}/edit`);
+      await page.getByText('Session Defaults').click();
+
+      await expect(page.locator('#defaultMode')).toHaveValue('plan');
+      await expect(page.getByLabel('Enable thinking (extended thinking) by default')).toBeChecked();
+      await expect(page.locator('#defaultEffortLevel')).toHaveValue('high');
+      await expect(page.getByLabel('Start sessions immediately')).not.toBeChecked();
+      await expect(page.locator('#defaultGitMode')).toHaveValue('worktree');
+      await expect(page.locator('#defaultGitBranch')).toHaveValue('feature/e2e-defaults');
+      await expect(page.locator('#model-select')).toHaveValue(modelOptionValue!);
+    });
+  });
+
+  // ============================================================
   // Test Suite 1: API Contract Tests
   // ============================================================
 


### PR DESCRIPTION
## Summary
Fixed a critical bug in project settings persistence where session defaults were being reset to empty values when saving project settings.

## Root Cause
`ProjectEditView` called `projectsStore.updateProject()` before collecting session-default values. The update toggled the loading state, which temporarily unmounted `ProjectSessionDefaults` and reset it to empty values before we could collect the form data.

## Changes
- **ProjectEditView.vue**: Capture defaults before the awaited project update to prevent child unmounting
- **ModelSelector.vue**: Fix `applyResolvedModel()` to emit provider ID even when the model value hasn't changed (but provider needs to be synchronized)
- **ProjectSessionDefaults.vue**: Refactored `collectNonDefaultValues()` to return a full snapshot including `false` and `null` values that must overwrite previous values on the server
- **E2E test**: Added comprehensive test in `tests/e2e/sessionDefaults.spec.ts` covering every session-default field (mode, thinkingEnabled, effortLevel, startImmediately, gitMode, gitBranch, model, providerId)

## Test Plan
- [x] Added E2E regression test that saves and reloads all session-default fields
- [x] Verified existing ModelSelector unit tests pass
- [x] Verified existing ProjectEditView unit tests pass (updated expectations to match new full-snapshot behavior)
- [x] Verified full session-defaults E2E spec passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)