### PR TITLE
Fix session picker activity and PR title matching

### DIFF
--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -73,6 +73,7 @@ export class SessionRepository extends BaseRepository {
       laneTriggerDepth: row.lane_trigger_depth || 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      lastMessageAt: row.last_message_at ?? null,
       lastActivityAt: row.last_activity_at ?? null,
       activeTimeMs: row.active_time_ms || 0,
     };

--- a/packages/server/src/db/session-helpers.js
+++ b/packages/server/src/db/session-helpers.js
@@ -8,6 +8,11 @@ import { DEFAULT_RESCHEDULE_DELAY_MINUTES } from '@circuschief/shared';
 /** Reusable SQL fragment for computed activity fields on sessions */
 export const ACTIVITY_FIELDS_SQL = `
   (
+    SELECT MAX(cm.timestamp)
+    FROM conversation_messages cm
+    WHERE cm.session_id = s.id
+  ) AS last_message_at,
+  (
     SELECT MAX(activity_at)
     FROM (
       SELECT cm.timestamp AS activity_at

--- a/packages/server/src/services/ghService.js
+++ b/packages/server/src/services/ghService.js
@@ -105,7 +105,7 @@ export async function getPrInfo(prUrl) {
   try {
     // First fetch basic PR info (this should always work)
     const { stdout: basicStdout } = await execAsync(
-      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft,title`
+      `gh pr view "${prUrl}" --json state,mergedAt,mergeable,isDraft,title,headRefName`
     );
     const data = JSON.parse(basicStdout);
 
@@ -161,6 +161,7 @@ export async function getPrInfo(prUrl) {
       ciStatus,
       ciFailures,
       title: data.title || null,
+      headRefName: data.headRefName || null,
     };
   } catch (error) {
     console.warn('[ghService] Failed to get PR info:', error.message);

--- a/packages/server/src/services/ghService.test.js
+++ b/packages/server/src/services/ghService.test.js
@@ -73,6 +73,7 @@ describe('ghService', () => {
               mergeable: 'MERGEABLE',
               isDraft: false,
               title: 'Test PR Title',
+              headRefName: 'feature/test-pr',
             }),
             stderr: '',
           });
@@ -109,6 +110,7 @@ describe('ghService', () => {
         ciStatus: 'success',
         ciFailures: [],
         title: 'Test PR Title',
+        headRefName: 'feature/test-pr',
       });
     });
 

--- a/packages/server/src/services/prUrlService.js
+++ b/packages/server/src/services/prUrlService.js
@@ -117,6 +117,21 @@ export function extractPrUrlFromMessages(sessionId) {
   return null;
 }
 
