### PR TITLE
Fix session chat overlay viewport height on iPad

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -269,6 +269,14 @@ describe('SessionChatOverlay', () => {
     return sessionChatOverlaySource.slice(start, end + 2);
   }
 
+  function getStyleBlocks(selector) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`${escaped}\\s*\\{[^}]*\\}`, 'g');
+    const blocks = sessionChatOverlaySource.match(pattern) || [];
+    expect(blocks.length).toBeGreaterThan(0);
+    return blocks;
+  }
+
   async function waitForTransition() {
     // In jsdom, CSS transitions don't actually run, so we manually
     // trigger the afterLeave hook to simulate the transition completing
@@ -1561,26 +1569,46 @@ describe('SessionChatOverlay', () => {
       const backdrop = document.querySelector('[data-testid="session-chat-overlay"]');
       expect(backdrop).toBeTruthy();
       expect(backdrop.style.top).toBe('');
+      expect(backdrop.style.right).toBe('');
+      expect(backdrop.style.bottom).toBe('');
       expect(backdrop.style.left).toBe('');
       expect(backdrop.style.width).toBe('');
       expect(backdrop.style.height).toBe('');
       wrapper.unmount();
     });
 
-    it('backdrop stylesheet uses fixed viewport geometry by default', () => {
+    it('backdrop stylesheet keeps the shell fixed to the full layout viewport', () => {
       const block = getStyleBlock('.overlay-backdrop');
       expect(block).toMatch(/position:\s*fixed/);
       expect(block).toMatch(/inset:\s*0/);
+      expect(block).toMatch(/min-height:\s*100vh/);
+      expect(block).toMatch(/min-height:\s*100dvh/);
       expect(block).toMatch(/z-index:\s*1200/);
-      expect(block).not.toMatch(/--viewport-offset-top/);
-      expect(block).not.toMatch(/--visual-viewport-height/);
-      expect(block).not.toMatch(/top:\s*var\(/);
-      expect(block).not.toMatch(/height:\s*var\(/);
     });
 
-    it('backdrop stylesheet opts tablet-sized viewports into visual viewport geometry', () => {
-      expect(sessionChatOverlaySource).toMatch(
-        /@media\s*\(min-width:\s*700px\)\s*and\s*\(min-height:\s*700px\)\s*\{[\s\S]*?\.overlay-backdrop\s*\{[\s\S]*?top:\s*var\(--viewport-offset-top,\s*0px\);[\s\S]*?height:\s*var\(--visual-viewport-height,\s*100dvh\);/
+    it('no backdrop stylesheet block uses visual viewport shell geometry', () => {
+      const blocks = getStyleBlocks('.overlay-backdrop');
+      for (const block of blocks) {
+        expect(block).not.toMatch(/--viewport-offset-top/);
+        expect(block).not.toMatch(/--visual-viewport-height/);
+        expect(block).not.toMatch(/height:\s*var\(/);
+        expect(block).not.toMatch(/top:\s*var\(/);
+        expect(block).not.toMatch(/bottom:\s*auto/);
+        expect(block).not.toMatch(/(?:^|[;\s])top\s*:/);
+        expect(block).not.toMatch(/(?:^|[;\s])right\s*:/);
+        expect(block).not.toMatch(/(?:^|[;\s])bottom\s*:/);
+        expect(block).not.toMatch(/(?:^|[;\s])left\s*:/);
+        expect(block).not.toMatch(/(?:^|[;\s])height\s*:/);
+        expect(block).not.toMatch(/(?:^|[;\s])width\s*:/);
+      }
+    });
+
+    it('source has no tablet media-query backdrop rule using visual viewport variables', () => {
+      expect(sessionChatOverlaySource).not.toMatch(
+        /@media\s*\(min-width:\s*700px\)\s*and\s*\(min-height:\s*700px\)\s*\{[\s\S]*?\.overlay-backdrop\s*\{[\s\S]*?--viewport-offset-top/
+      );
+      expect(sessionChatOverlaySource).not.toMatch(
+        /@media\s*\(min-width:\s*700px\)\s*and\s*\(min-height:\s*700px\)\s*\{[\s\S]*?\.overlay-backdrop\s*\{[\s\S]*?--visual-viewport-height/
       );
     });
 
@@ -1589,18 +1617,26 @@ describe('SessionChatOverlay', () => {
       expect(block).toMatch(/position:\s*absolute/);
       expect(block).toMatch(/inset:\s*0 0 0 auto/);
       expect(block).toMatch(/height:\s*100%/);
+      expect(block).toMatch(/min-height:\s*100%/);
+      expect(block).toMatch(/min-height:\s*100dvh/);
       expect(block).not.toMatch(/position:\s*fixed/);
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
       expect(block).not.toMatch(/top:\s*var\(/);
-      expect(block).not.toMatch(/min-height:\s*100vh/);
-      expect(block).not.toMatch(/min-height:\s*100dvh/);
     });
 
-    it('overlay shell keeps visual viewport variables out of phone-sized default geometry', () => {
+    it('overlay content has a viewport-height floor for Safari tablet layout', () => {
+      const block = getStyleBlock('.overlay-content');
+      expect(block).toMatch(/min-height:\s*100%/);
+      expect(block).toMatch(/min-height:\s*100dvh/);
+      expect(block).not.toMatch(/--viewport-offset-top/);
+      expect(block).not.toMatch(/--visual-viewport-height/);
+    });
+
+    it('overlay shell keeps visual viewport variables out of all shell geometry', () => {
       const shellBlocks = [
-        getStyleBlock('.overlay-backdrop'),
-        getStyleBlock('.overlay-panel-wrapper'),
+        ...getStyleBlocks('.overlay-backdrop'),
+        ...getStyleBlocks('.overlay-panel-wrapper'),
       ].join('\n');
       expect(shellBlocks).not.toMatch(/--viewport-offset-top/);
       expect(shellBlocks).not.toMatch(/--visual-viewport-height/);

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -972,6 +972,8 @@ defineExpose({
 .overlay-backdrop {
   position: fixed;
   inset: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
   z-index: 1200;
   background: rgb(17, 24, 39);
   display: block;
@@ -980,22 +982,13 @@ defineExpose({
   overscroll-behavior: none;
 }
 
-@media (min-width: 700px) and (min-height: 700px) {
-  .overlay-backdrop {
-    top: var(--viewport-offset-top, 0px);
-    right: 0;
-    bottom: auto;
-    left: 0;
-    height: var(--visual-viewport-height, 100dvh);
-  }
-}
-
 .overlay-panel-wrapper {
   position: absolute;
   inset: 0 0 0 auto;
   height: 100%;
+  min-height: 100%;
+  min-height: 100dvh;
   display: flex;
-  min-height: 0;
   max-width: 900px;
   width: 100%;
   overflow: visible;
@@ -1060,6 +1053,8 @@ defineExpose({
 .overlay-content {
   flex: 1;
   width: 100%;
+  min-height: 100%;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   /* `overflow: clip` (not `hidden`) disables programmatic scrolling as

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -2,9 +2,8 @@
  * SessionChatOverlay layout regression coverage.
  *
  * The overlay is teleported to body and scroll locking is applied to #app,
- * while tablet-sized layouts align the fixed backdrop to the visual viewport CSS variables.
- * This keeps the overlay out of the fixed app wrapper without losing the
- * iPadOS browser-chrome offset and height corrections.
+ * while the backdrop shell remains fixed to the full layout viewport. Stale
+ * visual viewport CSS variables must not move or resize that shell.
  *
  * HONEST SCOPE of the mobile projects (iphone-14, ipad-pro):
  * Playwright's mobile devices run chromium with only viewport size + UA
@@ -61,6 +60,73 @@ test.describe('SessionChatOverlay layout', () => {
     });
   }
 
+  async function injectStaleVisualViewportVariables(page: Page) {
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--viewport-offset-top', '260px');
+      document.documentElement.style.setProperty('--visual-viewport-height', '420px');
+    });
+    await page.waitForTimeout(50);
+  }
+
+  async function clearStaleVisualViewportVariables(page: Page) {
+    await page.evaluate(() => {
+      document.documentElement.style.removeProperty('--viewport-offset-top');
+      document.documentElement.style.removeProperty('--visual-viewport-height');
+    });
+  }
+
+  async function readOverlayLayout(page: Page) {
+    return page.evaluate(() => {
+      const rectFor = (selector: string) => {
+        const el = document.querySelector(selector) as HTMLElement;
+        const r = el.getBoundingClientRect();
+        return {
+          top: r.top,
+          bottom: r.bottom,
+          left: r.left,
+          right: r.right,
+          width: r.width,
+          height: r.height,
+        };
+      };
+
+      const shell = document.querySelector(
+        '[data-testid="session-chat-overlay"]'
+      ) as HTMLElement;
+      const s = shell.style;
+
+      return {
+        backdrop: rectFor('[data-testid="session-chat-overlay"]'),
+        panel: rectFor('.overlay-panel-wrapper'),
+        content: rectFor('.overlay-content'),
+        inner: { w: window.innerWidth, h: window.innerHeight },
+        inline: {
+          top: s.top,
+          right: s.right,
+          bottom: s.bottom,
+          left: s.left,
+          width: s.width,
+          height: s.height,
+        },
+      };
+    });
+  }
+
+  function expectBackdropCoversViewport(result: Awaited<ReturnType<typeof readOverlayLayout>>) {
+    expect(result.backdrop.top).toBeLessThanOrEqual(1);
+    expect(result.backdrop.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+    expect(result.backdrop.left).toBeLessThanOrEqual(1);
+    expect(result.backdrop.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+    expect(result.inline).toEqual({
+      top: '',
+      right: '',
+      bottom: '',
+      left: '',
+      width: '',
+      height: '',
+    });
+  }
+
   test('backdrop covers viewport and writes no inline geometry', async ({ page }) => {
     await navigateToSession(page);
     await openOverlay(page);
@@ -81,6 +147,8 @@ test.describe('SessionChatOverlay layout', () => {
         inner: { w: window.innerWidth, h: window.innerHeight },
         inline: {
           top: s.top,
+          right: s.right,
+          bottom: s.bottom,
           left: s.left,
           width: s.width,
           height: s.height,
@@ -92,7 +160,7 @@ test.describe('SessionChatOverlay layout', () => {
     expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
     expect(result.rect.left).toBeLessThanOrEqual(0);
     expect(result.rect.right).toBeGreaterThanOrEqual(result.inner.w);
-    expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
+    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 
   test('backdrop uses position: fixed at the viewport origin by default', async ({ page }) => {
@@ -121,94 +189,60 @@ test.describe('SessionChatOverlay layout', () => {
     await navigateToSession(page);
     await openOverlay(page);
 
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty('--viewport-offset-top', '260px');
-      document.documentElement.style.setProperty('--visual-viewport-height', '420px');
-    });
-    await page.waitForTimeout(50);
+    await injectStaleVisualViewportVariables(page);
 
     try {
-      const result = await page.evaluate(() => {
-        const el = document.querySelector(
-          '[data-testid="session-chat-overlay"]'
-        ) as HTMLElement;
-        const r = el.getBoundingClientRect();
-        return {
-          top: r.top,
-          bottom: r.bottom,
-          left: r.left,
-          right: r.right,
-          inner: { w: window.innerWidth, h: window.innerHeight },
-        };
-      });
-
-      expect(result.top).toBeLessThanOrEqual(1);
-      expect(result.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
-      expect(result.left).toBeLessThanOrEqual(1);
-      expect(result.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+      const result = await readOverlayLayout(page);
+      expectBackdropCoversViewport(result);
+      expect(result.content.top).toBeLessThanOrEqual(1);
+      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
     } finally {
-      await page.evaluate(() => {
-        document.documentElement.style.removeProperty('--viewport-offset-top');
-        document.documentElement.style.removeProperty('--visual-viewport-height');
-      });
+      await clearStaleVisualViewportVariables(page);
     }
   });
 
-  test('tablet-sized layouts let visual viewport CSS variables move and size the shell', async ({ page }) => {
+  test('744px tablet-sized layouts ignore stale visual viewport CSS variables', async ({ page }) => {
     await page.setViewportSize({ width: 744, height: 1000 });
     await navigateToSession(page);
     await openOverlay(page);
 
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty('--viewport-offset-top', '260px');
-      document.documentElement.style.setProperty('--visual-viewport-height', '420px');
-    });
-    await page.waitForTimeout(50);
+    await injectStaleVisualViewportVariables(page);
 
     try {
-      const result = await page.evaluate(() => {
-        const rectFor = (selector: string) => {
-          const el = document.querySelector(selector) as HTMLElement;
-          const r = el.getBoundingClientRect();
-          return {
-            top: r.top,
-            bottom: r.bottom,
-            left: r.left,
-            right: r.right,
-            width: r.width,
-          };
-        };
+      const result = await readOverlayLayout(page);
+      expectBackdropCoversViewport(result);
+      expect(result.panel.top).toBeLessThanOrEqual(1);
+      expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.panel.left).toBeLessThanOrEqual(1);
+      expect(result.panel.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+      expect(result.panel.width).toBeGreaterThanOrEqual(result.inner.w - 1);
+      expect(result.content.top).toBeLessThanOrEqual(1);
+      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+    } finally {
+      await clearStaleVisualViewportVariables(page);
+    }
+  });
 
-        return {
-          backdrop: rectFor('[data-testid="session-chat-overlay"]'),
-          panel: rectFor('.overlay-panel-wrapper'),
-          header: rectFor('.overlay-header'),
-          inner: { w: window.innerWidth, h: window.innerHeight },
-        };
-      });
+  test('800px tablet-sized layouts keep a right-aligned capped panel inside the full shell', async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 1000 });
+    await navigateToSession(page);
+    await openOverlay(page);
 
-      expect(result.backdrop.top).toBeGreaterThanOrEqual(259);
-      expect(result.backdrop.top).toBeLessThanOrEqual(261);
-      expect(result.backdrop.bottom).toBeGreaterThanOrEqual(679);
-      expect(result.backdrop.bottom).toBeLessThanOrEqual(681);
-      expect(result.backdrop.left).toBeLessThanOrEqual(1);
-      expect(result.backdrop.right).toBeGreaterThanOrEqual(result.inner.w - 1);
+    await injectStaleVisualViewportVariables(page);
 
-      expect(result.panel.top).toBeGreaterThanOrEqual(259);
-      expect(result.panel.top).toBeLessThanOrEqual(261);
-      expect(result.panel.bottom).toBeGreaterThanOrEqual(679);
-      expect(result.panel.bottom).toBeLessThanOrEqual(681);
+    try {
+      const result = await readOverlayLayout(page);
+      expectBackdropCoversViewport(result);
+      expect(result.panel.top).toBeLessThanOrEqual(1);
+      expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
       expect(result.panel.right).toBeGreaterThanOrEqual(result.inner.w - 1);
       expect(result.panel.right).toBeLessThanOrEqual(result.inner.w + 1);
-      expect(result.panel.width).toBeLessThanOrEqual(Math.min(result.inner.w, 900) + 1);
-
-      expect(result.header.top).toBeGreaterThanOrEqual(259);
-      expect(result.header.top).toBeLessThanOrEqual(261);
+      expect(result.panel.width).toBeLessThanOrEqual(701);
+      expect(result.panel.width).toBeGreaterThan(0);
+      expect(result.content.top).toBeLessThanOrEqual(1);
+      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
     } finally {
-      await page.evaluate(() => {
-        document.documentElement.style.removeProperty('--viewport-offset-top');
-        document.documentElement.style.removeProperty('--visual-viewport-height');
-      });
+      await clearStaleVisualViewportVariables(page);
     }
   });
 
@@ -229,13 +263,13 @@ test.describe('SessionChatOverlay layout', () => {
       return {
         rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
         inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, left: s.left, width: s.width, height: s.height },
+        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
       };
     });
 
     expect(result.rect.top).toBeLessThanOrEqual(0);
     expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
-    expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
+    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 
   test('covers viewport after focus/blur cycle on textarea', async ({ page }) => {
@@ -262,13 +296,13 @@ test.describe('SessionChatOverlay layout', () => {
       return {
         rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
         inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, left: s.left, width: s.width, height: s.height },
+        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
       };
     });
 
     expect(result.rect.top).toBeLessThanOrEqual(0);
     expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
-    expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
+    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 
   test('covers viewport after simulated orientation change', async ({ page }) => {
@@ -291,7 +325,7 @@ test.describe('SessionChatOverlay layout', () => {
       return {
         rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
         inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, left: s.left, width: s.width, height: s.height },
+        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
       };
     });
 
@@ -299,7 +333,7 @@ test.describe('SessionChatOverlay layout', () => {
     expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
     expect(result.rect.left).toBeLessThanOrEqual(0);
     expect(result.rect.right).toBeGreaterThanOrEqual(result.inner.w);
-    expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
+    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 
   test('covers viewport after simulated URL-bar retraction', async ({ page }) => {
@@ -322,13 +356,13 @@ test.describe('SessionChatOverlay layout', () => {
       return {
         rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
         inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, left: s.left, width: s.width, height: s.height },
+        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
       };
     });
 
     expect(result.rect.top).toBeLessThanOrEqual(0);
     expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
-    expect(result.inline).toEqual({ top: '', left: '', width: '', height: '' });
+    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 
 });


### PR DESCRIPTION
## Summary

Fixes iPad-only session chat overlay regression where focusing and then blurring the prompt input leaves the overlay shorter than the viewport, allowing the canvas detail view or session content underneath to show through the bottom.

## Root Cause

The overlay backdrop was sized using `window.visualViewport` dimensions on tablet-sized viewports via CSS media query. On iPad Safari, after the prompt input is focused and then blurred, `visualViewport.height` can remain stale or keyboard-shrunk. Since the tablet CSS used that value as the backdrop height and set `bottom: auto`, the overlay physically no longer covered the full layout viewport.

## Changes

### SessionChatOverlay.vue
- Removed the `@media (min-width: 700px) and (min-height: 700px)` rule that applied `--viewport-offset-top` and `--visual-viewport-height` to `.overlay-backdrop`
- Added `min-height: 100vh` and `min-height: 100dvh` to `.overlay-backdrop`, `.overlay-panel-wrapper`, and `.overlay-content` to ensure full viewport coverage
- The backdrop now remains fixed with `inset: 0` across all viewport sizes

### SessionChatOverlay.test.js
- Updated tests to verify the backdrop stays fixed to full layout viewport
- Added negative assertions to ensure no backdrop CSS block uses visual viewport variables
- Added `getStyleBlocks()` helper to inspect all CSS blocks for a selector (including media queries)
- Expanded inline style checks to include `right` and `bottom` properties

### session-chat-overlay-layout.spec.ts
- Updated file-level comments to describe the full-shell invariant
- Replaced test that expected visual viewport variables to move the shell with tests that verify the shell ignores stale variables
- Added helper functions for injecting stale visual viewport variables and reading overlay layout
- Added specific tests for 744px and 800px tablet viewports to verify panel wrapper behavior

## Test Plan

- [x] Unit tests updated and passing in `SessionChatOverlay.test.js`
- [x] E2E tests updated and passing in `session-chat-overlay-layout.spec.ts`
- [ ] Manual QA on real iPad Safari (Playwright cannot fully reproduce Safari visual viewport divergence)
  - Open session detail view
  - Open session chat overlay
  - Focus and blur prompt input
  - Verify overlay still covers full viewport
  - Verify no underlying content bleeds through
  - Test with canvas detail view underneath
  - Test orientation changes
- [ ] Smoke test iPhone Safari to ensure existing behavior unchanged
- [ ] Smoke test desktop/tablet browsers for overlay width, close handle, scrolling, and prompt controls

## Verification

```bash
yarn workspace @circuschief/web test -- SessionChatOverlay.test.js
./scripts/pw.sh test tests/e2e/session-chat-overlay-layout.spec.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)