### PR TITLE
Reduce session detail sub-navigation horizontal spacing

### DIFF
--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -215,6 +215,8 @@ function navigateToTab(tabId) {
   flex: 1 1 0;
   text-align: center;
   min-width: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- Adds tighter horizontal padding (0.5rem) to session detail tabs on desktop viewports to prevent text ellipsis
- Change is scoped to `.tabs-session-detail .tabs-desktop .tab` and does not affect mobile dropdown behavior or other tab bars

## Test plan
- [ ] Verify on desktop viewport (around 1280px) that all session detail tab names render without ellipses
- [ ] Verify on mobile viewport (below 640px) that dropdown behavior is unchanged
- [ ] Confirm other tab bars (Settings, Session List) are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)