### PR TITLE
Auto-detect project repo URL from git remotes on creation

### DIFF
--- a/packages/server/src/api/projects-session-create.js
+++ b/packages/server/src/api/projects-session-create.js
@@ -1,0 +1,105 @@
+import { sessions, projectDefaults } from '../database.js';
+import { ProjectDefaultsRepository } from '../db/ProjectDefaultsRepository.js';
+import { broadcastToProject } from '../websocket.js';
+import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+import {
+  generateInitialName,
+  prepareSessionConfig,
+  applyTemplateOverrides,
+  resolveNextTemplateId,
+  buildSchedulingUpdate,
+  setupAndStartSession,
+} from './projects-session-helpers.js';
+import { validateGitSettings } from './projects-helpers.js';
+
+/**
+ * Validate and prepare the session configuration from the request body.
+ * Returns { config, nextTemplateId } on success, or { error, status } on failure.
+ */
+export async function validateAndPrepareSessionConfig(reqBody, reqFiles, projectId, project) {
+  const projectDefs = projectDefaults.getByProjectId(projectId);
+  const systemDefaults = ProjectDefaultsRepository.getSystemDefaults();
+  const config = prepareSessionConfig(reqBody, projectDefs, systemDefaults);
+  config.files = reqFiles || [];
+
+  if (!config.prompt) {
+    return { error: 'Prompt is required', status: 400 };
+  }
+
+  if (config.parentSessionId) {
+    const parentSession = sessions.getById(config.parentSessionId);
+    if (!parentSession) {
+      return { error: 'Parent session not found', status: 404 };
+    }
+    if (parentSession.projectId !== projectId) {
+      return { error: 'Parent session does not belong to this project', status: 400 };
+    }
+  }
+
+  // Apply template overrides and resolve nextTemplateId
+  applyTemplateOverrides(config);
+  const { nextTemplateId, error: nextTemplateError } = resolveNextTemplateId(reqBody, config.nextTemplateId || null);
+  if (nextTemplateError) {
+    return { error: nextTemplateError, status: 400 };
+  }
+  config.nextTemplateId = nextTemplateId;
+
+  // Validate git settings for git repos
+  const { config: updatedConfig, error: gitError } = await validateGitSettings(config, project);
+  if (gitError) {
+    return { error: gitError, status: 400 };
+  }
+  Object.assign(config, updatedConfig);
+
+  return { config, nextTemplateId };
+}
+
+/**
+ * Create the session row and apply any post-create updates.
+ * Returns the created session (already persisted in DB).
+ */
+export function createSessionRow(projectId, config, nextTemplateId, initialStatus) {
+  const sessionName = config.name || generateInitialName(config.prompt);
+  const session = sessions.create(projectId, sessionName, config.prompt, {
+    mode: config.mode,
+    thinkingEnabled: config.thinkingEnabled,
+    gitBranch: config.gitBranch,
+    parentSessionId: config.parentSessionId,
+    status: initialStatus,
+    model: config.model,
+    providerId: config.providerId,
+    effortLevel: config.effortLevel,
+    agentType: config.agentType,
+  });
+
+  const postCreateUpdate = {
+    ...(nextTemplateId ? { nextTemplateId } : {}),
+    ...buildSchedulingUpdate(config, initialStatus),
+  };
+  if (Object.keys(postCreateUpdate).length > 0) {
+    sessions.update(session.id, postCreateUpdate);
+  }
+  return session;
+}
+
+/**
+ * Run setupAndStartSession and translate any failure into an error response,
+ * marking the session as errored and broadcasting the update.
+ */
+export async function startSessionOrFail(req, res, { session, config, project }) {
+  try {
+    const { updatedSession } = await setupAndStartSession({
+      session, config, project, projectId: req.params.id, files: config.files,
+    });
+    return res.status(201).json(updatedSession);
+  } catch (error) {
+    console.error('Git setup error:', error);
+    const updatedSession = sessions.update(session.id, { status: 'error', error: error.message });
+    broadcastToProject(req.params.id, WS_MESSAGE_TYPES.SESSION_UPDATED, {
+      projectId: req.params.id,
+      sessionId: session.id,
+      session: updatedSession,
+    });
+    return res.status(500).json({ error: `Git setup failed: ${error.message}` });
+  }
+}

--- a/packages/server/src/api/projects-session-defaults.js
+++ b/packages/server/src/api/projects-session-defaults.js
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import { projects, projectDefaults } from '../database.js';
+import { ProjectSessionDefaultsRequest } from '@circuschief/shared/contracts/projects';
+
+const ERR_PROJECT_NOT_FOUND = 'Project not found';
+
+const router = Router({ mergeParams: true });
+
+// GET /api/projects/:id/session-defaults - Get session defaults for project
+router.get('/', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
+  }
+
+  const defaults = projectDefaults.getByProjectId(req.params.id);
+  if (!defaults) {
+    return res.json(null);
+  }
+
+  res.json(defaults);
+});
+
+// POST /api/projects/:id/session-defaults - Update/create session defaults for project
+router.post('/', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
+  }
+
+  const result = ProjectSessionDefaultsRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.issues[0].message });
+  }
+
+  const updated = projectDefaults.upsert(req.params.id, result.data);
+  res.status(200).json(updated);
+});
+
+// DELETE /api/projects/:id/session-defaults - Reset session defaults for project
+router.delete('/', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
+  }
+
+  projectDefaults.resetToDefaults(req.params.id);
+  res.json({ message: 'Session defaults reset to system defaults' });
+});
+
+export default router;

--- a/packages/server/src/api/projects-templates.js
+++ b/packages/server/src/api/projects-templates.js
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { projects, sessionTemplates } from '../database.js';
+import { CreateSessionTemplateRequest } from '@circuschief/shared/contracts/templates';
+
+const ERR_PROJECT_NOT_FOUND = 'Project not found';
+const router = Router({ mergeParams: true });
+
+// GET - List available templates for project (project + global)
+router.get('/', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
+  }
+
+  const available = sessionTemplates.getAvailableForProject(req.params.id);
+  res.json(available);
+});
+
+// POST - Create project template
+router.post('/', (req, res) => {
+  const project = projects.getById(req.params.id);
+  if (!project) {
+    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
+  }
+
+  const result = CreateSessionTemplateRequest.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.issues[0].message });
+  }
+
+  const template = sessionTemplates.create({
+    projectId: req.params.id,
+    ...result.data,
+  });
+  res.status(201).json(template);
+});
+
+export default router;

--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -21,6 +21,7 @@ import { validateGitSettings, buildRunsBySession } from './projects-helpers.js';
 import { resolveAgentTypeFromModel } from '../services/sessionProvider.js';
 import { access, constants } from 'fs/promises';
 import { dirname, isAbsolute } from 'path';
+import { getRepositoryUrl } from '../services/gitService.js';
 
 // Error message constants
 const ERR_PROJECT_NOT_FOUND = 'Project not found';
