### PR TITLE
Fix duplicate "New Session" rows in session picker

### DIFF
--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -53,6 +53,7 @@ const mockSessionsStore = {
   addConversation: vi.fn(),
   updateConversation: vi.fn(),
   createSession: vi.fn(),
+  addSessionToList: vi.fn(),
 };
 
 vi.mock('../stores/sessions.js', () => ({
@@ -217,6 +218,12 @@ describe('SessionChatOverlay', () => {
     await router.isReady();
 
     mockSessionsStore.currentSession = { ...rootSession };
+    mockSessionsStore.sessions = [];
+    mockSessionsStore.addSessionToList.mockImplementation((session) => {
+      if (!mockSessionsStore.sessions.some(s => s.id === session.id)) {
+        mockSessionsStore.sessions.unshift(session);
+      }
+    });
     mockSessionsStore.getSessionById.mockReturnValue(null);
     mockSessionsStore.getSessionPath.mockReturnValue([rootSession]);
     mockSessionsStore.getRootSession.mockReturnValue(rootSession);
@@ -919,6 +926,50 @@ describe('SessionChatOverlay', () => {
       const btn = document.querySelector('[data-testid="overlay-add-session-btn"]');
       expect(btn).toBeTruthy();
       expect(btn.textContent.trim()).toContain('New Session');
+      wrapper.unmount();
+    });
+
+    it('uses addSessionToList when creating a child session', async () => {
+      const newSession = { id: 'new-sess', name: 'New Session', status: 'waiting', projectId: 'proj-123', parentSessionId: 'sess-root' };
+      mockSessionsStore.getSessionById.mockReturnValue({ ...rootSession, projectId: 'proj-123' });
+      api.createSession.mockResolvedValue(newSession);
+
+      const onSessionCreated = vi.fn();
+      const wrapper = mount(SessionChatOverlay, {
+        props: { sessionId: 'sess-root' },
+        attrs: { onSessionCreated },
+        global: { plugins: [router] },
+        attachTo: document.body,
+      });
+      await nextTick();
+
+      const btn = document.querySelector('[data-testid="overlay-add-session-btn"]');
+      btn.click();
+      await nextTick();
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockSessionsStore.addSessionToList).toHaveBeenCalledWith(newSession);
+      expect(mockSessionsStore.sessions.filter(s => s.id === newSession.id)).toHaveLength(1);
+      expect(onSessionCreated).toHaveBeenCalledWith(newSession);
+      wrapper.unmount();
+    });
+
+    it('does not duplicate a child session already present in the main store', async () => {
+      const newSession = { id: 'new-sess', name: 'New Session', status: 'waiting', projectId: 'proj-123', parentSessionId: 'sess-root' };
+      mockSessionsStore.sessions = [newSession];
+      mockSessionsStore.getSessionById.mockReturnValue({ ...rootSession, projectId: 'proj-123' });
+      api.createSession.mockResolvedValue(newSession);
+
+      const wrapper = mountOverlay();
+      await nextTick();
+
+      const btn = document.querySelector('[data-testid="overlay-add-session-btn"]');
+      btn.click();
+      await nextTick();
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockSessionsStore.addSessionToList).toHaveBeenCalledWith(newSession);
+      expect(mockSessionsStore.sessions.filter(s => s.id === newSession.id)).toHaveLength(1);
       wrapper.unmount();
     });
 

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -597,7 +597,7 @@ async function addChildSession() {
     });
 
     // Add to main store's session list (not the overlay's isolated state)
-    mainSessionsStore.sessions.unshift(newSession);
+    mainSessionsStore.addSessionToList(newSession);
 
     // Notify parent to rebuild session chain so it includes the new child.
     // Pass the full session so the parent does not have to wait for the

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -55,8 +55,14 @@ export const useSessionsStore = defineStore('sessions', {
     _findChildren: (state) => (parentId) => {
       const fromSessions = state.sessions.filter(s => s.parentSessionId === parentId);
       const fromActive = state.activeSessions.filter(s => s.parentSessionId === parentId);
-      const seen = new Set(fromSessions.map(s => s.id));
-      const merged = [...fromSessions];
+      const seen = new Set();
+      const merged = [];
+      for (const s of fromSessions) {
+        if (!seen.has(s.id)) {
+          merged.push(s);
+          seen.add(s.id);
+        }
+      }
       for (const s of fromActive) {
         if (!seen.has(s.id)) { merged.push(s); seen.add(s.id); }
       }

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -1144,6 +1144,19 @@ describe('Sessions Store', () => {
 
         expect(children).toEqual([]);
       });
+
+      it('deduplicates children with the same id within sessions', () => {
+        const store = useSessionsStore();
+        const parent = { id: 'parent-1', name: 'Parent', parentSessionId: null };
+        const child = { id: 'child-1', name: 'Child', parentSessionId: 'parent-1' };
+        const duplicateChild = { ...child, name: 'Duplicate Child' };
+        store.sessions = [parent, child, duplicateChild];
+
+        const children = store.getChildSessions(parent.id);
+
+        expect(children).toHaveLength(1);
+        expect(children.map((c) => c.id)).toEqual(['child-1']);
+      });
     });
 
     describe('hasChildren getter', () => {
@@ -5108,6 +5121,22 @@ describe('Sessions Store', () => {
 
         expect(result).toBe('idle');
       });
+    });
+  });
+
+  describe('addSessionToList', () => {
+    it('does not add duplicate sessions with the same id', () => {
+      const store = useSessionsStore();
+      const existingSession = { id: 'existing-session', name: 'Existing', status: 'completed' };
+      const newSession = { id: 'new-session', name: 'New', status: 'running' };
+      store.sessions = [existingSession];
+
+      store.addSessionToList(newSession);
+      store.addSessionToList(newSession);
+
+      expect(store.sessions.filter(s => s.id === newSession.id)).toHaveLength(1);
+      expect(store.sessions).toHaveLength(2);
+      expect(store.activeSessions.filter(s => s.id === newSession.id)).toHaveLength(1);
     });
   });
 

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -3761,6 +3761,153 @@ describe('SessionDetailView', () => {
       ]);
     });
 
