### PR TITLE
Fix new session button not responding to clicks

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -97,7 +97,7 @@
     <ConnectionBanner />
 
     <main class="app-main">
-      <router-view :key="$route.path" />
+      <router-view />
     </main>
 
     <ToastContainer />


### PR DESCRIPTION
## Summary
- Removed `:key="$route.path"` from `<router-view>` in `App.vue` to fix a bug where clicking the "+ Session" button on the session list view did nothing
- The path-based key caused a race condition: clicking the `<router-link>` triggered component teardown before navigation completed, swallowing the route change
- Other links (tab buttons) were unaffected because they use programmatic `router.push()` instead of `<router-link>`

## Test plan
- [ ] Navigate to a project's session list, click "+ Session" — should navigate to the new session form
- [ ] Verify tab switching (Sessions, Archived, Templates, Commands, Kanban) still works correctly
- [ ] Verify navigating between different projects still re-fetches data properly
- [ ] Test on mobile: the mobile "+ Session" button should also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)