### PR TITLE
Remove duplicate canvas modified timestamp from detail view

### DIFF
--- a/packages/web/src/components/CanvasFileViewer.test.js
+++ b/packages/web/src/components/CanvasFileViewer.test.js
@@ -251,7 +251,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.exists()).toBe(true);
       expect(metaElement.text()).toBe('');
     });
@@ -269,7 +269,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.exists()).toBe(true);
       expect(metaElement.text()).toBe('Modified just now');
     });
@@ -288,7 +288,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.text()).toBe('Modified 5m ago');
     });
 
@@ -306,7 +306,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.text()).toBe('Modified 2h ago');
     });
 
@@ -324,7 +324,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.text()).toBe('Modified 3d ago');
     });
 
@@ -342,7 +342,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.text()).toBe('Modified 1m ago');
     });
 
@@ -360,7 +360,7 @@ describe('CanvasFileViewer', () => {
         },
       });
 
-      const metaElement = wrapper.find('.viewer-meta');
+      const metaElement = wrapper.find('.viewer-header-bottom .viewer-meta');
       expect(metaElement.text()).toBe('Modified 1h ago');
     });
 
@@ -378,7 +378,7 @@ describe('CanvasFileViewer', () => {
       });
 
       // Initially shows "just now"
-      expect(wrapper.find('.viewer-meta').text()).toBe('Modified just now');
+      expect(wrapper.find('.viewer-header-bottom .viewer-meta').text()).toBe('Modified just now');
 
       // Update to an older timestamp
       const oneHourAgo = now - 60 * 60 * 1000;
@@ -395,7 +395,7 @@ describe('CanvasFileViewer', () => {
       await flushAll(wrapper);
 
       // Should now show "1h ago"
-      expect(wrapper.find('.viewer-meta').text()).toBe('Modified 1h ago');
+      expect(wrapper.find('.viewer-header-bottom .viewer-meta').text()).toBe('Modified 1h ago');
     });
   });
 

--- a/packages/web/src/components/CanvasFileViewerHeader.test.js
+++ b/packages/web/src/components/CanvasFileViewerHeader.test.js
@@ -99,10 +99,20 @@ describe('CanvasFileViewerHeader', () => {
     });
 
     it('displays modified timestamp in bottom container', () => {
-      const wrapper = mountComponent();
+      const updatedAt = Date.now() - 5 * 60 * 1000;
+      const wrapper = mountComponent({
+        item: {
+          id: '1',
+          filename: 'test-file.md',
+          type: 'markdown',
+          updatedAt,
+        },
+      });
 
       const bottomRow = wrapper.find('.viewer-header-bottom');
-      expect(bottomRow.find('.viewer-meta').exists()).toBe(true);
+      expect(wrapper.findAll('.viewer-meta')).toHaveLength(1);
+      expect(bottomRow.find('.viewer-meta').text()).toBe('Modified 5m ago');
+      expect(wrapper.find('.viewer-header-middle .viewer-meta').exists()).toBe(false);
     });
 
     it('displays untitled for missing filename', () => {

--- a/packages/web/src/components/CanvasFileViewerHeader.vue
+++ b/packages/web/src/components/CanvasFileViewerHeader.vue
@@ -21,7 +21,6 @@
       >/</span>
       <div class="viewer-filename-wrapper">
         <span class="viewer-filename">{{ item.filename || 'Untitled' }}</span>
-        <span class="viewer-meta">{{ formatLastModified(item.updatedAt) }}</span>
       </div>
 
       <div class="header-actions">


### PR DESCRIPTION
## Summary
- Remove duplicate modified timestamp from canvas file viewer header middle row
- Keep only the timestamp in the bottom row for a cleaner UI
- Update tests to verify only one timestamp is displayed

## Changes
- **CanvasFileViewerHeader.vue**: Remove the `<span class="viewer-meta">` timestamp from `.viewer-filename-wrapper` in the middle row
- **CanvasFileViewerHeader.test.js**: Add assertion to verify exactly one `.viewer-meta` exists and it's in the bottom row
- **CanvasFileViewer.test.js**: Update selectors from generic `.viewer-meta` to scoped `.viewer-header-bottom .viewer-meta` for more reliable tests

## Test plan
- [x] Run unit tests: `yarn workspace @circuschief/web test CanvasFileViewerHeader.test.js`
- [x] Run unit tests: `yarn workspace @circuschief/web test CanvasFileViewer.test.js`
- [ ] Visual check: Open a session with a canvas item and confirm only one "Modified ... ago" label appears in the header bottom row

🤖 Generated with [Claude Code](https://claude.com/claude-code)