### PR TITLE
Add refresh button to changes tab

### DIFF
--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -469,9 +469,9 @@ describe('ChangesTab', () => {
 
       // Should have mode toggle buttons + Expand/Collapse button
       const buttons = toolbar.findAll('button');
-      // At least 2 buttons: Local Changes + Expand/Collapse All
+      // At least 3 buttons: Local Changes + Expand/Collapse All + Refresh
       // (Compare to branch button only shows if defaultBranch is set)
-      expect(buttons.length).toBeGreaterThanOrEqual(2);
+      expect(buttons.length).toBeGreaterThanOrEqual(3);
       expect(toolbar.text()).toContain('Local Changes');
       expect(toolbar.text()).toMatch(/Expand All|Collapse All/);
     });
@@ -507,11 +507,12 @@ describe('ChangesTab', () => {
       const toolbar = wrapper.find('.changes-toolbar');
       expect(toolbar.exists()).toBe(true);
 
-      // Should have both mode toggle buttons
+      // Should have both mode toggle buttons + refresh button
       const buttons = toolbar.findAll('button');
-      expect(buttons.length).toBeGreaterThanOrEqual(2);
+      expect(buttons.length).toBeGreaterThanOrEqual(3);
       expect(toolbar.text()).toContain('Local Changes');
       expect(toolbar.text()).toContain('Compare to main');
+      expect(toolbar.text()).toContain('Refresh');
 
       // Should NOT show the Expand/Collapse button when there are no changes
       expect(toolbar.text()).not.toContain('Expand All');
@@ -1120,7 +1121,8 @@ index 1234567..abcdefg 100644
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
-      const button = wrapper.find('.btn-link');
+      const buttons = wrapper.findAll('.btn-link');
+      const button = buttons.find(b => b.text().includes('Expand All') || b.text().includes('Collapse All'));
       expect(button.text()).toBe('Expand All');
     });
 
@@ -1137,8 +1139,213 @@ index 1234567..abcdefg 100644
       wrapper.vm.toggleAllFiles(); // expand all
       await flushAll(wrapper);
 
-      const button = wrapper.find('.btn-link');
+      const buttons = wrapper.findAll('.btn-link');
+      const button = buttons.find(b => b.text().includes('Expand All') || b.text().includes('Collapse All'));
       expect(button.text()).toBe('Collapse All');
+    });
+  });
+
+  describe('refresh button', () => {
+    const stagedDiffFixture = `diff --git a/file1.js b/file1.js
+index 1234567..abcdefg 100644
+--- a/file1.js
++++ b/file1.js
+@@ -1,2 +1,3 @@
+ const x = 1;
++const y = 2;`;
+
+    it('renders refresh button in toolbar when changes are present', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      const refreshButton = wrapper.find('.refresh-button');
+      expect(refreshButton.exists()).toBe(true);
+      expect(refreshButton.text()).toContain('Refresh');
+    });
+
+    it('renders refresh button when no changes but defaultBranch exists', async () => {
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.refresh-button').exists()).toBe(true);
+    });
+
+    it('does not render refresh button when toolbar is hidden', async () => {
+      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
+      api.getSessionDefaultBranch.mockResolvedValue({ branch: null });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.find('.refresh-button').exists()).toBe(false);
+    });
+
+    it('calls fetchChanges when clicked', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      api.getSessionChanges.mockClear();
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const refreshButton = wrapper.find('.refresh-button');
+      await refreshButton.trigger('click');
+      await flushAll(wrapper);
+
+      expect(api.getSessionChanges).toHaveBeenCalledWith('test-session', 'local', null);
+      expect(api.getSessionChanges).toHaveBeenCalledTimes(1);
+    });
+
+    it('is disabled and shows spinner while refreshing', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Make next API call return a pending promise
+      let resolveRefresh;
+      api.getSessionChanges.mockImplementation(() => new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }));
+
+      const refreshButton = wrapper.find('.refresh-button');
+      await refreshButton.trigger('click');
+      await nextTick();
+      await wrapper.vm.$forceUpdate();
+      await nextTick();
+
+      // Button should be disabled
+      expect(refreshButton.attributes('disabled')).toBeDefined();
+      // Spinner should be visible
+      expect(refreshButton.find('.loading-spinner').exists()).toBe(true);
+      // Static icon should not be present
+      expect(refreshButton.text()).not.toContain('↻');
+
+      // Resolve the pending promise
+      resolveRefresh({ staged: stagedDiffFixture, unstaged: '', untracked: '' });
+      await flushAll(wrapper);
+
+      // After loading completes, spinner should be gone and static icon should return
+      const refreshedButton = wrapper.find('.refresh-button');
+      expect(refreshedButton.find('.loading-spinner').exists()).toBe(false);
+      expect(refreshedButton.text()).toContain('↻');
+    });
+
+    it('updates data after refresh completes', async () => {
+      const file2Diff = `diff --git a/file2.js b/file2.js
+index 1234567..abcdefg 100644
+--- a/file2.js
++++ b/file2.js
+@@ -1,2 +1,3 @@
+ const a = 1;
++const b = 2;`;
+
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.stagedFiles[0].displayPath).toBe('file1.js');
+
+      // Mock to return different data on refresh
+      api.getSessionChanges.mockResolvedValue({
+        staged: file2Diff,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const refreshButton = wrapper.find('.refresh-button');
+      await refreshButton.trigger('click');
+      await flushAll(wrapper);
+
+      expect(wrapper.vm.stagedFiles[0].displayPath).toBe('file2.js');
+    });
+
+    it('shows initial loading state on first mount', async () => {
+      let resolvePromise;
+      api.getSessionChanges.mockImplementation(() => new Promise((resolve) => {
+        resolvePromise = resolve;
+      }));
+
+      const wrapper = mountComponent();
+
+      await nextTick();
+      await wrapper.vm.$forceUpdate();
+      await nextTick();
+
+      // Full loading state should be shown
+      expect(wrapper.find('.loading-state').exists()).toBe(true);
+      // Toolbar should NOT be shown
+      expect(wrapper.find('.changes-toolbar').exists()).toBe(false);
+
+      // Resolve the promise
+      resolvePromise({ staged: '', unstaged: '', untracked: '' });
+      await flushAll(wrapper);
+
+      // After loading, the toolbar may or may not appear depending on data
+      // but the loading state should be gone
+      expect(wrapper.find('.loading-state').exists()).toBe(false);
+    });
+
+    it('keeps toolbar visible during refresh after initial load', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent();
+      await flushAll(wrapper);
+
+      // Toolbar should be visible after initial load
+      expect(wrapper.find('.changes-toolbar').exists()).toBe(true);
+
+      // Make next API call return a pending promise
+      let resolveRefresh;
+      api.getSessionChanges.mockImplementation(() => new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }));
+
+      const refreshButton = wrapper.find('.refresh-button');
+      await refreshButton.trigger('click');
+      await nextTick();
+      await wrapper.vm.$forceUpdate();
+      await nextTick();
+
+      // Toolbar should STILL be visible during refresh
+      expect(wrapper.find('.changes-toolbar').exists()).toBe(true);
+      // Full loading state should NOT be shown during refresh
+      expect(wrapper.find('.loading-state').exists()).toBe(false);
+
+      // Resolve to clean up
+      resolveRefresh({ staged: stagedDiffFixture, unstaged: '', untracked: '' });
+      await flushAll(wrapper);
     });
   });
 });

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="changes-tab">
     <div
