### PR TITLE
Change scheduled session names to open chat overlay instead of navigating

### DIFF
--- a/packages/web/src/components/ScheduledChildCard.test.js
+++ b/packages/web/src/components/ScheduledChildCard.test.js
@@ -88,11 +88,33 @@ describe('ScheduledChildCard.vue', () => {
     expect(wrapper.find('.status-scheduled').text()).toBe('scheduled');
   });
 
-  it('renders session name as a router-link to session detail', () => {
+  it('renders session name as a button that emits open-session-overlay on click', async () => {
+    // Note: Custom emit capture via wrapper.emitted() is unreliable with
+    // Vue 3 script setup SFCs (known Vue Test Utils limitation).
+    // Use attrs listener to capture the emitted event.
+    const overlaySpy = vi.fn();
+    const wrapper = mount(ScheduledChildCard, {
+      props: { session: baseSession, projectId: 'proj-1' },
+      attrs: { onOpenSessionOverlay: overlaySpy },
+      global: { stubs: globalStubs },
+    });
+    const button = wrapper.find('.session-name-link');
+    expect(button.exists()).toBe(true);
+    expect(button.element.tagName).toBe('BUTTON');
+    expect(button.find('.session-name').text()).toBe('Test Child');
+
+    await button.trigger('click');
+    expect(overlaySpy).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('button is keyboard accessible with tabindex', async () => {
     const wrapper = mountComponent();
-    const link = wrapper.find('.session-name-link');
-    expect(link.exists()).toBe(true);
-    expect(link.find('.session-name').text()).toBe('Test Child');
+    const button = wrapper.find('.session-name-link');
+    // Native <button> elements are inherently keyboard-accessible (Enter/Space trigger click)
+    // Verify it's a button element (not a div/span that would need tabindex)
+    expect(button.element.tagName).toBe('BUTTON');
+    // Buttons are focusable by default — no tabindex needed
+    expect(button.element.getAttribute('tabindex')).toBeNull();
   });
 
   it('renders timing info with countdown and absolute time', () => {

--- a/packages/web/src/components/ScheduledChildCard.vue
+++ b/packages/web/src/components/ScheduledChildCard.vue
@@ -3,14 +3,15 @@
     <!-- Header -->
     <div class="card-header">
       <div class="session-info">
-        <router-link
-          :to="`/sessions/${session.id}`"
+        <button
           class="session-name-link"
+          data-testid="scheduled-session-name-btn"
+          @click="handleSessionClick"
         >
           <h4 class="session-name">
             {{ session.name }}
           </h4>
-        </router-link>
+        </button>
       </div>
       <span class="status-badge status-scheduled">scheduled</span>
     </div>
@@ -108,6 +109,12 @@ const loading = ref(false);
 const showEditModal = ref(false);
 const showAutoRescheduleModal = ref(false);
 
+const emit = defineEmits(['open-session-overlay']);
+
+function handleSessionClick() {
+  emit('open-session-overlay', props.session.id);
+}
+
 const scheduledTimeDisplay = computed(() => {
   const time = new Date(props.session.scheduledAt);
   return formatDistanceToNow(time, { addSuffix: true });
@@ -171,8 +178,17 @@ async function handleTemplateChange(templateId) {
 }
 
 .session-name-link {
-  text-decoration: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
   color: inherit;
+  display: block;
+  width: 100%;
+  text-decoration: none;
   transition: color 0.2s;
 }
 

--- a/packages/web/src/components/SessionOverviewCard.vue
+++ b/packages/web/src/components/SessionOverviewCard.vue
@@ -141,6 +141,7 @@
           :session="s"
           :project-id="projectId"
           class="scheduled-session-card"
+          @open-session-overlay="(sessionId) => $emit('open-session-overlay', sessionId)"
         />
       </div>
     </div>
@@ -205,6 +206,8 @@ defineProps({
     default: null,
   },
 });
+
+defineEmits(['open-session-overlay']);
 
 </script>
 

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -24,6 +24,7 @@
       :has-warnings="hasWarnings"
       :scheduled-sessions="allScheduledSessions"
       :project-id="projectId"
+      @open-session-overlay="(sessionId) => emit('open-session-overlay', sessionId)"
     />
 
     <div
@@ -112,6 +113,8 @@ import {
   computeIdleSessionTime,
   formatDuration,
 } from '../composables/useSummaryHelpers.js';
+
+const emit = defineEmits(['open-session-overlay']);
 
 const props = defineProps({
   sessionId: { type: String, required: true },

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -54,6 +54,7 @@
           v-if="activeTab === 'summary'"
           :key="route.params.id"
           :session-id="route.params.id"
+          @open-session-overlay="handleScheduledSessionClick"
         />
         <ChangesTab
           v-else-if="activeTab === 'changes'"
@@ -395,6 +396,14 @@ function handleSessionCreated(msg) {
 
 function handleOverlayOpen() {
   resolveOverlayTarget();
+  chatOverlayOpen.value = true;
+}
+
+async function handleScheduledSessionClick(sessionId) {
+  // Rebuild session chain to ensure the target session is included
+  await buildSessionChain();
+  preferredOverlaySessionId.value = sessionId;
+  overlaySessionId.value = sessionId;
   chatOverlayOpen.value = true;
 }
 

--- a/tests/e2e/scheduled-session-overlay-click.spec.ts
+++ b/tests/e2e/scheduled-session-overlay-click.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  seedChildSession,
+  updateSessionScheduling,
+  waitForSessionToExist,
+  waitForSessionScheduled,
+  navigateAndWait,
+  cleanupAll,
+  getSession,
+} from './helpers';
+
+test.describe('Scheduled Session Name Click Opens Overlay', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    project = await seedProject('Scheduled Overlay Test', '/tmp/scheduled-overlay-test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupAll();
+  });
+
+  test('clicking a scheduled child session name opens overlay with that session selected', async ({ page }) => {
+    // Create a parent session (not scheduled, so it doesn't appear in its own scheduled list)
+    const parent = await seedSession(project.id, {
+      prompt: 'Parent prompt',
+      name: 'Parent Session',
+      startImmediately: false,
+    });
+
+    // Create a child session and mark it as scheduled
+    const child = await seedChildSession(project.id, parent.id, {
+      prompt: 'Child prompt',
+      name: 'Child Scheduled',
+    });
+    await waitForSessionToExist(child.id);
+    await updateSessionScheduling(child.id, {
+      status: 'scheduled',
+      scheduledAt: Date.now() + 3600000,
+    });
+    await waitForSessionScheduled(child.id);
+
+    // Navigate to parent's summary tab
+    await navigateAndWait(page, `/sessions/${parent.id}/summary`);
+
+    // Wait for the scheduled session card to render
+    const nameButton = page.locator('[data-testid="scheduled-session-name-btn"]');
+    await expect(nameButton).toBeVisible();
+    await expect(nameButton).toContainText('Child Scheduled');
+
+    // Record URL before click
+    const urlBefore = page.url();
+
+    // Click the child's name button
+    await nameButton.click();
+
+    // Verify overlay opens
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
+    await expect(overlay).toBeVisible();
+
+    // Open the picker dropdown
+    const pickerDropdown = page.locator('[data-testid="overlay-picker-trigger"]');
+    await expect(pickerDropdown).toBeVisible();
+    await pickerDropdown.click();
+
+    // Wait for the picker to open
+    const picker = page.locator('[data-testid="session-chat-picker"]');
+    await expect(picker).toBeVisible();
+
+    // Verify the child session is selected in the picker
+    const activePickerItem = page.locator('.picker-item--active .picker-item-name');
+    await expect(activePickerItem).toContainText('Child Scheduled');
+
+    // Verify URL did not change (no navigation)
+    expect(page.url()).toBe(urlBefore);
+  });
+
+  test('clicking a scheduled root session name opens overlay on that session', async ({ page }) => {
+    // Create a scheduled root session (it appears in its own scheduled list)
+    const session = await seedSession(project.id, {
+      prompt: 'Root scheduled prompt',
+      name: 'Root Scheduled',
+      startImmediately: false,
+    });
+    await waitForSessionToExist(session.id);
+    await updateSessionScheduling(session.id, {
+      status: 'scheduled',
+      scheduledAt: Date.now() + 3600000,
+    });
+    await waitForSessionScheduled(session.id);
+
+    // Navigate to its own summary tab
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+
+    // Wait for the scheduled session card to render
+    const nameButton = page.locator('[data-testid="scheduled-session-name-btn"]');
+    await expect(nameButton).toBeVisible();
+    await expect(nameButton).toContainText('Root Scheduled');
+
+    // Record URL before click
+    const urlBefore = page.url();
+
+    // Click the session's own name button
+    await nameButton.click();
+
+    // Verify overlay opens
+    const overlay = page.locator('[data-testid="session-chat-overlay"]');
+    await expect(overlay).toBeVisible();
+
+    // Verify URL did not change (no navigation)
+    expect(page.url()).toBe(urlBefore);
+  });
+});


### PR DESCRIPTION
## Summary

In the summary tab, clicking on scheduled session names now opens the session chat overlay with the clicked session selected, rather than navigating to a new page. This provides a more seamless experience when browsing scheduled child sessions.

## Changes

- **ScheduledChildCard.vue**: Replace `<router-link>` with `<button>` that emits `open-session-overlay` event
- **SessionOverviewCard.vue**: Pass-through the `open-session-overlay` event
- **SummaryTab.vue**: Pass-through the `open-session-overlay` event  
- **SessionDetailView.vue**: Handle event by rebuilding session chain and opening overlay with selected session
- **ScheduledChildCard.test.js**: Update unit test for button instead of router-link
- **scheduled-session-overlay-click.spec.ts**: New E2E tests for the behavior

## Test plan

- [x] Unit tests pass for ScheduledChildCard
- [x] E2E tests verify clicking scheduled session names opens overlay with correct session selected
- [x] E2E tests verify URL does not change (no navigation)
- [x] Manual testing: Navigate to session with scheduled children, click name, verify overlay opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)