### PR TITLE
Fix mobile session chat overlay keyboard layout

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -8,10 +8,11 @@
       <div
         v-if="visible"
         class="overlay-backdrop"
+        :class="{ 'overlay-keyboard-focus': keyboardFocusActive }"
         data-testid="session-chat-overlay"
         @click.self="close"
-        @focusin="() => requestVisualViewportUpdate()"
-        @focusout="() => requestVisualViewportSettle()"
+        @focusin="handleOverlayFocusIn"
+        @focusout="handleOverlayFocusOut"
       >
         <div
           class="overlay-panel-wrapper"
@@ -421,6 +422,7 @@ const closing = ref(false);
 const activeSessionId = ref(props.sessionId);
 const isMobile = ref(false);
 const isCreatingSession = ref(false);
+const keyboardFocusActive = ref(false);
 // Start as true so ConversationTab doesn't mount until loadSessionData completes.
 // This prevents a race condition where ConversationTab reads currentSession before
 // it has been set to the overlay's target session.
@@ -476,6 +478,7 @@ const nameEditInput = ref(null);
 // WebSocket subscription management (NOT useSessionInitializer)
 let currentSubscription = null;
 let wsCleanups = [];
+let keyboardFocusTimer = null;
 
 // Lightweight polling for the active session
 const {
@@ -781,6 +784,34 @@ function checkMobile() {
   isMobile.value = window.innerWidth < 768;
 }
 
+function isTextEntryElement(target) {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(target.closest('textarea, input, [contenteditable="true"]'));
+}
+
+function handleOverlayFocusIn(event) {
+  if (keyboardFocusTimer) {
+    clearTimeout(keyboardFocusTimer);
+    keyboardFocusTimer = null;
+  }
+  keyboardFocusActive.value = isTextEntryElement(event.target);
+  requestVisualViewportUpdate();
+  requestAnimationFrame(() => {
+    requestVisualViewportUpdate();
+    if (keyboardFocusActive.value) {
+      event.target?.scrollIntoView?.({ block: 'center', inline: 'nearest' });
+    }
+  });
+}
+
+function handleOverlayFocusOut() {
+  requestVisualViewportSettle();
+  keyboardFocusTimer = setTimeout(() => {
+    keyboardFocusActive.value = false;
+    keyboardFocusTimer = null;
+  }, 180);
+}
+
 function handleEscape(event) {
   if (event.key === 'Escape') {
     if (pickerOpen.value) {
@@ -878,6 +909,10 @@ onMounted(async () => {
 
 onUnmounted(() => {
   unlockBodyScroll();
+  if (keyboardFocusTimer) {
+    clearTimeout(keyboardFocusTimer);
+    keyboardFocusTimer = null;
+  }
   document.removeEventListener('keydown', handleEscape);
   document.removeEventListener('click', handleClickOutsidePicker, true);
   window.removeEventListener('resize', checkMobile);
@@ -898,6 +933,7 @@ defineExpose({
   isCreatingSession,
   switchingSession,
   pickerOpen,
+  keyboardFocusActive,
   handlePickerSelect,
   overlayBodyRef,
 });
@@ -1070,15 +1106,17 @@ defineExpose({
 
 .overlay-body {
   padding: 0 1rem;
-  /* Respect iOS home-indicator / bottom URL-bar gutter. Fall-back:
-     if Phase 6 QA reveals the gutter is not visible at the right
-     time, move the inset to `.input-form` or a dedicated wrapper. */
-  padding-bottom: max(0px, env(safe-area-inset-bottom));
+  --overlay-body-bottom-gutter: max(
+    env(safe-area-inset-bottom),
+    var(--visual-viewport-bottom-inset, 0px)
+  );
+  padding-bottom: var(--overlay-body-bottom-gutter);
   flex: 1;
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  scroll-padding-bottom: calc(var(--overlay-body-bottom-gutter) + 8rem);
   background: rgb(17, 24, 39);
 }
 
@@ -1123,7 +1161,9 @@ defineExpose({
   font-size: 1rem;
   font-weight: 600;
   color: var(--color-primary, #06b6d4);
-  word-break: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dropdown-trigger {
@@ -1199,9 +1239,38 @@ defineExpose({
   .overlay-header {
     --overlay-header-base-padding-top: 1rem;
 
+    gap: 0.25rem;
     padding-right: 0.5rem;
     padding-bottom: 0.375rem;
     padding-left: 0.5rem;
+  }
+
+  .overlay-keyboard-focus .overlay-header {
+    --overlay-header-base-padding-top: 0.5rem;
+
+    gap: 0.125rem;
+    padding-bottom: 0.25rem;
+  }
+
+  .overlay-keyboard-focus .overlay-header-selector {
+    display: none;
+  }
+
+  .overlay-keyboard-focus .overlay-root-name {
+    font-size: 0.875rem;
+  }
+
+  .overlay-keyboard-focus .back-to-sessions-text {
+    display: none;
+  }
+
+  .overlay-keyboard-focus .back-to-sessions-link {
+    margin-right: 0.5rem;
+    padding-inline: 0.5rem;
+  }
+
+  .overlay-keyboard-focus .add-session-btn {
+    padding-inline: 0.625rem;
   }
 }
 

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -81,6 +81,23 @@ export function computeSessionOverlayTopChromeInset(input = {}) {
   return isTabletSizedLayout(layoutWidth, layoutHeight) || tabletSignal ? offsetTop : 0;
 }
 
+export function computeVisualViewportBottomInset(input = {}) {
+  const layoutHeight = toFiniteNumber(input.layoutHeight);
+  const visualViewportHeight = toFiniteNumber(input.visualViewportHeight);
+  const offsetTop = toFiniteNumber(input.offsetTop) || 0;
+
+  if (!(layoutHeight > 0 && visualViewportHeight > 0)) {
+    return 0;
+  }
+
+  const bottomInset = layoutHeight - visualViewportHeight - offsetTop;
+  if (!Number.isFinite(bottomInset) || bottomInset <= 0) {
+    return 0;
+  }
+
+  return Math.round(bottomInset);
+}
+
 function getVisualViewportRect() {
   const { offsetTop, height } = window.visualViewport;
   return { offsetTop, height };
@@ -105,6 +122,11 @@ function writeVisualViewportVariables() {
     maxTouchPoints: navigator.maxTouchPoints,
     userAgent: navigator.userAgent,
   });
+  const bottomInset = computeVisualViewportBottomInset({
+    offsetTop: rect.offsetTop,
+    visualViewportHeight: rect.height,
+    layoutHeight: window.innerHeight,
+  });
   document.documentElement.style.setProperty(
     '--viewport-offset-top',
     getPixelValue(rect.offsetTop, '0px')
@@ -116,6 +138,10 @@ function writeVisualViewportVariables() {
   document.documentElement.style.setProperty(
     '--session-overlay-top-chrome-inset',
     `${overlayInset}px`
+  );
+  document.documentElement.style.setProperty(
+    '--visual-viewport-bottom-inset',
+    `${bottomInset}px`
   );
   return rect;
 }

--- a/packages/web/src/composables/useVisualViewport.test.js
+++ b/packages/web/src/composables/useVisualViewport.test.js
@@ -3,6 +3,7 @@ import { ref, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import {
   computeSessionOverlayTopChromeInset,
+  computeVisualViewportBottomInset,
   requestVisualViewportSettle,
   requestVisualViewportUpdate,
   useVisualViewport,
@@ -157,6 +158,15 @@ describe('useVisualViewport', () => {
       '--session-overlay-top-chrome-inset',
       overlayInset
     );
+    const bottomInset = computeVisualViewportBottomInset({
+      offsetTop: mockVisualViewport?.offsetTop,
+      visualViewportHeight: mockVisualViewport?.height,
+      layoutHeight: window.innerHeight,
+    });
+    expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
+      '--visual-viewport-bottom-inset',
+      `${bottomInset}px`
+    );
   }
 
   describe('computeSessionOverlayTopChromeInset', () => {
@@ -252,6 +262,38 @@ describe('useVisualViewport', () => {
           offsetTop,
         })
       ).toBe(0);
+    });
+  });
+
+  describe('computeVisualViewportBottomInset', () => {
+    it.each([
+      [
+        'keyboard-compressed phone viewport',
+        { layoutHeight: 844, offsetTop: 0, visualViewportHeight: 500 },
+        344,
+      ],
+      [
+        'offset visual viewport',
+        { layoutHeight: 1000, offsetTop: 32, visualViewportHeight: 820 },
+        148,
+      ],
+      [
+        'full-height viewport',
+        { layoutHeight: 844, offsetTop: 0, visualViewportHeight: 844 },
+        0,
+      ],
+      [
+        'oversized visual viewport',
+        { layoutHeight: 700, offsetTop: 0, visualViewportHeight: 800 },
+        0,
+      ],
+      [
+        'missing layout height',
+        { layoutHeight: undefined, offsetTop: 0, visualViewportHeight: 500 },
+        0,
+      ],
+    ])('%s', (_name, input, expected) => {
+      expect(computeVisualViewportBottomInset(input)).toBe(expected);
     });
   });
 
@@ -543,6 +585,7 @@ describe('useVisualViewport', () => {
       expect(document.documentElement.style.getPropertyValue('--viewport-offset-top')).toBe('0px');
       expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('812px');
       expect(document.documentElement.style.getPropertyValue('--session-overlay-top-chrome-inset')).toBe('0px');
+      expect(document.documentElement.style.getPropertyValue('--visual-viewport-bottom-inset')).toBe('0px');
     });
 
     it('writes sanitized overlay inset during settle sampling', async () => {

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -65,6 +65,7 @@ test.describe('SessionChatOverlay layout', () => {
     await page.evaluate(() => {
       document.documentElement.style.setProperty('--viewport-offset-top', '260px');
       document.documentElement.style.setProperty('--visual-viewport-height', '420px');
+      document.documentElement.style.setProperty('--visual-viewport-bottom-inset', '424px');
     });
     await page.waitForTimeout(50);
   }
@@ -81,6 +82,7 @@ test.describe('SessionChatOverlay layout', () => {
       document.documentElement.style.removeProperty('--viewport-offset-top');
       document.documentElement.style.removeProperty('--visual-viewport-height');
       document.documentElement.style.removeProperty('--session-overlay-top-chrome-inset');
+      document.documentElement.style.removeProperty('--visual-viewport-bottom-inset');
     });
   }
 
@@ -105,6 +107,7 @@ test.describe('SessionChatOverlay layout', () => {
       const rootStyle = getComputedStyle(document.documentElement);
       const content = document.querySelector('.overlay-content') as HTMLElement;
       const header = document.querySelector('.overlay-header') as HTMLElement;
+      const body = document.querySelector('.overlay-body') as HTMLElement;
       const s = shell.style;
 
       return {
@@ -122,6 +125,11 @@ test.describe('SessionChatOverlay layout', () => {
           sessionOverlayTopChromeInset: rootStyle
             .getPropertyValue('--session-overlay-top-chrome-inset')
             .trim(),
+          visualViewportBottomInset: rootStyle
+            .getPropertyValue('--visual-viewport-bottom-inset')
+            .trim(),
+          bodyPaddingBottom: getComputedStyle(body).paddingBottom,
+          bodyScrollPaddingBottom: getComputedStyle(body).scrollPaddingBottom,
         },
         inline: {
           top: s.top,
@@ -224,6 +232,8 @@ test.describe('SessionChatOverlay layout', () => {
       expect(result.computed.viewportOffsetTop).toBe(`${injectedViewportOffsetTop}px`);
       expect(result.computed.visualViewportHeight).toBe('420px');
       expect(result.computed.sessionOverlayTopChromeInset).toBe('0px');
+      expect(result.computed.visualViewportBottomInset).toBe('424px');
+      expect(parseFloat(result.computed.bodyPaddingBottom)).toBeGreaterThanOrEqual(423);
       expect(result.headerRow.top).toBeLessThan(80);
     } finally {
       await clearStaleVisualViewportVariables(page);


### PR DESCRIPTION
## Summary
- Track Visual Viewport bottom inset and apply keyboard-aware padding inside the session chat overlay body
- Scroll focused prompt inputs into view when the mobile keyboard changes viewport space
- Compact the mobile sticky header by ellipsizing long titles and hiding the selector row while text input is focused
- Add focused layout coverage for keyboard bottom inset behavior

## Verification
- yarn workspace @circuschief/web test src/composables/useVisualViewport.test.js src/components/SessionChatOverlay.test.js
- yarn test:e2e tests/e2e/session-chat-overlay-layout.spec.ts
- npx eslint packages/web/src/components/SessionChatOverlay.vue packages/web/src/composables/useVisualViewport.js packages/web/src/composables/useVisualViewport.test.js

Session summary: fixed mobile keyboard and long-header UX issues in the session chat overlay; committed as a37badae and pushed to circus-chief/f6f7-theres-couple-nasty-ux.