### PR TITLE
Consolidate duplicate test runs in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,29 +47,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Run unit tests
-        run: |
-          yarn workspace @circuschief/shared test
-          yarn workspace @circuschief/server test
-          yarn workspace @circuschief/web test
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Run coverage
+      - name: Run unit tests with coverage
         run: |
           yarn workspace @circuschief/shared test:coverage
           yarn workspace @circuschief/server test:coverage


### PR DESCRIPTION
## Summary
- Removes the redundant `unit-tests` job from `.github/workflows/test.yml` that was running `vitest run` without coverage
- Keeps the coverage job (renamed to `unit-tests`) that runs `vitest run --coverage` — a single job that provides both test results and coverage enforcement
- Coverage thresholds are still enforced by vitest config in each package

## Why
Tests were running **twice** on every push — once in `unit-tests` and again in `coverage`. Since `test:coverage` is just `vitest run --coverage`, the second job was pure waste. This cuts CI test runs from 6 (3 packages × 2 jobs) to 3.

## Test plan
- [ ] Verify CI runs only one test job instead of two on this PR
- [ ] Confirm coverage thresholds still fail the build if not met

🤖 Generated with [Claude Code](https://claude.com/claude-code)