+    it('handleOverlaySessionCreated inserts the created session through addSessionToList', async () => {
+      const parentSession = {
+        id: 'parent-1',
+        name: 'Parent Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        updatedAt: 1000,
+        createdAt: 500,
+      };
+      const childSession = {
+        id: 'child-1',
+        name: 'Child Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: 'parent-1',
+        updatedAt: 2000,
+        createdAt: 1500,
+      };
+
+      sessionsStore.currentSession = parentSession;
+      sessionsStore.sessions = [parentSession];
+      api.getProjectSessions.mockResolvedValue([parentSession]);
+      const addSessionToListSpy = vi.spyOn(sessionsStore, 'addSessionToList');
+
+      await router.push('/sessions/parent-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      wrapper.vm.chatOverlayOpen = true;
+      await nextTick();
+
+      const treeOverlay = wrapper.findComponent({ name: 'SessionChatOverlay' });
+      treeOverlay.vm.$emit('session-created', childSession);
+      await flushPromises();
+      await nextTick();
+
+      expect(addSessionToListSpy).toHaveBeenCalledWith(childSession);
+      expect(wrapper.vm.sessionChain.filter(entry => entry.session.id === childSession.id)).toHaveLength(1);
+    });
+
+    it('handleSessionCreated inserts a websocket-created child through addSessionToList', async () => {
+      const parentSession = {
+        id: 'parent-1',
+        name: 'Parent Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        updatedAt: 1000,
+        createdAt: 500,
+      };
+      const childSession = {
+        id: 'child-1',
+        name: 'Child Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: 'parent-1',
+        updatedAt: 2000,
+        createdAt: 1500,
+      };
+
+      sessionsStore.currentSession = parentSession;
+      sessionsStore.sessions = [parentSession];
+      api.getProjectSessions.mockResolvedValue([parentSession]);
+      const addSessionToListSpy = vi.spyOn(sessionsStore, 'addSessionToList');
+
+      await router.push('/sessions/parent-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      const handleSessionCreated = websocketHandlers.get(WS_MESSAGE_TYPES.SESSION_CREATED);
+      expect(handleSessionCreated).toBeTypeOf('function');
+      handleSessionCreated({ projectId: 'proj-1', session: childSession });
+      await flushPromises();
+      await nextTick();
+
+      expect(addSessionToListSpy).toHaveBeenCalledWith(childSession);
+      expect(wrapper.vm.sessionChain.filter(entry => entry.session.id === childSession.id)).toHaveLength(1);
+    });
+
+    it('session chain contains one entry per session id even if the store has duplicates', async () => {
+      const parentSession = {
+        id: 'parent-1',
+        name: 'Parent Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: null,
+        updatedAt: 1000,
+        createdAt: 500,
+      };
+      const duplicateChild = {
+        id: 'child-1',
+        name: 'Child Session',
+        status: 'waiting',
+        projectId: 'proj-1',
+        parentSessionId: 'parent-1',
+        updatedAt: 2000,
+        createdAt: 1500,
+      };
+
+      sessionsStore.currentSession = parentSession;
+      sessionsStore.sessions = [parentSession, duplicateChild, { ...duplicateChild }];
+      api.getProjectSessions.mockResolvedValue([parentSession, duplicateChild, { ...duplicateChild }]);
+
+      await router.push('/sessions/parent-1');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ConversationTab: true, ChangesTab: true, CanvasTab: true,
+            SummaryTab: true, CommandsTab: true, PrIndicators: true,
+          },
+        },
+      });
+
+      await flushPromises();
+      await nextTick();
+
+      expect(wrapper.vm.sessionChain.filter(entry => entry.session.id === duplicateChild.id)).toHaveLength(1);
+    });
+
     it('sorts session chain by picker recency instead of broad lastActivityAt', async () => {
       const sessionA = {
         id: 'session-a',

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -370,10 +370,8 @@ function handleSessionCreated(msg) {
   );
   if (!isChildOfTree) return;
 
-  // Add to store so getters work (push directly to sessions array)
-  if (!sessionsStore.getSessionById(newSession.id)) {
-    sessionsStore.sessions.push(newSession);
-  }
+  // Add to store so getters work
+  sessionsStore.addSessionToList(newSession);
 
   // Update overlay target BEFORE the async chain rebuild so it's set immediately
   if (newSession.status === 'running' || newSession.status === 'starting') {
@@ -408,8 +406,8 @@ async function handleOverlaySessionCreated(session) {
   preferredOverlaySession.value = createdSession || null;
   overlaySessionId.value = sessionId;
 
-  if (createdSession && !sessionsStore.getSessionById(sessionId)) {
-    sessionsStore.sessions.unshift(createdSession);
+  if (createdSession) {
+    sessionsStore.addSessionToList(createdSession);
   }
 
   await buildSessionChain();


### PR DESCRIPTION
## Summary
- Replace direct array mutations with idempotent `addSessionToList` to prevent duplicate session entries from racing create/event paths
- Harden `_findChildren` to deduplicate within the `sessions` array before merging `activeSessions`
- Add comprehensive test coverage for idempotency and deduplication

## Problem
The session chat overlay could show the same newly-created child session twice in the picker. This was caused by client-side state duplication where multiple code paths could insert the same session into the store:

- `SessionChatOverlay.vue` created a child session and inserted it with `sessions.unshift()`
- `SessionDetailView.vue`'s `handleOverlaySessionCreated` handler could insert the same session
- `SessionDetailView.vue`'s `handleSessionCreated` WebSocket handler could also insert it
- These paths could race and leave duplicate entries with the same `id` in `sessionsStore.sessions`
- `_findChildren` deduplicated across `sessions` and `activeSessions`, but not within `sessions` itself

## Solution
1. **Make insertion idempotent**: Replace all direct array mutations with `addSessionToList`, which checks for existing sessions by `id` before inserting
2. **Harden the getter**: Update `_findChildren` to deduplicate within `sessions` before merging `activeSessions`
3. **Add regression tests**: Comprehensive test coverage for:
   - `addSessionToList` idempotency
   - `_findChildren` deduplication
   - Overlay create path behavior
   - Detail view event handler behavior
   - Session chain deduplication

## Changes
- `SessionChatOverlay.vue`: Use `addSessionToList` instead of `sessions.unshift()`
- `SessionDetailView.vue`: Use `addSessionToList` in both event handlers
- `sessions.js`: Deduplicate within `sessions` array in `_findChildren`
- Added 240+ lines of test coverage across 3 test files

## Test plan
- [x] Unit tests pass for all modified files
- [x] Verified `addSessionToList` prevents duplicate sessions by id
- [x] Verified `_findChildren` deduplicates within sessions array
- [x] Verified overlay create path uses idempotent insertion
- [x] Verified detail view handlers use idempotent insertion
- [x] Verified session chain contains one entry per session id even with duplicates

Manual verification:
1. Start the app with `yarn dev`
2. Open a session that supports child sessions
3. Open the session chat overlay
4. Create a child session from the overlay
5. Confirm the picker shows one row for the new child
6. Refresh and confirm the row count remains correct
7. Create a second child and verify both appear exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)