### PR TITLE
Fix session list activity dates

### DIFF
--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -1517,6 +1517,70 @@ describe('SessionRepository', () => {
       expect(retrievedAfter.lastActivityAt).toBeGreaterThanOrEqual(newMessage.timestamp);
     });
 
+    it('reflects summary generation when it is newer than messages', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      const now = Date.now();
+      const summaryActivity = now + 60_000;
+
+      repo.db
+        .prepare(
+          `INSERT INTO session_summaries
+           (id, session_id, short_summary, full_summary, message_count, generated_at, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('summary-latest-activity', session.id, 'Short', 'Full', 1, summaryActivity, now, summaryActivity);
+
+      const retrieved = repo.getById(session.id);
+
+      expect(retrieved.lastActivityAt).toBe(summaryActivity);
+    });
+
+    it('reflects command runs when they are newer than messages', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      const now = Date.now();
+      const startedAt = now + 30_000;
+      const completedAt = now + 45_000;
+
+      repo.db
+        .prepare(
+          `INSERT INTO command_buttons
+           (id, project_id, label, command, sort_order, show_on_list, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('button-latest-activity', projectId, 'Test command', 'echo ok', 0, 1, now, now);
+      repo.db
+        .prepare(
+          `INSERT INTO command_runs
+           (id, session_id, button_id, status, output, exit_code, started_at, completed_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('run-latest-activity', session.id, 'button-latest-activity', 'success', '', 0, startedAt, completedAt);
+
+      const retrieved = repo.getById(session.id);
+
+      expect(retrieved.lastActivityAt).toBe(completedAt);
+    });
+
+    it('can derive lastActivityAt from summary activity when a session has no messages', () => {
+      const session = repo.create(projectId, 'Waiting', 'Prompt', {
+        status: 'waiting',
+      });
+      const now = Date.now();
+      const summaryActivity = Date.now() + 60_000;
+
+      repo.db
+        .prepare(
+          `INSERT INTO session_summaries
+           (id, session_id, short_summary, full_summary, message_count, generated_at, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('summary-no-message-activity', session.id, 'Short', 'Full', 0, summaryActivity, now, summaryActivity);
+
+      const retrieved = repo.getById(session.id);
+
+      expect(retrieved.lastActivityAt).toBe(summaryActivity);
+    });
+
     it('returns null for lastActivityAt when there are no messages (waiting session)', () => {
       // Create a waiting session (which doesn't create initial message)
       const session = repo.create(projectId, 'Test', 'Prompt', 'standard', false, null, null, 'waiting');

--- a/packages/server/src/db/session-helpers.js
+++ b/packages/server/src/db/session-helpers.js
@@ -7,7 +7,27 @@ import { DEFAULT_RESCHEDULE_DELAY_MINUTES } from '@circuschief/shared';
 
 /** Reusable SQL fragment for computed activity fields on sessions */
 export const ACTIVITY_FIELDS_SQL = `
-  (SELECT MAX(cm.timestamp) FROM conversation_messages cm WHERE cm.session_id = s.id) AS last_activity_at,
+  (
+    SELECT MAX(activity_at)
+    FROM (
+      SELECT cm.timestamp AS activity_at
+      FROM conversation_messages cm
+      WHERE cm.session_id = s.id
+      UNION ALL
+      SELECT ss.generated_at AS activity_at
+      FROM session_summaries ss
+      WHERE ss.session_id = s.id
+      UNION ALL
+      SELECT ss.updated_at AS activity_at
+      FROM session_summaries ss
+      WHERE ss.session_id = s.id
+      UNION ALL
+      SELECT COALESCE(cr.completed_at, cr.started_at) AS activity_at
+      FROM command_runs cr
+      WHERE cr.session_id = s.id
+    )
+    WHERE activity_at IS NOT NULL
+  ) AS last_activity_at,
   (CAST(
     CASE
       WHEN (SELECT MAX(cm2.timestamp) FROM conversation_messages cm2 WHERE cm2.session_id = s.id) IS NOT NULL


### PR DESCRIPTION
## Summary
- Include session summaries and command runs in the computed `lastActivityAt` value used by session lists
- Keep message-based active time calculation unchanged
- Add regression tests for summary and command-run activity newer than messages

## Context
The inspected session `cfbec3a4-eaf5-4b71-871e-b388fff2a3f8` has a stored summary updated after its latest persisted conversation message, but the list date was still based only on `conversation_messages.timestamp`. That made the card show April 16 even though later session-level activity existed.

## Test
- `yarn workspace @circuschief/server test src/db/SessionRepository.test.js`