@@ -65,17 +66,31 @@ router.post('/', async (req, res) => {
     return res.status(400).json({ error: result.error.issues[0].message });
   }
 
-  const { name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, worktreePath, kanbanEnabled } = result.data;
+  const { name, workingDirectory, systemPrompt, onSessionCreated, onSessionDeleted, worktreePath, kanbanEnabled, repoUrl } = result.data;
 
   const pathError = await validateWorktreePath(worktreePath);
   if (pathError) {
     return res.status(400).json({ error: pathError });
   }
 
+  // Resolve repoUrl:
+  // - string: use as-is (explicitly provided)
+  // - null: suppress detection (explicitly sent as null)
+  // - undefined: auto-detect from git remote
+  let resolvedRepoUrl = repoUrl;
+  if (resolvedRepoUrl === undefined) {
+    try {
+      resolvedRepoUrl = await getRepositoryUrl(workingDirectory);
+    } catch {
+      resolvedRepoUrl = null;
+    }
+  }
+
   const createOptions = {
     onSessionCreated: onSessionCreated || null,
     onSessionDeleted: onSessionDeleted || null,
     worktreePath: worktreePath || null,
+    repoUrl: resolvedRepoUrl,
   };
   if (kanbanEnabled !== undefined) {
     createOptions.kanbanEnabled = kanbanEnabled;

--- a/packages/server/src/api/projects.js
+++ b/packages/server/src/api/projects.js
@@ -1,27 +1,18 @@
 import { Router } from 'express';
-import { projects, sessions, sessionTemplates, projectDefaults, commandRuns } from '../database.js';
+import { projects, sessions, commandRuns } from '../database.js';
 import { commandRunner } from '../services/commandRunner.js';
-import { CreateProjectRequest, UpdateProjectRequest, ProjectSessionDefaultsRequest } from '@circuschief/shared/contracts/projects';
-import { ProjectDefaultsRepository } from '../db/ProjectDefaultsRepository.js';
-import { CreateSessionTemplateRequest } from '@circuschief/shared/contracts/templates';
-import { broadcastToProject } from '../websocket.js';
+import { CreateProjectRequest, UpdateProjectRequest } from '@circuschief/shared/contracts/projects';
 import projectCommandButtonsRouter from './projects-commandButtons.js';
-import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+import projectSessionDefaultsRouter from './projects-session-defaults.js';
+import projectTemplatesRouter from './projects-templates.js';
 import { handleUploadError, uploadMiddleware } from '../middleware/upload.js';
-import {
-  generateInitialName,
-  prepareSessionConfig,
-  applyTemplateOverrides,
-  resolveNextTemplateId,
-  determineInitialStatus,
-  buildSchedulingUpdate,
-  setupAndStartSession,
-} from './projects-session-helpers.js';
-import { validateGitSettings, buildRunsBySession } from './projects-helpers.js';
+import { determineInitialStatus } from './projects-session-helpers.js';
+import { buildRunsBySession } from './projects-helpers.js';
 import { resolveAgentTypeFromModel } from '../services/sessionProvider.js';
 import { access, constants } from 'fs/promises';
 import { dirname, isAbsolute } from 'path';
 import { getRepositoryUrl } from '../services/gitService.js';
+import { validateAndPrepareSessionConfig, createSessionRow, startSessionOrFail } from './projects-session-create.js';
 
 // Error message constants
 const ERR_PROJECT_NOT_FOUND = 'Project not found';
@@ -213,98 +204,6 @@ router.get('/:id/sessions', (req, res) => {
   }
 });
 
-/**
- * Validate and prepare the session configuration from the request body.
- * Returns { config, nextTemplateId } on success, or { error, status } on failure.
- */
-async function validateAndPrepareSessionConfig(reqBody, reqFiles, projectId, project) {
-  const projectDefs = projectDefaults.getByProjectId(projectId);
-  const systemDefaults = ProjectDefaultsRepository.getSystemDefaults();
-  const config = prepareSessionConfig(reqBody, projectDefs, systemDefaults);
-  config.files = reqFiles || [];
-
-  if (!config.prompt) {
-    return { error: 'Prompt is required', status: 400 };
-  }
-
-  if (config.parentSessionId) {
-    const parentSession = sessions.getById(config.parentSessionId);
-    if (!parentSession) {
-      return { error: 'Parent session not found', status: 404 };
-    }
-    if (parentSession.projectId !== projectId) {
-      return { error: 'Parent session does not belong to this project', status: 400 };
-    }
-  }
-
-  // Apply template overrides and resolve nextTemplateId
-  applyTemplateOverrides(config);
-  const { nextTemplateId, error: nextTemplateError } = resolveNextTemplateId(reqBody, config.nextTemplateId || null);
-  if (nextTemplateError) {
-    return { error: nextTemplateError, status: 400 };
-  }
-  config.nextTemplateId = nextTemplateId;
-
-  // Validate git settings for git repos
-  const { config: updatedConfig, error: gitError } = await validateGitSettings(config, project);
-  if (gitError) {
-    return { error: gitError, status: 400 };
-  }
-  Object.assign(config, updatedConfig);
-
-  return { config, nextTemplateId };
-}
-
-/**
- * Create the session row and apply any post-create updates.
- * Returns the created session (already persisted in DB).
- */
-function createSessionRow(projectId, config, nextTemplateId, initialStatus) {
-  const sessionName = config.name || generateInitialName(config.prompt);
-  const session = sessions.create(projectId, sessionName, config.prompt, {
-    mode: config.mode,
-    thinkingEnabled: config.thinkingEnabled,
-    gitBranch: config.gitBranch,
-    parentSessionId: config.parentSessionId,
-    status: initialStatus,
-    model: config.model,
-    providerId: config.providerId,
-    effortLevel: config.effortLevel,
-    agentType: config.agentType,
-  });
-
-  const postCreateUpdate = {
-    ...(nextTemplateId ? { nextTemplateId } : {}),
-    ...buildSchedulingUpdate(config, initialStatus),
-  };
-  if (Object.keys(postCreateUpdate).length > 0) {
-    sessions.update(session.id, postCreateUpdate);
-  }
-  return session;
-}
-
-/**
- * Run setupAndStartSession and translate any failure into an error response,
- * marking the session as errored and broadcasting the update.
- */
-async function startSessionOrFail(req, res, { session, config, project }) {
-  try {
-    const { updatedSession } = await setupAndStartSession({
-      session, config, project, projectId: req.params.id, files: config.files,
-    });
-    return res.status(201).json(updatedSession);
-  } catch (error) {
-    console.error('Git setup error:', error);
-    const updatedSession = sessions.update(session.id, { status: 'error', error: error.message });
-    broadcastToProject(req.params.id, WS_MESSAGE_TYPES.SESSION_UPDATED, {
-      projectId: req.params.id,
-      sessionId: session.id,
-      session: updatedSession,
-    });
-    return res.status(500).json({ error: `Git setup failed: ${error.message}` });
-  }
-}
-
 // POST /api/projects/:id/sessions - Create session
 // Supports both JSON and multipart/form-data (for file attachments)
 router.post('/:id/sessions', uploadMiddleware('files', 10), handleUploadError, async (req, res) => {
@@ -350,79 +249,13 @@ router.post('/:id/sessions', uploadMiddleware('files', 10), handleUploadError, a
   }
 });
 
-// GET /api/projects/:id/templates - List available templates for project (project + global)
-router.get('/:id/templates', (req, res) => {
-  const project = projects.getById(req.params.id);
-  if (!project) {
-    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
-  }
-
-  const available = sessionTemplates.getAvailableForProject(req.params.id);
-  res.json(available);
-});
-
-// POST /api/projects/:id/templates - Create project template
-router.post('/:id/templates', (req, res) => {
-  const project = projects.getById(req.params.id);
-  if (!project) {
-    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
-  }
-
-  const result = CreateSessionTemplateRequest.safeParse(req.body);
-  if (!result.success) {
-    return res.status(400).json({ error: result.error.issues[0].message });
-  }
-
-  const template = sessionTemplates.create({
-    projectId: req.params.id,
-    ...result.data,
-  });
-  res.status(201).json(template);
-});
+// Template routes are mounted as a sub-router
+router.use('/:id/templates', projectTemplatesRouter);
 
 // Command button routes are mounted as a sub-router
 router.use('/:id/command-buttons', projectCommandButtonsRouter);
 
-// GET /api/projects/:id/session-defaults - Get session defaults for project
-router.get('/:id/session-defaults', (req, res) => {
-  const project = projects.getById(req.params.id);
-  if (!project) {
-    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
-  }
-
-  const defaults = projectDefaults.getByProjectId(req.params.id);
-  if (!defaults) {
-    return res.json(null);
-  }
-
-  res.json(defaults);
-});
-
-// POST /api/projects/:id/session-defaults - Update/create session defaults for project
-router.post('/:id/session-defaults', (req, res) => {
-  const project = projects.getById(req.params.id);
-  if (!project) {
-    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
-  }
-
-  const result = ProjectSessionDefaultsRequest.safeParse(req.body);
-  if (!result.success) {
-    return res.status(400).json({ error: result.error.issues[0].message });
-  }
-
-  const updated = projectDefaults.upsert(req.params.id, result.data);
-  res.status(200).json(updated);
-});
-
-// DELETE /api/projects/:id/session-defaults - Reset session defaults for project
-router.delete('/:id/session-defaults', (req, res) => {
-  const project = projects.getById(req.params.id);
-  if (!project) {
-    return res.status(404).json({ error: ERR_PROJECT_NOT_FOUND });
-  }
-
-  projectDefaults.resetToDefaults(req.params.id);
-  res.json({ message: 'Session defaults reset to system defaults' });
-});
+// Session defaults routes are mounted as a sub-router
+router.use('/:id/session-defaults', projectSessionDefaultsRouter);
 
 export default router;

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -806,6 +806,148 @@ describe('Projects API', () => {
     });
   });
 
