### PR TITLE
Move Circus Time to project tabs

### DIFF
--- a/packages/web/src/router.js
+++ b/packages/web/src/router.js
@@ -47,6 +47,11 @@ const routes = [
     component: () => import('./views/SessionListView.vue'),
   },
   {
+    path: '/projects/:id/circus-time',
+    name: 'ProjectCircusTime',
+    component: () => import('./views/SessionListView.vue'),
+  },
+  {
     path: '/projects/:id/kanban',
     name: 'ProjectKanban',
     component: () => import('./views/SessionListView.vue'),

--- a/packages/web/src/views/SessionDetailView.test.js
+++ b/packages/web/src/views/SessionDetailView.test.js
@@ -27,9 +27,6 @@ vi.mock('../components/SummaryTab.vue', () => ({
 vi.mock('../components/CommandsTab.vue', () => ({
   default: { name: 'CommandsTab', template: '<div>Commands Tab</div>' }
 }));
-vi.mock('../components/CircusTimeTab.vue', () => ({
-  default: { name: 'CircusTimeTab', template: '<div>Circus Time Tab</div>' }
-}));
 vi.mock('../components/DuplicateSessionButton.vue', () => ({
   default: { name: 'DuplicateSessionButton', template: '<button @click="$emit(\'success\', { id: \'new\' })" :disabled="false">Duplicate</button>' }
 }));
@@ -209,7 +206,7 @@ describe('SessionDetailView', () => {
   }
 
   describe('tabs configuration', () => {
-    it('includes Summary, Changes, Canvas, Commands, and Circus Time tabs', async () => {
+    it('includes Summary, Changes, Canvas, and Commands tabs', async () => {
       sessionsStore.currentSession = {
         id: 'session-1',
         name: 'Test Session',
@@ -244,40 +241,7 @@ describe('SessionDetailView', () => {
         'changes',
         'canvas',
         'commands',
-        'circus-time',
       ]);
-    });
-
-    it('renders Circus Time tab content from a direct route', async () => {
-      sessionsStore.currentSession = {
-        id: 'session-1',
-        name: 'Test Session',
-        status: 'running',
-        projectId: 'project-1'
-      };
-
-      await router.push('/sessions/session-1/circus-time');
-      await router.isReady();
-
-      const wrapper = trackedMount(SessionDetailView, {
-        global: {
-          plugins: [pinia, router],
-          stubs: {
-            ChangesTab: true,
-            CanvasTab: true,
-            SummaryTab: true,
-            CommandsTab: true,
-
-            PrIndicators: true,
-            SchedulingInfo: true
-          }
-        }
-      });
-
-      await flushPromises();
-
-      expect(wrapper.findComponent({ name: 'CircusTimeTab' }).exists()).toBe(true);
-      expect(wrapper.text()).toContain('Circus Time Tab');
     });
 
     it('renders correct tab content for selected tab', async () => {

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -73,9 +73,6 @@
           :session-id="route.params.id"
           :project-id="sessionsStore.currentSession?.projectId"
         />
-        <CircusTimeTab
-          v-else-if="activeTab === 'circus-time'"
-        />
       </div>
 
       <!-- Session Chat Handle -->
@@ -124,7 +121,6 @@ import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
 import CommandsTab from '../components/CommandsTab.vue';
-import CircusTimeTab from '../components/CircusTimeTab.vue';
 import SessionHeaderPanel from '../components/SessionHeaderPanel.vue';
 import SessionTabsPanel from '../components/SessionTabsPanel.vue';
 import SessionChatHandle from '../components/SessionChatHandle.vue';
@@ -454,6 +450,16 @@ const { cleanup, initializeSession } = useSessionInitializer({
 
 const activeTab = computed(() => route.params.tab || 'summary');
 
+watch(
+  () => [route.params.tab, sessionsStore.currentSession?.projectId],
+  ([tab, projectId]) => {
+    if (tab === 'circus-time' && projectId) {
+      router.replace(`/projects/${projectId}/circus-time`);
+    }
+  },
+  { immediate: true }
+);
+
 // Command button status indicators for real-time updates (mirrors SessionCard behavior)
 const buttonStatusesToDisplay = computed(() => {
   // Access commandRunVersion to establish Vue dependency tracking.
@@ -505,7 +511,6 @@ const tabs = computed(() => [
   { id: 'changes', label: changesFileCount.value > 0 ? `Changes (${changesFileCount.value})` : 'Changes' },
   { id: 'canvas', label: canvasStore.groupedItems.length > 0 ? `Canvas (${canvasStore.groupedItems.length})` : 'Canvas' },
   { id: 'commands', label: 'Commands' },
-  { id: 'circus-time', label: 'Circus Time' }
 ]);
 
 // Watch for status changes from any source (optimistic updates, WebSocket, etc.)

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -19,6 +19,8 @@ const mockRouterPush = vi.fn((path) => {
     mockRoute.name = 'ProjectTemplates';
   } else if (path.includes('/commands')) {
     mockRoute.name = 'ProjectCommands';
+  } else if (path.includes('/circus-time')) {
+    mockRoute.name = 'ProjectCircusTime';
   } else if (path.includes('/kanban')) {
     mockRoute.name = 'ProjectKanban';
   } else {
@@ -375,6 +377,13 @@ vi.mock('../components/CommandButtonsPanel.vue', () => ({
     name: 'CommandButtonsPanel',
     props: ['projectId'],
     template: '<div class="command-buttons-panel" />',
+  }),
+}));
+
+vi.mock('../components/CircusTimeTab.vue', () => ({
+  default: defineComponent({
+    name: 'CircusTimeTab',
+    template: '<div class="circus-time-tab">Circus Time Tab</div>',
   }),
 }));
 
@@ -1620,15 +1629,33 @@ describe('SessionListView Archived Tab', () => {
       await flushAll(wrapper);
 
     const tabs = wrapper.findAll('.tab');
-    expect(tabs.length).toBe(4);
+    expect(tabs.length).toBe(5);
     expect(tabs[0].text()).toBe('Sessions');
     expect(tabs[1].text()).toBe('Archived');
     expect(tabs[2].text()).toBe('Templates');
     expect(tabs[3].text()).toBe('Commands');
+    expect(tabs[4].text()).toBe('Circus Time');
 
     // Sessions tab should be active
     expect(tabs[0].classes()).toContain('active');
     expect(tabs[1].classes()).not.toContain('active');
+  });
+
+  it('renders Circus Time as a project-level tab', async () => {
+    const wrapper = mount(SessionListView);
+    await flushAll(wrapper);
+
+    const circusTimeTab = wrapper
+      .findAll('.tabs-desktop .tab')
+      .find(tab => tab.text() === 'Circus Time');
+    expect(circusTimeTab).toBeTruthy();
+
+    await circusTimeTab.trigger('click');
+    await flushAll(wrapper);
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/projects/test-project-id/circus-time');
+    expect(wrapper.findComponent({ name: 'CircusTimeTab' }).exists()).toBe(true);
+    expect(wrapper.find('.circus-time-tab').text()).toContain('Circus Time Tab');
   });
 
   it('switches to Archived tab when clicked', async () => {

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -87,6 +87,13 @@
             Commands
           </button>
           <button
+            class="tab"
+            :class="{ active: activeTab === 'circus-time' }"
+            @click="router.push(`/projects/${route.params.id}/circus-time`)"
+          >
+            Circus Time
+          </button>
+          <button
             v-if="projectsStore.currentProject?.kanbanEnabled"
             class="tab"
             :class="{ active: activeTab === 'kanban' }"
@@ -123,6 +130,9 @@
           </option>
           <option value="commands">
             Commands
+          </option>
+          <option value="circus-time">
+            Circus Time
           </option>
           <option
             v-if="projectsStore.currentProject?.kanbanEnabled"
@@ -242,6 +252,9 @@
       <CommandButtonsPanel :project-id="route.params.id" />
     </div>
 
+    <!-- Circus Time Tab -->
+    <CircusTimeTab v-if="activeTab === 'circus-time'" />
+
     <!-- Kanban Tab -->
     <KanbanBoard
       v-if="activeTab === 'kanban'"
@@ -338,6 +351,7 @@ import SessionFiltersPanel from '../components/SessionFiltersPanel.vue';
 import ArchivedTabContent from '../components/ArchivedTabContent.vue';
 import TemplatesPanel from '../components/TemplatesPanel.vue';
 import CommandButtonsPanel from '../components/CommandButtonsPanel.vue';
+import CircusTimeTab from '../components/CircusTimeTab.vue';
 import KanbanBoard from '../components/KanbanBoard.vue';
 import AddSessionToLaneModal from '../components/AddSessionToLaneModal.vue';
 import ArchiveConfirmModal from '../components/ArchiveConfirmModal.vue';
@@ -361,6 +375,7 @@ const activeTab = computed(() => {
     case 'ArchivedSessions': return 'archived';
     case 'ProjectTemplates': return 'templates';
     case 'ProjectCommands': return 'commands';
+    case 'ProjectCircusTime': return 'circus-time';
     case 'ProjectKanban': return 'kanban';
     default: return 'sessions';
   }
@@ -374,6 +389,7 @@ function handleTabChange(tab) {
     archived: `/projects/${projectId}/archived`,
     templates: `/projects/${projectId}/templates`,
     commands: `/projects/${projectId}/commands`,
+    'circus-time': `/projects/${projectId}/circus-time`,
     kanban: `/projects/${projectId}/kanban`,
   };
   router.push(routes[tab]);

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -606,10 +606,7 @@ test.describe('Session Detail Tab Navigation', () => {
     await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}/commands`));
     await expect(page.locator('.tabs-desktop .tab').filter({ hasText: 'Commands' })).toHaveClass(/active/);
 
-    // Click Circus Time tab
-    await page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' }).click();
-    await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}/circus-time`));
-    await expect(page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' })).toHaveClass(/active/);
+    await expect(page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' })).toHaveCount(0);
   });
 
   test('deep linking to a specific tab works', async ({ page }) => {
@@ -623,11 +620,12 @@ test.describe('Session Detail Tab Navigation', () => {
     await expect(page).toHaveURL(new RegExp(`/sessions/${session.id}/canvas`));
   });
 
-  test('deep linking to Circus Time shows the CTA', async ({ page }) => {
-    await navigateAndWait(page, `/sessions/${session.id}/circus-time`);
+  test('project-level Circus Time tab shows the CTA', async ({ page }) => {
+    await navigateAndWait(page, `/projects/${project.id}/circus-time`);
 
     const circusTimeTab = page.locator('.tabs-desktop .tab').filter({ hasText: 'Circus Time' });
     await expect(circusTimeTab).toHaveClass(/active/);
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/circus-time`));
     await expect(page.getByRole('heading', { name: 'Circus Time' })).toBeVisible();
 
     const ctaLink = page.getByRole('link', { name: 'Get Circus Time' });
@@ -635,6 +633,13 @@ test.describe('Session Detail Tab Navigation', () => {
       'href',
       'https://mydayoff.lemonsqueezy.com/checkout/buy/2a60bdc7-058c-43d8-965b-6b7d785f0842'
     );
+  });
+
+  test('legacy session-level Circus Time URL redirects to project tab', async ({ page }) => {
+    await navigateAndWait(page, `/sessions/${session.id}/circus-time`);
+
+    await expect(page).toHaveURL(new RegExp(`/projects/${project.id}/circus-time`));
+    await expect(page.getByRole('heading', { name: 'Circus Time' })).toBeVisible();
   });
 
   test('back button navigates between tabs correctly', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Move Circus Time from the session detail tabs to the project/session-list tab bar at `/projects/:id/circus-time`.
- Remove the session detail Circus Time tab/content and render the existing `CircusTimeTab` from `SessionListView`.
- Preserve old `/sessions/:id/circus-time` links with a redirect to the project-level tab.
- Update focused unit and e2e navigation coverage for the new tab location.

## Verification
- `yarn --cwd packages/web test SessionListView.test.js SessionDetailView.test.js`
- `yarn test:e2e tests/e2e/filtering-navigation.spec.ts -g "session detail|project-level Circus Time|legacy session-level Circus Time"`