### PR TITLE
Move draft summary empty state into overview card

### DIFF
--- a/packages/web/src/components/SessionOverviewCard.test.js
+++ b/packages/web/src/components/SessionOverviewCard.test.js
@@ -118,6 +118,21 @@ describe('SessionOverviewCard.vue', () => {
       expect(wrapper.find('.session-overview').exists()).toBe(true);
       expect(wrapper.find('.overview-header').exists()).toBe(false);
     });
+
+    it('renders the not-started summary state inside the overview card', async () => {
+      const wrapper = mountComponent({
+        hasMetrics: true,
+        formattedDuration: '1m',
+        showNotStartedState: true,
+      });
+
+      expect(wrapper.find('.session-overview').exists()).toBe(true);
+      expect(wrapper.find('.overview-summary-empty').exists()).toBe(true);
+      expect(wrapper.text()).toContain("This session hasn't started yet.");
+      expect(wrapper.text()).toContain('Start the session or send a message to see a summary here.');
+      expect(wrapper.find('.overview-summary-empty button').exists()).toBe(false);
+      expect(wrapper.find('.overview-summary-empty').text()).not.toContain('Generate summary');
+    });
   });
 
 });

--- a/packages/web/src/components/SessionOverviewCard.vue
+++ b/packages/web/src/components/SessionOverviewCard.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    v-if="hasPrInfo || summary?.shortSummary || hasMetrics || scheduledSessions?.length > 0 || loading"
+    v-if="hasPrInfo || summary?.shortSummary || hasMetrics || scheduledSessions?.length > 0 || loading || showNotStartedState"
     class="session-overview card"
   >
     <div
-      v-if="hasPrInfo || summary?.shortSummary || hasMetrics || loading"
+      v-if="hasPrInfo || summary?.shortSummary || hasMetrics || loading || showNotStartedState"
       class="overview-header"
     >
       <h3>Session Overview</h3>
@@ -25,6 +25,17 @@
     >
       <span class="loading-spinner-small" />
       <span>Loading summary...</span>
+    </div>
+    <div
+      v-else-if="showNotStartedState"
+      class="overview-summary overview-summary-empty"
+    >
+      <p class="summary-empty-text">
+        This session hasn't started yet.
+      </p>
+      <p class="summary-empty-hint">
+        Start the session or send a message to see a summary here.
+      </p>
     </div>
 
     <!-- Overview Metrics -->
