### PR TITLE
Fix iPhone 12 mini overlay top-half unusability after keyboard blur

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -7,6 +7,7 @@
 
   /* Visual viewport offset for iOS Safari browser chrome (URL bar, tab bar) */
   --viewport-offset-top: 0px;
+  --session-overlay-top-chrome-inset: 0px;
 
   --color-background: #0d1117;
   --color-background-soft: #161b22;

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1625,21 +1625,26 @@ describe('SessionChatOverlay', () => {
       expect(block).not.toMatch(/top:\s*var\(/);
     });
 
-    it('overlay content has a viewport-height floor and visual top offset', () => {
+    it('overlay content has a viewport-height floor without visual viewport padding', () => {
       const block = getStyleBlock('.overlay-content');
       expect(block).toMatch(/min-height:\s*100%/);
       expect(block).toMatch(/min-height:\s*100dvh/);
-      expect(block).toMatch(
-        /padding-top:\s*max\(0px,\s*var\(--viewport-offset-top,\s*0px\)\)/
-      );
+      expect(block).toMatch(/overflow:\s*clip/);
+      expect(block).toMatch(/padding:\s*0/);
+      expect(block).not.toMatch(/padding-top/);
+      expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
     });
 
-    it('overlay header stays sticky within the padded content flow', () => {
+    it('overlay header stays sticky and consumes only the sanitized top chrome inset', () => {
       const block = getStyleBlock('.overlay-header');
+      expect(block).toMatch(/--overlay-header-base-padding-top:\s*0\.75rem/);
       expect(block).toMatch(/position:\s*-webkit-sticky/);
       expect(block).toMatch(/position:\s*sticky/);
       expect(block).toMatch(/top:\s*0/);
+      expect(block).toMatch(/padding:\s*var\(--overlay-header-base-padding-top\)\s*1rem\s*0\.375rem/);
+      expect(block).toMatch(/max\(var\(--overlay-header-base-padding-top\),\s*env\(safe-area-inset-top\)\)/);
+      expect(block).toMatch(/--session-overlay-top-chrome-inset/);
       expect(block).not.toMatch(/--viewport-offset-top/);
       expect(block).not.toMatch(/--visual-viewport-height/);
     });

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -1063,7 +1063,6 @@ defineExpose({
      was a historical failure mode when `overflow: hidden` was used here. */
   overflow: clip;
   padding: 0;
-  padding-top: max(0px, var(--viewport-offset-top, 0px));
   box-shadow: -4px 0 20px rgba(0, 0, 0, 0.5);
   position: relative;
   background: rgb(17, 24, 39);
@@ -1084,15 +1083,18 @@ defineExpose({
 }
 
 .overlay-header {
+  --overlay-header-base-padding-top: 0.75rem;
   position: -webkit-sticky;
   position: sticky;
   top: 0;
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  padding: 0.75rem 1rem 0.375rem;
-  /* Raise top padding to clear the iPhone notch when present. */
-  padding-top: max(0.75rem, env(safe-area-inset-top));
+  padding: var(--overlay-header-base-padding-top) 1rem 0.375rem;
+  padding-top: calc(
+    max(var(--overlay-header-base-padding-top), env(safe-area-inset-top)) +
+      var(--session-overlay-top-chrome-inset, 0px)
+  );
   background: var(--color-background-secondary, #1f2937);
   border-radius: 0;
   border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
@@ -1194,14 +1196,10 @@ defineExpose({
   }
 
   .overlay-header {
+    --overlay-header-base-padding-top: 1rem;
     padding-right: 0.5rem;
     padding-bottom: 0.375rem;
     padding-left: 0.5rem;
-    /* padding-top: keep the larger base value (the 1rem visual intent
-       of the old shorthand is already covered by the base
-       `max(0.75rem, env(safe-area-inset-top))` on devices with an
-       inset; raise the floor here for mobile without a notch). */
-    padding-top: max(1rem, env(safe-area-inset-top));
   }
 }
 

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -10,6 +10,7 @@ let settleStableSamples = 0;
 const SESSION_OVERLAY_TOP_CHROME_THRESHOLD = 64;
 const KEYBOARD_HEIGHT_DELTA_THRESHOLD = 120;
 const KEYBOARD_VIEWPORT_RATIO_THRESHOLD = 0.85;
+const TABLET_MIN_LAYOUT_DIMENSION = 700;
 
 function getPixelValue(value, fallback) {
   return Number.isFinite(value) ? `${value}px` : fallback;
@@ -18,6 +19,50 @@ function getPixelValue(value, fallback) {
 function getVisualViewportRect() {
   const { offsetTop, height } = window.visualViewport;
   return { offsetTop, height };
+}
+
+function isValidOffsetTop(offsetTop) {
+  return (
+    Number.isFinite(offsetTop) &&
+    offsetTop > 0 &&
+    offsetTop <= SESSION_OVERLAY_TOP_CHROME_THRESHOLD
+  );
+}
+
+function getDeviceType(userAgent, platform, maxTouchPoints) {
+  const ua = String(userAgent);
+  const devicePlatform = String(platform);
+  const touchPoints = Number(maxTouchPoints) || 0;
+  const isAndroid = /Android/i.test(ua);
+  const isAndroidMobile = isAndroid && /Mobile/i.test(ua);
+  const isIPhoneLike = /iPhone|iPod/i.test(`${ua} ${devicePlatform}`);
+  const isIPad =
+    /iPad/i.test(`${ua} ${devicePlatform}`) ||
+    (devicePlatform === 'MacIntel' && touchPoints > 1);
+  const isAndroidTablet = isAndroid && !/Mobile/i.test(ua);
+
+  return {
+    isPhone: isIPhoneLike || isAndroidMobile,
+    isTablet: isIPad || isAndroidTablet,
+  };
+}
+
+function hasKeyboardShapedViewport(layoutHeight, visualViewportHeight) {
+  return (
+    Number.isFinite(layoutHeight) &&
+    layoutHeight > 0 &&
+    Number.isFinite(visualViewportHeight) &&
+    (layoutHeight - visualViewportHeight > KEYBOARD_HEIGHT_DELTA_THRESHOLD ||
+      visualViewportHeight / layoutHeight < KEYBOARD_VIEWPORT_RATIO_THRESHOLD)
+  );
+}
+
+function hasTabletSizedLayout(layoutWidth, layoutHeight) {
+  return (
+    Number.isFinite(layoutWidth) &&
+    Number.isFinite(layoutHeight) &&
+    Math.min(layoutWidth, layoutHeight) >= TABLET_MIN_LAYOUT_DIMENSION
+  );
 }
 
 export function computeSessionOverlayTopChromeInset({
@@ -29,47 +74,20 @@ export function computeSessionOverlayTopChromeInset({
   platform = '',
   maxTouchPoints = 0,
 }) {
-  if (
-    !Number.isFinite(offsetTop) ||
-    offsetTop <= 0 ||
-    offsetTop > SESSION_OVERLAY_TOP_CHROME_THRESHOLD
-  ) {
+  if (!isValidOffsetTop(offsetTop)) {
     return 0;
   }
 
-  const ua = String(userAgent);
-  const devicePlatform = String(platform);
-  const touchPoints = Number(maxTouchPoints) || 0;
-  const isAndroid = /Android/i.test(ua);
-  const isAndroidMobile = isAndroid && /Mobile/i.test(ua);
-  const isIPhoneLike = /iPhone|iPod/i.test(`${ua} ${devicePlatform}`);
-  const hasPhoneSignal = isIPhoneLike || isAndroidMobile;
-
-  if (hasPhoneSignal) {
+  const deviceType = getDeviceType(userAgent, platform, maxTouchPoints);
+  if (deviceType.isPhone) {
     return 0;
   }
 
-  const hasKeyboardShapedViewport =
-    Number.isFinite(layoutHeight) &&
-    layoutHeight > 0 &&
-    Number.isFinite(visualViewportHeight) &&
-    (layoutHeight - visualViewportHeight > KEYBOARD_HEIGHT_DELTA_THRESHOLD ||
-      visualViewportHeight / layoutHeight < KEYBOARD_VIEWPORT_RATIO_THRESHOLD);
-
-  if (hasKeyboardShapedViewport) {
+  if (hasKeyboardShapedViewport(layoutHeight, visualViewportHeight)) {
     return 0;
   }
 
-  const isIPad =
-    /iPad/i.test(`${ua} ${devicePlatform}`) ||
-    (devicePlatform === 'MacIntel' && touchPoints > 1);
-  const isAndroidTablet = isAndroid && !/Mobile/i.test(ua);
-  const hasTabletSizedLayout =
-    Number.isFinite(layoutWidth) &&
-    Number.isFinite(layoutHeight) &&
-    Math.min(layoutWidth, layoutHeight) >= 700;
-
-  if (isIPad || isAndroidTablet || hasTabletSizedLayout) {
+  if (deviceType.isTablet || hasTabletSizedLayout(layoutWidth, layoutHeight)) {
     return offsetTop;
   }
 

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -7,6 +7,10 @@ let settleStartedAt = 0;
 let settleLastRect = null;
 let settleStableSamples = 0;
 
+const SESSION_OVERLAY_TOP_CHROME_THRESHOLD = 64;
+const KEYBOARD_HEIGHT_DELTA_THRESHOLD = 120;
+const KEYBOARD_VIEWPORT_RATIO_THRESHOLD = 0.85;
+
 function getPixelValue(value, fallback) {
   return Number.isFinite(value) ? `${value}px` : fallback;
 }
@@ -16,11 +20,67 @@ function getVisualViewportRect() {
   return { offsetTop, height };
 }
 
+export function computeSessionOverlayTopChromeInset({
+  offsetTop,
+  visualViewportHeight,
+  layoutWidth,
+  layoutHeight,
+  userAgent = '',
+  platform = '',
+  maxTouchPoints = 0,
+}) {
+  if (
+    !Number.isFinite(offsetTop) ||
+    offsetTop <= 0 ||
+    offsetTop > SESSION_OVERLAY_TOP_CHROME_THRESHOLD
+  ) {
+    return 0;
+  }
+
+  const ua = String(userAgent);
+  const devicePlatform = String(platform);
+  const touchPoints = Number(maxTouchPoints) || 0;
+  const isAndroid = /Android/i.test(ua);
+  const isAndroidMobile = isAndroid && /Mobile/i.test(ua);
+  const isIPhoneLike = /iPhone|iPod/i.test(`${ua} ${devicePlatform}`);
+  const hasPhoneSignal = isIPhoneLike || isAndroidMobile;
+
+  if (hasPhoneSignal) {
+    return 0;
+  }
+
+  const hasKeyboardShapedViewport =
+    Number.isFinite(layoutHeight) &&
+    layoutHeight > 0 &&
+    Number.isFinite(visualViewportHeight) &&
+    (layoutHeight - visualViewportHeight > KEYBOARD_HEIGHT_DELTA_THRESHOLD ||
+      visualViewportHeight / layoutHeight < KEYBOARD_VIEWPORT_RATIO_THRESHOLD);
+
+  if (hasKeyboardShapedViewport) {
+    return 0;
+  }
+
+  const isIPad =
+    /iPad/i.test(`${ua} ${devicePlatform}`) ||
+    (devicePlatform === 'MacIntel' && touchPoints > 1);
+  const isAndroidTablet = isAndroid && !/Mobile/i.test(ua);
+  const hasTabletSizedLayout =
+    Number.isFinite(layoutWidth) &&
+    Number.isFinite(layoutHeight) &&
+    Math.min(layoutWidth, layoutHeight) >= 700;
+
+  if (isIPad || isAndroidTablet || hasTabletSizedLayout) {
+    return offsetTop;
+  }
+
+  return 0;
+}
+
 function rectsMatch(a, b) {
   return a && b && a.offsetTop === b.offsetTop && a.height === b.height;
 }
 
-function writeVisualViewportVariables() {
+export function writeVisualViewportVariables() {
   if (!window.visualViewport) {
     return null;
   }
@@ -33,6 +93,19 @@ function writeVisualViewportVariables() {
   document.documentElement.style.setProperty(
     '--visual-viewport-height',
     getPixelValue(rect.height, '100dvh')
+  );
+  const sessionOverlayTopChromeInset = computeSessionOverlayTopChromeInset({
+    offsetTop: rect.offsetTop,
+    visualViewportHeight: rect.height,
+    layoutWidth: window.innerWidth,
+    layoutHeight: window.innerHeight,
+    userAgent: window.navigator?.userAgent,
+    platform: window.navigator?.platform,
+    maxTouchPoints: window.navigator?.maxTouchPoints,
+  });
+  document.documentElement.style.setProperty(
+    '--session-overlay-top-chrome-inset',
+    `${sessionOverlayTopChromeInset}px`
   );
   return rect;
 }
@@ -138,9 +211,9 @@ export function requestVisualViewportSettle(options = {}) {
  * This is needed for iOS Safari, where the browser chrome (URL bar + tab bar) can
  * physically overlap sticky-positioned elements when expanded.
  *
- * Sets --viewport-offset-top and --visual-viewport-height CSS variables on
- * document.documentElement. These can be used to align fixed and sticky elements
- * to the same visual viewport rectangle.
+ * Sets raw visual viewport CSS variables on document.documentElement, plus a
+ * session-overlay-specific sanitized top inset that avoids treating stale phone
+ * keyboard offsets as browser chrome.
  *
  * On browsers without visualViewport API, this no-ops and CSS fallbacks apply.
  */

--- a/packages/web/src/composables/useVisualViewport.test.js
+++ b/packages/web/src/composables/useVisualViewport.test.js
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ref, nextTick } from 'vue';
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import {
+  computeSessionOverlayTopChromeInset,
   requestVisualViewportSettle,
   requestVisualViewportUpdate,
   useVisualViewport,
+  writeVisualViewportVariables,
 } from './useVisualViewport.js';
 
 /**
@@ -20,10 +22,24 @@ describe('useVisualViewport', () => {
   let mockVisualViewport;
   let rafSpy;
   let cancelRafSpy;
+  let originalInnerWidth;
+  let originalInnerHeight;
 
   beforeEach(() => {
     // Save original visualViewport
     originalVisualViewport = window.visualViewport;
+    originalInnerWidth = window.innerWidth;
+    originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 768,
+    });
 
     // Mock requestAnimationFrame and cancelAnimationFrame
     rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => setTimeout(cb, 0));
@@ -43,6 +59,16 @@ describe('useVisualViewport', () => {
     } else {
       delete window.visualViewport;
     }
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalInnerWidth,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: originalInnerHeight,
+    });
 
     rafSpy.mockRestore();
     cancelRafSpy.mockRestore();
@@ -74,7 +100,7 @@ describe('useVisualViewport', () => {
     });
   }
 
-  function expectViewportVariables(offsetTop, height) {
+  function expectViewportVariables(offsetTop, height, sessionOverlayTopChromeInset = '0px') {
     expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
       '--viewport-offset-top',
       offsetTop
@@ -83,7 +109,151 @@ describe('useVisualViewport', () => {
       '--visual-viewport-height',
       height
     );
+    expect(document.documentElement.style.setProperty).toHaveBeenCalledWith(
+      '--session-overlay-top-chrome-inset',
+      sessionOverlayTopChromeInset
+    );
   }
+
+  function setLayoutViewport(width, height) {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: width,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: height,
+    });
+  }
+
+  describe('computeSessionOverlayTopChromeInset', () => {
+    it('returns 0 for an iPhone 12 mini keyboard-shaped viewport', () => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop: 260,
+          visualViewportHeight: 420,
+          layoutWidth: 375,
+          layoutHeight: 812,
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+          platform: 'iPhone',
+        })
+      ).toBe(0);
+    });
+
+    it('returns 0 for iPhone-like devices even with a small offset', () => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop: 32,
+          visualViewportHeight: 780,
+          layoutWidth: 375,
+          layoutHeight: 812,
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+          platform: 'iPhone',
+        })
+      ).toBe(0);
+    });
+
+    it('returns the offset for iPad user-agent and iPadOS touch-platform signals', () => {
+      const base = {
+        offsetTop: 32,
+        visualViewportHeight: 968,
+        layoutWidth: 744,
+        layoutHeight: 1000,
+      };
+
+      expect(
+        computeSessionOverlayTopChromeInset({
+          ...base,
+          userAgent:
+            'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+          platform: 'iPad',
+        })
+      ).toBe(32);
+      expect(
+        computeSessionOverlayTopChromeInset({
+          ...base,
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+          platform: 'MacIntel',
+          maxTouchPoints: 5,
+        })
+      ).toBe(32);
+    });
+
+    it('returns 0 for an iPad signal with a keyboard-shaped viewport', () => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop: 32,
+          visualViewportHeight: 600,
+          layoutWidth: 744,
+          layoutHeight: 1000,
+          userAgent:
+            'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+          platform: 'iPad',
+        })
+      ).toBe(0);
+    });
+
+    it('keeps Android Mobile at 0 and allows Android tablet offsets', () => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop: 32,
+          visualViewportHeight: 812,
+          layoutWidth: 412,
+          layoutHeight: 915,
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile Safari/537.36',
+        })
+      ).toBe(0);
+
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop: 32,
+          visualViewportHeight: 968,
+          layoutWidth: 800,
+          layoutHeight: 1000,
+          userAgent:
+            'Mozilla/5.0 (Linux; Android 14; Pixel Tablet) AppleWebKit/537.36 Safari/537.36',
+        })
+      ).toBe(32);
+    });
+
+    it.each([
+      [Number.NaN],
+      [Infinity],
+      [-1],
+      [0],
+      [65],
+    ])('returns 0 for invalid or over-threshold offset %s', (offsetTop) => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop,
+          visualViewportHeight: 968,
+          layoutWidth: 744,
+          layoutHeight: 1000,
+          platform: 'iPad',
+        })
+      ).toBe(0);
+    });
+
+    it('returns the offset for a tablet-sized layout without a phone signal', () => {
+      expect(
+        computeSessionOverlayTopChromeInset({
+          offsetTop: 32,
+          visualViewportHeight: 968,
+          layoutWidth: 744,
+          layoutHeight: 1000,
+          userAgent:
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36',
+          platform: 'Linux x86_64',
+        })
+      ).toBe(32);
+    });
+  });
 
   describe('Browser support detection', () => {
     it('returns without errors when visualViewport API is not supported', () => {
@@ -161,6 +331,17 @@ describe('useVisualViewport', () => {
       await nextTick();
 
       expectViewportVariables('0px', '0px');
+    });
+
+    it('writes raw viewport variables and the sanitized overlay inset', () => {
+      setLayoutViewport(744, 1000);
+      mockVisualViewport.offsetTop = 32;
+      mockVisualViewport.height = 968;
+
+      const rect = writeVisualViewportVariables();
+
+      expect(rect).toEqual({ offsetTop: 32, height: 968 });
+      expectViewportVariables('32px', '968px', '32px');
     });
   });
 
@@ -359,6 +540,7 @@ describe('useVisualViewport', () => {
       expectViewportVariables('0px', '812px');
       expect(document.documentElement.style.getPropertyValue('--viewport-offset-top')).toBe('0px');
       expect(document.documentElement.style.getPropertyValue('--visual-viewport-height')).toBe('812px');
+      expect(document.documentElement.style.getPropertyValue('--session-overlay-top-chrome-inset')).toBe('0px');
     });
 
     it('requestVisualViewportSettle no-ops without visualViewport support', () => {

--- a/tests/e2e/session-chat-overlay-layout.spec.ts
+++ b/tests/e2e/session-chat-overlay-layout.spec.ts
@@ -27,7 +27,6 @@ test.describe('SessionChatOverlay layout', () => {
 
   let project: any;
   let session: any;
-  const injectedViewportOffsetTop = 260;
 
   test.beforeEach(async () => {
     project = await seedProject('Overlay Layout', '/tmp/overlay-layout');
@@ -39,7 +38,8 @@ test.describe('SessionChatOverlay layout', () => {
     seedConversationHistory(session.id, 20);
   });
 
-  test.afterEach(async () => {
+  test.afterEach(async ({ page }) => {
+    await clearStaleVisualViewportVariables(page).catch(() => {});
     await cleanupCreatedResources();
   });
 
@@ -73,7 +73,18 @@ test.describe('SessionChatOverlay layout', () => {
     await page.evaluate(() => {
       document.documentElement.style.removeProperty('--viewport-offset-top');
       document.documentElement.style.removeProperty('--visual-viewport-height');
+      document.documentElement.style.removeProperty('--session-overlay-top-chrome-inset');
     });
+  }
+
+  async function injectSessionOverlayTopChromeInset(page: Page, insetPx: number) {
+    await page.evaluate((inset) => {
+      document.documentElement.style.setProperty(
+        '--session-overlay-top-chrome-inset',
+        `${inset}px`
+      );
+    }, insetPx);
+    await page.waitForTimeout(50);
   }
 
   async function readOverlayLayout(page: Page) {
@@ -94,6 +105,8 @@ test.describe('SessionChatOverlay layout', () => {
       const shell = document.querySelector(
         '[data-testid="session-chat-overlay"]'
       ) as HTMLElement;
+      const content = document.querySelector('.overlay-content') as HTMLElement;
+      const header = document.querySelector('.overlay-header') as HTMLElement;
       const s = shell.style;
 
       return {
@@ -101,6 +114,11 @@ test.describe('SessionChatOverlay layout', () => {
         panel: rectFor('.overlay-panel-wrapper'),
         content: rectFor('.overlay-content'),
         header: rectFor('.overlay-header'),
+        headerRow: rectFor('.overlay-header-row'),
+        computed: {
+          contentPaddingTop: getComputedStyle(content).paddingTop,
+          headerPaddingTop: getComputedStyle(header).paddingTop,
+        },
         inner: { w: window.innerWidth, h: window.innerHeight },
         inline: {
           top: s.top,
@@ -127,6 +145,16 @@ test.describe('SessionChatOverlay layout', () => {
       width: '',
       height: '',
     });
+  }
+
+  function expectContentCoversViewport(result: Awaited<ReturnType<typeof readOverlayLayout>>) {
+    expect(result.content.top).toBeLessThanOrEqual(1);
+    expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+  }
+
+  function expectHeaderAtViewportTop(result: Awaited<ReturnType<typeof readOverlayLayout>>) {
+    expect(result.header.top).toBeGreaterThanOrEqual(-1);
+    expect(result.header.top).toBeLessThanOrEqual(1);
   }
 
   test('backdrop covers viewport and writes no inline geometry', async ({ page }) => {
@@ -196,8 +224,40 @@ test.describe('SessionChatOverlay layout', () => {
     try {
       const result = await readOverlayLayout(page);
       expectBackdropCoversViewport(result);
-      expect(result.content.top).toBeLessThanOrEqual(1);
-      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expectContentCoversViewport(result);
+      expect(result.computed.contentPaddingTop).toBe('0px');
+    } finally {
+      await clearStaleVisualViewportVariables(page);
+    }
+  });
+
+  test('iPhone 12 mini stale visual viewport variables do not create a blank top band', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await navigateToSession(page);
+    await openOverlay(page);
+
+    await injectStaleVisualViewportVariables(page);
+
+    try {
+      const result = await readOverlayLayout(page);
+      expectBackdropCoversViewport(result);
+      expectContentCoversViewport(result);
+      expect(result.computed.contentPaddingTop).toBe('0px');
+      expectHeaderAtViewportTop(result);
+      expect(result.headerRow.top).toBeLessThan(80);
+
+      const hit = await page.evaluate(() => {
+        const el = document.elementFromPoint(20, 40) as HTMLElement | null;
+        return {
+          inOverlay: Boolean(el?.closest('[data-testid="session-chat-overlay"]')),
+          inHeader: Boolean(el?.closest('.overlay-header')),
+          isContentPaddingBand: Boolean(el?.classList.contains('overlay-content')),
+        };
+      });
+
+      expect(hit.inOverlay).toBe(true);
+      expect(hit.inHeader).toBe(true);
+      expect(hit.isContentPaddingBand).toBe(false);
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
@@ -218,8 +278,8 @@ test.describe('SessionChatOverlay layout', () => {
       expect(result.panel.left).toBeLessThanOrEqual(1);
       expect(result.panel.right).toBeGreaterThanOrEqual(result.inner.w - 1);
       expect(result.panel.width).toBeGreaterThanOrEqual(result.inner.w - 1);
-      expect(result.content.top).toBeLessThanOrEqual(1);
-      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expectContentCoversViewport(result);
+      expect(result.computed.contentPaddingTop).toBe('0px');
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
@@ -241,14 +301,14 @@ test.describe('SessionChatOverlay layout', () => {
       expect(result.panel.right).toBeLessThanOrEqual(result.inner.w + 1);
       expect(result.panel.width).toBeLessThanOrEqual(701);
       expect(result.panel.width).toBeGreaterThan(0);
-      expect(result.content.top).toBeLessThanOrEqual(1);
-      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
+      expectContentCoversViewport(result);
+      expect(result.computed.contentPaddingTop).toBe('0px');
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
   });
 
-  test('visual viewport top offset aligns the overlay header without moving the shell', async ({ page }) => {
+  test('stale visual viewport top offset does not move the overlay header or shell', async ({ page }) => {
     await page.setViewportSize({ width: 744, height: 1000 });
     await navigateToSession(page);
     await openOverlay(page);
@@ -260,10 +320,31 @@ test.describe('SessionChatOverlay layout', () => {
       expectBackdropCoversViewport(result);
       expect(result.panel.top).toBeLessThanOrEqual(1);
       expect(result.panel.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
-      expect(result.content.top).toBeLessThanOrEqual(1);
-      expect(result.content.bottom).toBeGreaterThanOrEqual(result.inner.h - 1);
-      expect(result.header.top).toBeGreaterThanOrEqual(injectedViewportOffsetTop - 1);
-      expect(result.header.top).toBeLessThanOrEqual(injectedViewportOffsetTop + 1);
+      expectContentCoversViewport(result);
+      expect(result.computed.contentPaddingTop).toBe('0px');
+      expectHeaderAtViewportTop(result);
+      expect(result.headerRow.top).toBeLessThan(80);
+    } finally {
+      await clearStaleVisualViewportVariables(page);
+    }
+  });
+
+  test('sanitized tablet top chrome inset pads header content without moving the shell', async ({ page }) => {
+    await page.setViewportSize({ width: 744, height: 1000 });
+    await navigateToSession(page);
+    await openOverlay(page);
+
+    const before = await readOverlayLayout(page);
+    await injectSessionOverlayTopChromeInset(page, 32);
+
+    try {
+      const after = await readOverlayLayout(page);
+      expectBackdropCoversViewport(after);
+      expectContentCoversViewport(after);
+      expectHeaderAtViewportTop(after);
+      expect(after.computed.contentPaddingTop).toBe('0px');
+      expect(after.headerRow.top - before.headerRow.top).toBeGreaterThanOrEqual(31);
+      expect(after.headerRow.top - before.headerRow.top).toBeLessThanOrEqual(34);
     } finally {
       await clearStaleVisualViewportVariables(page);
     }
@@ -277,22 +358,12 @@ test.describe('SessionChatOverlay layout', () => {
     await page.evaluate(() => window.scrollTo(0, 400));
     await openOverlay(page);
 
-    const result = await page.evaluate(() => {
-      const el = document.querySelector(
-        '[data-testid="session-chat-overlay"]'
-      ) as HTMLElement;
-      const r = el.getBoundingClientRect();
-      const s = el.style;
-      return {
-        rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
-        inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
-      };
-    });
-
-    expect(result.rect.top).toBeLessThanOrEqual(0);
-    expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
-    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
+    const result = await readOverlayLayout(page);
+    expectBackdropCoversViewport(result);
+    expectContentCoversViewport(result);
+    expectHeaderAtViewportTop(result);
+    expect(result.headerRow.top).toBeLessThan(80);
+    expect(result.computed.contentPaddingTop).toBe('0px');
   });
 
   test('covers viewport after focus/blur cycle on textarea', async ({ page }) => {
@@ -310,22 +381,12 @@ test.describe('SessionChatOverlay layout', () => {
     // deleted) to have run; also covers the focusout rAF debounce.
     await page.waitForTimeout(400);
 
-    const result = await page.evaluate(() => {
-      const el = document.querySelector(
-        '[data-testid="session-chat-overlay"]'
-      ) as HTMLElement;
-      const r = el.getBoundingClientRect();
-      const s = el.style;
-      return {
-        rect: { top: r.top, bottom: r.bottom, left: r.left, right: r.right },
-        inner: { w: window.innerWidth, h: window.innerHeight },
-        inline: { top: s.top, right: s.right, bottom: s.bottom, left: s.left, width: s.width, height: s.height },
-      };
-    });
-
-    expect(result.rect.top).toBeLessThanOrEqual(0);
-    expect(result.rect.bottom).toBeGreaterThanOrEqual(result.inner.h);
-    expect(result.inline).toEqual({ top: '', right: '', bottom: '', left: '', width: '', height: '' });
+    const result = await readOverlayLayout(page);
+    expectBackdropCoversViewport(result);
+    expectContentCoversViewport(result);
+    expectHeaderAtViewportTop(result);
+    expect(result.headerRow.top).toBeLessThan(80);
+    expect(result.computed.contentPaddingTop).toBe('0px');
   });
 
   test('covers viewport after simulated orientation change', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Sanitizes visual viewport top offset for session overlay to prevent stale keyboard offsets from creating blank content padding bands on phones
- Preserves iPad header visibility by applying sanitized inset only to header padding
- Adds comprehensive unit and E2E test coverage for device-specific behaviors

## Problem
On iPhone 12 mini, after focusing and then unfocusing the prompt textarea inside the session chat overlay, the top portion of the overlay becomes an inert blank band. This occurs because iOS Safari leaves `visualViewport.offsetTop` at keyboard-open values after blur, which was being consumed directly by `.overlay-content` as `padding-top`.

## Solution
- **Add sanitized top chrome inset**: New `--session-overlay-top-chrome-inset` CSS variable computed from raw visual viewport data
- **Device-aware filtering**: `computeSessionOverlayTopChromeInset()` returns 0 for phones and keyboard-shaped viewports, returns offset for tablets
- **Targeted CSS consumption**: Apply sanitized inset only to `.overlay-header` padding, not `.overlay-content`
- **Preserve iPad UX**: Tablet devices still get header padding to clear browser chrome

## Key Changes
- `packages/web/src/assets/main.css`: Add `--session-overlay-top-chrome-inset` variable
- `packages/web/src/composables/useVisualViewport.js`: Add `computeSessionOverlayTopChromeInset()` helper with device detection (iPhone, iPad, Android Mobile vs tablet)
- `packages/web/src/components/SessionChatOverlay.vue`: Remove raw `--viewport-offset-top` from `.overlay-content`, apply sanitized inset to `.overlay-header` padding
- Tests: Comprehensive unit tests for device detection logic, E2E tests for iPhone 12 mini stale offset scenario

## Explicit Non-Goals
This fix intentionally avoids broader keyboard-focus UI changes that caused prior regressions:
- No `overlay-keyboard-focus` class (from PR #893, reverted by #894)
- No session selector/actions hiding during focus
- No `scrollIntoView()` calls from overlay focus handlers
- No bottom visual viewport inset or keyboard-driven bottom padding
- No changes to body scroll lock, z-indexes, or overlay shell geometry

## Test Plan
**Unit tests** (`yarn workspace @circuschief/web test`):
- `computeSessionOverlayTopChromeInset()` for iPhone 12 mini, iPad, Android Mobile/tablet, edge cases
- `writeVisualViewportVariables()` writes raw vars + sanitized overlay var
- Component CSS contract tests updated for new padding behavior

**E2E tests** (`./scripts/pw.sh test`):
- iPhone 12 mini (375x812) with stale offset variables: asserts no blank band, header stays at top
- Tablet CSS consumption: sanitized inset pads header without moving shell
- Focus/blur cycle: maintains layout integrity

**Manual QA required** (Playwright device emulation doesn't reproduce iOS visual/layout viewport divergence):
- iPhone 12 mini Safari: focus textarea, dismiss keyboard, verify top-half is immediately usable
- iPad Safari: verify header visible with chrome expanded/collapsed, before/after focus/blur

## References
- Root cause analysis: Prior fix cycles in PRs #885, #888, #891, #893 (fixes) and #894, #895 (reverts)
- Implementation plan: [session-chat-overlay-iphone12mini-plan.md](canvas:session-chat-overlay-iphone12mini-plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)