### PR TITLE
Include README in npm package build

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -117,6 +117,9 @@ cpSync(join(ROOT, 'packages/shared/package.json'), join(DIST, 'packages/shared/p
 console.log('Copying packages/server/bin...');
 cpSync(join(ROOT, 'packages/server/bin'), join(DIST, 'packages/server/bin'), { recursive: true });
 
+console.log('Copying README.md...');
+cpSync(join(ROOT, 'README.md'), join(DIST, 'README.md'));
+
 // --- 4. Rewrite @circuschief/shared imports to relative paths ---
 console.log('Rewriting @circuschief/shared imports...');
 


### PR DESCRIPTION
## Summary
- Copy the repository README.md into dist-package during npm package assembly
- Ensures the published npm package includes README metadata for npmjs.com

## Verification
- node scripts/build-package.js --version=0.0.0-readme-test
- Confirmed dist-package/README.md was generated

Session summary: fixed the missing npm README by updating scripts/build-package.js, which publishes from dist-package, to copy README.md into that generated package root.