### PR TITLE
Fix session overlay viewport inset handling

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -7,6 +7,7 @@
 
   /* Visual viewport offset for iOS Safari browser chrome (URL bar, tab bar) */
   --viewport-offset-top: 0px;
+  --session-overlay-top-chrome-inset: 0px;
 
   --color-background: #0d1117;
   --color-background-soft: #161b22;

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1612,16 +1612,6 @@ describe('SessionChatOverlay', () => {
         /@media\s*\(min-width:\s*700px\)\s*and\s*\(min-height:\s*700px\)\s*\{[\s\S]*?\.overlay-backdrop\s*\{[\s\S]*?--visual-viewport-height/
       );
     });
-
-    it('main css defines the session overlay top chrome inset default', () => {
-      const fs = process.getBuiltinModule('fs');
-      const mainCssSource = fs.readFileSync(
-        'src/assets/main.css',
-        'utf8'
-      );
-      expect(mainCssSource).toMatch(/--session-overlay-top-chrome-inset:\s*0px/);
-    });
-
     it('panel-wrapper stylesheet is child geometry inside the backdrop', () => {
       const block = getStyleBlock('.overlay-panel-wrapper');
       expect(block).toMatch(/position:\s*absolute/);

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1591,6 +1591,7 @@ describe('SessionChatOverlay', () => {
       for (const block of blocks) {
         expect(block).not.toMatch(/--viewport-offset-top/);
         expect(block).not.toMatch(/--visual-viewport-height/);
+        expect(block).not.toMatch(/--session-overlay-top-chrome-inset/);
         expect(block).not.toMatch(/height:\s*var\(/);
         expect(block).not.toMatch(/top:\s*var\(/);
         expect(block).not.toMatch(/bottom:\s*auto/);
@@ -1612,6 +1613,15 @@ describe('SessionChatOverlay', () => {
       );
     });
 
+    it('main css defines the session overlay top chrome inset default', () => {
+      const fs = process.getBuiltinModule('fs');
+      const mainCssSource = fs.readFileSync(
+        'src/assets/main.css',
+        'utf8'
+      );
+      expect(mainCssSource).toMatch(/--session-overlay-top-chrome-inset:\s*0px/);
+    });
+
     it('panel-wrapper stylesheet is child geometry inside the backdrop', () => {
       const block = getStyleBlock('.overlay-panel-wrapper');
       expect(block).toMatch(/position:\s*absolute/);
@@ -1622,26 +1632,37 @@ describe('SessionChatOverlay', () => {
       expect(block).not.toMatch(/position:\s*fixed/);
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
+      expect(block).not.toMatch(/--session-overlay-top-chrome-inset/);
       expect(block).not.toMatch(/top:\s*var\(/);
     });
 
-    it('overlay content has a viewport-height floor and visual top offset', () => {
-      const block = getStyleBlock('.overlay-content');
-      expect(block).toMatch(/min-height:\s*100%/);
-      expect(block).toMatch(/min-height:\s*100dvh/);
-      expect(block).toMatch(
-        /padding-top:\s*max\(0px,\s*var\(--viewport-offset-top,\s*0px\)\)/
-      );
-      expect(block).not.toMatch(/--visual-viewport-height/);
+    it('overlay content has a viewport-height floor without viewport-driven padding', () => {
+      const blocks = getStyleBlocks('.overlay-content');
+      for (const block of blocks) {
+        expect(block).toMatch(/min-height:\s*100%/);
+        expect(block).toMatch(/min-height:\s*100dvh/);
+        expect(block).toMatch(/padding:\s*0/);
+        expect(block).not.toMatch(/--viewport-offset-top/);
+        expect(block).not.toMatch(/--visual-viewport-height/);
+        expect(block).not.toMatch(/--session-overlay-top-chrome-inset/);
+      }
     });
 
-    it('overlay header stays sticky within the padded content flow', () => {
+    it('overlay header consumes only the sanitized session chrome inset', () => {
       const block = getStyleBlock('.overlay-header');
       expect(block).toMatch(/position:\s*-webkit-sticky/);
       expect(block).toMatch(/position:\s*sticky/);
       expect(block).toMatch(/top:\s*0/);
+      expect(block).toMatch(/--overlay-header-base-padding-top:\s*0\.75rem/);
+      expect(block).toMatch(/--session-overlay-top-chrome-inset/);
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
+    });
+
+    it('mobile overlay header keeps the larger base padding floor', () => {
+      expect(sessionChatOverlaySource).toMatch(
+        /@media\s*\(max-width:\s*768px\)\s*\{[\s\S]*?\.overlay-header\s*\{[\s\S]*?--overlay-header-base-padding-top:\s*1rem/
+      );
     });
 
     it('overlay shell keeps visual viewport variables out of all shell geometry', () => {
@@ -1651,6 +1672,7 @@ describe('SessionChatOverlay', () => {
       ].join('\n');
       expect(shellBlocks).not.toMatch(/--viewport-offset-top/);
       expect(shellBlocks).not.toMatch(/--visual-viewport-height/);
+      expect(shellBlocks).not.toMatch(/--session-overlay-top-chrome-inset/);
     });
 
     it('content, header, and body declare solid backgrounds', () => {

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -1063,7 +1063,6 @@ defineExpose({
      was a historical failure mode when `overflow: hidden` was used here. */
   overflow: clip;
   padding: 0;
-  padding-top: max(0px, var(--viewport-offset-top, 0px));
   box-shadow: -4px 0 20px rgba(0, 0, 0, 0.5);
   position: relative;
   background: rgb(17, 24, 39);
@@ -1084,15 +1083,19 @@ defineExpose({
 }
 
 .overlay-header {
+  --overlay-header-base-padding-top: 0.75rem;
+
   position: -webkit-sticky;
   position: sticky;
   top: 0;
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  padding: 0.75rem 1rem 0.375rem;
-  /* Raise top padding to clear the iPhone notch when present. */
-  padding-top: max(0.75rem, env(safe-area-inset-top));
+  padding: var(--overlay-header-base-padding-top) 1rem 0.375rem;
+  padding-top: calc(
+    max(var(--overlay-header-base-padding-top), env(safe-area-inset-top)) +
+    var(--session-overlay-top-chrome-inset, 0px)
+  );
   background: var(--color-background-secondary, #1f2937);
   border-radius: 0;
   border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
@@ -1194,14 +1197,11 @@ defineExpose({
   }
 
   .overlay-header {
+    --overlay-header-base-padding-top: 1rem;
+
     padding-right: 0.5rem;
     padding-bottom: 0.375rem;
     padding-left: 0.5rem;
-    /* padding-top: keep the larger base value (the 1rem visual intent
-       of the old shorthand is already covered by the base
-       `max(0.75rem, env(safe-area-inset-top))` on devices with an
-       inset; raise the floor here for mobile without a notch). */
-    padding-top: max(1rem, env(safe-area-inset-top));
   }
 }
 

--- a/packages/web/src/components/sessionOverlayCssDefaults.test.js
+++ b/packages/web/src/components/sessionOverlayCssDefaults.test.js
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+describe('session overlay CSS defaults', () => {
+  it('main css defines the session overlay top chrome inset default', () => {
+    const mainCssSource = readFileSync(
+      resolve(currentDir, '..', 'assets', 'main.css'),
+      'utf8'
+    );
+
+    expect(mainCssSource).toMatch(/--session-overlay-top-chrome-inset:\s*0px/);
+  });
+});

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -34,9 +34,32 @@ function hasPhoneSignal({ platform = '', userAgent = '' }) {
   return /iPhone|iPod|Android.*Mobile|Mobile.*Android/i.test(signal);
 }
 
+function isValidTopChromeOffset(offsetTop) {
+  return offsetTop > 0 && offsetTop <= 64;
+}
+
+function isKeyboardShapedViewport(layoutHeight, visualViewportHeight) {
+  if (!(layoutHeight > 0 && visualViewportHeight > 0)) {
+    return false;
+  }
+
+  return (
+    layoutHeight - visualViewportHeight > 120 ||
+    visualViewportHeight / layoutHeight < 0.85
+  );
+}
+
+function isTabletSizedLayout(layoutWidth, layoutHeight) {
+  return (
+    layoutWidth > 0 &&
+    layoutHeight > 0 &&
+    Math.min(layoutWidth, layoutHeight) >= 700
+  );
+}
+
 export function computeSessionOverlayTopChromeInset(input = {}) {
   const offsetTop = toFiniteNumber(input.offsetTop);
-  if (!offsetTop || offsetTop < 0 || offsetTop > 64) {
+  if (!isValidTopChromeOffset(offsetTop)) {
     return 0;
   }
 
@@ -44,26 +67,18 @@ export function computeSessionOverlayTopChromeInset(input = {}) {
   const layoutHeight = toFiniteNumber(input.layoutHeight);
   const visualViewportHeight = toFiniteNumber(input.visualViewportHeight);
 
-  if (layoutHeight > 0 && visualViewportHeight > 0) {
-    if (layoutHeight - visualViewportHeight > 120) {
-      return 0;
-    }
-
-    if (visualViewportHeight / layoutHeight < 0.85) {
-      return 0;
-    }
+  if (isKeyboardShapedViewport(layoutHeight, visualViewportHeight)) {
+    return 0;
   }
 
   const tabletSignal = hasTabletSignal(input);
   const phoneSignal = hasPhoneSignal(input);
-  const tabletSized =
-    layoutWidth > 0 && layoutHeight > 0 && Math.min(layoutWidth, layoutHeight) >= 700;
 
   if (phoneSignal && !tabletSignal) {
     return 0;
   }
 
-  return tabletSized || tabletSignal ? offsetTop : 0;
+  return isTabletSizedLayout(layoutWidth, layoutHeight) || tabletSignal ? offsetTop : 0;
 }
 
 function getVisualViewportRect() {

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -11,6 +11,61 @@ function getPixelValue(value, fallback) {
   return Number.isFinite(value) ? `${value}px` : fallback;
 }
 
+function toFiniteNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function hasTabletSignal({ platform = '', userAgent = '', maxTouchPoints = 0 }) {
+  const normalizedPlatform = String(platform);
+  const normalizedUserAgent = String(userAgent);
+  const touchPoints = toFiniteNumber(maxTouchPoints) || 0;
+
+  return (
+    /iPad/i.test(normalizedUserAgent) ||
+    /iPad/i.test(normalizedPlatform) ||
+    (normalizedPlatform === 'MacIntel' && touchPoints > 1) ||
+    (/Android/i.test(normalizedUserAgent) && !/Mobile/i.test(normalizedUserAgent))
+  );
+}
+
+function hasPhoneSignal({ platform = '', userAgent = '' }) {
+  const signal = `${platform} ${userAgent}`;
+  return /iPhone|iPod|Android.*Mobile|Mobile.*Android/i.test(signal);
+}
+
+export function computeSessionOverlayTopChromeInset(input = {}) {
+  const offsetTop = toFiniteNumber(input.offsetTop);
+  if (!offsetTop || offsetTop < 0 || offsetTop > 64) {
+    return 0;
+  }
+
+  const layoutWidth = toFiniteNumber(input.layoutWidth);
+  const layoutHeight = toFiniteNumber(input.layoutHeight);
+  const visualViewportHeight = toFiniteNumber(input.visualViewportHeight);
+
+  if (layoutHeight > 0 && visualViewportHeight > 0) {
+    if (layoutHeight - visualViewportHeight > 120) {
+      return 0;
+    }
+
+    if (visualViewportHeight / layoutHeight < 0.85) {
+      return 0;
+    }
+  }
+
+  const tabletSignal = hasTabletSignal(input);
+  const phoneSignal = hasPhoneSignal(input);
+  const tabletSized =
+    layoutWidth > 0 && layoutHeight > 0 && Math.min(layoutWidth, layoutHeight) >= 700;
+
+  if (phoneSignal && !tabletSignal) {
+    return 0;
+  }
+
+  return tabletSized || tabletSignal ? offsetTop : 0;
+}
+
 function getVisualViewportRect() {
   const { offsetTop, height } = window.visualViewport;
   return { offsetTop, height };
@@ -26,6 +81,15 @@ function writeVisualViewportVariables() {
   }
 
   const rect = getVisualViewportRect();
+  const overlayInset = computeSessionOverlayTopChromeInset({
+    offsetTop: rect.offsetTop,
+    visualViewportHeight: rect.height,
+    layoutWidth: window.innerWidth,
+    layoutHeight: window.innerHeight,
+    platform: navigator.platform,
+    maxTouchPoints: navigator.maxTouchPoints,
+    userAgent: navigator.userAgent,
+  });
   document.documentElement.style.setProperty(
     '--viewport-offset-top',
     getPixelValue(rect.offsetTop, '0px')
@@ -33,6 +97,10 @@ function writeVisualViewportVariables() {
   document.documentElement.style.setProperty(
     '--visual-viewport-height',
     getPixelValue(rect.height, '100dvh')
+  );
+  document.documentElement.style.setProperty(
+    '--session-overlay-top-chrome-inset',
+    `${overlayInset}px`
   );
   return rect;
 }
@@ -138,9 +206,9 @@ export function requestVisualViewportSettle(options = {}) {
  * This is needed for iOS Safari, where the browser chrome (URL bar + tab bar) can
  * physically overlap sticky-positioned elements when expanded.
  *
- * Sets --viewport-offset-top and --visual-viewport-height CSS variables on
- * document.documentElement. These can be used to align fixed and sticky elements
- * to the same visual viewport rectangle.
+ * Sets raw visual viewport CSS variables on document.documentElement. It also
+ * writes a sanitized --session-overlay-top-chrome-inset for the session overlay
+ * header; fixed shells should not consume raw visual viewport offsets directly.
  *
  * On browsers without visualViewport API, this no-ops and CSS fallbacks apply.
  */

--- a/packages/web/src/composables/useVisualViewport.test.js
+++ b/packages/web/src/composables/useVisualViewport.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ref, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import {
+  computeSessionOverlayTopChromeInset,
   requestVisualViewportSettle,
   requestVisualViewportUpdate,
   useVisualViewport,
@@ -20,10 +21,27 @@ describe('useVisualViewport', () => {
   let mockVisualViewport;
   let rafSpy;
   let cancelRafSpy;
+  let originalInnerWidth;
+  let originalInnerHeight;
+  let originalNavigatorDescriptors;
 
   beforeEach(() => {
     // Save original visualViewport
     originalVisualViewport = window.visualViewport;
+    originalInnerWidth = window.innerWidth;
+    originalInnerHeight = window.innerHeight;
+    originalNavigatorDescriptors = {
+      platform: Object.getOwnPropertyDescriptor(navigator, 'platform'),
+      maxTouchPoints: Object.getOwnPropertyDescriptor(navigator, 'maxTouchPoints'),
+      userAgent: Object.getOwnPropertyDescriptor(navigator, 'userAgent'),
+    };
+
+    setWindowSize(1024, 768);
+    setNavigatorFields({
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+    });
 
     // Mock requestAnimationFrame and cancelAnimationFrame
     rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => setTimeout(cb, 0));
@@ -47,7 +65,47 @@ describe('useVisualViewport', () => {
     rafSpy.mockRestore();
     cancelRafSpy.mockRestore();
     vi.restoreAllMocks();
+    setWindowSize(originalInnerWidth, originalInnerHeight);
+    restoreNavigatorFields();
   });
+
+  function setWindowSize(width, height) {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: width,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: height,
+    });
+  }
+
+  function setNavigatorFields({ platform, maxTouchPoints, userAgent }) {
+    Object.defineProperty(navigator, 'platform', {
+      configurable: true,
+      value: platform,
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: maxTouchPoints,
+    });
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: userAgent,
+    });
+  }
+
+  function restoreNavigatorFields() {
+    for (const [key, descriptor] of Object.entries(originalNavigatorDescriptors)) {
+      if (descriptor) {
+        Object.defineProperty(navigator, key, descriptor);
+      } else {
+        delete navigator[key];
+      }
+    }
+  }
 
   /**
    * Helper component that uses the composable
@@ -74,7 +132,19 @@ describe('useVisualViewport', () => {
     });
   }
 
-  function expectViewportVariables(offsetTop, height) {
+  function expectedOverlayInset() {
+    return `${computeSessionOverlayTopChromeInset({
+      offsetTop: mockVisualViewport?.offsetTop,
+      visualViewportHeight: mockVisualViewport?.height,
+      layoutWidth: window.innerWidth,
+      layoutHeight: window.innerHeight,
+      platform: navigator.platform,
+      maxTouchPoints: navigator.maxTouchPoints,
+      userAgent: navigator.userAgent,
+    })}px`;
+  }
+
+  function expectViewportVariables(offsetTop, height, overlayInset = expectedOverlayInset()) {
     expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
       '--viewport-offset-top',
       offsetTop
@@ -83,7 +153,107 @@ describe('useVisualViewport', () => {
       '--visual-viewport-height',
       height
     );
+    expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
+      '--session-overlay-top-chrome-inset',
+      overlayInset
+    );
   }
+
+  describe('computeSessionOverlayTopChromeInset', () => {
+    const iphoneSignal = {
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148',
+    };
+    const ipadDesktopSignal = {
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Version/17.0 Safari/605.1.15',
+    };
+    const androidTabletSignal = {
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5,
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel Tablet) AppleWebKit/537.36 Chrome/120 Safari/537.36',
+    };
+    const androidMobileSignal = {
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5,
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36',
+    };
+
+    it.each([
+      [
+        'rejects stale iPhone keyboard offset',
+        { layoutWidth: 390, layoutHeight: 844, offsetTop: 260, visualViewportHeight: 420, ...iphoneSignal },
+        0,
+      ],
+      [
+        'rejects plausible iPhone portrait offset',
+        { layoutWidth: 390, layoutHeight: 844, offsetTop: 32, visualViewportHeight: 844, ...iphoneSignal },
+        0,
+      ],
+      [
+        'rejects plausible iPhone landscape offset',
+        { layoutWidth: 844, layoutHeight: 390, offsetTop: 32, visualViewportHeight: 390, ...iphoneSignal },
+        0,
+      ],
+      [
+        'accepts tablet-sized layout without phone signal',
+        { layoutWidth: 744, layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 1000 },
+        32,
+      ],
+      [
+        'rejects stale large tablet offset instead of clamping',
+        { layoutWidth: 744, layoutHeight: 1000, offsetTop: 260, visualViewportHeight: 1000 },
+        0,
+      ],
+      [
+        'rejects keyboard-compressed tablet height',
+        { layoutWidth: 744, layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 700 },
+        0,
+      ],
+      [
+        'accepts narrow iPadOS desktop-mode signal',
+        { layoutWidth: 500, layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 1000, ...ipadDesktopSignal },
+        32,
+      ],
+      [
+        'rejects narrow layout without tablet signal',
+        { layoutWidth: 500, layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 1000 },
+        0,
+      ],
+      [
+        'accepts Android tablet signal',
+        { layoutWidth: 500, layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 1000, ...androidTabletSignal },
+        32,
+      ],
+      [
+        'rejects Android Mobile signal',
+        { layoutWidth: 500, layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 1000, ...androidMobileSignal },
+        0,
+      ],
+    ])('%s', (_name, input, expected) => {
+      expect(computeSessionOverlayTopChromeInset(input)).toBe(expected);
+    });
+
+    it.each([
+      ['negative', -1],
+      ['NaN', NaN],
+      ['null', null],
+      ['undefined', undefined],
+      ['non-numeric', 'not-a-number'],
+      ['zero', 0],
+    ])('returns 0 for %s offsetTop', (_name, offsetTop) => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          layoutWidth: 744,
+          layoutHeight: 1000,
+          visualViewportHeight: 1000,
+          offsetTop,
+        })
+      ).toBe(0);
+    });
+  });
 
   describe('Browser support detection', () => {
     it('returns without errors when visualViewport API is not supported', () => {
@@ -161,6 +331,19 @@ describe('useVisualViewport', () => {
       await nextTick();
 
       expectViewportVariables('0px', '0px');
+    });
+
+    it('writes sanitized overlay inset in the same update as raw variables', async () => {
+      setWindowSize(744, 1000);
+      mockVisualViewport.offsetTop = 32;
+      mockVisualViewport.height = 1000;
+
+      createTestComponent();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      await nextTick();
+
+      expectViewportVariables('32px', '1000px', '32px');
     });
   });
 
@@ -359,6 +542,24 @@ describe('useVisualViewport', () => {
       expectViewportVariables('0px', '812px');
       expect(document.documentElement.style.getPropertyValue('--viewport-offset-top')).toBe('0px');
       expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('812px');
+      expect(document.documentElement.style.getPropertyValue('--session-overlay-top-chrome-inset')).toBe('0px');
+    });
+
+    it('writes sanitized overlay inset during settle sampling', async () => {
+      setWindowSize(744, 1000);
+      mockVisualViewport.offsetTop = 32;
+      mockVisualViewport.height = 1000;
+
+      requestVisualViewportSettle({
+        maxDurationMs: 60,
+        intervalMs: 10,
+        stableSampleCount: 1,
+        minDurationMs: 0,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 80));
+
+      expectViewportVariables('32px', '1000px', '32px');
     });
 
     it('requestVisualViewportSettle no-ops without visualViewport support', () => {

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -69,10 +69,18 @@ test.describe('SessionChatOverlay layout', () => {
     await page.waitForTimeout(50);
   }
 
+  async function injectSessionOverlayTopChromeInset(page: Page, value: string) {
+    await page.evaluate((inset) => {
+      document.documentElement.style.setProperty('--session-overlay-top-chrome-inset', inset);
+    }, value);
+    await page.waitForTimeout(50);
+  }
+
   async function clearStaleVisualViewportVariables(page: Page) {
     await page.evaluate(() => {
       document.documentElement.style.removeProperty('--viewport-offset-top');
       document.documentElement.style.removeProperty('--visual-viewport-height');
+      document.documentElement.style.removeProperty('--session-overlay-top-chrome-inset');
     });
   }
 
@@ -94,6 +102,9 @@ test.describe('SessionChatOverlay layout', () => {
       const shell = document.querySelector(
         '[data-testid="session-chat-overlay"]'
       ) as HTMLElement;
+      const rootStyle = getComputedStyle(document.documentElement);
+      const content = document.querySelector('.overlay-content') as HTMLElement;
+      const header = document.querySelector('.overlay-header') as HTMLElement;
       const s = shell.style;
 
       return {
@@ -101,7 +112,17 @@ test.describe('SessionChatOverlay layout', () => {
         panel: rectFor('.overlay-panel-wrapper'),
         content: rectFor('.overlay-content'),
         header: rectFor('.overlay-header'),
+        headerRow: rectFor('.overlay-header-row'),
         inner: { w: window.innerWidth, h: window.innerHeight },
+        computed: {
+          contentPaddingTop: getComputedStyle(content).paddingTop,
+          headerPaddingTop: getComputedStyle(header).paddingTop,
+          viewportOffsetTop: rootStyle.getPropertyValue('--viewport-offset-top').trim(),
+          visualViewportHeight: rootStyle.getPropertyValue('--visual-viewport-height').trim(),
+          sessionOverlayTopChromeInset: rootStyle
+            .getPropertyValue('--session-overlay-top-chrome-inset')
+            .trim(),
+        },
         inline: {
           top: s.top,
           right: s.right,
@@ -198,6 +219,12 @@ test.describe('SessionChatOverlay layout', () => {
       expectBackdropCoversViewport(result);
       expect(result.content.top).toBeLessThanOrEqual(1);
       expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.header.top).toBeLessThanOrEqual(1);
+      expect(result.computed.contentPaddingTop).toBe('0px');
+      expect(result.computed.viewportOffsetTop).toBe(`${injectedViewportOffsetTop}px`);
+      expect(result.computed.visualViewportHeight).toBe('420px');
+      expect(result.computed.sessionOverlayTopChromeInset).toBe('0px');
+      expect(result.headerRow.top).toBeLessThan(80);
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
@@ -220,6 +247,9 @@ test.describe('SessionChatOverlay layout', () => {
       expect(result.panel.width).toBeGreaterThanOrEqual(result.inner.w - 1);
       expect(result.content.top).toBeLessThanOrEqual(1);
       expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expect(result.header.top).toBeLessThanOrEqual(1);
+      expect(result.computed.contentPaddingTop).toBe('0px');
+      expect(result.computed.sessionOverlayTopChromeInset).toBe('0px');
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
@@ -248,12 +278,16 @@ test.describe('SessionChatOverlay layout', () => {
     }
   });
 
-  test('visual viewport top offset aligns the overlay header without moving the shell', async ({ page }) => {
+  test('sanitized top chrome inset pads the overlay header without moving the shell', async ({ page }) => {
     await page.setViewportSize({ width: 744, height: 1000 });
     await navigateToSession(page);
     await openOverlay(page);
 
-    await injectStaleVisualViewportVariables(page);
+    const baseline = await readOverlayLayout(page);
+    const baselineHeaderPadding = parseFloat(baseline.computed.headerPaddingTop);
+    const baselineHeaderRowTop = baseline.headerRow.top;
+
+    await injectSessionOverlayTopChromeInset(page, '32px');
 
     try {
       const result = await readOverlayLayout(page);
@@ -262,8 +296,14 @@ test.describe('SessionChatOverlay layout', () => {
       expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
       expect(result.content.top).toBeLessThanOrEqual(1);
       expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
-      expect(result.header.top).toBeGreaterThanOrEqual(injectedViewportOffsetTop - 1);
-      expect(result.header.top).toBeLessThanOrEqual(injectedViewportOffsetTop + 1);
+      expect(result.header.top).toBeLessThanOrEqual(1);
+      expect(result.computed.contentPaddingTop).toBe('0px');
+      expect(result.computed.sessionOverlayTopChromeInset).toBe('32px');
+      expect(parseFloat(result.computed.headerPaddingTop)).toBeCloseTo(
+        baselineHeaderPadding + 32,
+        0
+      );
+      expect(result.headerRow.top).toBeGreaterThanOrEqual(baselineHeaderRowTop + 31);
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
@@ -277,21 +317,14 @@ test.describe('SessionChatOverlay layout', () => {
     await page.evaluate(() => window.scrollTo(0, 400));
     await openOverlay(page);
 
-    const result = await page.evaluate(() => {
-      const el = document.querySelector(
-        '[data-testid="session-chat-overlay"]'
-      ) as HTMLElement;
-      const r = el.getBoundingClientRect();
-      const s = el.style;
-      return {
-        rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
-        inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
-      };
-    });
+    const result = await readOverlayLayout(page);
 
-    expect(result.rect.top).toBeLessThanOrEqual(0);
-    expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
+    expect(result.backdrop.top).toBeLessThanOrEqual(0);
+    expect(result.backdrop.bottom).toBeGreaterThanOrEqual(result.inner.h);
+    expect(result.header.top).toBeLessThanOrEqual(1);
+    expect(result.computed.contentPaddingTop).toBe('0px');
+    expect(result.computed.sessionOverlayTopChromeInset || '0px').toBe('0px');
+    expect(result.headerRow.top).toBeLessThan(80);
     expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 
@@ -310,21 +343,14 @@ test.describe('SessionChatOverlay layout', () => {
     // deleted) to have run; also covers the focusout rAF debounce.
     await page.waitForTimeout(400);
 
-    const result = await page.evaluate(() => {
-      const el = document.querySelector(
-        '[data-testid="session-chat-overlay"]'
-      ) as HTMLElement;
-      const r = el.getBoundingClientRect();
-      const s = el.style;
-      return {
-        rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
-        inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
-      };
-    });
+    const result = await readOverlayLayout(page);
 
-    expect(result.rect.top).toBeLessThanOrEqual(0);
-    expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
+    expect(result.backdrop.top).toBeLessThanOrEqual(0);
+    expect(result.backdrop.bottom).toBeGreaterThanOrEqual(result.inner.h);
+    expect(result.header.top).toBeLessThanOrEqual(1);
+    expect(result.computed.contentPaddingTop).toBe('0px');
+    expect(result.computed.sessionOverlayTopChromeInset || '0px').toBe('0px');
+    expect(result.headerRow.top).toBeLessThan(80);
     expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
   });
 


### PR DESCRIPTION
## Summary
- Stop `.overlay-content` from consuming raw `--viewport-offset-top`, so stale iPhone visual viewport state cannot push the chat content down after blur.
- Add a sanitized `--session-overlay-top-chrome-inset` computed from visual viewport data, rejecting phone, stale, and keyboard-compressed offsets while preserving tablet/iPad signals.
- Apply the sanitized inset only to the overlay header padding and expand unit/e2e coverage around iPhone blur, tablet layout, and header spacing.

## Session Summary Context
- The session summary identified gaps in the canvas plan around existing viewport variable consumers, explicit unit coverage, and Playwright assertions that only checked shell rectangles.
- This implementation keeps raw `--viewport-offset-top` available for non-overlay consumers while preventing it from driving overlay content geometry.

## Tests
- `yarn workspace @circuschief/web test src/composables/useVisualViewport.test.js src/components/SessionChatOverlay.test.js`
- `yarn test:e2e tests/e2e/session-chat-overlay-layout.spec.ts`
- `yarn workspace @circuschief/web build`