### PR TITLE
Fix session chat overlay picker to sort by direct message recency

### DIFF
--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -74,6 +74,7 @@ export class SessionRepository extends BaseRepository {
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       lastActivityAt: row.last_activity_at ?? null,
+      lastMessageAt: row.last_message_at ?? null,
       activeTimeMs: row.active_time_ms || 0,
     };
   }

--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -1722,6 +1722,65 @@ describe('SessionRepository', () => {
     });
   });
 
+  describe('lastMessageAt', () => {
+    it('returns newest conversation message timestamp without changing broad activity semantics', () => {
+      const session = repo.create(projectId, 'Test', 'Prompt');
+      const now = Date.now();
+      const messageAt = now + 10_000;
+      const summaryActivity = now + 60_000;
+
+      repo.db
+        .prepare('UPDATE conversation_messages SET timestamp = ? WHERE session_id = ?')
+        .run(messageAt, session.id);
+      repo.db
+        .prepare(
+          `INSERT INTO session_summaries
+           (id, session_id, short_summary, full_summary, message_count, generated_at, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('summary-newer-than-message', session.id, 'Short', 'Full', 1, summaryActivity, now, summaryActivity);
+
+      const retrieved = repo.getById(session.id);
+
+      expect(retrieved.lastMessageAt).toBe(messageAt);
+      expect(retrieved.lastActivityAt).toBe(summaryActivity);
+    });
+
+    it('returns null when a waiting or scheduled session has no messages', () => {
+      const waiting = repo.create(projectId, 'Waiting', 'Prompt', { status: 'waiting' });
+      const scheduled = repo.create(projectId, 'Scheduled', 'Prompt', { status: 'scheduled' });
+
+      expect(repo.getById(waiting.id).lastMessageAt).toBeNull();
+      expect(repo.getById(scheduled.id).lastMessageAt).toBeNull();
+    });
+
+    it('is included on mapped sessions from repository list methods', () => {
+      const parent = repo.create(projectId, 'Parent', 'Prompt');
+      const child = repo.create(projectId, 'Child', 'Prompt', { parentSessionId: parent.id });
+      const prSession = repo.update(parent.id, { prUrl: 'https://github.com/org/repo/pull/123' });
+      const scheduled = repo.create(projectId, 'Scheduled', 'Prompt', { status: 'scheduled' });
+      repo.update(scheduled.id, { scheduledAt: Date.now() - 1000 });
+
+      const results = [
+        repo.getById(parent.id),
+        repo.getByProjectId(projectId).find(s => s.id === parent.id),
+        repo.getActiveAndWaiting().find(s => s.id === parent.id),
+        repo.getChildSessions(parent.id).find(s => s.id === child.id),
+        repo.getSessionsWithPrUrls().find(s => s.id === prSession.id),
+        repo.getScheduledSessions().find(s => s.id === scheduled.id),
+        repo.getScheduledSessionsDue(Date.now()).find(s => s.id === scheduled.id),
+      ];
+
+      for (const session of results) {
+        expect(session).toBeDefined();
+        expect(session).toHaveProperty('lastMessageAt');
+      }
+      expect(results[0].lastMessageAt).toBeTypeOf('number');
+      expect(results[5].lastMessageAt).toBeNull();
+      expect(results[6].lastMessageAt).toBeNull();
+    });
+  });
+
   describe('activeTimeMs', () => {
     it('returns 0 for a session with no messages', () => {
       const session = repo.create(projectId, 'Test', 'Prompt', 'standard', false, null, null, 'waiting');

--- a/packages/server/src/db/session-helpers.js
+++ b/packages/server/src/db/session-helpers.js
@@ -28,6 +28,11 @@ export const ACTIVITY_FIELDS_SQL = `
     )
     WHERE activity_at IS NOT NULL
   ) AS last_activity_at,
+  (
+    SELECT MAX(cm.timestamp)
+    FROM conversation_messages cm
+    WHERE cm.session_id = s.id
+  ) AS last_message_at,
   (CAST(
     CASE
       WHEN (SELECT MAX(cm2.timestamp) FROM conversation_messages cm2 WHERE cm2.session_id = s.id) IS NOT NULL

--- a/packages/web/src/components/SessionChatPicker.test.js
+++ b/packages/web/src/components/SessionChatPicker.test.js
@@ -8,6 +8,7 @@ describe('SessionChatPicker', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    const now = Date.now();
 
     sessions = [
       {
@@ -15,9 +16,11 @@ describe('SessionChatPicker', () => {
           id: 'root-1',
           name: 'Root Session',
           status: 'completed',
-          createdAt: Date.now() - 7200000,
-          lastActivityAt: Date.now() - 3600000,
+          createdAt: now - 7200000,
+          lastActivityAt: now - 3600000,
         },
+        pickerTimestamp: now - 3600000,
+        pickerTimestampSource: 'lastMessageAt',
         depth: 0,
       },
       {
@@ -25,9 +28,11 @@ describe('SessionChatPicker', () => {
           id: 'child-1',
           name: 'Child Session 1',
           status: 'running',
-          createdAt: Date.now() - 3600000,
-          lastActivityAt: Date.now() - 1800000,
+          createdAt: now - 3600000,
+          lastActivityAt: now - 1800000,
         },
+        pickerTimestamp: now - 1800000,
+        pickerTimestampSource: 'lastMessageAt',
         depth: 1,
       },
       {
@@ -35,9 +40,11 @@ describe('SessionChatPicker', () => {
           id: 'child-2',
           name: 'Child Session 2',
           status: 'waiting',
-          createdAt: Date.now() - 1800000,
-          lastActivityAt: Date.now() - 900000,
+          createdAt: now - 1800000,
+          lastActivityAt: now - 900000,
         },
+        pickerTimestamp: now - 900000,
+        pickerTimestampSource: 'lastMessageAt',
         depth: 1,
       },
     ];
@@ -177,6 +184,16 @@ describe('SessionChatPicker', () => {
       expect(items[0].find('.picker-item-name').text()).toBe('Root Session');
       expect(items[1].find('.picker-item-name').text()).toBe('Child Session 1');
       expect(items[2].find('.picker-item-name').text()).toBe('Child Session 2');
+    });
+
+    it('renders items in the same order as the sessions prop', () => {
+      const unorderedSessions = [
+        { session: { id: 'older', name: 'Older', status: 'completed' }, pickerTimestamp: 1000, pickerTimestampSource: 'lastMessageAt', depth: 0 },
+        { session: { id: 'newer', name: 'Newer', status: 'completed' }, pickerTimestamp: 9000, pickerTimestampSource: 'lastMessageAt', depth: 0 },
+      ];
+      const wrapper = mountComponent({ sessions: unorderedSessions, activeSessionId: 'older' });
+      const names = wrapper.findAll('.picker-item-name').map(item => item.text());
+      expect(names).toEqual(['Older', 'Newer']);
     });
 
     it('truncates long session names with CSS', () => {
@@ -325,16 +342,16 @@ describe('SessionChatPicker', () => {
       });
     });
 
-    it('renders lastActivityAt when present with "Last activity" tooltip', () => {
+    it('renders pickerTimestamp with source-specific tooltip', () => {
       const wrapper = mountComponent();
       const firstItem = wrapper.findAll('.picker-item')[0];
       const dateEl = firstItem.find('.picker-item-date');
-      expect(dateEl.attributes('title')).toBe('Last activity');
+      expect(dateEl.attributes('title')).toContain('Last message:');
       expect(dateEl.text()).not.toBe('—');
       expect(dateEl.text().length).toBeGreaterThan(0);
     });
 
-    it('renders "—" placeholder with "No activity yet" tooltip when lastActivityAt is null', () => {
+    it('renders "—" placeholder with "No activity yet" tooltip when pickerTimestamp is null', () => {
       const wrapper = mountComponent({
         sessions: [{
           session: {
@@ -344,6 +361,8 @@ describe('SessionChatPicker', () => {
             createdAt: Date.now(),
             lastActivityAt: null,
           },
+          pickerTimestamp: null,
+          pickerTimestampSource: 'none',
           depth: 0,
         }],
         activeSessionId: 's-null',
@@ -354,18 +373,39 @@ describe('SessionChatPicker', () => {
       expect(dateEl.text()).toBe('—');
     });
 
-    it('flips tooltip between "Last activity" and "No activity yet" based on value', () => {
+    it('shows timestamp source labels for message, updated, created, and none entries', () => {
+      const timestamp = Date.now();
       const wrapper = mountComponent({
         sessions: [
-          { session: { id: 'has', name: 'Has', status: 'completed', createdAt: Date.now(), lastActivityAt: Date.now() }, depth: 0 },
-          { session: { id: 'none', name: 'None', status: 'waiting', createdAt: Date.now(), lastActivityAt: null }, depth: 0 },
+          { session: { id: 'message', name: 'Message', status: 'completed' }, pickerTimestamp: timestamp, pickerTimestampSource: 'lastMessageAt', depth: 0 },
+          { session: { id: 'updated', name: 'Updated', status: 'completed' }, pickerTimestamp: timestamp, pickerTimestampSource: 'updatedAt', depth: 0 },
+          { session: { id: 'created', name: 'Created', status: 'completed' }, pickerTimestamp: timestamp, pickerTimestampSource: 'createdAt', depth: 0 },
+          { session: { id: 'none', name: 'None', status: 'waiting' }, pickerTimestamp: null, pickerTimestampSource: 'none', depth: 0 },
         ],
-        activeSessionId: 'has',
+        activeSessionId: 'message',
         summaries: {},
       });
       const items = wrapper.findAll('.picker-item');
-      expect(items[0].find('.picker-item-date').attributes('title')).toBe('Last activity');
-      expect(items[1].find('.picker-item-date').attributes('title')).toBe('No activity yet');
+      expect(items[0].find('.picker-item-date').attributes('title')).toContain('Last message:');
+      expect(items[1].find('.picker-item-date').attributes('title')).toContain('Updated:');
+      expect(items[2].find('.picker-item-date').attributes('title')).toContain('Created:');
+      expect(items[3].find('.picker-item-date').attributes('title')).toBe('No activity yet');
+    });
+
+    it('uses full timestamp titles when visible labels are the same minute', () => {
+      const base = new Date('2026-05-12T12:34:05.000Z').getTime();
+      const wrapper = mountComponent({
+        sessions: [
+          { session: { id: 'first', name: 'First', status: 'completed', lastActivityAt: 1 }, pickerTimestamp: base, pickerTimestampSource: 'lastMessageAt', depth: 0 },
+          { session: { id: 'second', name: 'Second', status: 'completed', lastActivityAt: 2 }, pickerTimestamp: base + 30_000, pickerTimestampSource: 'lastMessageAt', depth: 0 },
+        ],
+        activeSessionId: 'first',
+        summaries: {},
+      });
+      const dates = wrapper.findAll('.picker-item-date');
+      expect(dates[0].text()).toBe(dates[1].text());
+      expect(dates[0].attributes('title')).not.toBe(dates[1].attributes('title'));
+      expect(dates[0].attributes('title')).not.toContain('Last activity');
     });
   });
 

--- a/packages/web/src/components/SessionChatPicker.vue
+++ b/packages/web/src/components/SessionChatPicker.vue
@@ -42,8 +42,8 @@
         <span class="picker-item-summary">{{ getSummaryText(entry.session.id) }}</span>
         <span
           class="picker-item-date"
-          :title="entry.session.lastActivityAt ? 'Last activity' : 'No activity yet'"
-        >{{ entry.session.lastActivityAt ? formatDate(entry.session.lastActivityAt) : '—' }}</span>
+          :title="getTimestampTitle(entry)"
+        >{{ entry.pickerTimestamp ? formatDate(entry.pickerTimestamp) : '—' }}</span>
       </div>
     </div>
   </div>
@@ -107,6 +107,23 @@ function formatDate(timestamp) {
   const diffMs = now - date;
   if (diffMs < 86400000) return `at ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
   return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function formatFullDate(timestamp) {
+  if (!timestamp) return '';
+  return new Date(timestamp).toLocaleString();
+}
+
+function getTimestampSourceLabel(source) {
+  if (source === 'lastMessageAt') return 'Last message';
+  if (source === 'updatedAt') return 'Updated';
+  if (source === 'createdAt') return 'Created';
+  return 'No activity yet';
+}
+
+function getTimestampTitle(entry) {
+  if (!entry?.pickerTimestamp) return 'No activity yet';
+  return `${getTimestampSourceLabel(entry.pickerTimestampSource)}: ${formatFullDate(entry.pickerTimestamp)}`;
 }
 
 function handleKeydown(event) {

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -4728,11 +4728,11 @@ describe('Sessions Store', () => {
         expect(store.messages).toHaveLength(1);
       });
 
-      it('bumps lastActivityAt on the session in the list when a new message arrives', () => {
+      it('bumps lastActivityAt and lastMessageAt on the session in the list when a new message arrives', () => {
         const store = useSessionsStore();
         store.sessions = [
-          { id: 'session-1', name: 'S1', lastActivityAt: 1000 },
-          { id: 'session-2', name: 'S2', lastActivityAt: 2000 },
+          { id: 'session-1', name: 'S1', lastActivityAt: 1000, lastMessageAt: 900 },
+          { id: 'session-2', name: 'S2', lastActivityAt: 2000, lastMessageAt: 2000 },
         ];
         store.currentSession = { id: 'session-1' };
 
@@ -4740,40 +4740,44 @@ describe('Sessions Store', () => {
 
         const updated = store.sessions.find((s) => s.id === 'session-1');
         expect(updated.lastActivityAt).toBe(5000);
+        expect(updated.lastMessageAt).toBe(5000);
         // Unrelated sessions are not affected.
         const other = store.sessions.find((s) => s.id === 'session-2');
         expect(other.lastActivityAt).toBe(2000);
+        expect(other.lastMessageAt).toBe(2000);
       });
 
-      it('never moves lastActivityAt backwards', () => {
+      it('never moves lastActivityAt or lastMessageAt backwards', () => {
         const store = useSessionsStore();
-        store.sessions = [{ id: 'session-1', name: 'S1', lastActivityAt: 5000 }];
+        store.sessions = [{ id: 'session-1', name: 'S1', lastActivityAt: 5000, lastMessageAt: 4500 }];
         store.currentSession = { id: 'session-1' };
 
         store.addMessage({ id: 'msg-1', sessionId: 'session-1', content: 'stale', timestamp: 1000 });
 
         const updated = store.sessions.find((s) => s.id === 'session-1');
         expect(updated.lastActivityAt).toBe(5000);
+        expect(updated.lastMessageAt).toBe(4500);
       });
 
-      it('bumps lastActivityAt for a different session than the current one', () => {
+      it('bumps lastActivityAt and lastMessageAt for a different session than the current one', () => {
         const store = useSessionsStore();
         store.sessions = [
-          { id: 'session-a', name: 'A', lastActivityAt: 1000 },
-          { id: 'session-b', name: 'B', lastActivityAt: 2000 },
+          { id: 'session-a', name: 'A', lastActivityAt: 1000, lastMessageAt: 1000 },
+          { id: 'session-b', name: 'B', lastActivityAt: 2000, lastMessageAt: 1500 },
         ];
         store.currentSession = { id: 'session-a' };
 
         store.addMessage({ id: 'msg-b', sessionId: 'session-b', content: 'background', timestamp: 9000 });
 
-        // lastActivityAt on the background session is still updated for list re-sorting.
+        // Timestamps on the background session are still updated for list re-sorting.
         const b = store.sessions.find((s) => s.id === 'session-b');
         expect(b.lastActivityAt).toBe(9000);
+        expect(b.lastMessageAt).toBe(9000);
         // The guard still prevents the message from being appended to the current session's messages.
         expect(store.messages).toHaveLength(0);
       });
 
-      it('bumps lastActivityAt when currentSession is null', () => {
+      it('adds lastMessageAt to existing sessions that do not have it yet', () => {
         const store = useSessionsStore();
         store.sessions = [{ id: 'session-1', name: 'S1', lastActivityAt: 1000 }];
         store.currentSession = null;
@@ -4782,6 +4786,7 @@ describe('Sessions Store', () => {
 
         const updated = store.sessions.find((s) => s.id === 'session-1');
         expect(updated.lastActivityAt).toBe(4000);
+        expect(updated.lastMessageAt).toBe(4000);
       });
     });
 

--- a/packages/web/src/stores/sessions/perSessionActions.js
+++ b/packages/web/src/stores/sessions/perSessionActions.js
@@ -67,25 +67,30 @@ export const perSessionActions = {
   addMessage(message) {
     // Bump list ordering for ALL inbound messages so background sessions re-sort
     // live in the project session list, not only the currently-open session.
-    this._bumpLastActivityAt(message);
+    this._bumpActivityTimestamps(message);
     if (this.currentSession && message.sessionId && message.sessionId !== this.currentSession.id) return;
     if (!this.messages.some(m => m.id === message.id)) this.messages.push(message);
   },
 
   /**
-   * Bump the `lastActivityAt` timestamp on the session lists so the session list
-   * view re-sorts and re-renders as new conversation turns arrive. Never moves
-   * the value backwards.
+   * Bump conversation-derived timestamps on the session lists so session views
+   * re-sort and re-render as new conversation turns arrive. Never moves either
+   * value backwards.
    */
-  _bumpLastActivityAt(message) {
+  _bumpActivityTimestamps(message) {
     if (!message?.sessionId) return;
     if (typeof this._updateSessionInAllLists !== 'function') return;
     const ts = message.timestamp ?? Date.now();
     const existing = this._findSessionById ? this._findSessionById(message.sessionId) : null;
-    const currentValue = existing?.lastActivityAt ?? 0;
-    if (!currentValue || ts > currentValue) {
-      this._updateSessionInAllLists(message.sessionId, { lastActivityAt: ts });
-    }
+    const updates = {};
+
+    const currentLastActivityAt = existing?.lastActivityAt ?? 0;
+    if (!currentLastActivityAt || ts > currentLastActivityAt) updates.lastActivityAt = ts;
+
+    const currentLastMessageAt = existing?.lastMessageAt ?? 0;
+    if (!currentLastMessageAt || ts > currentLastMessageAt) updates.lastMessageAt = ts;
+
+    if (Object.keys(updates).length > 0) this._updateSessionInAllLists(message.sessionId, updates);
   },
 
   // ==================== WORK LOG ACTIONS ====================

--- a/packages/web/src/utils/sessionPickerRecency.js
+++ b/packages/web/src/utils/sessionPickerRecency.js
@@ -1,0 +1,57 @@
+export function toTimestamp(value) {
+  if (value === null || value === undefined || value === '') return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function getSessionPickerRecency(session) {
+  // Use a fallback chain instead of MAX: lastMessageAt is the primary signal
+  // for "direct message recency". Only fall back to updatedAt when there are
+  // no messages, because updatedAt gets bumped by internal status changes
+  // (agent start, error, etc.) that are not user-visible "activity".
+  const lastMsg = toTimestamp(session?.lastMessageAt);
+  if (lastMsg > 0) return { source: 'lastMessageAt', time: lastMsg };
+
+  const updated = toTimestamp(session?.updatedAt);
+  if (updated > 0) return { source: 'updatedAt', time: updated };
+
+  const created = toTimestamp(session?.createdAt);
+  if (created > 0) return { source: 'createdAt', time: created };
+
+  return { source: 'none', time: 0 };
+}
+
+export function getSessionPickerRecentTime(session) {
+  return getSessionPickerRecency(session).time;
+}
+
+export function compareSessionChainEntries(a, b) {
+  const aSession = a?.session || {};
+  const bSession = b?.session || {};
+  const comparisons = [
+    getSessionPickerRecentTime(bSession) - getSessionPickerRecentTime(aSession),
+    toTimestamp(bSession.createdAt) - toTimestamp(aSession.createdAt),
+  ];
+  const firstDifference = comparisons.find(value => value !== 0);
+  if (firstDifference) return firstDifference;
+  return String(aSession.id || '').localeCompare(String(bSession.id || ''));
+}
+
+export function withPickerTimestamp(entry) {
+  const recency = getSessionPickerRecency(entry?.session);
+  return {
+    ...entry,
+    pickerTimestamp: recency.time || null,
+    pickerTimestampSource: recency.source,
+  };
+}
+
+export function sortSessionChain(entries) {
+  return [...entries].sort(compareSessionChainEntries).map(withPickerTimestamp);
+}

--- a/packages/web/src/utils/sessionPickerRecency.test.js
+++ b/packages/web/src/utils/sessionPickerRecency.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareSessionChainEntries,
+  getSessionPickerRecency,
+  sortSessionChain,
+  toTimestamp,
+  withPickerTimestamp,
+} from './sessionPickerRecency.js';
+
+describe('sessionPickerRecency', () => {
+  describe('toTimestamp', () => {
+    it('normalizes numeric, numeric string, and ISO timestamp values', () => {
+      expect(toTimestamp(1234)).toBe(1234);
+      expect(toTimestamp('5678')).toBe(5678);
+      expect(toTimestamp('2026-05-12T12:00:00.000Z')).toBe(
+        Date.parse('2026-05-12T12:00:00.000Z')
+      );
+    });
+
+    it('returns 0 for missing, empty, and invalid timestamp values', () => {
+      expect(toTimestamp(null)).toBe(0);
+      expect(toTimestamp(undefined)).toBe(0);
+      expect(toTimestamp('')).toBe(0);
+      expect(toTimestamp('   ')).toBe(0);
+      expect(toTimestamp(Number.NaN)).toBe(0);
+      expect(toTimestamp('not-a-date')).toBe(0);
+    });
+  });
+
+  describe('getSessionPickerRecency', () => {
+    it('prefers lastMessageAt over newer updatedAt and createdAt values', () => {
+      expect(getSessionPickerRecency({
+        lastMessageAt: 1000,
+        updatedAt: 9000,
+        createdAt: 8000,
+      })).toEqual({ source: 'lastMessageAt', time: 1000 });
+    });
+
+    it('falls back from missing or invalid lastMessageAt to updatedAt, then createdAt', () => {
+      expect(getSessionPickerRecency({
+        lastMessageAt: null,
+        updatedAt: 2000,
+        createdAt: 1000,
+      })).toEqual({ source: 'updatedAt', time: 2000 });
+
+      expect(getSessionPickerRecency({
+        lastMessageAt: 'invalid',
+        updatedAt: '',
+        createdAt: 1000,
+      })).toEqual({ source: 'createdAt', time: 1000 });
+    });
+
+    it('returns none when no usable timestamp is available', () => {
+      expect(getSessionPickerRecency({
+        lastMessageAt: null,
+        updatedAt: 'invalid',
+        createdAt: undefined,
+      })).toEqual({ source: 'none', time: 0 });
+    });
+  });
+
+  describe('sortSessionChain', () => {
+    it('sorts by picker recency and annotates entries with timestamp metadata', () => {
+      const entries = [
+        { session: { id: 'root', lastMessageAt: 1000, updatedAt: 9000, createdAt: 500 }, depth: 0 },
+        { session: { id: 'child-a', lastMessageAt: null, updatedAt: 3000, createdAt: 500 }, depth: 1 },
+        { session: { id: 'child-b', lastMessageAt: 4000, updatedAt: 2000, createdAt: 500 }, depth: 1 },
+      ];
+
+      const sorted = sortSessionChain(entries);
+
+      expect(sorted.map(entry => entry.session.id)).toEqual(['child-b', 'child-a', 'root']);
+      expect(sorted.map(entry => entry.pickerTimestamp)).toEqual([4000, 3000, 1000]);
+      expect(sorted.map(entry => entry.pickerTimestampSource)).toEqual([
+        'lastMessageAt',
+        'updatedAt',
+        'lastMessageAt',
+      ]);
+    });
+
+    it('uses createdAt and then id as stable tie breakers', () => {
+      const entries = [
+        { session: { id: 'b', lastMessageAt: 1000, createdAt: 100 }, depth: 0 },
+        { session: { id: 'a', lastMessageAt: 1000, createdAt: 100 }, depth: 0 },
+        { session: { id: 'newer-created', lastMessageAt: 1000, createdAt: 200 }, depth: 0 },
+      ];
+
+      expect(sortSessionChain(entries).map(entry => entry.session.id)).toEqual([
+        'newer-created',
+        'a',
+        'b',
+      ]);
+    });
+
+    it('does not mutate the original entries', () => {
+      const entries = [
+        { session: { id: 'older', lastMessageAt: 1000 }, depth: 0 },
+        { session: { id: 'newer', lastMessageAt: 2000 }, depth: 1 },
+      ];
+
+      const sorted = sortSessionChain(entries);
+
+      expect(entries.map(entry => entry.session.id)).toEqual(['older', 'newer']);
+      expect(entries[0]).not.toHaveProperty('pickerTimestamp');
+      expect(sorted).not.toBe(entries);
+    });
+  });
+
+  it('withPickerTimestamp preserves the entry while adding picker metadata', () => {
+    const entry = { session: { id: 'session-1', updatedAt: 1000 }, depth: 2 };
+
+    expect(withPickerTimestamp(entry)).toEqual({
+      ...entry,
+      pickerTimestamp: 1000,
+      pickerTimestampSource: 'updatedAt',
+    });
+  });
+
+  it('compareSessionChainEntries orders newer picker recency first', () => {
+    expect(compareSessionChainEntries(
+      { session: { id: 'older', lastMessageAt: 1000 } },
+      { session: { id: 'newer', lastMessageAt: 2000 } }
+    )).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -3195,7 +3195,7 @@ describe('SessionDetailView', () => {
       // Populate the sessions store with parent and a non-running child
       sessionsStore.sessions = [
         { id: 'parent-1', name: 'Parent Session', status: 'waiting', projectId: 'proj-1', parentSessionId: null },
-        { id: 'child-1', parentId: 'parent-1', name: 'Waiting Child', status: 'waiting', updatedAt: '2025-01-01T00:00:00Z', parentSessionId: 'parent-1' },
+        { id: 'child-1', parentId: 'parent-1', name: 'Waiting Child', status: 'waiting', parentSessionId: 'parent-1' },
       ];
 
       sessionsStore.currentSession = sessionsStore.sessions[0];
@@ -3223,12 +3223,12 @@ describe('SessionDetailView', () => {
       expect(wrapper.vm.overlaySessionId).toBe('parent-1');
     });
 
-    it('overlaySessionId picks the most recently updated running child', async () => {
+    it('overlaySessionId picks the running child with newest picker recency', async () => {
       // Populate the sessions store with parent and multiple children
       sessionsStore.sessions = [
         { id: 'parent-1', name: 'Parent Session', status: 'waiting', projectId: 'proj-1', parentSessionId: null },
-        { id: 'child-1', parentId: 'parent-1', name: 'Older Running Child', status: 'running', updatedAt: '2025-01-01T00:00:00Z', parentSessionId: 'parent-1' },
-        { id: 'child-2', parentId: 'parent-1', name: 'Newer Running Child', status: 'running', updatedAt: '2025-01-02T00:00:00Z', parentSessionId: 'parent-1' },
+        { id: 'child-1', parentId: 'parent-1', name: 'Newer Message Running Child', status: 'running', lastMessageAt: '2025-01-03T00:00:00Z', updatedAt: '2025-01-01T00:00:00Z', parentSessionId: 'parent-1' },
+        { id: 'child-2', parentId: 'parent-1', name: 'Newer Updated Running Child', status: 'running', updatedAt: '2025-01-02T00:00:00Z', parentSessionId: 'parent-1' },
         { id: 'child-3', parentId: 'parent-1', name: 'Waiting Child', status: 'waiting', updatedAt: '2025-01-03T00:00:00Z', parentSessionId: 'parent-1' },
       ];
 
@@ -3253,8 +3253,8 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      // overlaySessionId should be the most recently updated running child (child-2)
-      expect(wrapper.vm.overlaySessionId).toBe('child-2');
+      // overlaySessionId should use the same picker recency as the dropdown
+      expect(wrapper.vm.overlaySessionId).toBe('child-1');
     });
 
     it('overlaySessionId falls back to parent when getChildSessions returns empty array', async () => {
@@ -3362,8 +3362,8 @@ describe('SessionDetailView', () => {
       // Start with parent and two waiting children (no running sessions)
       sessionsStore.sessions = [
         { id: 'parent-1', name: 'Parent Session', status: 'waiting', projectId: 'proj-1', parentSessionId: null },
-        { id: 'child-1', name: 'Waiting Child 1', status: 'waiting', updatedAt: '2025-01-01T00:00:00Z', parentSessionId: 'parent-1' },
-        { id: 'child-2', name: 'Waiting Child 2', status: 'waiting', updatedAt: '2025-01-01T00:00:00Z', parentSessionId: 'parent-1' },
+        { id: 'child-1', name: 'Waiting Child 1', status: 'waiting', parentSessionId: 'parent-1' },
+        { id: 'child-2', name: 'Waiting Child 2', status: 'waiting', parentSessionId: 'parent-1' },
       ];
 
       sessionsStore.currentSession = sessionsStore.sessions[0];
@@ -3841,12 +3841,12 @@ describe('SessionDetailView', () => {
         'session-d',
         'session-a',
       ]);
-      expect(wrapper.vm.sessionChain.map(entry => entry.pickerTimestamp)).toEqual([5900, 5410, 5407, 5400]);
+      expect(wrapper.vm.sessionChain.map(entry => entry.pickerTimestamp)).toEqual([5900, 5410, 5407, 1000]);
       expect(wrapper.vm.sessionChain.map(entry => entry.pickerTimestampSource)).toEqual([
         'lastMessageAt',
         'updatedAt',
         'updatedAt',
-        'updatedAt',
+        'lastMessageAt',
       ]);
     });
 

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -10,6 +10,9 @@ import { useTodosStore } from '../stores/todos.js';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useProjectsStore } from '../stores/projects.js';
 import { useUiStore } from '../stores/ui.js';
+import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+
+const websocketHandlers = vi.hoisted(() => new Map());
 
 // Mock components
 vi.mock('../components/ChangesTab.vue', () => ({
@@ -105,8 +108,8 @@ vi.mock('../composables/useWebSocket.js', () => {
     useWebSocket: vi.fn(() => ({
       isConnected: { value: true },
       send: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
+      on: vi.fn((type, callback) => websocketHandlers.set(type, callback)),
+      off: vi.fn((type) => websocketHandlers.delete(type)),
       disconnect: vi.fn(),
       clearSessionBuffer: vi.fn(),
       onReconnect: vi.fn(() => () => {}),
@@ -155,6 +158,7 @@ describe('SessionDetailView', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    websocketHandlers.clear();
     pinia = createPinia();
     setActivePinia(pinia);
 
@@ -3602,6 +3606,8 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: null,
+        updatedAt: 1000,
+        createdAt: 500,
       };
       const previousChild = {
         id: 'previous-child',
@@ -3610,6 +3616,9 @@ describe('SessionDetailView', () => {
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
         lastActivityAt: 3000,
+        lastMessageAt: 2000,
+        updatedAt: 2000,
+        createdAt: 500,
       };
       const newChild = {
         id: 'new-child',
@@ -3617,6 +3626,9 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 4000,
+        updatedAt: 4000,
+        createdAt: 500,
       };
 
       sessionsStore.currentSession = parentSession;
@@ -3673,6 +3685,8 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: null,
+        updatedAt: 1000,
+        createdAt: 500,
       };
       const previousChild = {
         id: 'previous-child',
@@ -3681,6 +3695,9 @@ describe('SessionDetailView', () => {
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
         lastActivityAt: 3000,
+        lastMessageAt: 2000,
+        updatedAt: 2000,
+        createdAt: 500,
       };
       const newChild = {
         id: 'new-child',
@@ -3688,6 +3705,9 @@ describe('SessionDetailView', () => {
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'parent-1',
+        lastMessageAt: 4000,
+        updatedAt: 4000,
+        createdAt: 500,
       };
 
       sessionsStore.currentSession = parentSession;
@@ -3734,42 +3754,57 @@ describe('SessionDetailView', () => {
 
       expect(wrapper.vm.overlaySessionId).toBe('new-child');
       expect(wrapper.vm.sessionChain.some(entry => entry.session.id === 'new-child')).toBe(true);
+      expect(wrapper.vm.sessionChain.map(entry => entry.session.id)).toEqual([
+        'new-child',
+        'previous-child',
+        'parent-1',
+      ]);
     });
 
-    it('sorts session chain by lastActivityAt descending (most recent first)', async () => {
+    it('sorts session chain by picker recency instead of broad lastActivityAt', async () => {
       const sessionA = {
         id: 'session-a',
-        name: 'Session A (oldest)',
+        name: 'Session A (root with newer broad activity)',
         status: 'completed',
         projectId: 'proj-1',
         parentSessionId: null,
-        lastActivityAt: 1000,
+        lastActivityAt: 6000,
+        lastMessageAt: 1000,
+        updatedAt: 5400,
+        createdAt: 900,
       };
       const sessionB = {
         id: 'session-b',
-        name: 'Session B (middle)',
+        name: 'Session B (newest message)',
         status: 'running',
         projectId: 'proj-1',
         parentSessionId: 'session-a',
-        lastActivityAt: 3000,
+        lastActivityAt: 5900,
+        lastMessageAt: 5900,
+        updatedAt: 5900,
+        createdAt: 800,
       };
       const sessionC = {
         id: 'session-c',
-        name: 'Session C (newest)',
-        status: 'waiting',
-        projectId: 'proj-1',
-        parentSessionId: 'session-a',
-        lastActivityAt: 5000,
-      };
-      // Session D has no lastActivityAt, falls back to updatedAt
-      const sessionD = {
-        id: 'session-d',
-        name: 'Session D (fallback to updatedAt)',
+        name: 'Session C (updated fallback)',
         status: 'waiting',
         projectId: 'proj-1',
         parentSessionId: 'session-a',
         lastActivityAt: null,
-        updatedAt: 2000,
+        lastMessageAt: null,
+        updatedAt: 5410,
+        createdAt: 700,
+      };
+      const sessionD = {
+        id: 'session-d',
+        name: 'Session D (older updated fallback)',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: 'session-a',
+        lastActivityAt: null,
+        lastMessageAt: null,
+        updatedAt: 5407,
+        createdAt: 600,
       };
 
       sessionsStore.currentSession = sessionA;
@@ -3800,14 +3835,214 @@ describe('SessionDetailView', () => {
       await flushPromises();
       await nextTick();
 
-      // Should contain all 4 sessions
-      expect(wrapper.vm.sessionChain.length).toBe(4);
+      expect(wrapper.vm.sessionChain.map(entry => entry.session.id)).toEqual([
+        'session-b',
+        'session-c',
+        'session-d',
+        'session-a',
+      ]);
+      expect(wrapper.vm.sessionChain.map(entry => entry.pickerTimestamp)).toEqual([5900, 5410, 5407, 5400]);
+      expect(wrapper.vm.sessionChain.map(entry => entry.pickerTimestampSource)).toEqual([
+        'lastMessageAt',
+        'updatedAt',
+        'updatedAt',
+        'updatedAt',
+      ]);
+    });
 
-      // Order should be: C (5000), B (3000), D (2000 via updatedAt fallback), A (1000)
-      expect(wrapper.vm.sessionChain[0].session.id).toBe('session-c');
-      expect(wrapper.vm.sessionChain[1].session.id).toBe('session-b');
-      expect(wrapper.vm.sessionChain[2].session.id).toBe('session-d');
-      expect(wrapper.vm.sessionChain[3].session.id).toBe('session-a');
+    it('sorts child with newest direct message above root with newer broad activity', async () => {
+      const root = {
+        id: '15a42efa-5773-4e8a-a928-09878f8b2e6c',
+        name: 'Root with summary activity',
+        status: 'completed',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        lastActivityAt: 9000,
+        lastMessageAt: 1000,
+        updatedAt: 1000,
+        createdAt: 500,
+      };
+      const child = {
+        id: 'quick-response-child',
+        name: 'Quick response auto-submit checkbox implementation',
+        status: 'completed',
+        projectId: 'proj-1',
+        parentSessionId: root.id,
+        lastActivityAt: 8000,
+        lastMessageAt: 8000,
+        updatedAt: 8000,
+        createdAt: 700,
+      };
+
+      sessionsStore.currentSession = root;
+      sessionsStore.sessions = [root, child];
+
+      vi.spyOn(sessionsStore, 'getChildSessions', 'get').mockReturnValue(
+        (parentId) => parentId === root.id ? [child] : []
+      );
+      vi.spyOn(sessionsStore, 'getRootSession', 'get').mockReturnValue(() => root);
+      api.getProjectSessions.mockResolvedValue([root, child]);
+
+      await router.push(`/sessions/${root.id}`);
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.vm.sessionChain[0].session.id).toBe(child.id);
+      expect(wrapper.vm.sessionChain[1].session.id).toBe(root.id);
+    });
+
+    it('ignores invalid timestamps and sorts numeric and ISO timestamp strings', async () => {
+      const root = {
+        id: '231dcaa8-bf0c-478a-9885-f30a1376dfd3',
+        name: 'Root',
+        status: 'completed',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        lastMessageAt: '2000',
+        updatedAt: 2000,
+        createdAt: 1000,
+      };
+      const childA = {
+        id: 'child-a',
+        name: 'Numeric fallback',
+        status: 'completed',
+        projectId: 'proj-1',
+        parentSessionId: root.id,
+        lastMessageAt: 'not-a-date',
+        updatedAt: '2026-05-12T12:00:00.000Z',
+        createdAt: null,
+      };
+      const childB = {
+        id: 'child-b',
+        name: 'Older message',
+        status: 'completed',
+        projectId: 'proj-1',
+        parentSessionId: root.id,
+        lastMessageAt: '3000',
+        updatedAt: 'invalid',
+        createdAt: '1000',
+      };
+
+      sessionsStore.currentSession = root;
+      sessionsStore.sessions = [root, childA, childB];
+
+      vi.spyOn(sessionsStore, 'getChildSessions', 'get').mockReturnValue(
+        (parentId) => parentId === root.id ? [childA, childB] : []
+      );
+      vi.spyOn(sessionsStore, 'getRootSession', 'get').mockReturnValue(() => root);
+
+      api.getProjectSessions.mockResolvedValue([root, childA, childB]);
+
+      await router.push(`/sessions/${root.id}`);
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.vm.sessionChain.map(entry => entry.session.id)).toEqual([
+        'child-a',
+        'child-b',
+        root.id,
+      ]);
+      expect(wrapper.vm.sessionChain[0].pickerTimestampSource).toBe('updatedAt');
+      expect(wrapper.vm.sessionChain[1].pickerTimestampSource).toBe('lastMessageAt');
+    });
+
+    it('re-sorts sessionChain after a SESSION_UPDATED event while preserving depth', async () => {
+      const root = {
+        id: 'root',
+        name: 'Root',
+        status: 'completed',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        updatedAt: 1000,
+        createdAt: 500,
+      };
+      const childA = {
+        id: 'child-a',
+        name: 'Child A',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: root.id,
+        lastMessageAt: 1000,
+        updatedAt: 1000,
+        createdAt: 500,
+      };
+      const childB = {
+        id: 'child-b',
+        name: 'Child B',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: root.id,
+        lastMessageAt: 3000,
+        updatedAt: 3000,
+        createdAt: 500,
+      };
+
+      sessionsStore.currentSession = root;
+      sessionsStore.sessions = [root, childA, childB];
+
+      vi.spyOn(sessionsStore, 'getChildSessions', 'get').mockReturnValue(
+        (parentId) => parentId === root.id ? [childA, childB] : []
+      );
+      vi.spyOn(sessionsStore, 'getRootSession', 'get').mockReturnValue(() => root);
+      api.getProjectSessions.mockResolvedValue([root, childA, childB]);
+
+      await router.push('/sessions/root');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.vm.sessionChain[0].session.id).toBe('child-b');
+
+      const handleSessionUpdated = websocketHandlers.get(WS_MESSAGE_TYPES.SESSION_UPDATED);
+      expect(handleSessionUpdated).toBeTypeOf('function');
+      handleSessionUpdated({
+        session: {
+          ...childA,
+          lastMessageAt: 5000,
+          updatedAt: 5000,
+        },
+      });
+      await nextTick();
+
+      expect(wrapper.vm.sessionChain[0].session.id).toBe('child-a');
+      expect(wrapper.vm.sessionChain[0].depth).toBe(1);
+      expect(wrapper.vm.sessionChain[0].pickerTimestamp).toBe(5000);
+      expect(wrapper.vm.sessionChain[0].pickerTimestampSource).toBe('lastMessageAt');
     });
 
     it('fetches summaries for sessions in the chain', async () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -241,6 +241,62 @@ function collectTreeDepthFirst(root) {
   return tree;
 }
 
+function toTimestamp(value) {
+  if (value === null || value === undefined || value === '') return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getSessionPickerRecency(session) {
+  const candidates = [
+    { source: 'lastMessageAt', time: toTimestamp(session?.lastMessageAt) },
+    { source: 'updatedAt', time: toTimestamp(session?.updatedAt) },
+    { source: 'createdAt', time: toTimestamp(session?.createdAt) },
+  ];
+  const best = candidates.reduce(
+    (currentBest, candidate) => candidate.time > currentBest.time ? candidate : currentBest,
+    { source: 'none', time: 0 }
+  );
+  return best.time > 0 ? best : { source: 'none', time: 0 };
+}
+
+function getSessionPickerRecentTime(session) {
+  return getSessionPickerRecency(session).time;
+}
+
+function compareSessionChainEntries(a, b) {
+  const aSession = a?.session || {};
+  const bSession = b?.session || {};
+  const comparisons = [
+    getSessionPickerRecentTime(bSession) - getSessionPickerRecentTime(aSession),
+    toTimestamp(bSession.lastMessageAt) - toTimestamp(aSession.lastMessageAt),
+    toTimestamp(bSession.updatedAt) - toTimestamp(aSession.updatedAt),
+    toTimestamp(bSession.createdAt) - toTimestamp(aSession.createdAt),
+  ];
+  const firstDifference = comparisons.find(value => value !== 0);
+  if (firstDifference) return firstDifference;
+  return String(aSession.id || '').localeCompare(String(bSession.id || ''));
+}
+
+function withPickerTimestamp(entry) {
+  const recency = getSessionPickerRecency(entry?.session);
+  return {
+    ...entry,
+    pickerTimestamp: recency.time || null,
+    pickerTimestampSource: recency.source,
+  };
+}
+
+function sortSessionChain(entries) {
+  return [...entries].sort(compareSessionChainEntries).map(withPickerTimestamp);
+}
+
 /**
  * Build the full session tree from root, flattened depth-first with depth info.
  * Fetches project sessions and summaries for each session in the tree.
@@ -256,15 +312,10 @@ async function buildSessionChain() {
   if (session?.projectId) await mergeProjectSessionsToStore(session.projectId);
 
   const { root, earlyReturn } = findRootSession(sessionId);
-  if (earlyReturn) { sessionChain.value = earlyReturn; return; }
+  if (earlyReturn) { sessionChain.value = sortSessionChain(earlyReturn); return; }
   if (!root) return;
 
-  const tree = collectTreeDepthFirst(root);
-  tree.sort((a, b) => {
-    const aTime = a.session.lastActivityAt || a.session.updatedAt || a.session.createdAt || 0;
-    const bTime = b.session.lastActivityAt || b.session.updatedAt || b.session.createdAt || 0;
-    return bTime - aTime;
-  });
+  const tree = sortSessionChain(collectTreeDepthFirst(root));
   sessionChain.value = tree;
 
   // Fetch summaries for all sessions in the tree (non-blocking)
@@ -281,7 +332,7 @@ async function buildSessionChain() {
  * Resolve the overlay target session ID.
  * Priority order:
  * 1. Running/starting children (most recently updated)
- * 2. Session with the most recent conversation activity (lastActivityAt)
+ * 2. Session with the broadest recent activity signal (lastActivityAt)
  * 3. Current session (fallback)
  */
 function resolveOverlayTarget() {
@@ -348,13 +399,13 @@ function handleSessionUpdated(msg) {
     entry => entry.session.id === updatedSession.id
   );
   if (idx >= 0) {
-    // Replace the stale snapshot with the updated one, preserving depth
-    sessionChain.value[idx] = {
+    const updatedEntries = [...sessionChain.value];
+    // Replace the stale snapshot with the updated one, preserving depth.
+    updatedEntries[idx] = {
       ...sessionChain.value[idx],
       session: updatedSession,
     };
-    // Trigger Vue reactivity by replacing the array ref
-    sessionChain.value = [...sessionChain.value];
+    sessionChain.value = sortSessionChain(updatedEntries);
   }
 }
 
@@ -421,10 +472,10 @@ async function handleOverlaySessionCreated(session) {
     const parentEntry = sessionChain.value.find(
       entry => entry.session.id === preferredOverlaySession.value.parentSessionId
     );
-    sessionChain.value = [
+    sessionChain.value = sortSessionChain([
       { session: preferredOverlaySession.value, depth: parentEntry ? parentEntry.depth + 1 : 0 },
       ...sessionChain.value,
-    ];
+    ]);
   }
   resolveOverlayTarget();
 }

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -128,6 +128,7 @@ import ArchiveConfirmModal from '../components/ArchiveConfirmModal.vue';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { api } from '../composables/useApi.js';
 import { useWebSocket } from '../composables/useWebSocket.js';
+import { sortSessionChain } from '../utils/sessionPickerRecency.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 
 const route = useRoute();
@@ -241,62 +242,6 @@ function collectTreeDepthFirst(root) {
   return tree;
 }
 
-function toTimestamp(value) {
-  if (value === null || value === undefined || value === '') return 0;
-  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
-  if (typeof value === 'string' && value.trim() !== '') {
-    const numeric = Number(value);
-    if (Number.isFinite(numeric)) return numeric;
-  }
-
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function getSessionPickerRecency(session) {
-  const candidates = [
-    { source: 'lastMessageAt', time: toTimestamp(session?.lastMessageAt) },
-    { source: 'updatedAt', time: toTimestamp(session?.updatedAt) },
-    { source: 'createdAt', time: toTimestamp(session?.createdAt) },
-  ];
-  const best = candidates.reduce(
-    (currentBest, candidate) => candidate.time > currentBest.time ? candidate : currentBest,
-    { source: 'none', time: 0 }
-  );
-  return best.time > 0 ? best : { source: 'none', time: 0 };
-}
-
-function getSessionPickerRecentTime(session) {
-  return getSessionPickerRecency(session).time;
-}
-
-function compareSessionChainEntries(a, b) {
-  const aSession = a?.session || {};
-  const bSession = b?.session || {};
-  const comparisons = [
-    getSessionPickerRecentTime(bSession) - getSessionPickerRecentTime(aSession),
-    toTimestamp(bSession.lastMessageAt) - toTimestamp(aSession.lastMessageAt),
-    toTimestamp(bSession.updatedAt) - toTimestamp(aSession.updatedAt),
-    toTimestamp(bSession.createdAt) - toTimestamp(aSession.createdAt),
-  ];
-  const firstDifference = comparisons.find(value => value !== 0);
-  if (firstDifference) return firstDifference;
-  return String(aSession.id || '').localeCompare(String(bSession.id || ''));
-}
-
-function withPickerTimestamp(entry) {
-  const recency = getSessionPickerRecency(entry?.session);
-  return {
-    ...entry,
-    pickerTimestamp: recency.time || null,
-    pickerTimestampSource: recency.source,
-  };
-}
-
-function sortSessionChain(entries) {
-  return [...entries].sort(compareSessionChainEntries).map(withPickerTimestamp);
-}
-
 /**
  * Build the full session tree from root, flattened depth-first with depth info.
  * Fetches project sessions and summaries for each session in the tree.
@@ -331,8 +276,8 @@ async function buildSessionChain() {
 /**
  * Resolve the overlay target session ID.
  * Priority order:
- * 1. Running/starting children (most recently updated)
- * 2. Session with the broadest recent activity signal (lastActivityAt)
+ * 1. Running/starting children (most recent picker recency)
+ * 2. Session with the most recent picker recency
  * 3. Current session (fallback)
  */
 function resolveOverlayTarget() {
@@ -362,19 +307,13 @@ function resolveOverlayTarget() {
     .filter(entry => entry.session.id !== currentSessionId.value);
 
   if (runningChildren.length > 0) {
-    // Pick the most recently updated running child
-    const sorted = [...runningChildren].sort((a, b) =>
-      new Date(b.session.updatedAt || b.session.createdAt || 0) -
-      new Date(a.session.updatedAt || a.session.createdAt || 0)
-    );
+    const sorted = sortSessionChain(runningChildren);
     overlaySessionId.value = sorted[0].session.id;
     return;
   }
 
-  // No running children — select the session with the most recent conversation activity
-  const withActivity = chain
-    .filter(entry => entry.session.lastActivityAt)
-    .sort((a, b) => (b.session.lastActivityAt || 0) - (a.session.lastActivityAt || 0));
+  const withActivity = sortSessionChain(chain)
+    .filter(entry => entry.pickerTimestamp);
 
   if (withActivity.length > 0) {
     overlaySessionId.value = withActivity[0].session.id;


### PR DESCRIPTION
## Summary

Fix the session chat overlay picker to list sessions by direct message recency instead of broad activity timestamps. Previously, sessions with newer summary generation or command button runs could outrank sessions with more recent direct chat activity, making it harder to quickly switch back to the active conversation.

## Changes

### Server (`packages/server`)
- **Add `lastMessageAt` field**: New computed field from `MAX(conversation_messages.timestamp)` to track direct conversation activity
- **Preserve `lastActivityAt` semantics**: Existing field continues to include summaries, command runs, and messages for other views
- **Include in all queries**: `lastMessageAt` is now mapped in `getById()`, `getByProjectId()`, `getActiveAndWaiting()`, `getChildSessions()`, `getSessionsWithPrUrls()`, and scheduled session queries

### Web (`packages/web`)
- **Update live message handling**: `addMessage()` now bumps both `lastMessageAt` and `lastActivityAt` when a newer message arrives (never moves timestamps backwards)
- **Add picker recency helpers**: New sorting functions in `SessionDetailView.vue` compute effective picker timestamp from `lastMessageAt > updatedAt > createdAt` with proper null/invalid handling
- **Sort all sessionChain assignments**: Apply consistent picker recency sorting in `buildSessionChain()`, `handleSessionUpdated()`, and `handleOverlaySessionCreated()`
- **Update picker display**: Show timestamp with source-specific labels ("Last message", "Updated", "Created", or "No activity yet") and include full timestamp in title for disambiguation

## Test Plan

All tests pass:
- ✅ `packages/server/src/db/SessionRepository.test.js` - Verify `lastMessageAt` returns newest message timestamp without changing broad activity semantics
- ✅ `packages/web/src/stores/sessions.test.js` - Verify live message bumps both `lastMessageAt` and `lastActivityAt`, never backwards
- ✅ `packages/web/src/views/SessionDetailView.test.js` - Verify sessionChain sorts by picker recency, re-sorts after `SESSION_UPDATED` events, and handles new overlay-created children
- ✅ `packages/web/src/components/SessionChatPicker.test.js` - Verify timestamp display labels and full timestamp titles

## Acceptance Criteria

- ✅ Opening the session chat overlay shows the most recently active direct chat session at the top
- ✅ A child session with newer direct messages sorts above a root with only summary/command activity
- ✅ Sessions with no direct messages sort by `updatedAt` or `createdAt` fallback
- ✅ Summary generation and command button runs do not cause parent sessions to outrank more active children
- ✅ New live messages update the client-side recency field used by the picker
- ✅ Timestamps shown in the picker match the sorting criteria
- ✅ Ordering remains correct after WebSocket session updates and overlay session creation
- ✅ Existing overlay target selection behavior is preserved (running/starting child preference)

## Example Scenario

**Before**: Root session has summary activity at 9:00 AM, child has direct message at 8:55 AM → Root appears first in picker  
**After**: Child with direct message at 8:55 AM appears above root with summary at 9:00 AM

Co-Authored-By: Claude <noreply@anthropic.com>