+  describe('POST /api/projects repoUrl auto-detection', () => {
+    it('creates a project with repoUrl detected from origin HTTPS remote', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-https-'));
+      try {
+        execSync('git init', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.email "test@test.com"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.name "Test"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git remote add origin https://github.com/owner/repo.git', { cwd: newDir, stdio: 'ignore' });
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'HTTPS Remote Project',
+          workingDirectory: newDir,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBe('https://github.com/owner/repo');
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('creates a project with repoUrl detected and normalized from SSH remote', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-ssh-'));
+      try {
+        execSync('git init', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.email "test@test.com"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.name "Test"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git remote add origin git@github.com:owner/repo.git', { cwd: newDir, stdio: 'ignore' });
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'SSH Remote Project',
+          workingDirectory: newDir,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBe('https://github.com/owner/repo');
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('uses explicit repoUrl string from the request instead of detected remote', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-explicit-'));
+      try {
+        execSync('git init', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.email "test@test.com"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.name "Test"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git remote add origin https://github.com/owner/repo.git', { cwd: newDir, stdio: 'ignore' });
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'Explicit URL Project',
+          workingDirectory: newDir,
+          repoUrl: 'https://custom.url/repo',
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBe('https://custom.url/repo');
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('explicitly sends repoUrl: null to suppress detection', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-null-'));
+      try {
+        execSync('git init', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.email "test@test.com"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.name "Test"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git remote add origin https://github.com/owner/repo.git', { cwd: newDir, stdio: 'ignore' });
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'Null URL Project',
+          workingDirectory: newDir,
+          repoUrl: null,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBeNull();
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('omits repoUrl entirely for a git repo without remotes', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-noremote-'));
+      try {
+        execSync('git init', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.email "test@test.com"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.name "Test"', { cwd: newDir, stdio: 'ignore' });
+        // No remotes added
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'No Remote Project',
+          workingDirectory: newDir,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBeNull();
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('omits repoUrl entirely for a non-git directory', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-nongit-'));
+      try {
+        // No git init — plain directory
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'Non-Git Project',
+          workingDirectory: newDir,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBeNull();
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+
+    it('omits repoUrl for a git repo with a non-origin remote', async () => {
+      const newDir = mkdtempSync(join(tmpdir(), 'projects-repourl-upstream-'));
+      try {
+        execSync('git init', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.email "test@test.com"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git config user.name "Test"', { cwd: newDir, stdio: 'ignore' });
+        execSync('git remote add upstream https://github.com/other/repo.git', { cwd: newDir, stdio: 'ignore' });
+        // No origin remote
+
+        const res = await request(app).post('/api/projects').send({
+          name: 'Upstream Remote Project',
+          workingDirectory: newDir,
+        });
+
+        expect(res.status).toBe(201);
+        expect(res.body.repoUrl).toBe('https://github.com/other/repo');
+      } finally {
+        rmSync(newDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('GET /api/projects', () => {
     it('returns all projects', async () => {
       const res = await request(app).get('/api/projects');

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -37,7 +37,6 @@ vi.mock('../services/gitService.js', async (importOriginal) => {
 import projectsRouter, { validateWorktreePath } from './projects.js';
 import { broadcastToProject } from '../websocket.js';
 import { setupGitForSession } from '../services/gitSessionSetup.js';
-import { getRepositoryUrl } from '../services/gitService.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 
 describe('Projects API', () => {

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -22,10 +22,22 @@ vi.mock('../services/gitSessionSetup.js', () => ({
   setupGitForSession: vi.fn().mockResolvedValue({ workingDirectory: '/tmp/test', gitWorktree: null }),
 }));
 
+// Mock gitService.getRepositoryUrl to avoid spawning git processes during most tests.
+// The real implementation is restored in the "repoUrl auto-detection" describe block
+// so those tests can exercise the actual git command logic.
+vi.mock('../services/gitService.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getRepositoryUrl: vi.fn(actual.getRepositoryUrl),
+  };
+});
+
 // Import after mocks are set up
 import projectsRouter, { validateWorktreePath } from './projects.js';
 import { broadcastToProject } from '../websocket.js';
 import { setupGitForSession } from '../services/gitSessionSetup.js';
+import { getRepositoryUrl } from '../services/gitService.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 
 describe('Projects API', () => {

--- a/packages/server/src/services/gitDiff.js
+++ b/packages/server/src/services/gitDiff.js
@@ -1,0 +1,132 @@
+import { git } from './gitService.js';
+
+/**
+ * Get diff for a directory
+ * @param {string} directory
+ * @returns {Promise<string>}
+ */
+export async function getDiff(directory) {
+  try {
+    return await git(directory, 'diff');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Get staged diff for a directory
+ * @param {string} directory
+ * @returns {Promise<string>}
+ */
+export async function getStagedDiff(directory) {
+  try {
+    return await git(directory, 'diff --cached');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Get list of untracked files
+ * @param {string} directory
+ * @returns {Promise<string[]>}
+ */
+export async function getUntrackedFiles(directory) {
+  try {
+    const output = await git(directory, 'ls-files --others --exclude-standard');
+    if (!output) return [];
+    return output.split('\n').filter((line) => line.trim());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get diff for a directory compared to a specific branch
+ * @param {string} directory
+ * @param {string} branch - Branch to compare against (e.g., 'origin/main')
+ * @returns {Promise<string>}
+ */
+export async function getDiffAgainstBranch(directory, branch) {
+  try {
+    return await git(directory, `diff ${branch}`);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Get staged diff for a directory compared to a specific branch
+ * @param {string} directory
+ * @param {string} branch - Branch to compare against (e.g., 'origin/main')
+ * @returns {Promise<string>}
+ */
+export async function getStagedDiffAgainstBranch(directory, branch) {
+  try {
+    return await git(directory, `diff --cached ${branch}`);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Get diff between two git refs (e.g., comparing HEAD to origin/main)
+ * This shows the committed changes between two refs, ignoring working tree state
+ * @param {string} directory
+ * @param {string} fromRef - Base ref (e.g., 'origin/main')
+ * @param {string} toRef - Target ref (e.g., 'HEAD')
+ * @returns {Promise<string>}
+ */
+export async function getDiffBetweenRefs(directory, fromRef, toRef) {
+  try {
+    return await git(directory, `diff ${fromRef} ${toRef}`);
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Get count of files modified/added compared to a branch
+ * Includes committed changes + staged + unstaged + untracked files
+ * @param {string} directory - The git repository directory
+ * @param {string} branch - Branch to compare against (e.g., 'origin/main')
+ * @returns {Promise<number>} - Total count of unique files modified/added
+ */
+export async function getModifiedFilesCount(directory, branch) {
+  try {
+    // Get all modified files in one command using --name-only
+    // This includes: committed changes vs branch + staged
+    const committedAndStaged = await git(
+      directory,
+      `diff --name-only ${branch}...HEAD`
+    );
+
+    // Get unstaged changes (working tree vs index)
+    const unstaged = await git(directory, 'diff --name-only');
+
+    // Get untracked files
+    const untracked = await getUntrackedFiles(directory);
+
+    // Combine all files into a Set to get unique count
+    const allFiles = new Set();
+
+    if (committedAndStaged) {
+      committedAndStaged.split('\n').forEach(f => {
+        if (f.trim()) allFiles.add(f.trim());
+      });
+    }
+
+    if (unstaged) {
+      unstaged.split('\n').forEach(f => {
+        if (f.trim()) allFiles.add(f.trim());
+      });
+    }
+
+    untracked.forEach(f => allFiles.add(f));
+
+    return allFiles.size;
+  } catch (error) {
+    console.warn(`Failed to get modified files count for ${directory}:`, error.message);
+    return 0;
+  }
+}

--- a/packages/server/src/services/gitRepoUrl.js
+++ b/packages/server/src/services/gitRepoUrl.js
@@ -1,0 +1,174 @@
+import path from 'path';
+import { realpath, access } from 'fs/promises';
+import { isGitRepo, getWorktrees, git } from './gitService.js';
+
+/**
+ * Normalize a git remote URL into a clean HTTPS browser URL.
+ *
+ * Supported forms:
+ *   - https://github.com/owner/repo.git -> https://github.com/owner/repo
+ *   - https://github.com/owner/repo     -> https://github.com/owner/repo (already clean)
+ *   - git@github.com:owner/repo.git    -> https://github.com/owner/repo
+ *   - ssh://git@github.com/owner/repo.git -> https://github.com/owner/repo
+ *   - git@gitlab.com:owner/repo.git    -> https://gitlab.com/owner/repo
+ *   - https://gitlab.com/owner/repo.git -> https://gitlab.com/owner/repo
+ *   - https://bitbucket.org/owner/repo.git -> https://bitbucket.org/owner/repo
+ *   - http://git.example.com/owner/repo.git -> http://git.example.com/owner/repo
+ *   - git://github.com/owner/repo.git  -> https://github.com/owner/repo
+ *
+ * Query strings and fragments are stripped before matching.
+ *
+ * Returns null for empty, null, undefined, or unrecognizable inputs.
+ *
+ * @param {string|null|undefined} remoteUrl
+ * @returns {string|null}
+ */
+export function normalizeGitRemoteUrl(remoteUrl) {
+  if (!remoteUrl || typeof remoteUrl !== 'string') {
+    return null;
+  }
+
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // Strip query strings and fragments before matching
+  // (defensive: malformed remote configs shouldn't silently fail)
+  const cleaned = trimmed.replace(/[?#].*$/, '');
+
+  // SSH form: git@host:owner/repo.git or git@host:owner/repo
+  const sshMatch = cleaned.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return `https://${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  // SSH protocol form: ssh://git@host/owner/repo.git
+  const sshProtocolMatch = cleaned.match(/^ssh:\/\/git@([^/]+)\/(.+?)(?:\.git)?$/);
+  if (sshProtocolMatch) {
+    return `https://${sshProtocolMatch[1]}/${sshProtocolMatch[2]}`;
+  }
+
+  // HTTPS form: https://host/owner/repo.git or https://host/owner/repo
+  const httpsMatch = cleaned.match(/^https:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    return `https://${httpsMatch[1]}/${httpsMatch[2]}`;
+  }
+
+  // HTTP form: http://host/owner/repo.git or http://host/owner/repo
+  // Preserve the http:// scheme (unlike SSH->HTTPS conversion, HTTP remotes
+  // are intentional and the server may not support HTTPS).
+  const httpMatch = cleaned.match(/^http:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpMatch) {
+    return `http://${httpMatch[1]}/${httpMatch[2]}`;
+  }
+
+  // git:// protocol form: git://host/owner/repo.git or git://host/owner/repo
+  // Convert to HTTPS (same output as SSH).
+  const gitProtocolMatch = cleaned.match(/^git:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (gitProtocolMatch) {
+    return `https://${gitProtocolMatch[1]}/${gitProtocolMatch[2]}`;
+  }
+
+  // Unrecognized format
+  return null;
+}
+
+/**
+ * Parse the first remote URL from `git remote -v` output.
+ * @param {string} remoteVerbose - Raw output of `git remote -v`
+ * @returns {string|null} The extracted URL, or null if not parseable
+ */
+function parseFirstRemoteUrl(remoteVerbose) {
+  const firstLine = remoteVerbose.split('\n').find((r) => r.trim());
+  if (!firstLine) return null;
+
+  // git remote -v outputs: "remote_name\turl (fetch)"
+  const parts = firstLine.split('\t');
+  if (parts.length < 2) return null;
+
+  return parts[1].replace(/ \((?:fetch|push)\)$/, '');
+}
+
+/**
+ * Auto-detect the repository URL from a directory's git remotes.
+ *
+ * Prefers the "origin" remote. Falls back to the first configured remote.
+ * Normalizes SSH and HTTPS URLs into clean HTTPS browser URLs.
+ * Returns null if the directory is not a git repo or has no usable remotes.
+ *
+ * @param {string} directory
+ * @returns {Promise<string|null>}
+ */
+export async function getRepositoryUrl(directory) {
+  try {
+    // Fast-path: skip entirely if the directory is not a git repo.
+    // Uses a filesystem check (.git existence) instead of spawning a git process,
+    // which avoids unnecessary child_process overhead for non-git directories.
+    try {
+      await access(path.join(directory, '.git'));
+    } catch {
+      return null;
+    }
+
+    // Try origin first (with timeout to prevent indefinite blocking under load)
+    let rawUrl;
+    try {
+      rawUrl = await git(directory, 'config --get remote.origin.url', { timeout: 5000 });
+    } catch {
+      // No origin remote, try listing all remotes
+    }
+
+    // Fall back to first remote if origin doesn't exist
+    if (!rawUrl) {
+      try {
+        const remoteVerbose = await git(directory, 'remote -v', { timeout: 5000 });
+        rawUrl = parseFirstRemoteUrl(remoteVerbose);
+      } catch {
+        // No remotes at all
+      }
+    }
+
+    if (!rawUrl) {
+      return null;
+    }
+
+    return normalizeGitRemoteUrl(rawUrl);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect the worktree path for a directory by inspecting existing worktrees.
+ * If external worktrees exist, uses the parent directory of the first one.
+ * Otherwise, falls back to {directory}/.worktrees.
+ * @param {string} directory - The git repository directory
+ * @returns {Promise<{worktreePath: string, source: 'detected' | 'default'}>}
+ */
+export async function detectWorktreePath(directory) {
+  const isRepo = await isGitRepo(directory);
+  if (!isRepo) {
+    return { worktreePath: path.join(directory, '.worktrees'), source: 'default' };
+  }
+
+  // Resolve symlinks for consistent path comparison (e.g., /var -> /private/var on macOS)
+  let resolvedDir;
+  try {
+    resolvedDir = await realpath(directory);
+  } catch {
+    resolvedDir = path.resolve(directory);
+  }
+
+  const worktrees = await getWorktrees(directory);
+  // Filter out the main worktree (its path === directory or resolves to it)
+  const externalWorktrees = worktrees.filter(wt => path.resolve(wt.path) !== resolvedDir);
+
+  if (externalWorktrees.length > 0) {
+    // Use the parent directory of the first external worktree
+    const parentDir = path.dirname(path.resolve(externalWorktrees[0].path));
+    return { worktreePath: parentDir, source: 'detected' };
+  }
+
+  return { worktreePath: path.join(resolvedDir, '.worktrees'), source: 'default' };
+}

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -1,26 +1,40 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import path from 'path';
-import { realpath, access } from 'fs/promises';
 export {
   clearWorktreeCommitAttribution,
   configureWorktreeCommitAttribution,
   ensureWorktreeCommitAttributionHook,
 } from './gitCommitAttribution.js';
+export {
+  normalizeGitRemoteUrl,
+  getRepositoryUrl,
+  detectWorktreePath,
+} from './gitRepoUrl.js';
+export {
+  getDiff,
+  getStagedDiff,
+  getUntrackedFiles,
+  getDiffAgainstBranch,
+  getStagedDiffAgainstBranch,
+  getDiffBetweenRefs,
+  getModifiedFilesCount,
+} from './gitDiff.js';
+export {
+  branchExists,
+  checkoutBranch,
+  createWorktree,
+  removeWorktree,
+  createWorktreeForBranch,
+} from './gitWorktree.js';
 
 const execAsync = promisify(exec);
 
-// Cache for default branch detection per repository
-// Key: directory path, Value: { branch: string, timestamp: number }
+// Cache for default branch detection: directory -> { branch, timestamp }
 const defaultBranchCache = new Map();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_CACHE_SIZE = 100; // Maximum number of repositories to cache
 
-// Configurable logger for warning messages
-// Can be overridden via setLogger() for custom logging behavior
-let logger = {
-  warn: (...args) => console.warn(...args),
-};
+import { _setWorktreeLogger } from './gitWorktree.js';
 
 /**
  * Set a custom logger for git service warnings.
@@ -29,19 +43,15 @@ let logger = {
  * @param {Function} customLogger.warn - Function to handle warning messages
  */
 export function setLogger(customLogger) {
-  logger = customLogger;
+  _setWorktreeLogger(customLogger);
 }
 
-/**
- * Evict oldest entries from cache if it exceeds MAX_CACHE_SIZE.
- * Uses LRU-like eviction based on timestamp.
- */
+/** Evict oldest cache entries if size exceeds MAX_CACHE_SIZE (LRU-like). */
 function evictOldestCacheEntries() {
   if (defaultBranchCache.size <= MAX_CACHE_SIZE) {
     return;
   }
 
-  // Sort entries by timestamp and remove oldest ones
   const entries = [...defaultBranchCache.entries()];
   entries.sort((a, b) => a[1].timestamp - b[1].timestamp);
 
@@ -52,29 +62,15 @@ function evictOldestCacheEntries() {
 }
 
 /**
- * Safely fetch from origin remote.
- * Logs a warning if fetch fails but does not throw.
- * @param {string} directory - The git repository directory
- * @returns {Promise<boolean>} - True if fetch succeeded, false otherwise
- */
-async function safeFetchOrigin(directory) {
-  try {
-    await git(directory, 'fetch origin');
-    return true;
-  } catch (err) {
-    // No origin or network unavailable, proceed without fetch
-    logger.warn('Could not fetch from origin, proceeding with local refs:', err.message);
-    return false;
-  }
-}
-
-/**
  * Execute a git command in a directory
  * @param {string} directory
  * @param {string} command
+ * @param {Object} [opts]
+ * @param {Object} [opts.env]
+ * @param {number} [opts.timeout]
  * @returns {Promise<string>}
  */
-async function git(directory, command, opts = {}) {
+export async function git(directory, command, opts = {}) {
   const execOpts = { cwd: directory };
   if (opts.env) execOpts.env = opts.env;
   if (opts.timeout) execOpts.timeout = opts.timeout;
@@ -248,241 +244,8 @@ export async function getCurrentBranch(directory) {
 }
 
 /**
- * Create a new worktree
- * @param {string} directory
- * @param {string} branch
- * @param {string} worktreePath
- * @param {Object} options
- * @param {boolean} options.skipFetch - Skip fetching from origin (default: false)
- * @returns {Promise<{path: string, branch: string}>}
- */
-export async function createWorktree(directory, branch, worktreePath, options = {}) {
-  const { skipFetch = false } = options;
-
-  // Fetch latest from origin to ensure we have up-to-date default branch
-  if (!skipFetch) {
-    await safeFetchOrigin(directory);
-  }
-
-  // Get the default branch from origin (main or master)
-  const defaultBranch = await getOriginDefaultBranch(directory);
-  // Base new branch on origin's default branch to avoid including unrelated commits from HEAD
-  // Use --no-track to prevent the new branch from tracking the start-point (main/master)
-  await git(directory, `worktree add --no-track "${worktreePath}" -b "${branch}" ${defaultBranch}`);
-  return { path: worktreePath, branch };
-}
-
-/**
- * Remove a worktree
- * @param {string} directory
- * @param {string} path
- * @param {boolean} force - Force removal even if worktree has uncommitted changes
- */
-export async function removeWorktree(directory, worktreePath, force = false) {
-  const forceFlag = force ? '--force' : '';
-  await git(directory, `worktree remove ${forceFlag} "${worktreePath}"`);
-}
-
-/**
- * Get diff for a directory
- * @param {string} directory
- * @returns {Promise<string>}
- */
-export async function getDiff(directory) {
-  try {
-    return await git(directory, 'diff');
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Get staged diff for a directory
- * @param {string} directory
- * @returns {Promise<string>}
- */
-export async function getStagedDiff(directory) {
-  try {
-    return await git(directory, 'diff --cached');
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Check if a branch exists
- * @param {string} directory
- * @param {string} branch
- * @returns {Promise<boolean>}
- */
-export async function branchExists(directory, branch) {
-  try {
-    await git(directory, `rev-parse --verify refs/heads/${branch}`);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Checkout a branch, creating it if it doesn't exist
- * @param {string} directory
- * @param {string} branch
- * @returns {Promise<void>}
- */
-export async function checkoutBranch(directory, branch) {
-  const exists = await branchExists(directory, branch);
-  if (exists) {
-    await git(directory, `checkout "${branch}"`);
-  } else {
-    await git(directory, `checkout -b "${branch}"`);
-  }
-}
-
-/**
- * Create a worktree for a branch (creates branch if it doesn't exist)
- * @param {string} directory - Main repo directory
- * @param {string} branch - Branch name
- * @param {string} worktreePath - Path for the new worktree
- * @param {Object} options
- * @param {boolean} options.skipFetch - Skip fetching from origin (default: false)
- * @returns {Promise<{path: string, branch: string}>}
- */
-export async function createWorktreeForBranch(directory, branch, worktreePath, options = {}) {
-  const { skipFetch = false } = options;
-
-  // Fetch latest from origin to ensure we have up-to-date default branch
-  if (!skipFetch) {
-    await safeFetchOrigin(directory);
-  }
-
-  const exists = await branchExists(directory, branch);
-  if (exists) {
-    await git(directory, `worktree add "${worktreePath}" "${branch}"`);
-  } else {
-    // Get the default branch from origin (main or master)
-    const defaultBranch = await getOriginDefaultBranch(directory);
-    // Base new branch on origin's default branch to avoid including unrelated commits from HEAD
-    // Use --no-track to prevent the new branch from tracking the start-point (main/master)
-    await git(directory, `worktree add --no-track -b "${branch}" "${worktreePath}" ${defaultBranch}`);
-  }
-  return { path: worktreePath, branch };
-}
-
-/**
- * Get list of untracked files
- * @param {string} directory
- * @returns {Promise<string[]>}
- */
-export async function getUntrackedFiles(directory) {
-  try {
-    const output = await git(directory, 'ls-files --others --exclude-standard');
-    if (!output) return [];
-    return output.split('\n').filter((line) => line.trim());
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Get diff for a directory compared to a specific branch
- * @param {string} directory
- * @param {string} branch - Branch to compare against (e.g., 'origin/main')
- * @returns {Promise<string>}
- */
-export async function getDiffAgainstBranch(directory, branch) {
-  try {
-    return await git(directory, `diff ${branch}`);
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Get staged diff for a directory compared to a specific branch
- * @param {string} directory
- * @param {string} branch - Branch to compare against (e.g., 'origin/main')
- * @returns {Promise<string>}
- */
-export async function getStagedDiffAgainstBranch(directory, branch) {
-  try {
-    return await git(directory, `diff --cached ${branch}`);
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Get diff between two git refs (e.g., comparing HEAD to origin/main)
- * This shows the committed changes between two refs, ignoring working tree state
- * @param {string} directory
- * @param {string} fromRef - Base ref (e.g., 'origin/main')
- * @param {string} toRef - Target ref (e.g., 'HEAD')
- * @returns {Promise<string>}
- */
-export async function getDiffBetweenRefs(directory, fromRef, toRef) {
-  try {
-    return await git(directory, `diff ${fromRef} ${toRef}`);
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Get count of files modified/added compared to a branch
- * Includes committed changes + staged + unstaged + untracked files
- * @param {string} directory - The git repository directory
- * @param {string} branch - Branch to compare against (e.g., 'origin/main')
- * @returns {Promise<number>} - Total count of unique files modified/added
- */
-export async function getModifiedFilesCount(directory, branch) {
-  try {
-    // Get all modified files in one command using --name-only
-    // This includes: committed changes vs branch + staged
-    const committedAndStaged = await git(
-      directory,
-      `diff --name-only ${branch}...HEAD`
-    );
-
-    // Get unstaged changes (working tree vs index)
-    const unstaged = await git(directory, 'diff --name-only');
-
-    // Get untracked files
-    const untracked = await getUntrackedFiles(directory);
-
-    // Combine all files into a Set to get unique count
-    const allFiles = new Set();
-
-    // Parse committed+staged files
-    if (committedAndStaged) {
-      committedAndStaged.split('\n').forEach(f => {
-        if (f.trim()) allFiles.add(f.trim());
-      });
-    }
-
-    // Parse unstaged files
-    if (unstaged) {
-      unstaged.split('\n').forEach(f => {
-        if (f.trim()) allFiles.add(f.trim());
-      });
-    }
-
-    // Add untracked files
-    untracked.forEach(f => allFiles.add(f));
-
-    return allFiles.size;
-  } catch (error) {
-    logger.warn(`Failed to get modified files count for ${directory}:`, error.message);
-    return 0;
-  }
-}
-
-/**
  * Get the git author info from the global config (~/.gitconfig).
- *
- * Uses `--global` so that a contaminated local config (e.g. one that
- * already has Claude Code's identity) is bypassed.
- *
+ * Uses `--global` so that a contaminated local config is bypassed.
  * @param {string} directory
  * @param {Object} [options]
  * @param {Object} [options.env] - Custom environment variables (useful for tests)
@@ -503,17 +266,12 @@ export async function getGitAuthor(directory, { env } = {}) {
 
 /**
  * Pin the human developer's git identity in a worktree's config.
- *
- * Reads user.name/user.email from the main project directory and writes
- * them into the worktree-specific config (--worktree). This ensures the
- * human is always the commit Author, even if the session's environment
- * tries to override it. Claude Code already adds its own Co-Authored-By
- * trailer via its system prompt, so no hook is needed.
- *
- * Only call this for worktree directories, not the main repo.
- *
+ * Reads user.name/user.email from the main project directory and writes them
+ * into the worktree-specific config (--worktree). Only call for worktree dirs.
  * @param {string} worktreePath - The worktree directory
  * @param {string} projectDir - The main project directory (to read author from)
+ * @param {Object} [options]
+ * @param {Object} [options.env] - Custom environment variables (useful for tests)
  * @returns {Promise<boolean>} - True if author was pinned
  */
 export async function pinAuthorInWorktree(worktreePath, projectDir, { env } = {}) {
@@ -531,164 +289,3 @@ export async function pinAuthorInWorktree(worktreePath, projectDir, { env } = {}
   return true;
 }
 
-/**
- * Normalize a git remote URL into a clean HTTPS browser URL.
- *
- * Supported forms:
- *   - https://github.com/owner/repo.git -> https://github.com/owner/repo
- *   - https://github.com/owner/repo     -> https://github.com/owner/repo (already clean)
- *   - git@github.com:owner/repo.git    -> https://github.com/owner/repo
- *   - ssh://git@github.com/owner/repo.git -> https://github.com/owner/repo
- *   - git@gitlab.com:owner/repo.git    -> https://gitlab.com/owner/repo
- *   - https://gitlab.com/owner/repo.git -> https://gitlab.com/owner/repo
- *   - https://bitbucket.org/owner/repo.git -> https://bitbucket.org/owner/repo
- *   - http://git.example.com/owner/repo.git -> http://git.example.com/owner/repo
- *   - git://github.com/owner/repo.git  -> https://github.com/owner/repo
- *
- * Query strings and fragments are stripped before matching.
- *
- * Returns null for empty, null, undefined, or unrecognizable inputs.
- *
- * @param {string|null|undefined} remoteUrl
- * @returns {string|null}
- */
-export function normalizeGitRemoteUrl(remoteUrl) {
-  if (!remoteUrl || typeof remoteUrl !== 'string') {
-    return null;
-  }
-
-  const trimmed = remoteUrl.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  // Strip query strings and fragments before matching
-  // (defensive: malformed remote configs shouldn't silently fail)
-  const cleaned = trimmed.replace(/[?#].*$/, '');
-
-  // SSH form: git@host:owner/repo.git or git@host:owner/repo
-  const sshMatch = cleaned.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
-  if (sshMatch) {
-    return `https://${sshMatch[1]}/${sshMatch[2]}`;
-  }
-
-  // SSH protocol form: ssh://git@host/owner/repo.git
-  const sshProtocolMatch = cleaned.match(/^ssh:\/\/git@([^/]+)\/(.+?)(?:\.git)?$/);
-  if (sshProtocolMatch) {
-    return `https://${sshProtocolMatch[1]}/${sshProtocolMatch[2]}`;
-  }
-
-  // HTTPS form: https://host/owner/repo.git or https://host/owner/repo
-  const httpsMatch = cleaned.match(/^https:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
-  if (httpsMatch) {
-    return `https://${httpsMatch[1]}/${httpsMatch[2]}`;
-  }
-
-  // HTTP form: http://host/owner/repo.git or http://host/owner/repo
-  // Preserve the http:// scheme (unlike SSH→HTTPS conversion, HTTP remotes
-  // are intentional and the server may not support HTTPS).
-  const httpMatch = cleaned.match(/^http:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
-  if (httpMatch) {
-    return `http://${httpMatch[1]}/${httpMatch[2]}`;
-  }
-
-  // git:// protocol form: git://host/owner/repo.git or git://host/owner/repo
-  // Convert to HTTPS (same output as SSH).
-  const gitProtocolMatch = cleaned.match(/^git:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
-  if (gitProtocolMatch) {
-    return `https://${gitProtocolMatch[1]}/${gitProtocolMatch[2]}`;
-  }
-
-  // Unrecognized format
-  return null;
-}
-
-/**
- * Auto-detect the repository URL from a directory's git remotes.
- *
- * Prefers the "origin" remote. Falls back to the first configured remote.
- * Normalizes SSH and HTTPS URLs into clean HTTPS browser URLs.
- * Returns null if the directory is not a git repo or has no usable remotes.
- *
- * @param {string} directory
- * @returns {Promise<string|null>}
- */
-export async function getRepositoryUrl(directory) {
-  try {
-    // Fast-path: skip entirely if the directory is not a git repo.
-    // Uses a filesystem check (.git existence) instead of spawning a git process,
-    // which avoids unnecessary child_process overhead for non-git directories.
-    try {
-      await access(path.join(directory, '.git'));
-    } catch {
-      return null;
-    }
-
-    // Try origin first (with timeout to prevent indefinite blocking under load)
-    let rawUrl;
-    try {
-      rawUrl = await git(directory, 'config --get remote.origin.url', { timeout: 5000 });
-    } catch {
-      // No origin remote, try listing all remotes
-    }
-
-    // Fall back to first remote if origin doesn't exist
-    if (!rawUrl) {
-      try {
-        const remoteVerbose = await git(directory, 'remote -v', { timeout: 5000 });
-        const firstLine = remoteVerbose.split('\n').find((r) => r.trim());
-        if (firstLine) {
-          // git remote -v outputs: "remote_name\turl (fetch)"
-          const parts = firstLine.split('\t');
-          if (parts.length >= 2) {
-            rawUrl = parts[1].replace(/ \((?:fetch|push)\)$/, '');
-          }
-        }
-      } catch {
-        // No remotes at all
-      }
-    }
-
-    if (!rawUrl) {
-      return null;
-    }
-
-    return normalizeGitRemoteUrl(rawUrl);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Detect the worktree path for a directory by inspecting existing worktrees.
- * If external worktrees exist, uses the parent directory of the first one.
- * Otherwise, falls back to {directory}/.worktrees.
- * @param {string} directory - The git repository directory
- * @returns {Promise<{worktreePath: string, source: 'detected' | 'default'}>}
- */
-export async function detectWorktreePath(directory) {
-  const isRepo = await isGitRepo(directory);
-  if (!isRepo) {
-    return { worktreePath: path.join(directory, '.worktrees'), source: 'default' };
-  }
-
-  // Resolve symlinks for consistent path comparison (e.g., /var -> /private/var on macOS)
-  let resolvedDir;
-  try {
-    resolvedDir = await realpath(directory);
-  } catch {
-    resolvedDir = path.resolve(directory);
-  }
-
-  const worktrees = await getWorktrees(directory);
-  // Filter out the main worktree (its path === directory or resolves to it)
-  const externalWorktrees = worktrees.filter(wt => path.resolve(wt.path) !== resolvedDir);
-
-  if (externalWorktrees.length > 0) {
-    // Use the parent directory of the first external worktree
-    const parentDir = path.dirname(path.resolve(externalWorktrees[0].path));
-    return { worktreePath: parentDir, source: 'detected' };
-  }
-
-  return { worktreePath: path.join(resolvedDir, '.worktrees'), source: 'default' };
-}

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
-import { realpath } from 'fs/promises';
+import { realpath, access } from 'fs/promises';
 export {
   clearWorktreeCommitAttribution,
   configureWorktreeCommitAttribution,
@@ -77,6 +77,7 @@ async function safeFetchOrigin(directory) {
 async function git(directory, command, opts = {}) {
   const execOpts = { cwd: directory };
   if (opts.env) execOpts.env = opts.env;
+  if (opts.timeout) execOpts.timeout = opts.timeout;
   const { stdout } = await execAsync(`git ${command}`, execOpts);
   return stdout.trim();
 }
@@ -591,10 +592,19 @@ export function normalizeGitRemoteUrl(remoteUrl) {
  */
 export async function getRepositoryUrl(directory) {
   try {
-    // Try origin first
+    // Fast-path: skip entirely if the directory is not a git repo.
+    // Uses a filesystem check (.git existence) instead of spawning a git process,
+    // which avoids unnecessary child_process overhead for non-git directories.
+    try {
+      await access(path.join(directory, '.git'));
+    } catch {
+      return null;
+    }
+
+    // Try origin first (with timeout to prevent indefinite blocking under load)
     let rawUrl;
     try {
-      rawUrl = await git(directory, 'config --get remote.origin.url');
+      rawUrl = await git(directory, 'config --get remote.origin.url', { timeout: 5000 });
     } catch {
       // No origin remote, try listing all remotes
     }
@@ -602,10 +612,10 @@ export async function getRepositoryUrl(directory) {
     // Fall back to first remote if origin doesn't exist
     if (!rawUrl) {
       try {
-        const remotes = await git(directory, 'remote');
+        const remotes = await git(directory, 'remote', { timeout: 5000 });
         const firstRemote = remotes.split('\n').find((r) => r.trim());
         if (firstRemote) {
-          rawUrl = await git(directory, `config --get remote.${firstRemote.trim()}.url`);
+          rawUrl = await git(directory, `config --get remote.${firstRemote.trim()}.url`, { timeout: 5000 });
         }
       } catch {
         // No remotes at all

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -531,6 +531,98 @@ export async function pinAuthorInWorktree(worktreePath, projectDir, { env } = {}
 }
 
 /**
+ * Normalize a git remote URL into a clean HTTPS browser URL.
+ *
+ * Supported forms:
+ *   - https://github.com/owner/repo.git -> https://github.com/owner/repo
+ *   - https://github.com/owner/repo     -> https://github.com/owner/repo (already clean)
+ *   - git@github.com:owner/repo.git    -> https://github.com/owner/repo
+ *   - ssh://git@github.com/owner/repo.git -> https://github.com/owner/repo
+ *   - git@gitlab.com:owner/repo.git    -> https://gitlab.com/owner/repo
+ *   - https://gitlab.com/owner/repo.git -> https://gitlab.com/owner/repo
+ *   - https://bitbucket.org/owner/repo.git -> https://bitbucket.org/owner/repo
+ *
+ * Returns null for empty, null, undefined, or unrecognizable inputs.
+ *
+ * @param {string|null|undefined} remoteUrl
+ * @returns {string|null}
+ */
+export function normalizeGitRemoteUrl(remoteUrl) {
+  if (!remoteUrl || typeof remoteUrl !== 'string') {
+    return null;
+  }
+
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // SSH form: git@host:owner/repo.git or git@host:owner/repo
+  const sshMatch = trimmed.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return `https://${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  // SSH protocol form: ssh://git@host/owner/repo.git
+  const sshProtocolMatch = trimmed.match(/^ssh:\/\/git@([^/]+)\/(.+?)(?:\.git)?$/);
+  if (sshProtocolMatch) {
+    return `https://${sshProtocolMatch[1]}/${sshProtocolMatch[2]}`;
+  }
+
+  // HTTPS form: https://host/owner/repo.git or https://host/owner/repo
+  const httpsMatch = trimmed.match(/^https:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    return `https://${httpsMatch[1]}/${httpsMatch[2]}`;
+  }
+
+  // Unrecognized format
+  return null;
+}
+
+/**
+ * Auto-detect the repository URL from a directory's git remotes.
+ *
+ * Prefers the "origin" remote. Falls back to the first configured remote.
+ * Normalizes SSH and HTTPS URLs into clean HTTPS browser URLs.
+ * Returns null if the directory is not a git repo or has no usable remotes.
+ *
+ * @param {string} directory
+ * @returns {Promise<string|null>}
+ */
+export async function getRepositoryUrl(directory) {
+  try {
+    // Try origin first
+    let rawUrl;
+    try {
+      rawUrl = await git(directory, 'config --get remote.origin.url');
+    } catch {
+      // No origin remote, try listing all remotes
+    }
+
+    // Fall back to first remote if origin doesn't exist
+    if (!rawUrl) {
+      try {
+        const remotes = await git(directory, 'remote');
+        const firstRemote = remotes.split('\n').find((r) => r.trim());
+        if (firstRemote) {
+          rawUrl = await git(directory, `config --get remote.${firstRemote.trim()}.url`);
+        }
+      } catch {
+        // No remotes at all
+      }
+    }
+
+    if (!rawUrl) {
+      return null;
+    }
+
+    return normalizeGitRemoteUrl(rawUrl);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Detect the worktree path for a directory by inspecting existing worktrees.
  * If external worktrees exist, uses the parent directory of the first one.
  * Otherwise, falls back to {directory}/.worktrees.

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -542,6 +542,10 @@ export async function pinAuthorInWorktree(worktreePath, projectDir, { env } = {}
  *   - git@gitlab.com:owner/repo.git    -> https://gitlab.com/owner/repo
  *   - https://gitlab.com/owner/repo.git -> https://gitlab.com/owner/repo
  *   - https://bitbucket.org/owner/repo.git -> https://bitbucket.org/owner/repo
+ *   - http://git.example.com/owner/repo.git -> http://git.example.com/owner/repo
+ *   - git://github.com/owner/repo.git  -> https://github.com/owner/repo
+ *
+ * Query strings and fragments are stripped before matching.
  *
  * Returns null for empty, null, undefined, or unrecognizable inputs.
  *
@@ -558,22 +562,41 @@ export function normalizeGitRemoteUrl(remoteUrl) {
     return null;
   }
 
+  // Strip query strings and fragments before matching
+  // (defensive: malformed remote configs shouldn't silently fail)
+  const cleaned = trimmed.replace(/[?#].*$/, '');
+
   // SSH form: git@host:owner/repo.git or git@host:owner/repo
-  const sshMatch = trimmed.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  const sshMatch = cleaned.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
   if (sshMatch) {
     return `https://${sshMatch[1]}/${sshMatch[2]}`;
   }
 
   // SSH protocol form: ssh://git@host/owner/repo.git
-  const sshProtocolMatch = trimmed.match(/^ssh:\/\/git@([^/]+)\/(.+?)(?:\.git)?$/);
+  const sshProtocolMatch = cleaned.match(/^ssh:\/\/git@([^/]+)\/(.+?)(?:\.git)?$/);
   if (sshProtocolMatch) {
     return `https://${sshProtocolMatch[1]}/${sshProtocolMatch[2]}`;
   }
 
   // HTTPS form: https://host/owner/repo.git or https://host/owner/repo
-  const httpsMatch = trimmed.match(/^https:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  const httpsMatch = cleaned.match(/^https:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
   if (httpsMatch) {
     return `https://${httpsMatch[1]}/${httpsMatch[2]}`;
+  }
+
+  // HTTP form: http://host/owner/repo.git or http://host/owner/repo
+  // Preserve the http:// scheme (unlike SSH→HTTPS conversion, HTTP remotes
+  // are intentional and the server may not support HTTPS).
+  const httpMatch = cleaned.match(/^http:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpMatch) {
+    return `http://${httpMatch[1]}/${httpMatch[2]}`;
+  }
+
+  // git:// protocol form: git://host/owner/repo.git or git://host/owner/repo
+  // Convert to HTTPS (same output as SSH).
+  const gitProtocolMatch = cleaned.match(/^git:\/\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (gitProtocolMatch) {
+    return `https://${gitProtocolMatch[1]}/${gitProtocolMatch[2]}`;
   }
 
   // Unrecognized format
@@ -612,10 +635,14 @@ export async function getRepositoryUrl(directory) {
     // Fall back to first remote if origin doesn't exist
     if (!rawUrl) {
       try {
-        const remotes = await git(directory, 'remote', { timeout: 5000 });
-        const firstRemote = remotes.split('\n').find((r) => r.trim());
-        if (firstRemote) {
-          rawUrl = await git(directory, `config --get remote.${firstRemote.trim()}.url`, { timeout: 5000 });
+        const remoteVerbose = await git(directory, 'remote -v', { timeout: 5000 });
+        const firstLine = remoteVerbose.split('\n').find((r) => r.trim());
+        if (firstLine) {
+          // git remote -v outputs: "remote_name\turl (fetch)"
+          const parts = firstLine.split('\t');
+          if (parts.length >= 2) {
+            rawUrl = parts[1].replace(/ \((?:fetch|push)\)$/, '');
+          }
         }
       } catch {
         // No remotes at all

--- a/packages/server/src/services/gitService.test.js
+++ b/packages/server/src/services/gitService.test.js
@@ -16,8 +16,10 @@ import {
   getCurrentBranch,
   getGitAuthor,
   getOriginDefaultBranch,
+  getRepositoryUrl,
   getUntrackedFiles,
   ensureWorktreeCommitAttributionHook,
+  normalizeGitRemoteUrl,
   pinAuthorInWorktree,
   isGitRepo,
   setLogger,
@@ -1080,6 +1082,107 @@ describe('gitService', () => {
         const result = await detectWorktreePath(nonGitDir);
         expect(result.worktreePath).toBe(join(nonGitDir, '.worktrees'));
         expect(result.source).toBe('default');
+      } finally {
+        await rm(nonGitDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('normalizeGitRemoteUrl', () => {
+    it('normalizes HTTPS URL with .git suffix', () => {
+      expect(normalizeGitRemoteUrl('https://github.com/owner/repo.git'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('passes through already-clean HTTPS URL', () => {
+      expect(normalizeGitRemoteUrl('https://github.com/owner/repo'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('normalizes SSH shorthand with .git suffix', () => {
+      expect(normalizeGitRemoteUrl('git@github.com:owner/repo.git'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('normalizes SSH shorthand without .git suffix', () => {
+      expect(normalizeGitRemoteUrl('git@github.com:owner/repo'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('normalizes ssh:// protocol URL', () => {
+      expect(normalizeGitRemoteUrl('ssh://git@github.com/owner/repo.git'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('normalizes SSH GitLab URL', () => {
+      expect(normalizeGitRemoteUrl('git@gitlab.com:owner/repo.git'))
+        .toBe('https://gitlab.com/owner/repo');
+    });
+
+    it('normalizes HTTPS GitLab URL', () => {
+      expect(normalizeGitRemoteUrl('https://gitlab.com/owner/repo.git'))
+        .toBe('https://gitlab.com/owner/repo');
+    });
+
+    it('normalizes HTTPS Bitbucket URL', () => {
+      expect(normalizeGitRemoteUrl('https://bitbucket.org/owner/repo.git'))
+        .toBe('https://bitbucket.org/owner/repo');
+    });
+
+    it('returns null for empty string', () => {
+      expect(normalizeGitRemoteUrl('')).toBeNull();
+    });
+
+    it('returns null for null', () => {
+      expect(normalizeGitRemoteUrl(null)).toBeNull();
+    });
+
+    it('returns null for undefined', () => {
+      expect(normalizeGitRemoteUrl(undefined)).toBeNull();
+    });
+
+    it('returns null for garbage string', () => {
+      expect(normalizeGitRemoteUrl('not-a-valid-url')).toBeNull();
+    });
+  });
+
+  describe('getRepositoryUrl', () => {
+    it('detects and normalizes origin HTTPS remote', async () => {
+      execSync('git remote remove origin', { cwd: testDir });
+      execSync('git remote add origin https://github.com/owner/repo.git', { cwd: testDir });
+
+      const url = await getRepositoryUrl(testDir);
+      expect(url).toBe('https://github.com/owner/repo');
+    });
+
+    it('detects and normalizes SSH remote', async () => {
+      execSync('git remote remove origin', { cwd: testDir });
+      execSync('git remote add origin git@github.com:owner/repo.git', { cwd: testDir });
+
+      const url = await getRepositoryUrl(testDir);
+      expect(url).toBe('https://github.com/owner/repo');
+    });
+
+    it('falls back to first remote when origin does not exist', async () => {
+      execSync('git remote remove origin', { cwd: testDir });
+      execSync('git remote add upstream https://github.com/other/repo.git', { cwd: testDir });
+
+      const url = await getRepositoryUrl(testDir);
+      expect(url).toBe('https://github.com/other/repo');
+    });
+
+    it('returns null for git repo without remotes', async () => {
+      execSync('git remote remove origin', { cwd: testDir });
+
+      const url = await getRepositoryUrl(testDir);
+      expect(url).toBeNull();
+    });
+
+    it('returns null for non-git directory', async () => {
+      const nonGitDir = await mkdtemp(join(tmpdir(), 'non-git-repourl-'));
+      try {
+        const url = await getRepositoryUrl(nonGitDir);
+        expect(url).toBeNull();
       } finally {
         await rm(nonGitDir, { recursive: true, force: true });
       }

--- a/packages/server/src/services/gitService.test.js
+++ b/packages/server/src/services/gitService.test.js
@@ -1144,6 +1144,36 @@ describe('gitService', () => {
     it('returns null for garbage string', () => {
       expect(normalizeGitRemoteUrl('not-a-valid-url')).toBeNull();
     });
+
+    it('strips query string from HTTPS URL', () => {
+      expect(normalizeGitRemoteUrl('https://github.com/owner/repo.git?foo=bar'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('strips fragment from SSH shorthand', () => {
+      expect(normalizeGitRemoteUrl('git@github.com:owner/repo.git#branch'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('normalizes HTTP URL with .git suffix', () => {
+      expect(normalizeGitRemoteUrl('http://git.example.com/owner/repo.git'))
+        .toBe('http://git.example.com/owner/repo');
+    });
+
+    it('passes through already-clean HTTP URL', () => {
+      expect(normalizeGitRemoteUrl('http://git.example.com/owner/repo'))
+        .toBe('http://git.example.com/owner/repo');
+    });
+
+    it('normalizes git:// protocol URL with .git suffix', () => {
+      expect(normalizeGitRemoteUrl('git://github.com/owner/repo.git'))
+        .toBe('https://github.com/owner/repo');
+    });
+
+    it('normalizes git:// protocol URL without .git suffix', () => {
+      expect(normalizeGitRemoteUrl('git://gitlab.com/owner/repo'))
+        .toBe('https://gitlab.com/owner/repo');
+    });
   });
 
   describe('getRepositoryUrl', () => {
@@ -1186,6 +1216,24 @@ describe('gitService', () => {
       } finally {
         await rm(nonGitDir, { recursive: true, force: true });
       }
+    });
+
+    it('detects repo URL from worktree via .git fast-path', async () => {
+      // Replace the default local bare-repo origin with an HTTPS remote
+      execSync('git remote remove origin', { cwd: testDir });
+      execSync('git remote add origin https://github.com/owner/repo.git', { cwd: testDir });
+
+      // Create a git worktree from the test directory
+      const worktreePath = join(testDir, '.worktrees', 'repo-url-test');
+      await createWorktreeForBranch(testDir, 'repo-url-test', worktreePath, { skipFetch: true });
+
+      // In a worktree, .git is a *file* (containing a gitdir reference), not a directory.
+      // The fs.access() fast-path works for both, but this path was previously untested.
+      const url = await getRepositoryUrl(worktreePath);
+      expect(url).toBe('https://github.com/owner/repo');
+
+      // Clean up worktree before the shared afterEach deletes testDir
+      execSync(`git worktree remove --force "${worktreePath}"`, { cwd: testDir });
     });
   });
 });

--- a/packages/server/src/services/gitWorktree.js
+++ b/packages/server/src/services/gitWorktree.js
@@ -1,0 +1,127 @@
+import { git, getOriginDefaultBranch } from './gitService.js';
+
+// Configurable logger for warning messages
+let logger = {
+  warn: (...args) => console.warn(...args),
+};
+
+/**
+ * Set a custom logger for git worktree warnings.
+ * @param {Object} customLogger - Logger object with a warn method
+ */
+export function _setWorktreeLogger(customLogger) {
+  logger = customLogger;
+}
+
+/**
+ * Safely fetch from origin remote.
+ * Logs a warning if fetch fails but does not throw.
+ * @param {string} directory - The git repository directory
+ * @returns {Promise<boolean>} - True if fetch succeeded, false otherwise
+ */
+async function safeFetchOrigin(directory) {
+  try {
+    await git(directory, 'fetch origin');
+    return true;
+  } catch (err) {
+    // No origin or network unavailable, proceed without fetch
+    logger.warn('Could not fetch from origin, proceeding with local refs:', err.message);
+    return false;
+  }
+}
+
+/**
+ * Check if a branch exists
+ * @param {string} directory
+ * @param {string} branch
+ * @returns {Promise<boolean>}
+ */
+export async function branchExists(directory, branch) {
+  try {
+    await git(directory, `rev-parse --verify refs/heads/${branch}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checkout a branch, creating it if it doesn't exist
+ * @param {string} directory
+ * @param {string} branch
+ * @returns {Promise<void>}
+ */
+export async function checkoutBranch(directory, branch) {
+  const exists = await branchExists(directory, branch);
+  if (exists) {
+    await git(directory, `checkout "${branch}"`);
+  } else {
+    await git(directory, `checkout -b "${branch}"`);
+  }
+}
+
+/**
+ * Create a new worktree
+ * @param {string} directory
+ * @param {string} branch
+ * @param {string} worktreePath
+ * @param {Object} options
+ * @param {boolean} options.skipFetch - Skip fetching from origin (default: false)
+ * @returns {Promise<{path: string, branch: string}>}
+ */
+export async function createWorktree(directory, branch, worktreePath, options = {}) {
+  const { skipFetch = false } = options;
+
+  // Fetch latest from origin to ensure we have up-to-date default branch
+  if (!skipFetch) {
+    await safeFetchOrigin(directory);
+  }
+
+  // Get the default branch from origin (main or master)
+  const defaultBranch = await getOriginDefaultBranch(directory);
+  // Base new branch on origin's default branch to avoid including unrelated commits from HEAD
+  // Use --no-track to prevent the new branch from tracking the start-point (main/master)
+  await git(directory, `worktree add --no-track "${worktreePath}" -b "${branch}" ${defaultBranch}`);
+  return { path: worktreePath, branch };
+}
+
+/**
+ * Remove a worktree
+ * @param {string} directory
+ * @param {string} path
+ * @param {boolean} force - Force removal even if worktree has uncommitted changes
+ */
+export async function removeWorktree(directory, worktreePath, force = false) {
+  const forceFlag = force ? '--force' : '';
+  await git(directory, `worktree remove ${forceFlag} "${worktreePath}"`);
+}
+
+/**
+ * Create a worktree for a branch (creates branch if it doesn't exist)
+ * @param {string} directory - Main repo directory
+ * @param {string} branch - Branch name
+ * @param {string} worktreePath - Path for the new worktree
+ * @param {Object} options
+ * @param {boolean} options.skipFetch - Skip fetching from origin (default: false)
+ * @returns {Promise<{path: string, branch: string}>}
+ */
+export async function createWorktreeForBranch(directory, branch, worktreePath, options = {}) {
+  const { skipFetch = false } = options;
+
+  // Fetch latest from origin to ensure we have up-to-date default branch
+  if (!skipFetch) {
+    await safeFetchOrigin(directory);
+  }
+
+  const exists = await branchExists(directory, branch);
+  if (exists) {
+    await git(directory, `worktree add "${worktreePath}" "${branch}"`);
+  } else {
+    // Get the default branch from origin (main or master)
+    const defaultBranch = await getOriginDefaultBranch(directory);
+    // Base new branch on origin's default branch to avoid including unrelated commits from HEAD
+    // Use --no-track to prevent the new branch from tracking the start-point (main/master)
+    await git(directory, `worktree add --no-track -b "${branch}" "${worktreePath}" ${defaultBranch}`);
+  }
+  return { path: worktreePath, branch };
+}

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { mkdirSync, mkdtempSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { execSync } from 'child_process';
 import { cleanupAll, getProject, seedProject, API_URL } from './helpers';
 
 test.describe('Project Management', () => {
@@ -178,5 +179,33 @@ test.describe('Project Management', () => {
     const project = await getProject(projectId!);
     expect(project).not.toBeNull();
     expect(project.systemPrompt).toBe(customPrompt);
+  });
+
+  test('auto-detects repoUrl from git remote on project creation', async () => {
+    // Create a temp directory with a git repo and HTTPS origin
+    const tmpDir = mkdtempSync('/tmp/e2e-repourl-');
+    try {
+      execSync('git init', { cwd: tmpDir });
+      execSync('git remote add origin https://github.com/e2e-test/e2e-repo.git', { cwd: tmpDir });
+
+      // Create project via the API
+      const response = await fetch(`${API_URL}/api/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'repoUrl detection test',
+          workingDirectory: tmpDir,
+        }),
+      });
+
+      expect(response.ok).toBe(true);
+      const project = await response.json();
+      expect(project.repoUrl).toBe('https://github.com/e2e-test/e2e-repo');
+
+      // Clean up the project via API
+      await fetch(`${API_URL}/api/projects/${project.id}`, { method: 'DELETE' });
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- **Auto-detect repo URL on project creation**: When `POST /api/projects` is called without an explicit `repoUrl`, the server now reads the `origin` remote (or falls back to the first configured remote) from the project's `workingDirectory` and normalizes it into a clean HTTPS browser URL
- **Normalize common git remote formats**: Added `normalizeGitRemoteUrl()` to handle SSH shorthand (`git@github.com:org/repo.git`), `ssh://` protocol, and HTTPS URLs with `.git` suffixes
- **Three-way `repoUrl` resolution**: `undefined` (omitted) triggers auto-detection, `null` (explicitly sent) suppresses detection, and a string is used as-is

## Test plan
- [x] 12 unit tests for `normalizeGitRemoteUrl` covering HTTPS, SSH, ssh://, GitLab, Bitbucket formats plus null/undefined/garbage edge cases
- [x] 5 unit tests for `getRepositoryUrl` covering origin detection, SSH normalization, non-origin fallback, no remotes, and non-git directories
- [x] 7 API integration tests for `POST /api/projects` repoUrl auto-detection covering all resolution paths (HTTPS origin, SSH origin, explicit string, explicit null, no remotes, non-git dir, non-origin fallback)
- [ ] Manual verification: create a project from a git repo directory and confirm repoUrl is populated in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)