### PR TITLE
Add Circus Time session tab

### DIFF
--- a/packages/web/src/components/CircusTimeTab.test.js
+++ b/packages/web/src/components/CircusTimeTab.test.js
@@ -17,11 +17,11 @@ describe('CircusTimeTab', () => {
     expect(text).toContain('helps fund both Circus Chief and the Circus Time add-on');
   });
 
-  it('links to the Circus Time checkout in a new tab', () => {
+  it('links to the Circus Time store in a new tab', () => {
     const wrapper = mount(CircusTimeTab);
     const link = wrapper.get('a');
 
-    expect(link.attributes('href')).toBe('https://mydayoff.lemonsqueezy.com/checkout');
+    expect(link.attributes('href')).toBe('https://mydayoff.lemonsqueezy.com/');
     expect(link.attributes('target')).toBe('_blank');
     expect(link.attributes('rel')).toBe('noopener noreferrer');
   });

--- a/packages/web/src/components/CircusTimeTab.test.js
+++ b/packages/web/src/components/CircusTimeTab.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CircusTimeTab from './CircusTimeTab.vue';
+
+describe('CircusTimeTab', () => {
+  it('renders the Circus Time CTA content', () => {
+    const wrapper = mount(CircusTimeTab);
+
+    expect(wrapper.find('h3').text()).toContain('Circus Time');
+
+    const text = wrapper.text();
+    expect(text).toContain('Configure recurring tasks that invoke templates');
+    expect(text).toContain('make HTTP calls, or execute commands');
+    expect(text).toContain('The Circus Time add-on is still in development.');
+    expect(text).toContain('If Circus Chief is useful to you');
+    expect(text).toContain('purchasing an early Circus Time license');
+    expect(text).toContain('helps fund both Circus Chief and the Circus Time add-on');
+  });
+
+  it('links to the Circus Time checkout in a new tab', () => {
+    const wrapper = mount(CircusTimeTab);
+    const link = wrapper.get('a');
+
+    expect(link.attributes('href')).toBe('https://mydayoff.lemonsqueezy.com/checkout');
+    expect(link.attributes('target')).toBe('_blank');
+    expect(link.attributes('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/packages/web/src/components/CircusTimeTab.test.js
+++ b/packages/web/src/components/CircusTimeTab.test.js
@@ -21,7 +21,9 @@ describe('CircusTimeTab', () => {
     const wrapper = mount(CircusTimeTab);
     const link = wrapper.get('a');
 
-    expect(link.attributes('href')).toBe('https://mydayoff.lemonsqueezy.com/');
+    expect(link.attributes('href')).toBe(
+      'https://mydayoff.lemonsqueezy.com/checkout/buy/2a60bdc7-058c-43d8-965b-6b7d785f0842'
+    );
     expect(link.attributes('target')).toBe('_blank');
     expect(link.attributes('rel')).toBe('noopener noreferrer');
   });

--- a/packages/web/src/components/CircusTimeTab.vue
+++ b/packages/web/src/components/CircusTimeTab.vue
@@ -17,7 +17,7 @@
       </div>
       <a
         class="btn btn-primary"
-        href="https://mydayoff.lemonsqueezy.com/checkout"
+        href="https://mydayoff.lemonsqueezy.com/"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/packages/web/src/components/CircusTimeTab.vue
+++ b/packages/web/src/components/CircusTimeTab.vue
@@ -1,0 +1,80 @@
+<template>
+  <section class="circus-time-tab">
+    <div class="circus-time-panel">
+      <div class="circus-time-copy">
+        <p class="eyebrow">Proprietary add-on</p>
+        <h3>Circus Time</h3>
+        <p>
+          Configure recurring tasks that invoke templates, make HTTP calls, or
+          execute commands on any recurring schedule.
+        </p>
+        <p>
+          The Circus Time add-on is still in development. If Circus Chief is
+          useful to you, you can support ongoing development by purchasing an
+          early Circus Time license. Your support helps fund both Circus Chief
+          and the Circus Time add-on.
+        </p>
+      </div>
+      <a
+        class="btn btn-primary"
+        href="https://mydayoff.lemonsqueezy.com/checkout"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Get Circus Time
+      </a>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.circus-time-tab {
+  padding: 1rem 0;
+}
+
+.circus-time-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background: var(--color-background-soft);
+}
+
+.circus-time-copy {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 44rem;
+}
+
+.eyebrow {
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+h3 {
+  color: var(--color-text);
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
+p {
+  color: var(--color-text-soft);
+}
+
+.btn {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+  .circus-time-panel {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/packages/web/src/components/CircusTimeTab.vue
+++ b/packages/web/src/components/CircusTimeTab.vue
@@ -17,7 +17,7 @@
       </div>
       <a
         class="btn btn-primary"
-        href="https://mydayoff.lemonsqueezy.com/"
+        href="https://mydayoff.lemonsqueezy.com/checkout/buy/2a60bdc7-058c-43d8-965b-6b7d785f0842"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -14,16 +14,16 @@ describe('SessionTabsPanel', () => {
         { path: '/projects/:id/sessions', component: { template: '<div />' } },
       ],
     });
-    await router.push('/sessions/session-1/conversation');
+    await router.push('/sessions/session-1/summary');
     await router.isReady();
   });
 
   const defaultTabs = [
     { id: 'summary', label: 'Summary' },
-    { id: 'conversation', label: 'Conversations' },
     { id: 'changes', label: 'Changes' },
     { id: 'canvas', label: 'Canvas' },
     { id: 'commands', label: 'Commands' },
+    { id: 'circus-time', label: 'Circus Time' },
   ];
 
   function mountPanel(props = {}) {
@@ -32,7 +32,7 @@ describe('SessionTabsPanel', () => {
       props: {
         sessionId: 'session-1',
         projectId: 'proj-1',
-        activeTab: 'conversation',
+        activeTab: 'summary',
         tabs: defaultTabs,
         hasChanges: false,
         canvasCount: 0,
@@ -46,10 +46,10 @@ describe('SessionTabsPanel', () => {
       const wrapper = mountPanel();
       const text = wrapper.text();
       expect(text).toContain('Summary');
-      expect(text).toContain('Conversations');
       expect(text).toContain('Changes');
       expect(text).toContain('Canvas');
       expect(text).toContain('Commands');
+      expect(text).toContain('Circus Time');
     });
 
     it('renders back link with icon to sessions list', () => {
@@ -131,14 +131,14 @@ describe('SessionTabsPanel', () => {
       const pushSpy = vi.spyOn(router, 'push');
       const wrapper = mountPanel();
       const select = wrapper.find('.tab-select');
-      await select.setValue('canvas');
-      expect(pushSpy).toHaveBeenCalledWith('/sessions/session-1/canvas');
+      await select.setValue('circus-time');
+      expect(pushSpy).toHaveBeenCalledWith('/sessions/session-1/circus-time');
     });
   });
 
   describe('active tab', () => {
     it('marks active tab with active class', () => {
-      const wrapper = mountPanel({ activeTab: 'conversation' });
+      const wrapper = mountPanel({ activeTab: 'summary' });
       const desktopTabs = wrapper.findAll('.tabs-desktop .tab');
       const activeTab = desktopTabs.find(t => t.classes().includes('active'));
       expect(activeTab).toBeDefined();

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -27,6 +27,9 @@ vi.mock('../components/SummaryTab.vue', () => ({
 vi.mock('../components/CommandsTab.vue', () => ({
   default: { name: 'CommandsTab', template: '<div>Commands Tab</div>' }
 }));
+vi.mock('../components/CircusTimeTab.vue', () => ({
+  default: { name: 'CircusTimeTab', template: '<div>Circus Time Tab</div>' }
+}));
 vi.mock('../components/DuplicateSessionButton.vue', () => ({
   default: { name: 'DuplicateSessionButton', template: '<button @click="$emit(\'success\', { id: \'new\' })" :disabled="false">Duplicate</button>' }
 }));
@@ -206,11 +209,12 @@ describe('SessionDetailView', () => {
   }
 
   describe('tabs configuration', () => {
-    it('includes Summary, Changes, Canvas, Commands tabs', async () => {
+    it('includes Summary, Changes, Canvas, Commands, and Circus Time tabs', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
-        status: 'running'
+        status: 'running',
+        projectId: 'project-1'
       };
 
       await router.push('/sessions/session-1');
@@ -233,9 +237,47 @@ describe('SessionDetailView', () => {
 
       await flushPromises();
 
-      const text = wrapper.text();
-      // The exact tab names may vary, but these components should be referenced
-      expect(wrapper.findComponent({ name: 'SummaryTab' }).exists() || text).toBeTruthy();
+      const tabsPanel = wrapper.findComponent({ name: 'SessionTabsPanel' });
+      expect(tabsPanel.exists()).toBe(true);
+      expect(tabsPanel.props('tabs').map(tab => tab.id)).toEqual([
+        'summary',
+        'changes',
+        'canvas',
+        'commands',
+        'circus-time',
+      ]);
+    });
+
+    it('renders Circus Time tab content from a direct route', async () => {
+      sessionsStore.currentSession = {
+        id: 'session-1',
+        name: 'Test Session',
+        status: 'running',
+        projectId: 'project-1'
+      };
+
+      await router.push('/sessions/session-1/circus-time');
+      await router.isReady();
+
+      const wrapper = trackedMount(SessionDetailView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: {
+            ChangesTab: true,
+            CanvasTab: true,
+            SummaryTab: true,
+            CommandsTab: true,
+
+            PrIndicators: true,
+            SchedulingInfo: true
+          }
+        }
+      });
+
+      await flushPromises();
+
+      expect(wrapper.findComponent({ name: 'CircusTimeTab' }).exists()).toBe(true);
+      expect(wrapper.text()).toContain('Circus Time Tab');
     });
 
     it('renders correct tab content for selected tab', async () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -73,6 +73,9 @@
           :session-id="route.params.id"
           :project-id="sessionsStore.currentSession?.projectId"
         />
+        <CircusTimeTab
+          v-else-if="activeTab === 'circus-time'"
+        />
       </div>
 
       <!-- Session Chat Handle -->
@@ -121,6 +124,7 @@ import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
 import CommandsTab from '../components/CommandsTab.vue';
+import CircusTimeTab from '../components/CircusTimeTab.vue';
 import SessionHeaderPanel from '../components/SessionHeaderPanel.vue';
 import SessionTabsPanel from '../components/SessionTabsPanel.vue';
 import SessionChatHandle from '../components/SessionChatHandle.vue';
@@ -500,7 +504,8 @@ const tabs = computed(() => [
   { id: 'summary', label: 'Summary' },
   { id: 'changes', label: changesFileCount.value > 0 ? `Changes (${changesFileCount.value})` : 'Changes' },
   { id: 'canvas', label: canvasStore.groupedItems.length > 0 ? `Canvas (${canvasStore.groupedItems.length})` : 'Canvas' },
-  { id: 'commands', label: 'Commands' }
+  { id: 'commands', label: 'Commands' },
+  { id: 'circus-time', label: 'Circus Time' }
 ]);
 
 // Watch for status changes from any source (optimistic updates, WebSocket, etc.)

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -551,7 +551,7 @@ test.describe('Archived Sessions Tab', () => {
 });
 
 // ============================================================
-// Category 5: Session Detail Tab Navigation (6 tests)
+// Category 5: Session Detail Tab Navigation (7 tests)
 // ============================================================
 
 test.describe('Session Detail Tab Navigation', () => {
@@ -605,6 +605,11 @@ test.describe('Session Detail Tab Navigation', () => {
     await page.locator('.tabs-desktop .tab').filter({ hasText: 'Commands' }).click();
     await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}/commands`));
     await expect(page.locator('.tabs-desktop .tab').filter({ hasText: 'Commands' })).toHaveClass(/active/);
+
+    // Click Circus Time tab
+    await page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' }).click();
+    await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}/circus-time`));
+    await expect(page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' })).toHaveClass(/active/);
   });
 
   test('deep linking to a specific tab works', async ({ page }) => {
@@ -616,6 +621,17 @@ test.describe('Session Detail Tab Navigation', () => {
 
     // URL should stay at canvas
     await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}/canvas`));
+  });
+
+  test('deep linking to Circus Time shows the CTA', async ({ page }) => {
+    await navigateAndWait(page, `/sessions/${session.id}/circus-time`);
+
+    const circusTimeTab = page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' });
+    await expect(circusTimeTab).toHaveClass(/active/);
+    await expect(page.getByRole('heading', { name: 'Circus Time' })).toBeVisible();
+
+    const ctaLink = page.getByRole('link', { name: 'Get Circus Time' });
+    await expect(ctaLink).toHaveAttribute('href', 'https://mydayoff.lemonsqueezy.com/checkout');
   });
 
   test('back button navigates between tabs correctly', async ({ page }) => {

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -631,7 +631,7 @@ test.describe('Session Detail Tab Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Circus Time' })).toBeVisible();
 
     const ctaLink = page.getByRole('link', { name: 'Get Circus Time' });
-    await expect(ctaLink).toHaveAttribute('href', 'https://mydayoff.lemonsqueezy.com/checkout');
+    await expect(ctaLink).toHaveAttribute('href', 'https://mydayoff.lemonsqueezy.com/');
   });
 
   test('back button navigates between tabs correctly', async ({ page }) => {

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -631,7 +631,10 @@ test.describe('Session Detail Tab Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Circus Time' })).toBeVisible();
 
     const ctaLink = page.getByRole('link', { name: 'Get Circus Time' });
-    await expect(ctaLink).toHaveAttribute('href', 'https://mydayoff.lemonsqueezy.com/');
+    await expect(ctaLink).toHaveAttribute(
+      'href',
+      'https://mydayoff.lemonsqueezy.com/checkout/buy/2a60bdc7-058c-43d8-965b-6b7d785f0842'
+    );
   });
 
   test('back button navigates between tabs correctly', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a Circus Time tab to the session detail view
- add CTA copy describing the unreleased add-on and early license support
- link the CTA to the Lemon Squeezy checkout URL
- cover the new tab in unit and Playwright navigation tests

## Tests
- yarn workspace @circuschief/web test src/components/CircusTimeTab.test.js
- yarn workspace @circuschief/web test src/views/SessionDetailView.test.js
- yarn workspace @circuschief/web test src/components/SessionTabsPanel.test.js
- ./scripts/pw.sh test tests/e2e/filtering-navigation.spec.ts

## Session Summary Note
The session summary was reviewed. It appears stale in places, still referencing the earlier store URL and pending copy confirmation, so this PR body reflects the final committed diff.