### PR TITLE
Fix mobile viewport drift and touch-action conflicts with text editing

### DIFF
--- a/packages/web/src/assets/main.css
+++ b/packages/web/src/assets/main.css
@@ -38,16 +38,46 @@
   padding: 0;
 }
 
-/* Prevent double-tap and pinch zoom on iOS/iPadOS */
+/* Preserve native text-editing gestures while keeping fast taps on controls. */
 html {
-  touch-action: manipulation;
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
 }
 
-/* Ensure interactive elements also respect this */
-button, a, input, select, textarea {
+button,
+a,
+select,
+input[type="button"],
+input[type="checkbox"],
+input[type="color"],
+input[type="date"],
+input[type="datetime-local"],
+input[type="file"],
+input[type="hidden"],
+input[type="image"],
+input[type="month"],
+input[type="radio"],
+input[type="range"],
+input[type="reset"],
+input[type="submit"],
+input[type="time"],
+input[type="week"] {
   touch-action: manipulation;
+}
+
+textarea,
+input:not([type]),
+input[type=""],
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="password"],
+input[type="number"],
+[contenteditable],
+[contenteditable] * {
+  touch-action: auto;
 }
 
 body {

--- a/packages/web/src/components/ResizableTextarea.test.js
+++ b/packages/web/src/components/ResizableTextarea.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import ResizableTextarea from './ResizableTextarea.vue';
+import resizableTextareaSource from './ResizableTextarea.vue?raw';
 
 describe('ResizableTextarea', () => {
   let wrapper;
@@ -316,21 +317,20 @@ describe('ResizableTextarea', () => {
       expect(handle.exists()).toBe(true);
     });
 
-    it('has touchstart event listener on resize handle', async () => {
-      wrapper = mount(ResizableTextarea);
-      const handle = wrapper.find('.resize-handle');
-
-      expect(handle.exists()).toBe(true);
+    it('does not bind touch resize to the handle', () => {
+      expect(resizableTextareaSource).not.toMatch(/@touchstart/);
     });
   });
 
   describe('mobile support', () => {
-    it('supports touch events for mobile', () => {
+    it('hides the custom resize handle on coarse pointers', () => {
       wrapper = mount(ResizableTextarea);
       const handle = wrapper.find('.resize-handle');
 
-      // Verify that touch-action: none is set for mobile
       expect(handle.exists()).toBe(true);
+      expect(resizableTextareaSource).toMatch(/@media\s*\(pointer:\s*coarse\)/);
+      expect(resizableTextareaSource).toMatch(/\.resize-handle\s*\{[\s\S]*?display:\s*none/);
+      expect(resizableTextareaSource).not.toMatch(/touch-action:\s*none/);
     });
   });
 

--- a/packages/web/src/components/ResizableTextarea.vue
+++ b/packages/web/src/components/ResizableTextarea.vue
@@ -10,7 +10,6 @@
       class="resize-handle"
       aria-hidden="true"
       @mousedown="startResize"
-      @touchstart.prevent="startResize"
     >
       <svg
         width="16"
@@ -212,7 +211,6 @@ onMounted(() => {
   color: var(--color-text-soft, #6b7280);
   opacity: 0.5;
   transition: opacity 0.15s;
-  touch-action: none; /* Critical for mobile - prevents scroll interference */
   user-select: none;
   -webkit-user-select: none;
   border-radius: 4px;
@@ -224,14 +222,9 @@ onMounted(() => {
   background: rgba(255, 255, 255, 0.05);
 }
 
-/* Ensure the handle is visible on mobile */
 @media (pointer: coarse) {
   .resize-handle {
-    width: 32px;
-    height: 32px;
-    bottom: 2px;
-    right: 2px;
-    opacity: 0.6;
+    display: none;
   }
 }
 </style>

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1744,6 +1744,30 @@ describe('SessionChatOverlay', () => {
       wrapper.unmount();
     });
 
+    it('prompt focus schedules an initial prompt visibility adjustment', async () => {
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(() => 1);
+      const wrapper = mountOverlay();
+      await nextTick();
+      await new Promise(r => setTimeout(r, 10));
+      requestAnimationFrameSpy.mockClear();
+
+      await wrapper.findComponent({ name: 'ConversationTab' }).vm.$emit('prompt-focus', new FocusEvent('focus'));
+
+      expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+
+      requestAnimationFrameSpy.mockRestore();
+      wrapper.unmount();
+    });
+
+    it('runDriftCheck skips repeated prompt visibility checks while text editing is active', () => {
+      expect(sessionChatOverlaySource).toMatch(/isActiveTextEditing/);
+      expect(sessionChatOverlaySource).toMatch(
+        /if\s*\(\s*isOverlayPromptFocused\.value\s*&&\s*!isActiveTextEditing\(\)\s*\)\s*\{\s*requestPromptVisibilityCheck\(\);/s,
+      );
+    });
+
     it('content, header, and body declare solid backgrounds', () => {
       for (const selector of ['.overlay-content', '.overlay-header', '.overlay-body']) {
         const block = getStyleBlock(selector);

--- a/packages/web/src/components/SessionChatOverlay.vue
+++ b/packages/web/src/components/SessionChatOverlay.vue
@@ -379,6 +379,7 @@ import {
   requestVisualViewportUpdate,
   checkOverlayViewportDrift,
   clearOverlayViewportDrift,
+  isActiveTextEditing,
   onVisualViewportChange,
   setSessionOverlayPromptFocus,
 } from '../composables/useVisualViewport.js';
@@ -948,7 +949,7 @@ function getBackdropEl() {
 
 function runDriftCheck() {
   checkOverlayViewportDrift(getBackdropEl());
-  if (isOverlayPromptFocused.value) {
+  if (isOverlayPromptFocused.value && !isActiveTextEditing()) {
     requestPromptVisibilityCheck();
   }
 }

--- a/packages/web/src/components/touchActionCss.test.js
+++ b/packages/web/src/components/touchActionCss.test.js
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readMainCss() {
+  return readFileSync(resolve(__dirname, '..', 'assets', 'main.css'), 'utf8');
+}
+
+function getRule(source, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`${escaped}\\s*\\{[\\s\\S]*?\\}`));
+  expect(match, `${selector} should exist`).toBeTruthy();
+  return match[0];
+}
+
+describe('Touch action CSS regression guard', () => {
+  it('does not force touch-action manipulation on the root document', () => {
+    const htmlRule = getRule(readMainCss(), 'html');
+
+    expect(htmlRule).not.toMatch(/touch-action:\s*manipulation/);
+  });
+
+  it('keeps textarea out of touch-action manipulation selectors', () => {
+    const source = readMainCss();
+    const manipulationRules = source.match(/[^{}]+\{[^{}]*touch-action:\s*manipulation[^{}]*\}/g) || [];
+
+    expect(manipulationRules.length).toBeGreaterThan(0);
+    for (const rule of manipulationRules) {
+      const selector = rule.slice(0, rule.indexOf('{'));
+      expect(selector).not.toMatch(/\btextarea\b/);
+    }
+  });
+
+  it('explicitly restores native touch behavior for editable controls', () => {
+    const source = readMainCss();
+    const autoRules = source.match(/[^{}]+\{[^{}]*touch-action:\s*auto[^{}]*\}/g) || [];
+    const editableRule = autoRules.join('\n');
+
+    expect(editableRule).toMatch(/\btextarea\b/);
+    expect(editableRule).toMatch(/input:not\(\[type\]\)/);
+    expect(editableRule).toMatch(/input\[type="text"\]/);
+    expect(editableRule).toMatch(/\[contenteditable\]/);
+  });
+});

--- a/packages/web/src/composables/sessionOverlayViewport.js
+++ b/packages/web/src/composables/sessionOverlayViewport.js
@@ -1,0 +1,173 @@
+const SESSION_OVERLAY_TOP_CHROME_THRESHOLD = 64;
+const KEYBOARD_HEIGHT_DELTA_THRESHOLD = 120;
+const KEYBOARD_VIEWPORT_RATIO_THRESHOLD = 0.85;
+const TABLET_MIN_LAYOUT_DIMENSION = 700;
+const DRIFT_THRESHOLD_PX = 2;
+
+const TEXT_LIKE_INPUT_TYPES = new Set([
+  '',
+  'text',
+  'search',
+  'email',
+  'url',
+  'tel',
+  'password',
+  'number',
+]);
+
+function isValidOffsetTop(offsetTop) {
+  return (
+    Number.isFinite(offsetTop) &&
+    offsetTop > 0 &&
+    offsetTop <= SESSION_OVERLAY_TOP_CHROME_THRESHOLD
+  );
+}
+
+function getDeviceType(userAgent, platform, maxTouchPoints) {
+  const ua = String(userAgent);
+  const devicePlatform = String(platform);
+  const touchPoints = Number(maxTouchPoints) || 0;
+  const isAndroid = /Android/i.test(ua);
+  const isAndroidMobile = isAndroid && /Mobile/i.test(ua);
+  const isIPhoneLike = /iPhone|iPod/i.test(`${ua} ${devicePlatform}`);
+  const isIPad =
+    /iPad/i.test(`${ua} ${devicePlatform}`) ||
+    (devicePlatform === 'MacIntel' && touchPoints > 1);
+  const isAndroidTablet = isAndroid && !/Mobile/i.test(ua);
+
+  return {
+    isPhone: isIPhoneLike || isAndroidMobile,
+    isTablet: isIPad || isAndroidTablet,
+  };
+}
+
+function hasKeyboardShapedViewport(layoutHeight, visualViewportHeight) {
+  return (
+    Number.isFinite(layoutHeight) &&
+    layoutHeight > 0 &&
+    Number.isFinite(visualViewportHeight) &&
+    (layoutHeight - visualViewportHeight > KEYBOARD_HEIGHT_DELTA_THRESHOLD ||
+      visualViewportHeight / layoutHeight < KEYBOARD_VIEWPORT_RATIO_THRESHOLD)
+  );
+}
+
+function hasTabletSizedLayout(layoutWidth, layoutHeight) {
+  return (
+    Number.isFinite(layoutWidth) &&
+    Number.isFinite(layoutHeight) &&
+    Math.min(layoutWidth, layoutHeight) >= TABLET_MIN_LAYOUT_DIMENSION
+  );
+}
+
+export function isTextEditingElement(element) {
+  if (!element || element.nodeType !== 1) {
+    return false;
+  }
+
+  const editableElement = element.closest?.('[contenteditable]');
+  if (editableElement) {
+    const contentEditable = editableElement.getAttribute('contenteditable');
+    return contentEditable === null || contentEditable.toLowerCase() !== 'false';
+  }
+
+  const tagName = element.tagName?.toLowerCase();
+  if (tagName === 'textarea') {
+    return true;
+  }
+
+  if (tagName !== 'input') {
+    return false;
+  }
+
+  return TEXT_LIKE_INPUT_TYPES.has((element.getAttribute('type') || '').toLowerCase());
+}
+
+export function isActiveTextEditing() {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  return isTextEditingElement(document.activeElement);
+}
+
+export function computeSessionOverlayTopChromeInset({
+  offsetTop,
+  visualViewportHeight,
+  layoutWidth,
+  layoutHeight,
+  userAgent = '',
+  platform = '',
+  maxTouchPoints = 0,
+}) {
+  if (!isValidOffsetTop(offsetTop)) {
+    return 0;
+  }
+
+  const deviceType = getDeviceType(userAgent, platform, maxTouchPoints);
+  if (deviceType.isPhone) {
+    return 0;
+  }
+
+  if (hasKeyboardShapedViewport(layoutHeight, visualViewportHeight)) {
+    return 0;
+  }
+
+  if (deviceType.isTablet || hasTabletSizedLayout(layoutWidth, layoutHeight)) {
+    return offsetTop;
+  }
+
+  return 0;
+}
+
+export function checkOverlayViewportDrift(
+  element,
+  { writeVisualViewportVariables = () => null } = {}
+) {
+  if (!element) return;
+
+  if (isActiveTextEditing()) {
+    writeVisualViewportVariables();
+    return;
+  }
+
+  if (window.scrollY !== 0) {
+    window.scrollTo(0, 0);
+  }
+
+  if (!window.visualViewport) {
+    writeVisualViewportVariables();
+    return;
+  }
+
+  const { offsetTop, height } = window.visualViewport;
+  const layoutWidth = window.innerWidth;
+  const layoutHeight = window.innerHeight;
+  const deviceType = getDeviceType(
+    window.navigator?.userAgent,
+    window.navigator?.platform,
+    window.navigator?.maxTouchPoints,
+  );
+
+  const shouldCorrect =
+    !deviceType.isPhone &&
+    !hasKeyboardShapedViewport(layoutHeight, height) &&
+    (deviceType.isTablet || hasTabletSizedLayout(layoutWidth, layoutHeight)) &&
+    offsetTop > DRIFT_THRESHOLD_PX;
+
+  if (shouldCorrect) {
+    element.style.top = `${offsetTop}px`;
+    element.style.bottom = 'auto';
+    element.style.height = `${height}px`;
+  } else {
+    clearOverlayViewportDrift(element);
+  }
+
+  writeVisualViewportVariables();
+}
+
+export function clearOverlayViewportDrift(element) {
+  if (!element) return;
+  element.style.top = '';
+  element.style.bottom = '';
+  element.style.height = '';
+}
+

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -1,7 +1,20 @@
 import { onMounted, onUnmounted } from 'vue';
 import { computeSessionOverlayKeyboardBottomInset } from './sessionOverlayKeyboardInset.js';
+import {
+  checkOverlayViewportDrift as checkOverlayViewportDriftElement,
+  clearOverlayViewportDrift,
+  computeSessionOverlayTopChromeInset,
+  isActiveTextEditing,
+  isTextEditingElement,
+} from './sessionOverlayViewport.js';
 
 export { computeSessionOverlayKeyboardBottomInset } from './sessionOverlayKeyboardInset.js';
+export {
+  clearOverlayViewportDrift,
+  computeSessionOverlayTopChromeInset,
+  isActiveTextEditing,
+  isTextEditingElement,
+} from './sessionOverlayViewport.js';
 
 let rafId = null;
 let settleRafId = null;
@@ -11,11 +24,6 @@ let settleLastRect = null;
 let settleStableSamples = 0;
 let isSessionOverlayPromptFocused = false;
 
-const SESSION_OVERLAY_TOP_CHROME_THRESHOLD = 64;
-const KEYBOARD_HEIGHT_DELTA_THRESHOLD = 120;
-const KEYBOARD_VIEWPORT_RATIO_THRESHOLD = 0.85;
-const TABLET_MIN_LAYOUT_DIMENSION = 700;
-
 function getPixelValue(value, fallback) {
   return Number.isFinite(value) ? `${value}px` : fallback;
 }
@@ -23,120 +31,6 @@ function getPixelValue(value, fallback) {
 function getVisualViewportRect() {
   const { offsetTop, height } = window.visualViewport;
   return { offsetTop, height };
-}
-
-function isValidOffsetTop(offsetTop) {
-  return (
-    Number.isFinite(offsetTop) &&
-    offsetTop > 0 &&
-    offsetTop <= SESSION_OVERLAY_TOP_CHROME_THRESHOLD
-  );
-}
-
-function getDeviceType(userAgent, platform, maxTouchPoints) {
-  const ua = String(userAgent);
-  const devicePlatform = String(platform);
-  const touchPoints = Number(maxTouchPoints) || 0;
-  const isAndroid = /Android/i.test(ua);
-  const isAndroidMobile = isAndroid && /Mobile/i.test(ua);
-  const isIPhoneLike = /iPhone|iPod/i.test(`${ua} ${devicePlatform}`);
-  const isIPad =
-    /iPad/i.test(`${ua} ${devicePlatform}`) ||
-    (devicePlatform === 'MacIntel' && touchPoints > 1);
-  const isAndroidTablet = isAndroid && !/Mobile/i.test(ua);
-
-  return {
-    isPhone: isIPhoneLike || isAndroidMobile,
-    isTablet: isIPad || isAndroidTablet,
-  };
-}
-
-function hasKeyboardShapedViewport(layoutHeight, visualViewportHeight) {
-  return (
-    Number.isFinite(layoutHeight) &&
-    layoutHeight > 0 &&
-    Number.isFinite(visualViewportHeight) &&
-    (layoutHeight - visualViewportHeight > KEYBOARD_HEIGHT_DELTA_THRESHOLD ||
-      visualViewportHeight / layoutHeight < KEYBOARD_VIEWPORT_RATIO_THRESHOLD)
-  );
-}
-
-function hasTabletSizedLayout(layoutWidth, layoutHeight) {
-  return (
-    Number.isFinite(layoutWidth) &&
-    Number.isFinite(layoutHeight) &&
-    Math.min(layoutWidth, layoutHeight) >= TABLET_MIN_LAYOUT_DIMENSION
-  );
-}
-
-const TEXT_LIKE_INPUT_TYPES = new Set([
-  '',
-  'text',
-  'search',
-  'email',
-  'url',
-  'tel',
-  'password',
-  'number',
-]);
-
-export function isTextEditingElement(element) {
-  if (!element || element.nodeType !== 1) {
-    return false;
-  }
-
-  const editableElement = element.closest?.('[contenteditable]');
-  if (editableElement) {
-    const contentEditable = editableElement.getAttribute('contenteditable');
-    return contentEditable === null || contentEditable.toLowerCase() !== 'false';
-  }
-
-  const tagName = element.tagName?.toLowerCase();
-  if (tagName === 'textarea') {
-    return true;
-  }
-
-  if (tagName !== 'input') {
-    return false;
-  }
-
-  return TEXT_LIKE_INPUT_TYPES.has((element.getAttribute('type') || '').toLowerCase());
-}
-
-export function isActiveTextEditing() {
-  if (typeof document === 'undefined') {
-    return false;
-  }
-  return isTextEditingElement(document.activeElement);
-}
-
-export function computeSessionOverlayTopChromeInset({
-  offsetTop,
-  visualViewportHeight,
-  layoutWidth,
-  layoutHeight,
-  userAgent = '',
-  platform = '',
-  maxTouchPoints = 0,
-}) {
-  if (!isValidOffsetTop(offsetTop)) {
-    return 0;
-  }
-
-  const deviceType = getDeviceType(userAgent, platform, maxTouchPoints);
-  if (deviceType.isPhone) {
-    return 0;
-  }
-
-  if (hasKeyboardShapedViewport(layoutHeight, visualViewportHeight)) {
-    return 0;
-  }
-
-  if (deviceType.isTablet || hasTabletSizedLayout(layoutWidth, layoutHeight)) {
-    return offsetTop;
-  }
-
-  return 0;
 }
 
 export function setSessionOverlayPromptFocus(focused) {
@@ -294,98 +188,8 @@ export function requestVisualViewportSettle(options = {}) {
   settleRafId = requestAnimationFrame(sample);
 }
 
-// ---------------------------------------------------------------------------
-// Overlay viewport-drift correction
-//
-// On iPad Safari the visual viewport can shift relative to the layout viewport
-// when the browser chrome (URL bar / tab bar) collapses or expands, during
-// scroll-bounce, or after tab switches. `position: fixed` elements follow the
-// *layout* viewport, so they drift off-screen even though JS APIs like
-// `getBoundingClientRect` and `window.scrollY` still report 0.
-//
-// `checkOverlayViewportDrift` reads `visualViewport.offsetTop` and pins the
-// overlay element to the visual viewport via inline styles when drift > threshold.
-// ---------------------------------------------------------------------------
-const DRIFT_THRESHOLD_PX = 2;
-
-/**
- * Check for visual-viewport drift and correct the given element's position.
- *
- * Intended to be called periodically (setInterval) and/or on visualViewport
- * scroll/resize events while a fullscreen overlay is open.
- *
- * The correction only applies on tablets / large-screen devices when the
- * software keyboard is NOT open. On phones the browser-chrome drift issue
- * doesn't occur, and when the keyboard is open the viewport offset is
- * expected (not drift) — repositioning the overlay would fight the
- * keyboard and push the focused input out of view.
- *
- * @param {HTMLElement|null} element  The overlay backdrop element to pin.
- */
 export function checkOverlayViewportDrift(element) {
-  if (!element) return;
-
-  if (isActiveTextEditing()) {
-    writeVisualViewportVariables();
-    return;
-  }
-
-  // Force window scroll to 0 — page should never scroll while overlay is open.
-  if (window.scrollY !== 0) {
-    window.scrollTo(0, 0);
-  }
-
-  if (!window.visualViewport) {
-    writeVisualViewportVariables();
-    return;
-  }
-
-  const { offsetTop, height } = window.visualViewport;
-  const layoutWidth = window.innerWidth;
-  const layoutHeight = window.innerHeight;
-
-  // Use the same guard logic as computeSessionOverlayTopChromeInset:
-  // skip phones entirely, skip when the keyboard is open, and only
-  // correct on tablets / large-screen devices.
-  const deviceType = getDeviceType(
-    window.navigator?.userAgent,
-    window.navigator?.platform,
-    window.navigator?.maxTouchPoints,
-  );
-
-  const shouldCorrect =
-    !deviceType.isPhone &&
-    !hasKeyboardShapedViewport(layoutHeight, height) &&
-    (deviceType.isTablet || hasTabletSizedLayout(layoutWidth, layoutHeight)) &&
-    offsetTop > DRIFT_THRESHOLD_PX;
-
-  if (shouldCorrect) {
-    // Drift detected — override CSS `inset: 0` with explicit position.
-    // Inline styles beat scoped-CSS specificity, so this wins over `inset`.
-    element.style.top = `${offsetTop}px`;
-    element.style.bottom = 'auto';
-    element.style.height = `${height}px`;
-  } else {
-    // No drift (or phone / keyboard open) — clear inline overrides so
-    // the CSS `inset: 0` rule applies normally.
-    element.style.top = '';
-    element.style.bottom = '';
-    element.style.height = '';
-  }
-
-  writeVisualViewportVariables();
-}
-
-/**
- * Clear any inline position overrides applied by `checkOverlayViewportDrift`.
- *
- * @param {HTMLElement|null} element  The overlay backdrop element.
- */
-export function clearOverlayViewportDrift(element) {
-  if (!element) return;
-  element.style.top = '';
-  element.style.bottom = '';
-  element.style.height = '';
+  checkOverlayViewportDriftElement(element, { writeVisualViewportVariables });
 }
 
 /**

--- a/packages/web/src/composables/useVisualViewport.js
+++ b/packages/web/src/composables/useVisualViewport.js
@@ -69,6 +69,47 @@ function hasTabletSizedLayout(layoutWidth, layoutHeight) {
   );
 }
 
+const TEXT_LIKE_INPUT_TYPES = new Set([
+  '',
+  'text',
+  'search',
+  'email',
+  'url',
+  'tel',
+  'password',
+  'number',
+]);
+
+export function isTextEditingElement(element) {
+  if (!element || element.nodeType !== 1) {
+    return false;
+  }
+
+  const editableElement = element.closest?.('[contenteditable]');
+  if (editableElement) {
+    const contentEditable = editableElement.getAttribute('contenteditable');
+    return contentEditable === null || contentEditable.toLowerCase() !== 'false';
+  }
+
+  const tagName = element.tagName?.toLowerCase();
+  if (tagName === 'textarea') {
+    return true;
+  }
+
+  if (tagName !== 'input') {
+    return false;
+  }
+
+  return TEXT_LIKE_INPUT_TYPES.has((element.getAttribute('type') || '').toLowerCase());
+}
+
+export function isActiveTextEditing() {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  return isTextEditingElement(document.activeElement);
+}
+
 export function computeSessionOverlayTopChromeInset({
   offsetTop,
   visualViewportHeight,
@@ -283,6 +324,11 @@ const DRIFT_THRESHOLD_PX = 2;
  */
 export function checkOverlayViewportDrift(element) {
   if (!element) return;
+
+  if (isActiveTextEditing()) {
+    writeVisualViewportVariables();
+    return;
+  }
 
   // Force window scroll to 0 — page should never scroll while overlay is open.
   if (window.scrollY !== 0) {

--- a/packages/web/src/composables/useVisualViewport.test.js
+++ b/packages/web/src/composables/useVisualViewport.test.js
@@ -12,6 +12,8 @@ import {
   checkOverlayViewportDrift,
   clearOverlayViewportDrift,
   onVisualViewportChange,
+  isActiveTextEditing,
+  isTextEditingElement,
 } from './useVisualViewport.js';
 
 /**
@@ -264,6 +266,79 @@ describe('useVisualViewport', () => {
           platform: 'Linux x86_64',
         })
       ).toBe(32);
+    });
+  });
+
+  describe('text editing detection', () => {
+    it('returns true for textarea elements', () => {
+      expect(isTextEditingElement(document.createElement('textarea'))).toBe(true);
+    });
+
+    it.each([
+      [null],
+      [''],
+      ['text'],
+      ['search'],
+      ['email'],
+      ['url'],
+      ['tel'],
+      ['password'],
+      ['number'],
+    ])('returns true for text-like input type %s', (type) => {
+      const input = document.createElement('input');
+      if (type !== null) {
+        input.setAttribute('type', type);
+      }
+
+      expect(isTextEditingElement(input)).toBe(true);
+    });
+
+    it('returns true for contenteditable elements and descendants', () => {
+      const editor = document.createElement('div');
+      editor.setAttribute('contenteditable', 'true');
+      const child = document.createElement('span');
+      editor.appendChild(child);
+
+      expect(isTextEditingElement(editor)).toBe(true);
+      expect(isTextEditingElement(child)).toBe(true);
+    });
+
+    it.each([
+      'checkbox',
+      'radio',
+      'range',
+      'button',
+      'submit',
+      'reset',
+      'file',
+      'color',
+      'date',
+      'datetime-local',
+      'month',
+      'time',
+      'week',
+      'hidden',
+      'image',
+    ])('returns false for non-text input type %s', (type) => {
+      const input = document.createElement('input');
+      input.setAttribute('type', type);
+
+      expect(isTextEditingElement(input)).toBe(false);
+    });
+
+    it('isActiveTextEditing follows document.activeElement', () => {
+      const textarea = document.createElement('textarea');
+      const button = document.createElement('button');
+      document.body.append(textarea, button);
+
+      textarea.focus();
+      expect(isActiveTextEditing()).toBe(true);
+
+      button.focus();
+      expect(isActiveTextEditing()).toBe(false);
+
+      textarea.remove();
+      button.remove();
     });
   });
 
@@ -900,6 +975,55 @@ describe('useVisualViewport', () => {
       checkOverlayViewportDrift(element);
 
       expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('does not reset window scroll while an editable control is focused', () => {
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        writable: true,
+        value: 50,
+      });
+      mockVisualViewport = {
+        offsetTop: 32,
+        height: 968,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      };
+      window.visualViewport = mockVisualViewport;
+      const textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+      textarea.focus();
+
+      checkOverlayViewportDrift(element);
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
+
+      textarea.remove();
+    });
+
+    it('does not set or clear drift styles while an editable control is focused', () => {
+      mockVisualViewport = {
+        offsetTop: 32,
+        height: 968,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      };
+      window.visualViewport = mockVisualViewport;
+      element.style.top = '12px';
+      element.style.bottom = 'auto';
+      element.style.height = '700px';
+      const input = document.createElement('input');
+      input.type = 'text';
+      document.body.appendChild(input);
+      input.focus();
+
+      checkOverlayViewportDrift(element);
+
+      expect(element.style.top).toBe('12px');
+      expect(element.style.bottom).toBe('auto');
+      expect(element.style.height).toBe('700px');
+
+      input.remove();
     });
 
     it('does not call scrollTo when window.scrollY is 0', () => {


### PR DESCRIPTION
## Summary
- **Fix touch-action CSS** to preserve native text editing gestures (caret dragging, text selection) while keeping fast tap response on buttons/controls — removes blanket `touch-action: manipulation` from `html`/`textarea`/`input` and targets only non-text interactive elements
- **Keep session chat prompt visible above iOS keyboard accessories** by computing a dynamic bottom inset (`sessionOverlayKeyboardInset.js`) that accounts for the keyboard overlap, accessory bar height, and minimum usable overlay area
- **Fix viewport drift watchdog** to skip aggressive drift correction when the user is actively text editing (caret dragging), preventing the overlay from jumping around during caret positioning
- **Fix duplicate session rows** in session picker by deduplicating `_findChildren` results before merging with active sessions
- Extract `sessionOverlayKeyboardInset.js` as a pure, testable module with device-type detection and keyboard-height geometry calculations

## Test plan
- [ ] Verify text editing (caret dragging, text selection) works correctly in session overlay on iPad Safari
- [ ] Verify keyboard accessory bar doesn't obscure the prompt composer on iPad
- [ ] Verify session overlay viewport doesn't drift while text editing
- [ ] Verify buttons/links still have fast tap response (no double-tap zoom)
- [ ] Verify no duplicate sessions appear in session picker
- [ ] Run unit tests: `yarn workspace @circuschief/web test`
- [ ] Run E2E tests: `./scripts/pw.sh test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)