### PR TITLE
Fix iPad session chat header offset

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1625,10 +1625,21 @@ describe('SessionChatOverlay', () => {
       expect(block).not.toMatch(/top:\s*var\(/);
     });
 
-    it('overlay content has a viewport-height floor for Safari tablet layout', () => {
+    it('overlay content has a viewport-height floor and visual top offset', () => {
       const block = getStyleBlock('.overlay-content');
       expect(block).toMatch(/min-height:\s*100%/);
       expect(block).toMatch(/min-height:\s*100dvh/);
+      expect(block).toMatch(
+        /padding-top:\s*max\(0px,\s*var\(--viewport-offset-top,\s*0px\)\)/
+      );
+      expect(block).not.toMatch(/--visual-viewport-height/);
+    });
+
+    it('overlay header stays sticky within the padded content flow', () => {
+      const block = getStyleBlock('.overlay-header');
+      expect(block).toMatch(/position:\s*-webkit-sticky/);
+      expect(block).toMatch(/position:\s*sticky/);
+      expect(block).toMatch(/top:\s*0/);
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
     });

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -1063,6 +1063,7 @@ defineExpose({
      was a historical failure mode when `overflow: hidden` was used here. */
   overflow: clip;
   padding: 0;
+  padding-top: max(0px, var(--viewport-offset-top, 0px));
   box-shadow: -4px 0 20px rgba(0, 0, 0, 0.5);
   position: relative;
   background: rgb(17, 24, 39);
@@ -1083,6 +1084,7 @@ defineExpose({
 }
 
 .overlay-header {
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   display: flex;

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -27,6 +27,7 @@ test.describe('SessionChatOverlay layout', () => {
 
   let project: any;
   let session: any;
+  const injectedViewportOffsetTop = 260;
 
   test.beforeEach(async () => {
     project = await seedProject('Overlay Layout', '/tmp/overlay-layout');
@@ -99,6 +100,7 @@ test.describe('SessionChatOverlay layout', () => {
         backdrop: rectFor('[data-testid="session-chat-overlay"]'),
         panel: rectFor('.overlay-panel-wrapper'),
         content: rectFor('.overlay-content'),
+        header: rectFor('.overlay-header'),
         inner: { w: window.innerWidth, h: window.innerHeight },
         inline: {
           top: s.top,
@@ -184,7 +186,7 @@ test.describe('SessionChatOverlay layout', () => {
     expect(computed.left).toBe('0px');
   });
 
-  test('narrow phone-sized layouts ignore stale visual viewport CSS variables', async ({ page }) => {
+  test('narrow phone-sized shell geometry ignores stale visual viewport CSS variables', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await navigateToSession(page);
     await openOverlay(page);
@@ -201,7 +203,7 @@ test.describe('SessionChatOverlay layout', () => {
     }
   });
 
-  test('744px tablet-sized layouts ignore stale visual viewport CSS variables', async ({ page }) => {
+  test('744px tablet-sized shell geometry ignores stale visual viewport CSS variables', async ({ page }) => {
     await page.setViewportSize({ width: 744, height: 1000 });
     await navigateToSession(page);
     await openOverlay(page);
@@ -241,6 +243,27 @@ test.describe('SessionChatOverlay layout', () => {
       expect(result.panel.width).toBeGreaterThan(0);
       expect(result.content.top).toBeLessThanOrEqual(1);
       expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+    } finally {
+      await clearStaleVisualViewportVariables(page);
+    }
+  });
+
+  test('visual viewport top offset aligns the overlay header without moving the shell', async ({ page }) => {
+    await page.setViewportSize({ width: 744, height: 1000 });
+    await navigateToSession(page);
+    await openOverlay(page);
+
+    await injectStaleVisualViewportVariables(page);
+
+    try {
+      const result = await readOverlayLayout(page);
+      expectBackdropCoversViewport(result);
+      expect(result.panel.top).toBeLessThanOrEqual(1);
+      expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.content.top).toBeLessThanOrEqual(1);
+      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.header.top).toBeGreaterThanOrEqual(injectedViewportOffsetTop - 1);
+      expect(result.header.top).toBeLessThanOrEqual(injectedViewportOffsetTop + 1);
     } finally {
       await clearStaleVisualViewportVariables(page);
     }


### PR DESCRIPTION
## Summary
- Apply the visual viewport top offset as overlay content padding so the header stays visible after iPad keyboard dismissal.
- Keep the backdrop and panel pinned to the layout viewport to avoid reintroducing the bottom gap regression.
- Add unit and Playwright coverage for the scoped offset contract.

## Tests
- yarn workspace @circuschief/web test -- SessionChatOverlay.test.js
- ./scripts/pw.sh test tests/e2e/session-chat-overlay-layout.spec.ts

## Notes
- Real-device iPad Safari QA is still recommended because Chromium emulation does not reproduce WebKit visual viewport behavior exactly.