### PR TITLE
Harden E2E assertions for real UX

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { expect, Page, Locator } from '@playwright/test';
 import { readFileSync, existsSync, mkdirSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
@@ -269,6 +269,57 @@ export async function waitForElement(
     timeout: options.timeout || 10000,
   });
   return element;
+}
+
+export async function expectFullyInViewport(locator: Locator) {
+  await expect(locator).toBeVisible();
+  await locator.scrollIntoViewIfNeeded();
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) throw new Error('Element has no bounding box');
+
+  const viewport = locator.page().viewportSize();
+  expect(viewport).not.toBeNull();
+  if (!viewport) throw new Error('Page has no viewport size');
+
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.y).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+  expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+}
+
+export async function expectHitTestable(locator: Locator, options: { requireEnabled?: boolean } = {}) {
+  await expect(locator).toBeVisible();
+  if (options.requireEnabled) {
+    await expect(locator).toBeEnabled();
+  }
+  await locator.scrollIntoViewIfNeeded();
+  await expectFullyInViewport(locator);
+
+  const result = await locator.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const topElement = document.elementFromPoint(x, y);
+    const target = el as HTMLElement;
+
+    return {
+      isHitTestable: Boolean(topElement && (target === topElement || target.contains(topElement))),
+      topTag: topElement?.tagName ?? null,
+      topClass: topElement instanceof HTMLElement ? topElement.className : null,
+      center: { x, y },
+      rect: {
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      },
+    };
+  });
+
+  expect(result).toMatchObject({ isHitTestable: true });
 }
 
 /**

--- a/tests/e2e/path-chooser.spec.ts
+++ b/tests/e2e/path-chooser.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { seedProject, cleanupAll } from './helpers';
+import { seedProject, cleanupAll, expectFullyInViewport, expectHitTestable } from './helpers';
 
 test.describe('Path Chooser', () => {
   test.beforeEach(async () => {
@@ -16,33 +16,37 @@ test.describe('Path Chooser', () => {
     // Assert the path chooser structure is present
     await expect(page.locator('.path-chooser')).toBeVisible();
     await expect(page.locator('.path-chooser input[type="text"]')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Browse' })).toBeVisible();
+    await expectHitTestable(page.getByRole('button', { name: 'Browse' }), { requireEnabled: true });
   });
 
   test('opens directory browser modal when Browse is clicked', async ({ page }) => {
     await page.goto('/projects/new');
 
-    await page.click('button:has-text("Browse")');
+    const browseButton = page.getByRole('button', { name: 'Browse' });
+    await expectHitTestable(browseButton, { requireEnabled: true });
+    await browseButton.click();
 
     // Assert modal is visible with correct structure
     await expect(page.locator('.path-browser-overlay')).toBeVisible();
-    await expect(page.locator('.path-browser')).toBeVisible();
+    await expectFullyInViewport(page.locator('.path-browser'));
     await expect(page.locator('.browser-header')).toBeVisible();
     await expect(page.locator('.browser-content')).toBeVisible();
     await expect(page.locator('.browser-footer')).toBeVisible();
 
     // Assert modal has Cancel and Select buttons
-    await expect(page.locator('.browser-footer button:has-text("Cancel")')).toBeVisible();
-    await expect(page.locator('.browser-footer button:has-text("Select")')).toBeVisible();
+    await expectHitTestable(page.locator('.browser-footer button:has-text("Cancel")'), { requireEnabled: true });
+    await expectHitTestable(page.locator('.browser-footer button:has-text("Select")'), { requireEnabled: true });
   });
 
   test('closes modal when Cancel is clicked', async ({ page }) => {
     await page.goto('/projects/new');
 
-    await page.click('button:has-text("Browse")');
+    await page.getByRole('button', { name: 'Browse' }).click();
     await expect(page.locator('.path-browser-overlay')).toBeVisible();
 
-    await page.click('.browser-footer button:has-text("Cancel")');
+    const cancelButton = page.locator('.browser-footer button:has-text("Cancel")');
+    await expectHitTestable(cancelButton, { requireEnabled: true });
+    await cancelButton.click();
 
     await expect(page.locator('.path-browser-overlay')).not.toBeVisible();
   });
@@ -62,10 +66,12 @@ test.describe('Path Chooser', () => {
   test('closes modal when X button is clicked', async ({ page }) => {
     await page.goto('/projects/new');
 
-    await page.click('button:has-text("Browse")');
+    await page.getByRole('button', { name: 'Browse' }).click();
     await expect(page.locator('.path-browser-overlay')).toBeVisible();
 
-    await page.click('.browser-close');
+    const closeButton = page.locator('.browser-close');
+    await expectHitTestable(closeButton, { requireEnabled: true });
+    await closeButton.click();
 
     await expect(page.locator('.path-browser-overlay')).not.toBeVisible();
   });
@@ -184,7 +190,9 @@ test.describe('Path Chooser Selection', () => {
     const selectedPath = await page.locator('.browser-path').textContent();
 
     // Click Select
-    await page.click('.browser-footer button:has-text("Select")');
+    const selectButton = page.locator('.browser-footer button:has-text("Select")');
+    await expectHitTestable(selectButton, { requireEnabled: true });
+    await selectButton.click();
 
     // Modal should close
     await expect(page.locator('.path-browser-overlay')).not.toBeVisible();
@@ -245,7 +253,7 @@ test.describe('Path Chooser in Edit View', () => {
     await page.goto(`/projects/${project.id}/edit`);
 
     await expect(page.locator('.path-chooser')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Browse' })).toBeVisible();
+    await expectHitTestable(page.getByRole('button', { name: 'Browse' }), { requireEnabled: true });
 
     // Should have the existing path value
     const inputValue = await page.locator('.path-chooser input').inputValue();

--- a/tests/e2e/quick-response-dialog-fixed-footer.spec.ts
+++ b/tests/e2e/quick-response-dialog-fixed-footer.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 import {
   seedProject,
   cleanupCreatedResources,
+  expectFullyInViewport,
+  expectHitTestable,
 } from './helpers';
 
 /**
@@ -39,17 +41,14 @@ test.describe('Quick Response Dialog - Fixed Footer with Save Button', () => {
     }
 
     const manageBtn = page.getByRole('button', { name: 'Manage Quick Responses' });
-    if (await manageBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await manageBtn.click();
-      await page.waitForLoadState('networkidle');
-    }
+    await expectHitTestable(manageBtn, { requireEnabled: true });
+    await manageBtn.click();
+    await page.waitForLoadState('networkidle');
 
     // First, create a quick response
-    const addButtons = page.getByRole('button', { name: /\+ Add/ });
-    if (await addButtons.first().isVisible({ timeout: 3000 }).catch(() => false)) {
-      await addButtons.first().click();
-      await page.waitForTimeout(300);
-    }
+    const addButton = page.getByRole('button', { name: /\+ Add/ }).first();
+    await expectHitTestable(addButton, { requireEnabled: true });
+    await addButton.click();
 
     // Find the Add dialog by looking for a dialog that contains the QR form fields
     let addDialog = page.locator('[role="dialog"]').filter({ has: page.locator('#qr-label') });
@@ -63,6 +62,7 @@ test.describe('Quick Response Dialog - Fixed Footer with Save Button', () => {
     await contentTextarea.fill('This is a test response content');
 
     const saveButton = addDialog.locator('button[type="submit"]');
+    await expectHitTestable(saveButton, { requireEnabled: true });
     await saveButton.click();
 
     // Wait for the Add dialog's form to disappear (the dialog with #qr-label should close)
@@ -74,7 +74,7 @@ test.describe('Quick Response Dialog - Fixed Footer with Save Button', () => {
 
     // Now find and click the edit button for the created response
     const editButtons = page.getByRole('button', { name: /edit/i });
-    await expect(editButtons.first()).toBeVisible({ timeout: 5000 });
+    await expectHitTestable(editButtons.first(), { requireEnabled: true });
     await editButtons.first().click();
 
     // The edit dialog should now be open - find it by the QR form fields
@@ -88,12 +88,13 @@ test.describe('Quick Response Dialog - Fixed Footer with Save Button', () => {
     // Verify Save button is visible in footer
     const footer = dialog.locator('.dialog-footer');
     await expect(footer).toBeVisible();
+    await expectFullyInViewport(footer);
 
     const editSaveButton = footer.locator('button[type="submit"]');
     await expect(editSaveButton).toBeVisible();
+    await expectHitTestable(editSaveButton, { requireEnabled: true });
 
     // Verify button says "Save Changes" or similar
-    const buttonText = await editSaveButton.textContent();
-    expect(buttonText?.trim()).toMatch(/Save Changes|Save/);
+    await expect(editSaveButton).toHaveText(/Save Changes|Save/);
   });
 });

--- a/tests/e2e/save-button-demo.spec.ts
+++ b/tests/e2e/save-button-demo.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { seedProject, cleanupAll, navigateAndWait } from './helpers';
+import { seedProject, cleanupAll, navigateAndWait, expectHitTestable } from './helpers';
 
-test('Quick Response Dialog - Save Button Visible', async ({ page, baseURL }) => {
+test('Quick Response Dialog - Save Button Visible', async ({ page }) => {
   await cleanupAll();
 
   try {
@@ -9,74 +9,44 @@ test('Quick Response Dialog - Save Button Visible', async ({ page, baseURL }) =>
     const project = await seedProject('[TEST] Save Button Demo', '/tmp/save-button-demo');
 
     // Navigate to project edit page
-    await navigateAndWait(page, `${baseURL}/#/projects/${project.id}/edit`);
+    await navigateAndWait(page, `/projects/${project.id}/edit`);
 
-    // Get the project data to verify
-    const projectsResponse = await page.evaluate(async (projectId) => {
-      const res = await fetch(`/api/projects/${projectId}`);
-      return await res.json();
-    }, project.id);
-
-    if (projectsResponse && projectsResponse.id) {
-      // Expand Quick Responses section if needed
-      const details = page.locator('details').filter({ hasText: 'Quick Responses' });
-      if (await details.isVisible({ timeout: 3000 }).catch(() => false)) {
-        const summary = details.locator('summary');
-        if (await summary.isVisible()) {
-          await summary.click();
-          await page.waitForTimeout(300);
-        }
-      }
-
-      // Click "Manage Quick Responses" button
-      const manageBtn = page.getByRole('button', { name: 'Manage Quick Responses' });
-      if (await manageBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await manageBtn.click();
-        await page.waitForLoadState('networkidle');
-      }
-
-      // Click "+ Add" button to open dialog
-      const addButtons = page.getByRole('button', { name: /\+ Add/ });
-      if (await addButtons.first().isVisible({ timeout: 3000 }).catch(() => false)) {
-        await addButtons.first().click();
+    // Expand Quick Responses section if needed
+    const details = page.locator('details').filter({ hasText: 'Quick Responses' });
+    if (await details.isVisible({ timeout: 3000 }).catch(() => false)) {
+      const summary = details.locator('summary');
+      if (await summary.isVisible()) {
+        await summary.click();
         await page.waitForTimeout(300);
-      }
-
-      // Get the dialog and take a full screenshot showing both buttons
-      const dialog = page.locator('[role="dialog"]').first();
-
-      if (await dialog.isVisible({ timeout: 5000 }).catch(() => false)) {
-        // Set a reasonable viewport height to show the full dialog
-        await page.setViewportSize({ width: 600, height: 1000 });
-        await page.waitForTimeout(500);
-
-        // Take screenshot of entire page showing the dialog with buttons
-        await page.screenshot({ path: 'screenshots/dialog-with-save-button.png', fullPage: false });
-        console.log('✓ Screenshot with Save button saved');
-
-        // Scroll within dialog to show footer
-        await dialog.evaluate(el => {
-          const content = el.querySelector('.dialog-content');
-          if (content) content.scrollTop = content.scrollHeight;
-        });
-        await page.waitForTimeout(300);
-
-        // Take another screenshot showing the footer clearly
-        await page.screenshot({ path: 'screenshots/dialog-footer-buttons.png', fullPage: false });
-        console.log('✓ Screenshot of footer buttons saved');
-
-        // Fill in the form to make it look complete
-        const labelInput = dialog.locator('#qr-label');
-        await labelInput.fill('Test Response');
-        const contentTextarea = dialog.locator('#qr-content');
-        await contentTextarea.fill('This is a test quick response message');
-        await page.waitForTimeout(300);
-
-        // Take a final screenshot with filled form and visible Save button
-        await page.screenshot({ path: 'screenshots/dialog-filled-with-save.png', fullPage: false });
-        console.log('✓ Screenshot with filled form and Save button saved');
       }
     }
+
+    // Click "Manage Quick Responses" button
+    const manageBtn = page.getByRole('button', { name: 'Manage Quick Responses' });
+    await expectHitTestable(manageBtn, { requireEnabled: true });
+    await manageBtn.click();
+    await page.waitForLoadState('networkidle');
+
+    // Click "+ Add" button to open dialog
+    const addButton = page.getByRole('button', { name: /\+ Add/ }).first();
+    await expectHitTestable(addButton, { requireEnabled: true });
+    await addButton.click();
+
+    // Get the dialog and verify its save affordance is actually usable.
+    const dialog = page.locator('[role="dialog"]').filter({ has: page.locator('#qr-label') });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    const labelInput = dialog.locator('#qr-label');
+    await expect(labelInput).toBeVisible();
+    await labelInput.fill('Test Response');
+
+    const contentTextarea = dialog.locator('#qr-content');
+    await expect(contentTextarea).toBeVisible();
+    await contentTextarea.fill('This is a test quick response message');
+
+    const saveButton = dialog.locator('.dialog-footer button[type="submit"]');
+    await expect(saveButton).toHaveText(/Save/);
+    await expectHitTestable(saveButton, { requireEnabled: true });
   } finally {
     await cleanupAll();
   }

--- a/tests/e2e/scroll-to-bottom.spec.ts
+++ b/tests/e2e/scroll-to-bottom.spec.ts
@@ -8,6 +8,7 @@ import {
   waitForSessionToExist,
   waitForSessionStatus,
   updateSessionStatus,
+  expectHitTestable,
 } from './helpers';
 import { API_READY } from './timeouts';
 
@@ -69,6 +70,7 @@ test.describe('scroll-to-bottom button', () => {
     });
 
     await expect(btn).toBeVisible({ timeout: 5000 });
+    await expectHitTestable(btn, { requireEnabled: true });
 
     const stickyOffset = await body.evaluate((el) => {
       const h = el as HTMLElement;
@@ -131,6 +133,8 @@ test.describe('scroll-to-bottom button', () => {
 
     await expect(toBottomBtn).toBeVisible({ timeout: 5000 });
     await expect(toClaudeBtn).toBeVisible({ timeout: 5000 });
+    await expectHitTestable(toBottomBtn, { requireEnabled: true });
+    await expectHitTestable(toClaudeBtn, { requireEnabled: true });
 
     const controlsOffset = await body.evaluate((el) => {
       const h = el as HTMLElement;

--- a/tests/e2e/session-navigation.spec.ts
+++ b/tests/e2e/session-navigation.spec.ts
@@ -4,6 +4,7 @@ import {
   cleanupAll,
   navigateAndWait,
   getAPIURL,
+  expectHitTestable,
 } from './helpers';
 
 test.describe('Session List Icon Navigation', () => {
@@ -41,6 +42,7 @@ test.describe('Session List Icon Navigation', () => {
     // Find and verify back icon link
     const backLink = page.locator('.tab-back');
     await expect(backLink).toBeVisible();
+    await expectHitTestable(backLink);
     await expect(backLink.locator('.back-icon')).toBeVisible();
     await expect(backLink.locator('svg')).toHaveCount(2);
 

--- a/tests/e2e/system-indicators.spec.ts
+++ b/tests/e2e/system-indicators.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { expectFullyInViewport, expectHitTestable } from './helpers';
 
 /**
  * E2E tests for System Resource Indicators.
@@ -27,37 +28,48 @@ test.describe('System Resource Indicators', () => {
 
   test('indicators appear in the header within 15 seconds', async ({ page }) => {
     // Wait for the container to become visible (hidden until first WS broadcast)
-    const container = await page.waitForSelector('[data-testid="system-indicators"]', {
-      timeout: 15000,
-    });
-    expect(container).toBeTruthy();
+    const container = page.locator('[data-testid="system-indicators"]');
+    await expect(container).toBeVisible({ timeout: 15000 });
+    await expectFullyInViewport(container);
   });
 
   test('all three indicators are present after data arrives', async ({ page }) => {
     // Wait for container to appear
-    await page.waitForSelector('[data-testid="system-indicators"]', { timeout: 15000 });
+    await expect(page.locator('[data-testid="system-indicators"]')).toBeVisible({ timeout: 15000 });
 
     // CPU and memory are always present
-    expect(await page.locator('[data-testid="indicator-cpu"]').count()).toBe(1);
-    expect(await page.locator('[data-testid="indicator-memory"]').count()).toBe(1);
+    const cpu = page.locator('[data-testid="indicator-cpu"]');
+    const memory = page.locator('[data-testid="indicator-memory"]');
+    await expect(cpu).toHaveCount(1);
+    await expect(memory).toHaveCount(1);
+    await expectHitTestable(cpu);
+    await expectHitTestable(memory);
 
     // Disk may or may not be present depending on OS support (null on failure)
     // Just verify it doesn't cause an error
-    const diskCount = await page.locator('[data-testid="indicator-disk"]').count();
+    const disk = page.locator('[data-testid="indicator-disk"]');
+    const diskCount = await disk.count();
     expect(diskCount).toBeGreaterThanOrEqual(0);
     expect(diskCount).toBeLessThanOrEqual(1);
+    if (diskCount === 1) {
+      await expectHitTestable(disk);
+    }
   });
 
   test('bars have non-zero width after data arrives', async ({ page }) => {
-    await page.waitForSelector('[data-testid="system-indicators"]', { timeout: 15000 });
+    await expect(page.locator('[data-testid="system-indicators"]')).toBeVisible({ timeout: 15000 });
 
     // Check CPU bar width
     const cpuBar = page.locator('[data-testid="indicator-bar-cpu"]');
+    await expect(cpuBar).toBeVisible();
+    await expectFullyInViewport(cpuBar);
     const cpuWidth = await cpuBar.evaluate((el) => el.getBoundingClientRect().width);
     expect(cpuWidth).toBeGreaterThan(0);
 
     // Check memory bar width
     const memBar = page.locator('[data-testid="indicator-bar-memory"]');
+    await expect(memBar).toBeVisible();
+    await expectFullyInViewport(memBar);
     const memWidth = await memBar.evaluate((el) => el.getBoundingClientRect().width);
     expect(memWidth).toBeGreaterThan(0);
   });
@@ -103,7 +115,8 @@ test.describe('System Resource Indicators', () => {
     await page.waitForTimeout(6000);
 
     // Component should still be visible
-    expect(await page.locator('[data-testid="system-indicators"]').isVisible()).toBe(true);
+    await expect(page.locator('[data-testid="system-indicators"]')).toBeVisible();
+    await expectFullyInViewport(page.locator('[data-testid="system-indicators"]'));
 
     // Tooltip should still be in the correct format
     const updatedCpuTitle = await cpuEl.getAttribute('title');


### PR DESCRIPTION
## Summary
- Add shared Playwright helpers for viewport containment and center-point hit testing.
- Harden E2E assertions for quick response dialogs, path chooser modals, scroll controls, system indicators, save button demo flow, and session back navigation.
- Replace screenshot/debug or DOM-only checks with assertions that controls are visible, enabled where applicable, in viewport, and actually hit-testable.

## Audit Notes
- Fixed: quick response dialog footer controls could pass while clipped or covered.
- Fixed: path chooser Browse, Cancel, Select, and close controls could pass while unusable.
- Fixed: system indicators could pass DOM count/width checks while hidden, offscreen, or covered.
- Fixed: scroll buttons could pass visibility checks while another sticky element intercepted clicks.
- Fixed: save-button demo could pass through screenshots/conditional branches without proving Save was usable.
- Fixed: session back icon asserted SVG/title presence but not click usability.

## Follow-up Candidates
- debug-new-session-button.spec.ts is still screenshot/log oriented and should assert the New Session button is hit-testable and creates/selects the draft.
- model-selector-default.spec.ts still leans on debug screenshots and count/inputValue checks; it should assert visible/enabled selector UX in viewport.
- command modal/button specs should add modal viewport/hit-test checks for status indicators, output headers, Run, and Kill controls.
- filter specs rely heavily on class checks; they should prefer accessible selected/pressed state plus visible filtered results.

## Verification
- ./scripts/pw.sh test tests/e2e/quick-response-dialog-fixed-footer.spec.ts tests/e2e/system-indicators.spec.ts tests/e2e/path-chooser.spec.ts tests/e2e/scroll-to-bottom.spec.ts --project=chromium passed, 29/29.
- ./scripts/pw.sh test tests/e2e/save-button-demo.spec.ts tests/e2e/session-navigation.spec.ts --project=chromium passed, 3/3.
- Re-ran path-chooser plus quick-response-dialog-fixed-footer after final tweaks: 18/18 passed.
- yarn tsc --noEmit is not a valid root check here because there is no root tsconfig.json; TypeScript printed help and exited 1.