@@ -204,6 +215,10 @@ defineProps({
     type: String,
     default: null,
   },
+  showNotStartedState: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 </script>
@@ -236,10 +251,28 @@ defineProps({
   font-size: 0.875rem;
 }
 
+.overview-summary-empty {
+  text-align: center;
+}
+
 .overview-summary .summary-text {
   margin: 0 0 0.5rem;
   font-size: 0.875rem;
   color: var(--color-text);
+  line-height: 1.4;
+}
+
+.summary-empty-text {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--color-text);
+  margin: 0 0 0.5rem;
+}
+
+.summary-empty-hint {
+  font-size: 0.875rem;
+  color: var(--color-text-soft);
+  margin: 0;
   line-height: 1.4;
 }
 

--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -966,51 +966,27 @@ describe('SummaryTab', () => {
       expect(wrapper.find('.summary-empty-state').exists()).toBe(true);
       expect(wrapper.text()).toContain("This session hasn't started yet.");
       expect(wrapper.text()).toContain('Start the session or send a message to see a summary here.');
-      expect(wrapper.find('.summary-empty-state .summary-generate-action').exists()).toBe(true);
-      expect(wrapper.find('.summary-empty-state .summary-generate-action').text()).toContain('Generate summary');
+      expect(wrapper.find('.summary-empty-state button').exists()).toBe(false);
+      expect(wrapper.find('.summary-empty-state').text()).not.toContain('Generate summary');
     });
 
-    it('generates and renders a missing summary from the empty state', async () => {
-      api.generateSessionSummary.mockResolvedValue({
-        shortSummary: 'Generated summary',
-        fullSummary: 'Generated full summary text',
-      });
+    it('renders not-started state inside the overview card when overview content is present', async () => {
+      sessionsStore.currentSession = {
+        id: 'sess-123',
+        status: 'waiting',
+        activeTimeMs: 60000,
+      };
+      sessionsStore.sessions = [sessionsStore.currentSession];
 
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      await wrapper.find('.summary-empty-state .summary-generate-action').trigger('click');
-      await flushAll(wrapper);
-
-      expect(api.generateSessionSummary).toHaveBeenCalledWith('sess-123');
-      expect(wrapper.findComponent({ name: 'SummaryContent' }).exists()).toBe(true);
-      expect(wrapper.text()).toContain('Generated full summary text');
-    });
-
-    it('disables the missing-summary generate action while generation is pending', async () => {
-      let resolveGenerate;
-      api.generateSessionSummary.mockReturnValue(new Promise((resolve) => {
-        resolveGenerate = resolve;
-      }));
-
-      const wrapper = mountComponent();
-      await flushAll(wrapper);
-
-      const generateButton = wrapper.find('.summary-empty-state .summary-generate-action');
-      await generateButton.trigger('click');
-      await nextTick();
-
-      expect(generateButton.attributes('disabled')).toBeDefined();
-      expect(generateButton.find('.loading-spinner').exists()).toBe(true);
-
-      resolveGenerate({
-        shortSummary: 'Generated summary',
-        fullSummary: 'Generated after pending',
-      });
-      await flushAll(wrapper);
-
-      expect(wrapper.findComponent({ name: 'SummaryContent' }).exists()).toBe(true);
-      expect(wrapper.text()).toContain('Generated after pending');
+      expect(wrapper.find('.session-overview').exists()).toBe(true);
+      expect(wrapper.find('.summary-empty-state').exists()).toBe(false);
+      expect(wrapper.find('.session-overview .overview-summary-empty').exists()).toBe(true);
+      expect(wrapper.find('.session-overview').text()).toContain("This session hasn't started yet.");
+      expect(wrapper.find('.session-overview .overview-summary-empty button').exists()).toBe(false);
+      expect(wrapper.find('.session-overview .overview-summary-empty').text()).not.toContain('Generate summary');
     });
 
     it('does not show empty state while loading', async () => {

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -24,6 +24,7 @@
       :has-warnings="hasWarnings"
       :scheduled-sessions="allScheduledSessions"
       :project-id="projectId"
+      :show-not-started-state="showNotStartedStateInOverview"
     />
 
     <div
@@ -52,7 +53,7 @@
 
     <!-- Empty state for sessions with no content -->
     <div
-      v-else-if="!latestResponse && !isRunning"
+      v-else-if="showStandaloneNotStartedState"
       class="summary-empty-state"
     >
       <div class="summary-empty-state-content">
@@ -62,17 +63,6 @@
         <p class="summary-empty-state-hint">
           Start the session or send a message to see a summary here.
         </p>
-        <button
-          class="btn-link summary-generate-action"
-          :disabled="generatingManual"
-          @click="handleRegenerate"
-        >
-          <span
-            v-if="generatingManual"
-            class="loading-spinner"
-          />
-          Generate summary
-        </button>
       </div>
     </div>
 
@@ -213,6 +203,14 @@ const hasMetrics = computed(() =>
   sessionCount.value > 1 || hasNonZeroTokens.value || formattedDuration.value || filesCount.value > 0
 );
 
+const isNotStartedEmptyState = computed(() => !latestResponse.value && !isRunning.value);
+const showNotStartedStateInOverview = computed(() =>
+  Boolean(isNotStartedEmptyState.value && (hasMetrics.value || allScheduledSessions.value.length > 0))
+);
+const showStandaloneNotStartedState = computed(() =>
+  Boolean(isNotStartedEmptyState.value && !showNotStartedStateInOverview.value)
+);
+
 onMounted(async () => {
   loading.value = true;
   try {
@@ -312,10 +310,6 @@ async function handleRegenerate() {
   color: var(--color-text-soft);
   margin: 0;
   line-height: 1.4;
-}
-
-.summary-generate-action {
-  margin-top: 1rem;
 }
 
 .missing-summary-action {


### PR DESCRIPTION
## Summary

- Move the draft/not-started empty state into `SessionOverviewCard` when overview content is present.
- Keep `SummaryTab` responsible for the standalone empty state only when there is no overview card.
- Hide the `Generate summary` link whenever the "This session hasn't started yet." message is displayed, while preserving generation for missing summaries after output exists.

## Verification

- `yarn workspace @circuschief/web test SummaryTab.test.js SessionOverviewCard.test.js`