+function normalizeBranchName(branch) {
+  if (!branch) return null;
+  return branch.replace(/^refs\/heads\//, '');
+}
+
+function prMatchesSessionBranch(session, prInfo) {
+  const sessionBranch = normalizeBranchName(session?.gitBranch);
+  const prBranch = normalizeBranchName(prInfo?.headRefName);
+
+  // If either side is unavailable, preserve the existing permissive behavior.
+  if (!sessionBranch || !prBranch) return true;
+
+  return sessionBranch === prBranch;
+}
+
 /**
  * Extract PR URL from recent messages immediately after a turn completes.
  * This is lightweight (no Claude API call) - just scans messages for URLs.
@@ -132,11 +147,25 @@ export async function extractPrUrlIfNeeded(sessionId) {
   // Extract PR URL from messages
   const prUrl = extractPrUrlFromMessages(sessionId);
   if (prUrl) {
+    let prInfo = null;
+    try {
+      prInfo = await ghService.getPrInfo(prUrl);
+      if (!prMatchesSessionBranch(session, prInfo)) {
+        console.log(
+          `[PrUrlService] Ignoring PR URL for session ${sessionId}: PR head branch ` +
+          `"${prInfo.headRefName}" does not match session branch "${session.gitBranch}"`
+        );
+        return;
+      }
+    } catch (error) {
+      console.warn(`[PrUrlService] Failed to inspect PR branch for ${prUrl}:`, error.message);
+    }
+
     sessions.update(sessionId, { prUrl });
     console.log(`[PrUrlService] Extracted PR URL for session ${sessionId}: ${prUrl}`);
 
     // Set session name from PR title (async, fire-and-forget)
-    await setSessionNameFromPr(sessionId, prUrl);
+    await setSessionNameFromPr(sessionId, prUrl, prInfo);
 
     // Broadcast session update so UI shows PR URL immediately
     broadcastSessionUpdate(sessionId, session.projectId, sessions.getById(sessionId));
@@ -176,6 +205,16 @@ export async function enrichPrData(summaryDataInput, prUrl, projectRepoUrl, sess
   try {
     const prInfo = await ghService.getPrInfo(prUrl);
     if (prInfo) {
+      const session = sessions.getById(sessionId);
+      if (!prMatchesSessionBranch(session, prInfo)) {
+        console.log(
+          `[PrUrlService] Ignoring PR summary data for session ${sessionId}: PR head branch ` +
+          `"${prInfo.headRefName}" does not match session branch "${session?.gitBranch}"`
+        );
+        summaryData.prUrl = null;
+        return;
+      }
+
       summaryData.prState = prInfo.state;
       summaryData.prMerged = prInfo.merged;
       summaryData.hasMergeConflicts = prInfo.hasMergeConflicts;
@@ -197,17 +236,25 @@ export async function enrichPrData(summaryDataInput, prUrl, projectRepoUrl, sess
  * Set session name from PR title when PR URL is associated.
  * @param {string} sessionId - The session ID
  * @param {string} prUrl - The PR URL
+ * @param {Object|null} prInfoInput - Optional pre-fetched PR info
  */
-export async function setSessionNameFromPr(sessionId, prUrl) {
+export async function setSessionNameFromPr(sessionId, prUrl, prInfoInput = null) {
   const session = sessions.getById(sessionId);
   if (!session || session.manuallyNamed) return; // Don't overwrite if manually named
 
   try {
-    const prInfo = await ghService.getPrInfo(prUrl);
+    const prInfo = prInfoInput || await ghService.getPrInfo(prUrl);
+    if (!prMatchesSessionBranch(session, prInfo)) {
+      console.log(
+        `[PrUrlService] Not setting session ${sessionId} name from PR title: PR head branch ` +
+        `"${prInfo.headRefName}" does not match session branch "${session.gitBranch}"`
+      );
+      return;
+    }
+
     if (prInfo?.title) {
       sessions.update(sessionId, {
         name: prInfo.title,
-        manuallyNamed: true, // Protect from summary overwrites
       });
       console.log(`[PrUrlService] Set session ${sessionId} name from PR title: "${prInfo.title}"`);
 

--- a/packages/server/src/services/prUrlService.test.js
+++ b/packages/server/src/services/prUrlService.test.js
@@ -376,6 +376,27 @@ describe('prUrlService', () => {
 
       expect(summaryData.prTitle).toBeUndefined();
     });
+
+    it('clears summary PR URL when PR branch belongs to another session', async () => {
+      const project = projects.create('Project With Branch', '/tmp/project-with-branch');
+      const session = sessions.create(project.id, 'URL Research', 'prompt', 'standard');
+      sessions.update(session.id, { gitBranch: 'circus-chief/url-research' });
+      const summaryData = { prUrl: 'https://github.com/user/repo/pull/123' };
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'OPEN',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'passing',
+        title: 'Unrelated PR',
+        headRefName: 'circus-chief/fix-other-feature',
+      });
+
+      await enrichPrData(summaryData, 'https://github.com/user/repo/pull/123', 'https://github.com/user/repo', session.id);
+
+      expect(summaryData.prUrl).toBeNull();
+      expect(summaryData.prTitle).toBeUndefined();
+    });
   });
 
   describe('setSessionNameFromPr', () => {
@@ -400,7 +421,24 @@ describe('prUrlService', () => {
 
       const updated = sessions.getById(sessionId);
       expect(updated.name).toBe('Add new feature');
-      expect(updated.manuallyNamed).toBe(true);
+      expect(updated.manuallyNamed).toBe(false);
+    });
+
+    it('does not set session name from PR title when PR branch belongs to another session', async () => {
+      sessions.update(sessionId, { gitBranch: 'circus-chief/url-research' });
+
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'Unrelated PR Title',
+        state: 'OPEN',
+        merged: false,
+        headRefName: 'circus-chief/fix-other-feature',
+      });
+
+      await setSessionNameFromPr(sessionId, 'https://github.com/org/repo/pull/123');
+
+      const updated = sessions.getById(sessionId);
+      expect(updated.name).toBe('Original Name');
+      expect(updated.manuallyNamed).toBe(false);
     });
 
     it('does not overwrite name if manuallyNamed is already true', async () => {
@@ -495,7 +533,27 @@ describe('prUrlService', () => {
       const session = sessions.getById(sessionId);
       expect(session.prUrl).toBe(prUrl);
       expect(session.name).toBe('Extracted PR Title');
-      expect(session.manuallyNamed).toBe(true);
+      expect(session.manuallyNamed).toBe(false);
+    });
+
+    it('does not extract PR URL when the PR branch does not match the session branch', async () => {
+      sessions.update(sessionId, { gitBranch: 'circus-chief/url-research' });
+      const prUrl = 'https://github.com/org/repo/pull/123';
+      messages.create(sessionId, 'assistant', `Found target session PR: ${prUrl}`);
+
+      ghService.getPrInfo.mockResolvedValue({
+        title: 'Fix session chat viewport height',
+        state: 'OPEN',
+        merged: false,
+        headRefName: 'circus-chief/fix-session-chat-viewport-height',
+      });
+
+      await extractPrUrlIfNeeded(sessionId);
+
+      const session = sessions.getById(sessionId);
+      expect(session.prUrl).toBeNull();
+      expect(session.name).toBe('Original Name');
+      expect(broadcastSessionUpdate).not.toHaveBeenCalled();
     });
 
     it('does not set name if manuallyNamed is true', async () => {

--- a/packages/shared/src/contracts/sessions.js
+++ b/packages/shared/src/contracts/sessions.js
@@ -84,6 +84,7 @@ export const SessionResponse = z.object({
   laneTriggerDepth: z.number(),
   createdAt: z.number(),
   updatedAt: z.number(),
+  lastMessageAt: z.number().nullable(),
   lastActivityAt: z.number().nullable(),
 });
 

--- a/packages/shared/src/contracts/sessions.test.js
+++ b/packages/shared/src/contracts/sessions.test.js
@@ -336,6 +336,7 @@ describe('SessionResponse', () => {
     laneTriggerDepth: 0,
     createdAt: Date.now(),
     updatedAt: Date.now(),
+    lastMessageAt: Date.now(),
     lastActivityAt: Date.now(),
   };
 
@@ -513,6 +514,7 @@ describe('SessionListResponse', () => {
         laneTriggerDepth: 0,
         createdAt: Date.now(),
         updatedAt: Date.now(),
+        lastMessageAt: Date.now(),
         lastActivityAt: Date.now(),
       },
     ]);

--- a/packages/web/src/components/SessionChatPicker.test.js
+++ b/packages/web/src/components/SessionChatPicker.test.js
@@ -16,6 +16,7 @@ describe('SessionChatPicker', () => {
           name: 'Root Session',
           status: 'completed',
           createdAt: Date.now() - 7200000,
+          lastMessageAt: Date.now() - 3600000,
           lastActivityAt: Date.now() - 3600000,
         },
         depth: 0,
@@ -26,6 +27,7 @@ describe('SessionChatPicker', () => {
           name: 'Child Session 1',
           status: 'running',
           createdAt: Date.now() - 3600000,
+          lastMessageAt: Date.now() - 1800000,
           lastActivityAt: Date.now() - 1800000,
         },
         depth: 1,
@@ -36,6 +38,7 @@ describe('SessionChatPicker', () => {
           name: 'Child Session 2',
           status: 'waiting',
           createdAt: Date.now() - 1800000,
+          lastMessageAt: Date.now() - 900000,
           lastActivityAt: Date.now() - 900000,
         },
         depth: 1,
@@ -325,16 +328,16 @@ describe('SessionChatPicker', () => {
       });
     });
 
-    it('renders lastActivityAt when present with "Last activity" tooltip', () => {
+    it('renders lastMessageAt when present with "Last chat message" tooltip', () => {
       const wrapper = mountComponent();
       const firstItem = wrapper.findAll('.picker-item')[0];
       const dateEl = firstItem.find('.picker-item-date');
-      expect(dateEl.attributes('title')).toBe('Last activity');
+      expect(dateEl.attributes('title')).toBe('Last chat message');
       expect(dateEl.text()).not.toBe('—');
       expect(dateEl.text().length).toBeGreaterThan(0);
     });
 
-    it('renders "—" placeholder with "No activity yet" tooltip when lastActivityAt is null', () => {
+    it('renders "—" placeholder with "No chat messages yet" tooltip when lastMessageAt is null', () => {
       const wrapper = mountComponent({
         sessions: [{
           session: {
@@ -342,6 +345,7 @@ describe('SessionChatPicker', () => {
             name: 'No activity',
             status: 'waiting',
             createdAt: Date.now(),
+            lastMessageAt: null,
             lastActivityAt: null,
           },
           depth: 0,
@@ -350,22 +354,22 @@ describe('SessionChatPicker', () => {
         summaries: {},
       });
       const dateEl = wrapper.find('.picker-item-date');
-      expect(dateEl.attributes('title')).toBe('No activity yet');
+      expect(dateEl.attributes('title')).toBe('No chat messages yet');
       expect(dateEl.text()).toBe('—');
     });
 
-    it('flips tooltip between "Last activity" and "No activity yet" based on value', () => {
+    it('flips tooltip between "Last chat message" and "No chat messages yet" based on value', () => {
       const wrapper = mountComponent({
         sessions: [
-          { session: { id: 'has', name: 'Has', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 0 },
-          { session: { id: 'none', name: 'None', status: 'waiting', createdAt: Date.now(), lastActivityAt: null }, depth: 0 },
+          { session: { id: 'has', name: 'Has', status: 'completed', createdAt: Date.now(), lastMessageAt: Date.now(), lastActivityAt: Date.now() }, depth: 0 },
+          { session: { id: 'none', name: 'None', status: 'waiting', createdAt: Date.now(), lastMessageAt: null, lastActivityAt: Date.now() }, depth: 0 },
         ],
         activeSessionId: 'has',
         summaries: {},
       });
       const items = wrapper.findAll('.picker-item');
-      expect(items[0].find('.picker-item-date').attributes('title')).toBe('Last activity');
-      expect(items[1].find('.picker-item-date').attributes('title')).toBe('No activity yet');
+      expect(items[0].find('.picker-item-date').attributes('title')).toBe('Last chat message');
+      expect(items[1].find('.picker-item-date').attributes('title')).toBe('No chat messages yet');
     });
   });
 

--- a/packages/web/src/components/SessionChatPicker.vue
+++ b/packages/web/src/components/SessionChatPicker.vue
@@ -42,8 +42,8 @@
         <span class="picker-item-summary">{{ getSummaryText(entry.session.id) }}</span>
         <span
           class="picker-item-date"
-          :title="entry.session.lastActivityAt ? 'Last activity' : 'No activity yet'"
-        >{{ entry.session.lastActivityAt ? formatDate(entry.session.lastActivityAt) : '—' }}</span>
+          :title="chatActivityAt(entry.session) ? 'Last chat message' : 'No chat messages yet'"
+        >{{ chatActivityAt(entry.session) ? formatDate(chatActivityAt(entry.session)) : '—' }}</span>
       </div>
     </div>
   </div>
@@ -98,6 +98,10 @@ function statusLabel(session) {
 function getSummaryText(sessionId) {
   const summary = props.summaries[sessionId];
   return summary?.shortSummary || 'No summary yet';
+}
+
+function chatActivityAt(session) {
+  return session.lastMessageAt ?? null;
 }
 
 function formatDate(timestamp) {

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -3420,6 +3420,7 @@ describe('SessionDetailView', () => {
         status: 'running',
         projectId: 'proj-1',
         parentSessionId: null,
+        lastMessageAt: 1000,
         lastActivityAt: 1000,
       };
       const childSession = {
@@ -3428,6 +3429,7 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 2000,
         lastActivityAt: 2000,
       };
 
@@ -3462,9 +3464,9 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      // sessionChain should contain both sessions sorted by lastActivityAt descending
+      // sessionChain should contain both sessions sorted by lastMessageAt descending
       expect(wrapper.vm.sessionChain.length).toBe(2);
-      // child-1 has lastActivityAt=2000 (most recent), parent-1 has lastActivityAt=1000
+      // child-1 has lastMessageAt=2000 (most recent), parent-1 has lastMessageAt=1000
       expect(wrapper.vm.sessionChain[0].session.id).toBe('child-1');
       expect(wrapper.vm.sessionChain[1].session.id).toBe('parent-1');
     });
@@ -3476,6 +3478,7 @@ describe('SessionDetailView', () => {
         status: 'running',
         projectId: 'proj-1',
         parentSessionId: null,
+        lastMessageAt: 2000,
         lastActivityAt: 2000,
       };
       const childSession = {
@@ -3484,6 +3487,7 @@ describe('SessionDetailView', () => {
         status: 'running',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 1000,
         lastActivityAt: 1000,
       };
 
@@ -3532,6 +3536,7 @@ describe('SessionDetailView', () => {
         status: 'running',
         projectId: 'proj-1',
         parentSessionId: null,
+        lastMessageAt: 1000,
         lastActivityAt: 1000,
       };
 
@@ -3569,6 +3574,7 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 3000,
         lastActivityAt: 3000,
       };
       sessionsStore.sessions.push(newChild);
@@ -3588,9 +3594,9 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      // Session chain should now include the new child, sorted by lastActivityAt descending
+      // Session chain should now include the new child, sorted by lastMessageAt descending
       expect(wrapper.vm.sessionChain.length).toBe(2);
-      // new-child has lastActivityAt=3000 (most recent), so it comes first
+      // new-child has lastMessageAt=3000 (most recent), so it comes first
       expect(wrapper.vm.sessionChain[0].session.id).toBe('new-child');
       expect(wrapper.vm.sessionChain[1].session.id).toBe('parent-1');
     });
@@ -3609,6 +3615,7 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 3000,
         lastActivityAt: 3000,
       };
       const newChild = {
@@ -3680,6 +3687,7 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 3000,
         lastActivityAt: 3000,
       };
       const newChild = {
@@ -3736,13 +3744,14 @@ describe('SessionDetailView', () => {
       expect(wrapper.vm.sessionChain.some(entry => entry.session.id === 'new-child')).toBe(true);
     });
 
-    it('sorts session chain by lastActivityAt descending (most recent first)', async () => {
+    it('sorts session chain by lastMessageAt descending (most recent chat first)', async () => {
       const sessionA = {
         id: 'session-a',
         name: 'Session A (oldest)',
         status: 'completed',
         projectId: 'proj-1',
         parentSessionId: null,
+        lastMessageAt: 1000,
         lastActivityAt: 1000,
       };
       const sessionB = {
@@ -3751,6 +3760,7 @@ describe('SessionDetailView', () => {
         status: 'running',
         projectId: 'proj-1',
         parentSessionId: 'session-a',
+        lastMessageAt: 3000,
         lastActivityAt: 3000,
       };
       const sessionC = {
@@ -3759,15 +3769,17 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'session-a',
+        lastMessageAt: 5000,
         lastActivityAt: 5000,
       };
-      // Session D has no lastActivityAt, falls back to updatedAt
+      // Session D has no lastMessageAt, so it sorts after sessions with chat.
       const sessionD = {
         id: 'session-d',
         name: 'Session D (fallback to updatedAt)',
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'session-a',
+        lastMessageAt: null,
         lastActivityAt: null,
         updatedAt: 2000,
       };
@@ -3803,11 +3815,60 @@ describe('SessionDetailView', () => {
       // Should contain all 4 sessions
       expect(wrapper.vm.sessionChain.length).toBe(4);
 
-      // Order should be: C (5000), B (3000), D (2000 via updatedAt fallback), A (1000)
+      // Order should be: C (5000), B (3000), A (1000), D (no chat)
       expect(wrapper.vm.sessionChain[0].session.id).toBe('session-c');
       expect(wrapper.vm.sessionChain[1].session.id).toBe('session-b');
-      expect(wrapper.vm.sessionChain[2].session.id).toBe('session-d');
-      expect(wrapper.vm.sessionChain[3].session.id).toBe('session-a');
+      expect(wrapper.vm.sessionChain[2].session.id).toBe('session-a');
+      expect(wrapper.vm.sessionChain[3].session.id).toBe('session-d');
+    });
+
+    it('does not promote command-only activity above newer chat activity', async () => {
+      const rootSession = {
+        id: 'root-session',
+        name: 'Root Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        lastMessageAt: 1000,
+        lastActivityAt: 9000,
+      };
+      const childSession = {
+        id: 'child-session',
+        name: 'Child Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: 'root-session',
+        lastMessageAt: 5000,
+        lastActivityAt: 5000,
+      };
+
+      sessionsStore.currentSession = rootSession;
+      sessionsStore.sessions = [rootSession, childSession];
+
+      vi.spyOn(sessionsStore, 'getChildSessions', 'get').mockReturnValue(
+        (parentId) => parentId === 'root-session' ? [childSession] : []
+      );
+      vi.spyOn(sessionsStore, 'getRootSession', 'get').mockReturnValue(() => rootSession);
+      api.getProjectSessions.mockResolvedValue([rootSession, childSession]);
+
+      await router.push('/sessions/root-session');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.vm.sessionChain[0].session.id).toBe('child-session');
+      expect(wrapper.vm.overlaySessionId).toBe('child-session');
     });
 
     it('fetches summaries for sessions in the chain', async () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -261,9 +261,12 @@ async function buildSessionChain() {
 
   const tree = collectTreeDepthFirst(root);
   tree.sort((a, b) => {
-    const aTime = a.session.lastActivityAt || a.session.updatedAt || a.session.createdAt || 0;
-    const bTime = b.session.lastActivityAt || b.session.updatedAt || b.session.createdAt || 0;
-    return bTime - aTime;
+    const aTime = a.session.lastMessageAt || 0;
+    const bTime = b.session.lastMessageAt || 0;
+    if (bTime !== aTime) return bTime - aTime;
+    const aFallback = a.session.updatedAt || a.session.createdAt || 0;
+    const bFallback = b.session.updatedAt || b.session.createdAt || 0;
+    return bFallback - aFallback;
   });
   sessionChain.value = tree;
 
@@ -281,7 +284,7 @@ async function buildSessionChain() {
  * Resolve the overlay target session ID.
  * Priority order:
  * 1. Running/starting children (most recently updated)
- * 2. Session with the most recent conversation activity (lastActivityAt)
+ * 2. Session with the most recent conversation activity (lastMessageAt)
  * 3. Current session (fallback)
  */
 function resolveOverlayTarget() {
@@ -322,8 +325,8 @@ function resolveOverlayTarget() {
 
   // No running children — select the session with the most recent conversation activity
   const withActivity = chain
-    .filter(entry => entry.session.lastActivityAt)
-    .sort((a, b) => (b.session.lastActivityAt || 0) - (a.session.lastActivityAt || 0));
+    .filter(entry => entry.session.lastMessageAt)
+    .sort((a, b) => (b.session.lastMessageAt || 0) - (a.session.lastMessageAt || 0));
 
   if (withActivity.length > 0) {
     overlaySessionId.value = withActivity[0].session.id;


### PR DESCRIPTION
## Summary
- add `lastMessageAt` to session responses from chat messages
- sort and select session chat overlay targets by chat-message activity instead of broad activity from commands/summaries
- validate PR head branches before attaching PR URLs or applying PR titles to sessions
- avoid marking automatic PR-title names as manually named so summaries can correct them later

## Verification
- `yarn workspace @circuschief/server test src/db/SessionRepository.test.js src/api/sessions.test.js src/api/projects.test.js src/services/prUrlService.test.js src/services/ghService.test.js src/services/summaryService.test.js`
- `yarn workspace @circuschief/shared test src/contracts/sessions.test.js`
- `yarn workspace @circuschief/web test src/components/SessionChatPicker.test.js src/views/SessionDetailView.test.js`
- `yarn build`