### PR TITLE
Default OpenAI commit attribution

### DIFF
--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -264,6 +264,9 @@ export const allMigrations = validateMigrations([
   // --- Update expired Gemini Flash Lite preview model to stable GA ---
   pr.get('providers-update-gemini-flash-lite-model'),
 
+  // --- Backfill official OpenAI commit attribution ---
+  pr.get('providers-backfill-built-in-openai-attribution'),
+
   // --- Project session defaults: add 'current' git mode ---
   p.get('project_session_defaults-git_mode-add-current'),
 

--- a/packages/server/src/db/migrations/miscMigrations.test.js
+++ b/packages/server/src/db/migrations/miscMigrations.test.js
@@ -4,6 +4,7 @@ import { providerMigrations } from './providerMigrations.js';
 import { getDatabase, ProjectRepository } from '../index.js';
 import { allMigrations } from './index.js';
 import { OPENAI_MODELS } from '@circuschief/shared';
+import { BUILT_IN_OPENAI_COMMIT_ATTRIBUTION } from '../seedBaselineData.js';
 
 const seedMigration = miscMigrations.find(m => m.name === 'quick_responses-seed-defaults');
 const seedTemplatesMigration = miscMigrations.find(m => m.name === 'session_templates-seed-defaults');
@@ -379,6 +380,7 @@ describe('session_templates-seed-defaults migration', () => {
 
 const addKindMigration = providerMigrations.find(m => m.name === 'providers-add-kind');
 const seedOpenAIMigration = providerMigrations.find(m => m.name === 'providers-seed-built-in-openai');
+const backfillOpenAIAttributionMigration = providerMigrations.find(m => m.name === 'providers-backfill-built-in-openai-attribution');
 
 describe('providers-add-kind migration', () => {
   it('exists in the migrations module', () => {
@@ -443,7 +445,7 @@ describe('providers-add-kind migration', () => {
 });
 
 describe('providers-seed-built-in-openai migration', () => {
-  it('fresh DB has one built-in OpenAI provider with null auth/base URL', () => {
+  it('fresh DB has one built-in OpenAI provider with default attribution and null auth/base URL', () => {
     const db = getDatabase();
     const rows = db
       .prepare('SELECT * FROM providers WHERE id = ?')
@@ -456,6 +458,7 @@ describe('providers-seed-built-in-openai migration', () => {
       is_built_in: 1,
       base_url: null,
       auth_token: null,
+      commit_attribution_override: BUILT_IN_OPENAI_COMMIT_ATTRIBUTION,
     });
   });
 
@@ -504,5 +507,44 @@ describe('providers-seed-built-in-openai migration', () => {
 
     expect(openAISeedIdx).toBeGreaterThan(kindIdx);
     expect(openAISeedIdx).toBeGreaterThan(historicalSeedIdx);
+  });
+});
+
+describe('providers-backfill-built-in-openai-attribution migration', () => {
+  it('fills null attribution on the built-in OpenAI provider', () => {
+    const db = getDatabase();
+    db.prepare(
+      'UPDATE providers SET commit_attribution_override = NULL WHERE id = ?'
+    ).run('openai-default');
+
+    backfillOpenAIAttributionMigration.up(db);
+
+    const row = db.prepare(
+      'SELECT commit_attribution_override FROM providers WHERE id = ?'
+    ).get('openai-default');
+    expect(row.commit_attribution_override).toBe(BUILT_IN_OPENAI_COMMIT_ATTRIBUTION);
+  });
+
+  it('preserves an existing built-in OpenAI attribution override', () => {
+    const db = getDatabase();
+    const customAttribution = 'Co-authored-by: Custom Codex <custom@example.com>';
+    db.prepare(
+      'UPDATE providers SET commit_attribution_override = ? WHERE id = ?'
+    ).run(customAttribution, 'openai-default');
+
+    backfillOpenAIAttributionMigration.up(db);
+
+    const row = db.prepare(
+      'SELECT commit_attribution_override FROM providers WHERE id = ?'
+    ).get('openai-default');
+    expect(row.commit_attribution_override).toBe(customAttribution);
+  });
+
+  it('is registered after the built-in OpenAI seed migration', () => {
+    const names = allMigrations.map(m => m.name);
+    const openAISeedIdx = names.indexOf('providers-seed-built-in-openai');
+    const attributionBackfillIdx = names.indexOf('providers-backfill-built-in-openai-attribution');
+
+    expect(attributionBackfillIdx).toBeGreaterThan(openAISeedIdx);
   });
 });

--- a/packages/server/src/db/migrations/providerMigrations.js
+++ b/packages/server/src/db/migrations/providerMigrations.js
@@ -1,5 +1,6 @@
 import { OPENAI_MODELS, GEMINI_MODELS } from '@circuschief/shared';
 import { addColumnIfMissing, tableExists } from './migrationUtils.js';
+import { BUILT_IN_OPENAI_COMMIT_ATTRIBUTION } from '../seedBaselineData.js';
 
 function seedBuiltInAnthropicProvider(db) {
   const providerId = 'anthropic-default';
@@ -39,10 +40,10 @@ function seedBuiltInOpenAIProvider(db) {
 
   db.prepare(
     `INSERT OR IGNORE INTO providers (
-       id, name, base_url, auth_token, kind, is_built_in, created_at, updated_at
+       id, name, base_url, auth_token, kind, commit_attribution_override, is_built_in, created_at, updated_at
      )
-     VALUES (?, ?, NULL, NULL, 'openai', 1, ?, ?)`
-  ).run(providerId, 'OpenAI (Official)', now, now);
+     VALUES (?, ?, NULL, NULL, 'openai', ?, 1, ?, ?)`
+  ).run(providerId, 'OpenAI (Official)', BUILT_IN_OPENAI_COMMIT_ATTRIBUTION, now, now);
 
   const insertModel = db.prepare(
     `INSERT OR IGNORE INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
@@ -78,6 +79,17 @@ function seedBuiltInGoogleProvider(db) {
 function seedBuiltInProviders(db) {
   seedBuiltInAnthropicProvider(db);
   seedBuiltInOpenAIProvider(db);
+}
+
+function backfillBuiltInOpenAIAttribution(db) {
+  db.prepare(
+    `UPDATE providers
+     SET commit_attribution_override = ?, updated_at = ?
+     WHERE id = 'openai-default'
+       AND is_built_in = 1
+       AND kind = 'openai'
+       AND commit_attribution_override IS NULL`
+  ).run(BUILT_IN_OPENAI_COMMIT_ATTRIBUTION, Date.now());
 }
 
 function updateBuiltInModels(db) {
@@ -246,5 +258,9 @@ export const providerMigrations = [
          WHERE model = ?`
       ).run('gemini-2.5-flash-lite', 'gemini-2.5-flash-lite-preview-06-17');
     },
+  },
+  {
+    name: 'providers-backfill-built-in-openai-attribution',
+    up(db) { backfillBuiltInOpenAIAttribution(db); },
   },
 ];

--- a/packages/server/src/db/seedBaselineData.js
+++ b/packages/server/src/db/seedBaselineData.js
@@ -13,6 +13,8 @@ export const BUILT_IN_OPENAI_PROVIDER = {
   kind: 'openai',
 };
 
+export const BUILT_IN_OPENAI_COMMIT_ATTRIBUTION = 'Co-authored-by: Codex <noreply@openai.com>';
+
 export const BUILT_IN_GOOGLE_PROVIDER = {
   id: 'google-default',
   name: 'Google (Official)',
@@ -90,10 +92,17 @@ function seedBuiltInProviders(db) {
 
   db.prepare(
     `INSERT OR IGNORE INTO providers (
-       id, name, base_url, auth_token, kind, is_built_in, created_at, updated_at
+       id, name, base_url, auth_token, kind, commit_attribution_override, is_built_in, created_at, updated_at
      )
-     VALUES (?, ?, NULL, NULL, ?, 1, ?, ?)`
-  ).run(BUILT_IN_OPENAI_PROVIDER.id, BUILT_IN_OPENAI_PROVIDER.name, BUILT_IN_OPENAI_PROVIDER.kind, now, now);
+     VALUES (?, ?, NULL, NULL, ?, ?, 1, ?, ?)`
+  ).run(
+    BUILT_IN_OPENAI_PROVIDER.id,
+    BUILT_IN_OPENAI_PROVIDER.name,
+    BUILT_IN_OPENAI_PROVIDER.kind,
+    BUILT_IN_OPENAI_COMMIT_ATTRIBUTION,
+    now,
+    now
+  );
 
   const insertModel = db.prepare(
     `INSERT OR IGNORE INTO provider_models (

--- a/packages/server/src/db/seedBaselineData.test.js
+++ b/packages/server/src/db/seedBaselineData.test.js
@@ -4,6 +4,7 @@ import { DatabaseManager } from './DatabaseManager.js';
 import {
   BUILT_IN_ANTHROPIC_MODELS,
   BUILT_IN_ANTHROPIC_PROVIDER,
+  BUILT_IN_OPENAI_COMMIT_ATTRIBUTION,
   BUILT_IN_OPENAI_MODELS,
   BUILT_IN_OPENAI_PROVIDER,
   BUILT_IN_GOOGLE_MODELS,
@@ -42,7 +43,7 @@ describe('seedBaselineData', () => {
         is_built_in: 1,
         base_url: null,
         auth_token: null,
-        commit_attribution_override: null,
+        commit_attribution_override: BUILT_IN_OPENAI_COMMIT_ATTRIBUTION,
       });
     });
   });

--- a/tests/e2e/commit-attribution-settings.spec.ts
+++ b/tests/e2e/commit-attribution-settings.spec.ts
@@ -17,6 +17,7 @@ import {
 } from './helpers';
 
 const CLAUDE_ATTRIBUTION = 'Co-authored-by: Claude E2E <claude-e2e@example.com>';
+const OFFICIAL_CODEX_ATTRIBUTION = 'Co-authored-by: Codex <noreply@openai.com>';
 const CODEX_ATTRIBUTION = 'Co-authored-by: Codex E2E <codex-e2e@example.com>';
 
 test.describe.configure({ mode: 'serial' });
@@ -25,22 +26,22 @@ test.describe('Commit attribution provider settings', () => {
   test.beforeEach(async () => {
     await cleanupProviders();
     await cleanupCreatedResources();
-    await resetBuiltInAttribution();
+    await resetBuiltInAttributionDefaults();
   });
 
   test.afterEach(async () => {
-    await resetBuiltInAttribution();
+    await resetBuiltInAttributionDefaults();
     await cleanupProviders();
     await cleanupCreatedResources();
   });
 
-  test('built-in providers show blank attribution by default and hide connection controls', async ({ page }) => {
+  test('built-in providers show default attribution and hide connection controls', async ({ page }) => {
     const anthropic = await builtInProvider('anthropic');
     const openai = await builtInProvider('openai');
 
     await expectBuiltInAttributionModal(page, anthropic.name, '');
     await closeModal(page);
-    await expectBuiltInAttributionModal(page, openai.name, '');
+    await expectBuiltInAttributionModal(page, openai.name, OFFICIAL_CODEX_ATTRIBUTION);
   });
 
   test('built-in Anthropic override persists after reload and clears to null', async ({ page }) => {
@@ -123,12 +124,12 @@ test.describe('Commit attribution launch behavior', () => {
     test.skip(!captureEnabled, 'Set E2E_AGENT_SPAWN_CAPTURE_FILE before starting the e2e server to enable spawn-capture launch assertions.');
     await cleanupProviders();
     await cleanupCreatedResources();
-    await resetBuiltInAttribution();
+    await resetBuiltInAttributionDefaults();
     clearCaptureFile();
   });
 
   test.afterEach(async () => {
-    await resetBuiltInAttribution();
+    await resetBuiltInAttributionDefaults();
     await cleanupProviders();
     await cleanupCreatedResources();
     clearCaptureFile();
@@ -188,7 +189,22 @@ test.describe('Commit attribution launch behavior', () => {
     expectAttributionEnv(await waitForSpawn('claude-code'), CLAUDE_ATTRIBUTION);
   });
 
-  test('built-in OpenAI blank attribution does not pass commit attribution env or native config', async () => {
+  test('built-in OpenAI default attribution passes commit attribution env', async () => {
+    const project = await seedProject('Codex Blank Attribution Project', process.cwd());
+    const session = await seedSession(project.id, {
+      prompt: 'Codex default attribution e2e',
+      model: await firstBuiltInOpenAIModel(),
+      startImmediately: true,
+    });
+
+    await waitForStatus(session.id, 'waiting', 60000);
+    expectAttributionEnv(await waitForSpawn('codex'), OFFICIAL_CODEX_ATTRIBUTION);
+  });
+
+  test('built-in OpenAI cleared attribution does not pass commit attribution env or native config', async () => {
+    const openai = await builtInProvider('openai');
+    await updateProvider(openai.id, { commitAttributionOverride: null });
+
     const project = await seedProject('Codex Blank Attribution Project', process.cwd());
     const session = await seedSession(project.id, {
       prompt: 'Codex blank attribution e2e',
@@ -290,12 +306,14 @@ async function closeModal(page: any) {
   await expect(page.locator('.modal')).toBeHidden();
 }
 
-async function resetBuiltInAttribution() {
+async function resetBuiltInAttributionDefaults() {
   const providers = await getProviders();
   await Promise.all(
     providers
       .filter((provider: any) => provider.isBuiltIn)
-      .map((provider: any) => updateProvider(provider.id, { commitAttributionOverride: null }))
+      .map((provider: any) => updateProvider(provider.id, {
+        commitAttributionOverride: provider.kind === 'openai' ? OFFICIAL_CODEX_ATTRIBUTION : null,
+      }))
   );
 }
 


### PR DESCRIPTION
## Summary
- Give the built-in OpenAI provider the default Codex co-author trailer so OpenAI-backed Codex sessions attribute commits without user configuration.
- Backfill existing databases where the official OpenAI provider still has a null attribution override.
- Update provider seeding, migration, and attribution launch tests for the new default while preserving explicit opt-out behavior.

## Context
Session d7ec7299-9658-4e36-93d0-8ff31b72c0aa used an OpenAI Codex model to merge Dependabot PRs, but its commits were not attributed because openai-default had no commit_attribution_override and the launch path only sets CIRCUSCHIEF_COMMIT_ATTRIBUTION when that provider value is present.

Session summary: merged Dependabot PRs #905-#908, resolved a yarn.lock conflict, yarn install --frozen-lockfile and yarn build passed, and yarn test was inconclusive after Vitest hung.

## Verification
- git diff --check
- yarn workspace @circuschief/server test seedBaselineData.test.js miscMigrations.test.js