-      v-if="loading"
+      v-if="initialLoading"
       class="loading-state"
     >
       <span class="loading-spinner" />
@@ -9,7 +9,7 @@
     </div>
 
     <div
-      v-else-if="error"
+      v-else-if="error && !hasLoaded"
       class="error-message"
     >
       {{ error }}
@@ -43,14 +43,26 @@
             Compare to {{ branchLabel }}
           </button>
         </div>
-        <button
-          v-if="hasChanges"
-          class="btn-link"
-          :disabled="loading"
-          @click="toggleAllFiles"
-        >
-          {{ allExpanded ? 'Collapse All' : 'Expand All' }}
-        </button>
+        <div class="toolbar-actions">
+          <button
+            v-if="hasChanges"
+            class="btn-link"
+            :disabled="loading"
+            @click="toggleAllFiles"
+          >
+            {{ allExpanded ? 'Collapse All' : 'Expand All' }}
+          </button>
+          <button
+            class="btn-link refresh-button"
+            :disabled="loading"
+            title="Refresh changes"
+            @click="fetchChanges"
+          >
+            <span v-if="loading" class="loading-spinner" />
+            <span v-else>↻</span>
+            Refresh
+          </button>
+        </div>
       </div>
 
       <!-- Empty state: Show when no changes in current mode -->
@@ -159,6 +171,9 @@ const loading = ref(false);
 const error = ref(null);
 const compareMode = ref('local');
 const defaultBranch = ref(null);
+const hasLoaded = ref(false);
+
+const initialLoading = computed(() => loading.value && !hasLoaded.value);
 
 // Per-mode state tracking for expand/collapse
 // Keys in expandedFiles are "section:filepath", e.g., "staged:src/api.js"
@@ -322,6 +337,7 @@ async function fetchChanges() {
 
     // Initialize mode state for the current mode after data is available
     initializeModeState(compareMode.value);
+    hasLoaded.value = true;
   } catch (err) {
     error.value = err.message;
   } finally {
@@ -503,5 +519,17 @@ defineExpose({
   letter-spacing: 0.05em;
   color: var(--color-text-soft);
   margin: 0;
+}
+
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.refresh-button .loading-spinner {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-width: 1.5px;
 }
 </style>


### PR DESCRIPTION
## Summary
- Adds a manual refresh button to the ChangesTab toolbar so users can reload git changes without waiting for polling or toggling compare modes
- Introduces an `initialLoading` vs `loading` distinction so the toolbar stays visible during refresh while still showing a full loading spinner on first mount
- The refresh button uses the existing `loading-spinner` component with a spinning animation while fetching, and is disabled during load to prevent double-fetches

## Test plan
- [x] 51 unit tests pass (43 existing + 8 new)
- [x] New tests cover: refresh button visibility in toolbar, visibility when no changes but defaultBranch exists, hidden when toolbar is hidden, calls fetchChanges on click, disabled + spinner while loading, data updates after refresh, initial loading state, toolbar stays visible during refresh
- [x] Updated 3 existing tests that broke due to new button count and `.btn-link` selector ambiguity
- [ ] Manual: verify refresh button works in browser with active session
- [ ] Manual: verify spinning animation during load
- [ ] Manual: verify button is disabled while loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)