### PR TITLE
Fix duplicate quick-response templates by removing legacy seeding paths

### DIFF
--- a/packages/server/src/db/DatabaseManager.js
+++ b/packages/server/src/db/DatabaseManager.js
@@ -5,6 +5,7 @@ import { dirname, join } from 'path';
 import crypto from 'crypto';
 import { allMigrations } from './migrations/index.js';
 import { seedBaselineData } from './seedBaselineData.js';
+import { bootstrapDefaultSessionTemplates } from './bootstrapDefaultSessionTemplates.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,6 +30,11 @@ export class DatabaseManager {
     this.#db.pragma('journal_mode = WAL');
     this.#db.pragma('foreign_keys = ON');
 
+    // Detect first run BEFORE executing schema so we can distinguish a fresh
+    // database from an existing one being upgraded. A first-run database has
+    // no application tables yet; an existing one already has them.
+    const isFirstRun = !this.#hasApplicationTables();
+
     // Run schema
     const schema = readFileSync(join(__dirname, '..', 'schema.sql'), 'utf-8');
     this.#db.exec(schema);
@@ -39,7 +45,23 @@ export class DatabaseManager {
     // Run post-baseline migrations for existing databases.
     this.#runMigrations();
 
+    // Bootstrap default session templates once on a fresh database only.
+    bootstrapDefaultSessionTemplates(this.#db, { isFirstRun });
+
     return this.#db;
+  }
+
+  /**
+   * Return true when the database already contains application tables (i.e. it
+   * is an existing database, not freshly created).
+   * @private
+   * @returns {boolean}
+   */
+  #hasApplicationTables() {
+    const row = this.#db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='projects' LIMIT 1")
+      .get();
+    return row !== undefined;
   }
 
   /**

--- a/packages/server/src/db/DatabaseManager.test.js
+++ b/packages/server/src/db/DatabaseManager.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { DatabaseManager } from './DatabaseManager.js';
 import { repairMissingSessionParentsFromWorktree } from './migrations/index.js';
+import { bootstrapDefaultSessionTemplates } from './bootstrapDefaultSessionTemplates.js';
+import { DEFAULT_SESSION_TEMPLATES, DEFAULT_SESSION_TEMPLATE_PROMPTS } from './defaultSessionTemplates.js';
+import { miscMigrations } from './migrations/miscMigrations.js';
 
 describe('DatabaseManager', () => {
   let manager;
@@ -792,6 +795,143 @@ describe('DatabaseManager', () => {
 
       expect(providerModelsSchema.sql).toContain('REFERENCES providers(id)');
       expect(providerModelsSchema.sql).not.toContain('REFERENCES model_providers');
+    });
+  });
+
+  describe('default session template bootstrap (integration)', () => {
+    it('fresh in-memory DB contains exactly six default global templates', () => {
+      const db = manager.get();
+      const rows = db.prepare(
+        'SELECT * FROM session_templates WHERE project_id IS NULL ORDER BY name'
+      ).all();
+
+      expect(rows).toHaveLength(DEFAULT_SESSION_TEMPLATES.length);
+      const names = rows.map(r => r.name).sort();
+      expect(names).toEqual(DEFAULT_SESSION_TEMPLATES.map(t => t.name).sort());
+    });
+
+    it('fresh in-memory DB has no session_templates with legacy_quick_response_id', () => {
+      const db = manager.get();
+      const count = db.prepare(
+        'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+      ).get().cnt;
+      expect(count).toBe(0);
+    });
+
+    it('fresh in-memory DB has zero quick_responses rows', () => {
+      const db = manager.get();
+      const count = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
+      expect(count).toBe(0);
+    });
+
+    it('visible quick-response templates are exactly Put a plan on the canvas, Yes, and Continue in sort order', () => {
+      const db = manager.get();
+      const rows = db.prepare(`
+        SELECT name, prompt, quick_response_auto_submit, quick_response_sort_order
+        FROM session_templates
+        WHERE project_id IS NULL AND show_in_quick_responses = 1
+        ORDER BY quick_response_sort_order
+      `).all();
+
+      expect(rows).toHaveLength(3);
+      expect(rows[0].name).toBe('Put a plan on the canvas');
+      expect(rows[0].prompt).toBe(DEFAULT_SESSION_TEMPLATE_PROMPTS.PUT_PLAN);
+      expect(rows[0].quick_response_auto_submit).toBe(0);
+      expect(rows[0].quick_response_sort_order).toBe(0);
+
+      expect(rows[1].name).toBe('Yes');
+      expect(rows[1].prompt).toBe(DEFAULT_SESSION_TEMPLATE_PROMPTS.YES);
+      expect(rows[1].quick_response_auto_submit).toBe(1);
+      expect(rows[1].quick_response_sort_order).toBe(1);
+
+      expect(rows[2].name).toBe('Continue');
+      expect(rows[2].prompt).toBe(DEFAULT_SESSION_TEMPLATE_PROMPTS.CONTINUE);
+      expect(rows[2].quick_response_auto_submit).toBe(1);
+      expect(rows[2].quick_response_sort_order).toBe(2);
+    });
+
+    it('fresh DB sets the default_session_templates_bootstrapped flag', () => {
+      const db = manager.get();
+      const setting = db.prepare(
+        "SELECT value FROM app_settings WHERE key = 'default_session_templates_bootstrapped'"
+      ).get();
+      expect(setting?.value).toBe('true');
+    });
+
+    it('existing DB with bootstrap flag set and zero templates: startup does not recreate defaults', () => {
+      const db = manager.get();
+
+      // Delete all session templates and ensure flag remains set
+      db.prepare('DELETE FROM session_templates').run();
+      const flagSet = db.prepare(
+        "SELECT value FROM app_settings WHERE key = 'default_session_templates_bootstrapped'"
+      ).get();
+      expect(flagSet?.value).toBe('true');
+
+      // Simulate another startup (flag already set — no templates should be inserted)
+      bootstrapDefaultSessionTemplates(db, { isFirstRun: true });
+
+      const count = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
+      expect(count).toBe(0);
+    });
+
+    it('existing DB without bootstrap flag and zero templates: sets flag but does NOT recreate defaults', () => {
+      // Simulates upgrading from an old version: the DB exists (isFirstRun=false) but
+      // the flag has never been written. User may have already deleted templates before
+      // upgrading — they should stay deleted.
+      const db = manager.get();
+
+      // Pretend the flag was never written
+      db.prepare("DELETE FROM app_settings WHERE key = 'default_session_templates_bootstrapped'").run();
+      db.prepare('DELETE FROM session_templates').run();
+
+      bootstrapDefaultSessionTemplates(db, { isFirstRun: false });
+
+      // Flag should now be set
+      const setting = db.prepare(
+        "SELECT value FROM app_settings WHERE key = 'default_session_templates_bootstrapped'"
+      ).get();
+      expect(setting?.value).toBe('true');
+
+      // No templates should have been created
+      const count = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
+      expect(count).toBe(0);
+    });
+
+    it('existing DB with legacy converted templates: migration removes those rows and leaves normal templates', () => {
+      const db = manager.get();
+
+      // Insert a row that looks like a legacy-converted template
+      const now = Date.now();
+      db.prepare(`
+        INSERT INTO session_templates (
+          id, project_id, name, prompt, thinking_enabled, mode,
+          show_in_quick_responses, quick_response_auto_submit,
+          quick_response_sort_order, legacy_quick_response_id,
+          created_at, updated_at
+        ) VALUES (?, NULL, ?, ?, 1, 'yolo', 1, 1, 5, ?, ?, ?)
+      `).run('legacy-row', 'Legacy Item', 'legacy content', 'some-qr-id', now, now);
+
+      // Verify it's there
+      const before = db.prepare(
+        'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+      ).get().cnt;
+      expect(before).toBe(1);
+
+      // Run the cleanup migration again (it's idempotent)
+      const migration = miscMigrations.find(m => m.name === 'session_templates-remove-legacy-quick-response-templates');
+      migration.up(db);
+
+      // Legacy row is gone; normal templates remain
+      const legacy = db.prepare(
+        'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+      ).get().cnt;
+      expect(legacy).toBe(0);
+
+      const normal = db.prepare(
+        'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NULL'
+      ).get().cnt;
+      expect(normal).toBeGreaterThanOrEqual(0); // defaults may or may not be present depending on prior test state
     });
   });
 });

--- a/packages/server/src/db/bootstrapDefaultSessionTemplates.js
+++ b/packages/server/src/db/bootstrapDefaultSessionTemplates.js
@@ -1,0 +1,73 @@
+import { randomUUID } from 'node:crypto';
+import { DEFAULT_SESSION_TEMPLATES } from './defaultSessionTemplates.js';
+
+const BOOTSTRAP_KEY = 'default_session_templates_bootstrapped';
+
+/**
+ * One-time first-run bootstrap for default global session templates.
+ *
+ * Rules:
+ *  - If `default_session_templates_bootstrapped` is already `true` in app_settings,
+ *    do nothing (fast path for all subsequent startups).
+ *  - If the database is NOT a first-run (i.e. an existing database being upgraded),
+ *    set the flag and return without inserting any templates.
+ *  - If the database IS a first-run AND no global templates exist yet, insert the
+ *    six default templates.
+ *  - Always set the flag at the end so future startups skip this code entirely.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {{ isFirstRun: boolean }} options
+ */
+export function bootstrapDefaultSessionTemplates(db, { isFirstRun }) {
+  // Fast path: already bootstrapped.
+  const existing = db
+    .prepare("SELECT value FROM app_settings WHERE key = ?")
+    .get(BOOTSTRAP_KEY);
+  if (existing?.value === 'true') return;
+
+  const now = Date.now();
+
+  if (!isFirstRun) {
+    // Existing database being upgraded — do not insert defaults; just mark done.
+    db.prepare(
+      "INSERT OR REPLACE INTO app_settings (key, value, updated_at) VALUES (?, ?, ?)"
+    ).run(BOOTSTRAP_KEY, 'true', now);
+    return;
+  }
+
+  // Fresh database: insert defaults only if there are no global templates yet.
+  const count = db
+    .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL')
+    .get().cnt;
+
+  if (count === 0) {
+    const insert = db.prepare(`
+      INSERT INTO session_templates (
+        id, project_id, name, prompt,
+        next_template_id, thinking_enabled,
+        git_branch, git_mode, model, mode, effort_level, target_lane_id,
+        show_in_quick_responses, quick_response_auto_submit,
+        quick_response_sort_order, legacy_quick_response_id,
+        created_at, updated_at
+      ) VALUES (?, NULL, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, ?, ?, ?, NULL, ?, ?)
+    `);
+
+    for (const item of DEFAULT_SESSION_TEMPLATES) {
+      insert.run(
+        randomUUID(),
+        item.name,
+        item.prompt,
+        item.showInQuickResponses ? 1 : 0,
+        item.quickResponseAutoSubmit ? 1 : 0,
+        item.quickResponseSortOrder,
+        now,
+        now
+      );
+    }
+  }
+
+  // Mark bootstrapped regardless of whether defaults were inserted.
+  db.prepare(
+    "INSERT OR REPLACE INTO app_settings (key, value, updated_at) VALUES (?, ?, ?)"
+  ).run(BOOTSTRAP_KEY, 'true', now);
+}

--- a/packages/server/src/db/defaultSessionTemplates.js
+++ b/packages/server/src/db/defaultSessionTemplates.js
@@ -1,0 +1,85 @@
+/**
+ * Default global session template definitions.
+ *
+ * Exported from a single location so that bootstrapDefaultSessionTemplates and
+ * tests can reference the same constants without duplication.
+ */
+
+/**
+ * Prompt strings for the default global session templates.
+ * Exported so tests can assert verbatim equality.
+ */
+export const DEFAULT_SESSION_TEMPLATE_PROMPTS = {
+  REVIEW: `Review the plan on the canvas. If there's more than one plan then review the most recently updated plan. if there are no plans on the canvas then look for the most recently updated plan on the root session canvas.
+
+Make sure there are tests explicitly called out for all changes. Make sure that all context necessary to hand off the task is included in the plan.
+
+Are there any gaps in the plan? Is test coverage spelled out explicitly? Does the code match the assumptions in the plan?
+
+Update the plan according to your review recommendations.`,
+  IMPLEMENT: `Implement the plan on the canvas. If there's more than one plan on the canvas then use the most recently updated plan. If you don't see a plan on the canvas then look at the parent session's canvas.`,
+  PR: `Ensure all relevant changes are committed and pushed. Then determine the session's goals. You can typically find details about the goals of the session by looking at the most recently modified markdown documents on the root session's canvas - these are typically plans that were implemented during the session. You can also look at the root session's summary, but don't trigger a new summary to be created if the summary is missing.
+
+Create a draft pr and ensure all changes are committed and pushed.`,
+  PUT_PLAN: `Put a plan on the canvas to get this done`,
+  YES: `Yes`,
+  CONTINUE: `Continue`,
+};
+
+/**
+ * The six default global session templates created on a fresh database.
+ *
+ * Workflow templates (show_in_quick_responses = false):
+ *   - Review the plan
+ *   - Implement the plan on the canvas
+ *   - Create/update PR
+ *
+ * Quick-response-backed templates (show_in_quick_responses = true):
+ *   - Put a plan on the canvas  (auto_submit = false, sort_order = 0)
+ *   - Yes                       (auto_submit = true,  sort_order = 1)
+ *   - Continue                  (auto_submit = true,  sort_order = 2)
+ */
+export const DEFAULT_SESSION_TEMPLATES = [
+  {
+    name: 'Review the plan',
+    prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.REVIEW,
+    showInQuickResponses: false,
+    quickResponseAutoSubmit: false,
+    quickResponseSortOrder: 0,
+  },
+  {
+    name: 'Implement the plan on the canvas',
+    prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.IMPLEMENT,
+    showInQuickResponses: false,
+    quickResponseAutoSubmit: false,
+    quickResponseSortOrder: 0,
+  },
+  {
+    name: 'Create/update PR',
+    prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.PR,
+    showInQuickResponses: false,
+    quickResponseAutoSubmit: false,
+    quickResponseSortOrder: 0,
+  },
+  {
+    name: 'Put a plan on the canvas',
+    prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.PUT_PLAN,
+    showInQuickResponses: true,
+    quickResponseAutoSubmit: false,
+    quickResponseSortOrder: 0,
+  },
+  {
+    name: 'Yes',
+    prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.YES,
+    showInQuickResponses: true,
+    quickResponseAutoSubmit: true,
+    quickResponseSortOrder: 1,
+  },
+  {
+    name: 'Continue',
+    prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.CONTINUE,
+    showInQuickResponses: true,
+    quickResponseAutoSubmit: true,
+    quickResponseSortOrder: 2,
+  },
+];

--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -243,14 +243,9 @@ export const allMigrations = validateMigrations([
   // --- Sessions default mode / thinking defaults (table recreation) ---
   s.get('sessions-migrate-default-mode-thinking'),
 
-  // --- Seed default global quick responses ---
-  m.get('quick_responses-seed-defaults'),
-
-  // --- Convert legacy quick responses into template-backed quick responses ---
-  m.get('session_templates-convert-quick-responses'),
-
-  // --- Seed default global session templates ---
-  m.get('session_templates-seed-defaults'),
+  // --- Remove template rows created by the legacy quick-response conversion.
+  //     This fixes the duplicate quick-response items users were seeing.
+  m.get('session_templates-remove-legacy-quick-response-templates'),
 
   // --- Update built-in Opus model to 4.7 ---
   pr.get('providers-update-built-in-opus-4-7'),

--- a/packages/server/src/db/migrations/miscMigrations.js
+++ b/packages/server/src/db/migrations/miscMigrations.js
@@ -3,127 +3,13 @@
  * app_settings, providers, provider_models, agent_call_logs.
  * Each export is an array of { name, up(db) } migration objects.
  */
-import { randomUUID } from 'node:crypto';
 import { addColumnIfMissing } from './migrationUtils.js';
 
 /**
  * Prompt strings for the default global session templates.
- * Exported so tests can assert verbatim equality.
+ * Re-exported from defaultSessionTemplates for backward compatibility.
  */
-export const DEFAULT_SESSION_TEMPLATE_PROMPTS = {
-  REVIEW: `Review the plan on the canvas. If there's more than one plan then review the most recently updated plan. if there are no plans on the canvas then look for the most recently updated plan on the root session canvas.
-
-Make sure there are tests explicitly called out for all changes. Make sure that all context necessary to hand off the task is included in the plan.
-
-Are there any gaps in the plan? Is test coverage spelled out explicitly? Does the code match the assumptions in the plan?
-
-Update the plan according to your review recommendations.`,
-  IMPLEMENT: `Implement the plan on the canvas. If there's more than one plan on the canvas then use the most recently updated plan. If you don't see a plan on the canvas then look at the parent session's canvas.`,
-  PR: `Ensure all relevant changes are committed and pushed. Then determine the session's goals. You can typically find details about the goals of the session by looking at the most recently modified markdown documents on the root session's canvas - these are typically plans that were implemented during the session. You can also look at the root session's summary, but don't trigger a new summary to be created if the summary is missing.
-
-Create a draft pr and ensure all changes are committed and pushed.`,
-};
-
-/**
- * Seed default global session templates when no global template exists.
- * Idempotent: if any global session template already exists, does nothing.
- */
-function seedDefaultSessionTemplates(db) {
-  const count = db.prepare(
-    `SELECT COUNT(*) AS cnt
-     FROM session_templates
-     WHERE project_id IS NULL
-       AND legacy_quick_response_id IS NULL`
-  ).get().cnt;
-  if (count > 0) return;
-
-  const defaults = [
-    { name: 'Review the plan', prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.REVIEW },
-    { name: 'Implement the plan on the canvas', prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.IMPLEMENT },
-    { name: 'Create/update PR', prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.PR },
-  ];
-
-  const stmt = db.prepare(`
-    INSERT INTO session_templates (
-      id, project_id, name, prompt,
-      next_template_id, thinking_enabled,
-      git_branch, git_mode, model, mode, effort_level, target_lane_id,
-      show_in_quick_responses, quick_response_auto_submit,
-      quick_response_sort_order, legacy_quick_response_id,
-      created_at, updated_at
-    ) VALUES (?, NULL, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, 0, 0, 0, NULL, ?, ?)
-  `);
-
-  const now = Date.now();
-  for (const item of defaults) {
-    stmt.run(randomUUID(), item.name, item.prompt, now, now);
-  }
-}
-
-/**
- * Seed default global quick responses when the table is empty.
- */
-function seedDefaultQuickResponses(db) {
-  const count = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
-  if (count > 0) return;
-
-  const defaults = [
-    { label: 'Put a plan on the canvas', content: 'Put a plan on the canvas to get this done', autoSubmit: false, sortOrder: 0 },
-    { label: 'Yes', content: 'Yes', autoSubmit: true, sortOrder: 1 },
-    { label: 'Review the plan', content: `Review the plan on the canvas. Are there any issues that you can find? Is test coverage specified explicitly enough? Does the current code match the assumptions in the plan?\n\nList the issues that you find and then update the plan on the canvas to address any issues that you find. Don't talk about issues with the original plan in the plan itself. Just tell me what the issues are, and update the plan so that the plan doesn't have the issues.`, autoSubmit: true, sortOrder: 2 },
-    { label: 'Implement the plan on the canvas', content: 'Implement the plan on the canvas', autoSubmit: true, sortOrder: 3 },
-    { label: 'Create / Update PR', content: `Ensure all relevant changes are committed and pushed. Then look at the session's summary and create a draft PR if no PR already exists.`, autoSubmit: true, sortOrder: 4 },
-    { label: 'Review PR', content: 'Look at the PR related to the root session. Review the PR. Are there any issues? Are best practices adhered to? Does the PR accomplish the goal? Are all changes covered by tests?', autoSubmit: true, sortOrder: 5 },
-    { label: 'Add tests', content: 'Inspect the changes on our branch. For each change, ensure we have tests that assert the change is working in the expected way. Implement the tests.', autoSubmit: true, sortOrder: 6 },
-    { label: 'Merge in main', content: 'Merge in the latest main branch', autoSubmit: true, sortOrder: 7 },
-    { label: 'Add tests to the plan', content: 'Call out specific test cases in the plan, we should have an assertion for each change called for in the plan', autoSubmit: true, sortOrder: 8 },
-    { label: 'Tests are failing', content: 'Tests are failing. Look at the canvas for details', autoSubmit: true, sortOrder: 9 },
-    { label: 'Continue', content: 'Continue', autoSubmit: true, sortOrder: 10 },
-  ];
-
-  const stmt = db.prepare(
-    `INSERT INTO quick_responses
-     (id, project_id, label, content, auto_submit, category, sort_order, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  );
-
-  const now = Date.now();
-  for (const item of defaults) {
-    stmt.run(randomUUID(), null, item.label, item.content, item.autoSubmit ? 1 : 0, null, item.sortOrder, now, now);
-  }
-}
-
-function convertQuickResponsesToTemplates(db) {
-  const rows = db.prepare('SELECT * FROM quick_responses ORDER BY sort_order ASC, created_at ASC').all();
-  const exists = db.prepare(
-    'SELECT 1 FROM session_templates WHERE legacy_quick_response_id = ? LIMIT 1'
-  );
-  const insert = db.prepare(`
-    INSERT INTO session_templates (
-      id, project_id, name, prompt,
-      next_template_id, thinking_enabled,
-      git_branch, git_mode, model, mode, effort_level, target_lane_id,
-      show_in_quick_responses, quick_response_auto_submit,
-      quick_response_sort_order, legacy_quick_response_id,
-      created_at, updated_at
-    ) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, ?, ?, ?, ?, ?)
-  `);
-
-  for (const row of rows) {
-    if (exists.get(row.id)) continue;
-    insert.run(
-      randomUUID(),
-      row.project_id || null,
-      row.label,
-      row.content,
-      row.auto_submit ? 1 : 0,
-      row.sort_order ?? 0,
-      row.id,
-      row.created_at,
-      row.updated_at
-    );
-  }
-}
+export { DEFAULT_SESSION_TEMPLATE_PROMPTS } from '../defaultSessionTemplates.js';
 
 /** @type {Array<{name: string, up: (db: import('better-sqlite3').Database) => void}>} */
 export const miscMigrations = [
@@ -224,21 +110,17 @@ export const miscMigrations = [
     },
   },
 
-  // --- Seed default global quick responses ---
+  // --- Remove template rows that were created by the legacy quick-response
+  //     conversion migration. These rows have a non-null legacy_quick_response_id
+  //     and are the root cause of the duplicate quick-response items users see.
+  //     Templates created directly by users (legacy_quick_response_id IS NULL)
+  //     are left untouched.
   {
-    name: 'quick_responses-seed-defaults',
-    up(db) { seedDefaultQuickResponses(db); },
+    name: 'session_templates-remove-legacy-quick-response-templates',
+    up(db) {
+      db.prepare(
+        'DELETE FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+      ).run();
+    },
   },
-
-  {
-    name: 'session_templates-convert-quick-responses',
-    up(db) { convertQuickResponsesToTemplates(db); },
-  },
-
-  // --- Seed default global session templates ---
-  {
-    name: 'session_templates-seed-defaults',
-    up(db) { seedDefaultSessionTemplates(db); },
-  },
-
 ];

--- a/packages/server/src/db/migrations/miscMigrations.test.js
+++ b/packages/server/src/db/migrations/miscMigrations.test.js
@@ -6,375 +6,122 @@ import { allMigrations } from './index.js';
 import { OPENAI_MODELS } from '@circuschief/shared';
 import { BUILT_IN_OPENAI_COMMIT_ATTRIBUTION } from '../seedBaselineData.js';
 
-const seedMigration = miscMigrations.find(m => m.name === 'quick_responses-seed-defaults');
-const seedTemplatesMigration = miscMigrations.find(m => m.name === 'session_templates-seed-defaults');
-const convertQuickResponsesMigration = miscMigrations.find(m => m.name === 'session_templates-convert-quick-responses');
+const removeLegacyTemplatesMigration = miscMigrations.find(
+  m => m.name === 'session_templates-remove-legacy-quick-response-templates'
+);
 
-const expectedDefaults = [
-  { label: 'Put a plan on the canvas', content: 'Put a plan on the canvas to get this done', autoSubmit: false, sortOrder: 0 },
-  { label: 'Yes', content: 'Yes', autoSubmit: true, sortOrder: 1 },
-  { label: 'Review the plan', content: `Review the plan on the canvas. Are there any issues that you can find? Is test coverage specified explicitly enough? Does the current code match the assumptions in the plan?\n\nList the issues that you find and then update the plan on the canvas to address any issues that you find. Don't talk about issues with the original plan in the plan itself. Just tell me what the issues are, and update the plan so that the plan doesn't have the issues.`, autoSubmit: true, sortOrder: 2 },
-  { label: 'Implement the plan on the canvas', content: 'Implement the plan on the canvas', autoSubmit: true, sortOrder: 3 },
-  { label: 'Create / Update PR', content: `Ensure all relevant changes are committed and pushed. Then look at the session's summary and create a draft PR if no PR already exists.`, autoSubmit: true, sortOrder: 4 },
-  { label: 'Review PR', content: 'Look at the PR related to the root session. Review the PR. Are there any issues? Are best practices adhered to? Does the PR accomplish the goal? Are all changes covered by tests?', autoSubmit: true, sortOrder: 5 },
-  { label: 'Add tests', content: 'Inspect the changes on our branch. For each change, ensure we have tests that assert the change is working in the expected way. Implement the tests.', autoSubmit: true, sortOrder: 6 },
-  { label: 'Merge in main', content: 'Merge in the latest main branch', autoSubmit: true, sortOrder: 7 },
-  { label: 'Add tests to the plan', content: 'Call out specific test cases in the plan, we should have an assertion for each change called for in the plan', autoSubmit: true, sortOrder: 8 },
-  { label: 'Tests are failing', content: 'Tests are failing. Look at the canvas for details', autoSubmit: true, sortOrder: 9 },
-  { label: 'Continue', content: 'Continue', autoSubmit: true, sortOrder: 10 },
-];
-
-describe('quick_responses-seed-defaults migration', () => {
-  it('seeds 11 default global quick responses on fresh database', () => {
-    const db = getDatabase();
-    const rows = db.prepare('SELECT * FROM quick_responses ORDER BY sort_order').all();
-
-    expect(rows).toHaveLength(11);
-
-    // All should be global (project_id IS NULL) with no category
-    for (const row of rows) {
-      expect(row.project_id).toBeNull();
-      expect(row.category).toBeNull();
-    }
-
-    // Verify each record matches expected data
-    for (let i = 0; i < expectedDefaults.length; i++) {
-      const row = rows[i];
-      const expected = expectedDefaults[i];
-      expect(row.label).toBe(expected.label);
-      expect(row.content).toBe(expected.content);
-      expect(row.auto_submit).toBe(expected.autoSubmit ? 1 : 0);
-      expect(row.sort_order).toBe(expected.sortOrder);
-    }
+describe('session_templates-remove-legacy-quick-response-templates migration', () => {
+  it('is defined and has an up() function', () => {
+    expect(removeLegacyTemplatesMigration).toBeDefined();
+    expect(typeof removeLegacyTemplatesMigration.up).toBe('function');
   });
 
-  it('does not insert when table already has records', () => {
-    const db = getDatabase();
-    // The seed migration already ran during initDatabase, so 11 records exist
-    const countBefore = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
-    expect(countBefore).toBe(11);
-
-    // Call the migration again
-    seedMigration.up(db);
-
-    const countAfter = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
-    expect(countAfter).toBe(11);
+  it('is registered in allMigrations', () => {
+    const names = allMigrations.map(m => m.name);
+    expect(names).toContain('session_templates-remove-legacy-quick-response-templates');
   });
 
-  it('does not insert when only project-specific responses exist', () => {
-    const db = getDatabase();
-    // Clear all seeded global responses
-    db.prepare('DELETE FROM quick_responses').run();
-
-    // Create a real project (needed for FK constraint on project_id)
-    const projectRepo = new ProjectRepository();
-    const project = projectRepo.create('Test Project', '/tmp/test');
-
-    // Insert a project-specific quick response
-    db.prepare(
-      `INSERT INTO quick_responses (id, project_id, label, content, auto_submit, sort_order, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run('test-id', project.id, 'Project Response', 'content', 0, 0, Date.now(), Date.now());
-
-    // Call the migration
-    seedMigration.up(db);
-
-    // Should still only have 1 record (the project-specific one)
-    const count = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
-    expect(count).toBe(1);
-  });
-
-  it('seeds correctly after all records are deleted', () => {
-    const db = getDatabase();
-    // Clear everything
-    db.prepare('DELETE FROM quick_responses').run();
-
-    // Call the migration
-    seedMigration.up(db);
-
-    // Should now have 11 records
-    const rows = db.prepare('SELECT * FROM quick_responses ORDER BY sort_order').all();
-    expect(rows).toHaveLength(11);
-
-    // Spot-check a few records
-    expect(rows[0].label).toBe('Put a plan on the canvas');
-    expect(rows[0].auto_submit).toBe(0);
-    expect(rows[1].label).toBe('Yes');
-    expect(rows[1].auto_submit).toBe(1);
-    expect(rows[10].label).toBe('Continue');
-  });
-});
-
-describe('session_templates-convert-quick-responses migration', () => {
-  it('converts legacy quick responses into quick response templates', () => {
-    const db = getDatabase();
-    db.prepare('DELETE FROM session_templates').run();
-    db.prepare('DELETE FROM quick_responses').run();
-
-    const projectRepo = new ProjectRepository();
-    const project = projectRepo.create('Quick Response Project', '/tmp/quick-response-project');
-    const now = Date.now();
-
-    db.prepare(
-      `INSERT INTO quick_responses (id, project_id, label, content, auto_submit, sort_order, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?), (?, NULL, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      'project-quick-response',
-      project.id,
-      'Project Response',
-      'Project content',
-      1,
-      7,
-      now - 2,
-      now - 1,
-      'global-quick-response',
-      'Global Response',
-      'Global content',
-      0,
-      2,
-      now - 4,
-      now - 3
-    );
-
-    convertQuickResponsesMigration.up(db);
-
-    const rows = db
-      .prepare('SELECT * FROM session_templates ORDER BY quick_response_sort_order')
-      .all();
-
-    expect(rows).toHaveLength(2);
-    expect(rows[0]).toMatchObject({
-      project_id: null,
-      name: 'Global Response',
-      prompt: 'Global content',
-      show_in_quick_responses: 1,
-      quick_response_auto_submit: 0,
-      quick_response_sort_order: 2,
-      legacy_quick_response_id: 'global-quick-response',
-      thinking_enabled: null,
-      mode: null,
-    });
-    expect(rows[1]).toMatchObject({
-      project_id: project.id,
-      name: 'Project Response',
-      prompt: 'Project content',
-      show_in_quick_responses: 1,
-      quick_response_auto_submit: 1,
-      quick_response_sort_order: 7,
-      legacy_quick_response_id: 'project-quick-response',
-      next_template_id: null,
-    });
-
-    const legacyCount = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
-    expect(legacyCount).toBe(2);
-  });
-
-  it('is idempotent when rerun', () => {
-    const db = getDatabase();
-    const countBefore = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
-
-    convertQuickResponsesMigration.up(db);
-
-    const countAfter = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
-    expect(countAfter).toBe(countBefore);
-  });
-});
-
-const expectedSessionTemplateNames = [
-  'Review the plan',
-  'Implement the plan on the canvas',
-  'Create/update PR',
-];
-
-const expectedSessionTemplatePrompts = {
-  'Review the plan': DEFAULT_SESSION_TEMPLATE_PROMPTS.REVIEW,
-  'Implement the plan on the canvas': DEFAULT_SESSION_TEMPLATE_PROMPTS.IMPLEMENT,
-  'Create/update PR': DEFAULT_SESSION_TEMPLATE_PROMPTS.PR,
-};
-
-describe('session_templates-seed-defaults migration', () => {
-  it('seeds exactly 3 global session templates on a fresh DB', () => {
-    const db = getDatabase();
-    const rows = db
-      .prepare('SELECT * FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .all();
-
-    expect(rows).toHaveLength(3);
-
-    const names = rows.map(r => r.name).sort();
-    expect(names).toEqual([...expectedSessionTemplateNames].sort());
-  });
-
-  it('stores each prompt verbatim (golden strings)', () => {
-    const db = getDatabase();
-    const rows = db
-      .prepare('SELECT name, prompt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .all();
-
-    for (const row of rows) {
-      expect(row.prompt).toBe(expectedSessionTemplatePrompts[row.name]);
-    }
-  });
-
-  it('uses the expected default column values on every seeded row', () => {
-    const db = getDatabase();
-    const rows = db
-      .prepare('SELECT * FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .all();
-
-    for (const row of rows) {
-      expect(row.project_id).toBeNull();
-      expect(row.mode).toBe('yolo');
-      expect(row.thinking_enabled).toBe(1);
-      expect(row.next_template_id).toBeNull();
-      expect(row.git_branch).toBeNull();
-      expect(row.git_mode).toBeNull();
-      expect(row.model).toBeNull();
-      expect(row.effort_level).toBeNull();
-      expect(row.target_lane_id).toBeNull();
-      expect(row.show_in_quick_responses).toBe(0);
-      expect(row.quick_response_auto_submit).toBe(0);
-      expect(row.quick_response_sort_order).toBe(0);
-      expect(row.legacy_quick_response_id).toBeNull();
-    }
-  });
-
-  it('populates created_at and updated_at as numeric timestamps near now', () => {
-    const db = getDatabase();
-    const rows = db
-      .prepare('SELECT created_at, updated_at FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .all();
-    const now = Date.now();
-
-    for (const row of rows) {
-      expect(typeof row.created_at).toBe('number');
-      expect(typeof row.updated_at).toBe('number');
-      expect(Math.abs(now - row.created_at)).toBeLessThan(10_000);
-      expect(Math.abs(now - row.updated_at)).toBeLessThan(10_000);
-    }
-  });
-
-  it('assigns non-null, distinct string IDs to each seeded row', () => {
-    const db = getDatabase();
-    const rows = db
-      .prepare('SELECT id FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .all();
-
-    expect(rows).toHaveLength(3);
-    const ids = rows.map(r => r.id);
-    for (const id of ids) {
-      expect(typeof id).toBe('string');
-      expect(id.length).toBeGreaterThan(0);
-    }
-    expect(new Set(ids).size).toBe(3);
-  });
-
-  it('is idempotent when re-run on an already-seeded DB', () => {
-    const db = getDatabase();
-    const countBefore = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .get().cnt;
-    expect(countBefore).toBe(3);
-
-    seedTemplatesMigration.up(db);
-
-    const countAfter = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .get().cnt;
-    expect(countAfter).toBe(3);
-  });
-
-  it('does not seed when any global template already exists', () => {
+  it('removes only rows with a non-null legacy_quick_response_id', () => {
     const db = getDatabase();
     db.prepare('DELETE FROM session_templates').run();
 
-    // Insert a single hand-crafted global template
     const now = Date.now();
-    db.prepare(
-      `INSERT INTO session_templates (
-         id, project_id, name, prompt,
-         next_template_id, thinking_enabled,
-         git_branch, git_mode, model, mode, effort_level, target_lane_id,
-         created_at, updated_at
-       ) VALUES (?, NULL, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, ?, ?)`
-    ).run('existing-global-id', 'Existing Global', 'existing prompt', now, now);
-
-    seedTemplatesMigration.up(db);
-
-    const count = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates')
-      .get().cnt;
-    expect(count).toBe(1);
-  });
-
-  it('does seed when only project-scoped templates exist', () => {
-    const db = getDatabase();
-    db.prepare('DELETE FROM session_templates').run();
-
-    // Create a real project (needed for FK on project_id)
     const projectRepo = new ProjectRepository();
-    const project = projectRepo.create('Template Project', '/tmp/template-project');
+    const project = projectRepo.create('Migration Test Project', '/tmp/migration-test');
 
-    const now = Date.now();
-    db.prepare(
-      `INSERT INTO session_templates (
-         id, project_id, name, prompt,
-         next_template_id, thinking_enabled,
-         git_branch, git_mode, model, mode, effort_level, target_lane_id,
-         created_at, updated_at
-       ) VALUES (?, ?, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, ?, ?)`
-    ).run('project-scoped-id', project.id, 'Project Scoped', 'project prompt', now, now);
+    // Insert a template that simulates a legacy converted row (should be deleted)
+    db.prepare(`
+      INSERT INTO session_templates (
+        id, project_id, name, prompt, thinking_enabled, mode,
+        show_in_quick_responses, quick_response_auto_submit,
+        quick_response_sort_order, legacy_quick_response_id,
+        created_at, updated_at
+      ) VALUES (?, NULL, ?, ?, 1, 'yolo', 1, 1, 0, ?, ?, ?)
+    `).run('legacy-tpl-1', 'Legacy Response', 'legacy content', 'some-legacy-qr-id', now, now);
 
-    seedTemplatesMigration.up(db);
+    // Insert a normal template (should NOT be deleted)
+    db.prepare(`
+      INSERT INTO session_templates (
+        id, project_id, name, prompt, thinking_enabled, mode,
+        show_in_quick_responses, quick_response_auto_submit,
+        quick_response_sort_order, legacy_quick_response_id,
+        created_at, updated_at
+      ) VALUES (?, NULL, ?, ?, 1, 'yolo', 0, 0, 0, NULL, ?, ?)
+    `).run('normal-tpl-1', 'Normal Template', 'normal prompt', now, now);
 
-    const total = db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt;
-    const globals = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .get().cnt;
-    const scoped = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NOT NULL')
-      .get().cnt;
+    // Insert a project-scoped normal template (should NOT be deleted)
+    db.prepare(`
+      INSERT INTO session_templates (
+        id, project_id, name, prompt, thinking_enabled, mode,
+        show_in_quick_responses, quick_response_auto_submit,
+        quick_response_sort_order, legacy_quick_response_id,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, 1, 'yolo', 1, 1, 0, NULL, ?, ?)
+    `).run('project-tpl-1', project.id, 'Project Template', 'project prompt', now, now);
 
-    expect(total).toBe(4);
-    expect(globals).toBe(3);
-    expect(scoped).toBe(1);
+    // Insert another legacy converted row for a different project (should be deleted)
+    db.prepare(`
+      INSERT INTO session_templates (
+        id, project_id, name, prompt, thinking_enabled, mode,
+        show_in_quick_responses, quick_response_auto_submit,
+        quick_response_sort_order, legacy_quick_response_id,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, 1, 'yolo', 1, 0, 2, ?, ?, ?)
+    `).run('legacy-tpl-2', project.id, 'Project Legacy', 'project legacy content', 'another-legacy-qr-id', now, now);
+
+    removeLegacyTemplatesMigration.up(db);
+
+    const remaining = db.prepare('SELECT id FROM session_templates ORDER BY id').all().map(r => r.id);
+    expect(remaining).toHaveLength(2);
+    expect(remaining).toContain('normal-tpl-1');
+    expect(remaining).toContain('project-tpl-1');
+    expect(remaining).not.toContain('legacy-tpl-1');
+    expect(remaining).not.toContain('legacy-tpl-2');
   });
 
-  it('is wired into allMigrations (fresh DB already contains the 3 defaults)', () => {
-    // getDatabase() runs the full allMigrations list via initDatabase, so
-    // fetching a fresh handle should yield exactly 3 global templates without
-    // having to invoke seedTemplatesMigration manually.
+  it('is idempotent (safe to run when no legacy rows exist)', () => {
     const db = getDatabase();
-    const count = db
-      .prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL')
-      .get().cnt;
-    expect(count).toBe(3);
+    // All legacy rows should already be gone after the migration runs on fresh DB.
+    const legacyCount = db.prepare(
+      'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+    ).get().cnt;
+    expect(legacyCount).toBe(0);
+
+    // Running again should not throw or change anything.
+    expect(() => removeLegacyTemplatesMigration.up(db)).not.toThrow();
+
+    expect(db.prepare(
+      'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+    ).get().cnt).toBe(0);
   });
 
-  it('writes (or provides a DB default for) every column in session_templates', () => {
+  it('fresh DB has zero session_templates with legacy_quick_response_id set', () => {
     const db = getDatabase();
-    // Columns explicitly written by the seed INSERT
-    const explicit = new Set([
-      'id', 'project_id', 'name', 'prompt',
-      'next_template_id', 'thinking_enabled',
-      'git_branch', 'git_mode', 'model', 'mode', 'effort_level', 'target_lane_id',
-      'show_in_quick_responses', 'quick_response_auto_submit',
-      'quick_response_sort_order', 'legacy_quick_response_id',
-      'created_at', 'updated_at',
-    ]);
+    const count = db.prepare(
+      'SELECT COUNT(*) AS cnt FROM session_templates WHERE legacy_quick_response_id IS NOT NULL'
+    ).get().cnt;
+    expect(count).toBe(0);
+  });
 
-    const columns = db.prepare('PRAGMA table_info(session_templates)').all();
-    for (const col of columns) {
-      const isExplicit = explicit.has(col.name);
-      // SQLite exposes the declared DEFAULT in `dflt_value`; any non-null value
-      // here means the column has a DB-level default the INSERT can rely on.
-      const hasDefault = col.dflt_value !== null;
-      expect(
-        isExplicit || hasDefault,
-        `Column "${col.name}" is not written by the seed INSERT and has no DB default; ` +
-        `either update seedDefaultSessionTemplates to write it, or give it a DB default.`,
-      ).toBe(true);
-    }
+  it('DEFAULT_SESSION_TEMPLATE_PROMPTS is exported from miscMigrations for backward compatibility', () => {
+    expect(typeof DEFAULT_SESSION_TEMPLATE_PROMPTS.REVIEW).toBe('string');
+    expect(typeof DEFAULT_SESSION_TEMPLATE_PROMPTS.IMPLEMENT).toBe('string');
+    expect(typeof DEFAULT_SESSION_TEMPLATE_PROMPTS.PR).toBe('string');
+  });
+
+  it('quick_responses-seed-defaults is not in allMigrations', () => {
+    const names = allMigrations.map(m => m.name);
+    expect(names).not.toContain('quick_responses-seed-defaults');
+  });
+
+  it('session_templates-convert-quick-responses is not in allMigrations', () => {
+    const names = allMigrations.map(m => m.name);
+    expect(names).not.toContain('session_templates-convert-quick-responses');
+  });
+
+  it('session_templates-seed-defaults is not in allMigrations', () => {
+    const names = allMigrations.map(m => m.name);
+    expect(names).not.toContain('session_templates-seed-defaults');
   });
 });
 

--- a/packages/server/src/db/seedBaselineData.js
+++ b/packages/server/src/db/seedBaselineData.js
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { OPENAI_MODELS, GEMINI_MODELS } from '@circuschief/shared';
 
 export const BUILT_IN_ANTHROPIC_PROVIDER = {
@@ -47,40 +46,6 @@ export const BUILT_IN_GOOGLE_MODELS = GEMINI_MODELS.map((model) => ({
   tier: 'custom',
 }));
 
-export const DEFAULT_QUICK_RESPONSES = [
-  { label: 'Put a plan on the canvas', content: 'Put a plan on the canvas to get this done', autoSubmit: false, sortOrder: 0 },
-  { label: 'Yes', content: 'Yes', autoSubmit: true, sortOrder: 1 },
-  { label: 'Review the plan', content: `Review the plan on the canvas. Are there any issues that you can find? Is test coverage specified explicitly enough? Does the current code match the assumptions in the plan?\n\nList the issues that you find and then update the plan on the canvas to address any issues that you find. Don't talk about issues with the original plan in the plan itself. Just tell me what the issues are, and update the plan so that the plan doesn't have the issues.`, autoSubmit: true, sortOrder: 2 },
-  { label: 'Implement the plan on the canvas', content: 'Implement the plan on the canvas', autoSubmit: true, sortOrder: 3 },
-  { label: 'Create / Update PR', content: `Ensure all relevant changes are committed and pushed. Then look at the session's summary and create a draft PR if no PR already exists.`, autoSubmit: true, sortOrder: 4 },
-  { label: 'Review PR', content: 'Look at the PR related to the root session. Review the PR. Are there any issues? Are best practices adhered to? Does the PR accomplish the goal? Are all changes covered by tests?', autoSubmit: true, sortOrder: 5 },
-  { label: 'Add tests', content: 'Inspect the changes on our branch. For each change, ensure we have tests that assert the change is working in the expected way. Implement the tests.', autoSubmit: true, sortOrder: 6 },
-  { label: 'Merge in main', content: 'Merge in the latest main branch', autoSubmit: true, sortOrder: 7 },
-  { label: 'Add tests to the plan', content: 'Call out specific test cases in the plan, we should have an assertion for each change called for in the plan', autoSubmit: true, sortOrder: 8 },
-  { label: 'Tests are failing', content: 'Tests are failing. Look at the canvas for details', autoSubmit: true, sortOrder: 9 },
-  { label: 'Continue', content: 'Continue', autoSubmit: true, sortOrder: 10 },
-];
-
-export const DEFAULT_SESSION_TEMPLATE_PROMPTS = {
-  REVIEW: `Review the plan on the canvas. If there's more than one plan then review the most recently updated plan. if there are no plans on the canvas then look for the most recently updated plan on the root session canvas.
-
-Make sure there are tests explicitly called out for all changes. Make sure that all context necessary to hand off the task is included in the plan.
-
-Are there any gaps in the plan? Is test coverage spelled out explicitly? Does the code match the assumptions in the plan?
-
-Update the plan according to your review recommendations.`,
-  IMPLEMENT: `Implement the plan on the canvas. If there's more than one plan on the canvas then use the most recently updated plan. If you don't see a plan on the canvas then look at the parent session's canvas.`,
-  PR: `Ensure all relevant changes are committed and pushed. Then determine the session's goals. You can typically find details about the goals of the session by looking at the most recently modified markdown documents on the root session's canvas - these are typically plans that were implemented during the session. You can also look at the root session's summary, but don't trigger a new summary to be created if the summary is missing.
-
-Create a draft pr and ensure all changes are committed and pushed.`,
-};
-
-export const DEFAULT_SESSION_TEMPLATES = [
-  { name: 'Review the plan', prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.REVIEW },
-  { name: 'Implement the plan on the canvas', prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.IMPLEMENT },
-  { name: 'Create/update PR', prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.PR },
-];
-
 function seedBuiltInProviders(db) {
   const now = Date.now();
 
@@ -124,46 +89,6 @@ function seedBuiltInProviders(db) {
   }
 }
 
-function seedDefaultQuickResponses(db) {
-  const count = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
-  if (count > 0) return;
-
-  const now = Date.now();
-  const stmt = db.prepare(
-    `INSERT INTO quick_responses (
-       id, project_id, label, content, auto_submit, category, sort_order, created_at, updated_at
-     )
-     VALUES (?, NULL, ?, ?, ?, NULL, ?, ?, ?)`
-  );
-
-  for (const item of DEFAULT_QUICK_RESPONSES) {
-    stmt.run(randomUUID(), item.label, item.content, item.autoSubmit ? 1 : 0, item.sortOrder, now, now);
-  }
-}
-
-function seedDefaultSessionTemplates(db) {
-  const count = db.prepare(
-    'SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL'
-  ).get().cnt;
-  if (count > 0) return;
-
-  const now = Date.now();
-  const stmt = db.prepare(`
-    INSERT INTO session_templates (
-      id, project_id, name, prompt,
-      next_template_id, thinking_enabled,
-      git_branch, git_mode, model, mode, effort_level, target_lane_id,
-      created_at, updated_at
-    ) VALUES (?, NULL, ?, ?, NULL, 1, NULL, NULL, NULL, 'yolo', NULL, NULL, ?, ?)
-  `);
-
-  for (const item of DEFAULT_SESSION_TEMPLATES) {
-    stmt.run(randomUUID(), item.name, item.prompt, now, now);
-  }
-}
-
 export function seedBaselineData(db) {
   seedBuiltInProviders(db);
-  seedDefaultQuickResponses(db);
-  seedDefaultSessionTemplates(db);
 }

--- a/packages/server/src/db/seedBaselineData.test.js
+++ b/packages/server/src/db/seedBaselineData.test.js
@@ -8,16 +8,19 @@ import {
   BUILT_IN_OPENAI_MODELS,
   BUILT_IN_OPENAI_PROVIDER,
   BUILT_IN_GOOGLE_MODELS,
-  DEFAULT_QUICK_RESPONSES,
-  DEFAULT_SESSION_TEMPLATES,
   seedBaselineData,
 } from './seedBaselineData.js';
+import {
+  DEFAULT_SESSION_TEMPLATES,
+  DEFAULT_SESSION_TEMPLATE_PROMPTS,
+} from './defaultSessionTemplates.js';
+import { bootstrapDefaultSessionTemplates } from './bootstrapDefaultSessionTemplates.js';
 
 function withDb(fn) {
   const manager = new DatabaseManager();
   const db = manager.init(':memory:');
   try {
-    return fn(db);
+    return fn(db, manager);
   } finally {
     manager.close();
   }
@@ -87,87 +90,130 @@ describe('seedBaselineData', () => {
     });
   });
 
-  it('creates default global quick responses in sort order', () => {
+  it('does not create default global quick_responses on startup', () => {
     withDb((db) => {
-      const rows = db.prepare(
-        'SELECT project_id, label, content, auto_submit, category, sort_order FROM quick_responses ORDER BY sort_order'
-      ).all();
-
-      expect(rows).toHaveLength(DEFAULT_QUICK_RESPONSES.length);
-      expect(rows.map((row) => ({
-        projectId: row.project_id,
-        label: row.label,
-        content: row.content,
-        autoSubmit: row.auto_submit === 1,
-        category: row.category,
-        sortOrder: row.sort_order,
-      }))).toEqual(DEFAULT_QUICK_RESPONSES.map((row) => ({
-        projectId: null,
-        label: row.label,
-        content: row.content,
-        autoSubmit: row.autoSubmit,
-        category: null,
-        sortOrder: row.sortOrder,
-      })));
+      const count = db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt;
+      expect(count).toBe(0);
     });
   });
 
-  it('creates expected default global session templates with golden prompts', () => {
+  it('creates exactly six default global session templates on a fresh DB', () => {
     withDb((db) => {
       const rows = db.prepare(
-        'SELECT project_id, name, prompt, thinking_enabled, mode, next_template_id, git_branch, git_mode, model, effort_level, target_lane_id FROM session_templates WHERE project_id IS NULL AND (legacy_quick_response_id IS NULL) ORDER BY name'
+        'SELECT * FROM session_templates WHERE project_id IS NULL ORDER BY name'
       ).all();
 
       expect(rows).toHaveLength(DEFAULT_SESSION_TEMPLATES.length);
-      for (const expected of DEFAULT_SESSION_TEMPLATES) {
-        const actual = rows.find((row) => row.name === expected.name);
-        expect(actual).toMatchObject({
-          project_id: null,
-          prompt: expected.prompt,
-          thinking_enabled: 1,
-          mode: 'yolo',
-          next_template_id: null,
-          git_branch: null,
-          git_mode: null,
-          model: null,
-          effort_level: null,
-          target_lane_id: null,
-        });
+
+      const names = rows.map((r) => r.name).sort();
+      expect(names).toEqual(DEFAULT_SESSION_TEMPLATES.map((t) => t.name).sort());
+    });
+  });
+
+  it('creates workflow templates with show_in_quick_responses = 0 and correct prompts', () => {
+    withDb((db) => {
+      const workflowTemplates = DEFAULT_SESSION_TEMPLATES.filter((t) => !t.showInQuickResponses);
+      const rows = db.prepare(
+        'SELECT * FROM session_templates WHERE project_id IS NULL AND show_in_quick_responses = 0 ORDER BY name'
+      ).all();
+
+      expect(rows).toHaveLength(workflowTemplates.length);
+      for (const expected of workflowTemplates) {
+        const actual = rows.find((r) => r.name === expected.name);
+        expect(actual).toBeDefined();
+        expect(actual.prompt).toBe(expected.prompt);
+        expect(actual.thinking_enabled).toBe(1);
+        expect(actual.mode).toBe('yolo');
+        expect(actual.legacy_quick_response_id).toBeNull();
       }
     });
   });
 
-  it('does not duplicate rows when rerun', () => {
+  it('creates quick-response-backed templates with expected fields and sort order', () => {
+    withDb((db) => {
+      const rows = db.prepare(
+        `SELECT name, prompt, show_in_quick_responses, quick_response_auto_submit,
+                quick_response_sort_order, legacy_quick_response_id
+         FROM session_templates
+         WHERE project_id IS NULL AND show_in_quick_responses = 1
+         ORDER BY quick_response_sort_order`
+      ).all();
+
+      expect(rows).toHaveLength(3);
+
+      // Put a plan on the canvas — sort_order 0, auto_submit 0
+      expect(rows[0]).toMatchObject({
+        name: 'Put a plan on the canvas',
+        prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.PUT_PLAN,
+        show_in_quick_responses: 1,
+        quick_response_auto_submit: 0,
+        quick_response_sort_order: 0,
+        legacy_quick_response_id: null,
+      });
+
+      // Yes — sort_order 1, auto_submit 1
+      expect(rows[1]).toMatchObject({
+        name: 'Yes',
+        prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.YES,
+        show_in_quick_responses: 1,
+        quick_response_auto_submit: 1,
+        quick_response_sort_order: 1,
+        legacy_quick_response_id: null,
+      });
+
+      // Continue — sort_order 2, auto_submit 1
+      expect(rows[2]).toMatchObject({
+        name: 'Continue',
+        prompt: DEFAULT_SESSION_TEMPLATE_PROMPTS.CONTINUE,
+        show_in_quick_responses: 1,
+        quick_response_auto_submit: 1,
+        quick_response_sort_order: 2,
+        legacy_quick_response_id: null,
+      });
+    });
+  });
+
+  it('sets the bootstrap flag so a second startup does not recreate deleted templates', () => {
+    withDb((db) => {
+      // Verify the bootstrap flag was set
+      const setting = db.prepare(
+        "SELECT value FROM app_settings WHERE key = 'default_session_templates_bootstrapped'"
+      ).get();
+      expect(setting?.value).toBe('true');
+
+      // Delete all session templates (simulate a user deleting defaults)
+      db.prepare('DELETE FROM session_templates').run();
+      expect(db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt).toBe(0);
+
+      // Calling bootstrapDefaultSessionTemplates again is a no-op since the flag is set.
+      bootstrapDefaultSessionTemplates(db, { isFirstRun: true });
+
+      // Templates should still be gone
+      expect(db.prepare('SELECT COUNT(*) AS cnt FROM session_templates').get().cnt).toBe(0);
+    });
+  });
+
+  it('does not duplicate providers or models when seedBaselineData is rerun', () => {
     withDb((db) => {
       seedBaselineData(db);
       expect(db.prepare('SELECT COUNT(*) AS cnt FROM providers').get().cnt).toBe(3);
       expect(db.prepare('SELECT COUNT(*) AS cnt FROM provider_models').get().cnt)
         .toBe(BUILT_IN_ANTHROPIC_MODELS.length + BUILT_IN_OPENAI_MODELS.length + BUILT_IN_GOOGLE_MODELS.length);
-      expect(db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt)
-        .toBe(DEFAULT_QUICK_RESPONSES.length);
-      expect(db.prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL').get().cnt)
-        .toBe(DEFAULT_SESSION_TEMPLATES.length);
     });
   });
 
-  it('keeps quick response empty-table behavior', () => {
-    withDb((db) => {
-      db.prepare('DELETE FROM quick_responses').run();
-      const now = Date.now();
-      db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
-        .run('project-quick-response', 'Project', '/tmp/project', now, now);
-      db.prepare(
-        'INSERT INTO quick_responses (id, project_id, label, content, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-      ).run('project-response', 'project-quick-response', 'Project', 'Project', 0, now, now);
-
-      seedBaselineData(db);
-      expect(db.prepare('SELECT COUNT(*) AS cnt FROM quick_responses').get().cnt).toBe(1);
-    });
-  });
-
-  it('seeds global templates when only project-scoped templates exist', () => {
-    withDb((db) => {
+  it('seeds global templates when only project-scoped templates exist (bootstrap not yet set)', () => {
+    // This test directly calls bootstrapDefaultSessionTemplates to verify it
+    // creates defaults when the flag is not set and isFirstRun is true, even
+    // when project-scoped templates already exist.
+    const manager = new DatabaseManager();
+    const db = manager.init(':memory:');
+    try {
+      // Reset bootstrap flag and remove all templates
+      db.prepare("DELETE FROM app_settings WHERE key = 'default_session_templates_bootstrapped'").run();
       db.prepare('DELETE FROM session_templates').run();
+
+      // Insert a project-scoped template
       const now = Date.now();
       db.prepare('INSERT INTO projects (id, name, working_directory, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
         .run('project-template-owner', 'Project', '/tmp/project', now, now);
@@ -177,11 +223,15 @@ describe('seedBaselineData', () => {
         ) VALUES (?, ?, ?, ?, 1, 'yolo', ?, ?)`
       ).run('project-template', 'project-template-owner', 'Project Template', 'Project prompt', now, now);
 
-      seedBaselineData(db);
-      expect(db.prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL AND legacy_quick_response_id IS NULL').get().cnt)
+      // Bootstrap with isFirstRun = true (flag is gone, so it should insert defaults)
+      bootstrapDefaultSessionTemplates(db, { isFirstRun: true });
+
+      expect(db.prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NULL').get().cnt)
         .toBe(DEFAULT_SESSION_TEMPLATES.length);
       expect(db.prepare('SELECT COUNT(*) AS cnt FROM session_templates WHERE project_id IS NOT NULL').get().cnt)
         .toBe(1);
-    });
+    } finally {
+      manager.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Remove the `quick_responses-seed-defaults`, `session_templates-convert-quick-responses`, and `session_templates-seed-defaults` migrations that ran on every startup and caused deleted templates to reappear
- Add a one-time first-run bootstrap (`bootstrapDefaultSessionTemplates`) guarded by an `app_settings` flag so defaults are only inserted on a brand-new database
- Add a cleanup migration (`session_templates-remove-legacy-quick-response-templates`) for existing databases to delete rows created by the old quick-response conversion (`legacy_quick_response_id IS NOT NULL`)
- Consolidate default template constants into a single `defaultSessionTemplates.js` module, eliminating duplication between `seedBaselineData.js` and `miscMigrations.js`
- New defaults include the 3 workflow templates plus `Yes`, `Continue`, and `Put a plan on the canvas` as proper template-backed quick responses with correct `show_in_quick_responses`, `quick_response_auto_submit`, and `quick_response_sort_order` fields

## Test plan

- [x] `seedBaselineData.test.js` — asserts no `quick_responses` seeded, 6 global templates on fresh DB, correct quick-response fields/sort order, bootstrap flag prevents recreation of deleted templates
- [x] `miscMigrations.test.js` — asserts old migrations are absent from `allMigrations`, new cleanup migration removes only `legacy_quick_response_id IS NOT NULL` rows, idempotency checks
- [x] `DatabaseManager.test.js` — integration tests covering: 6 templates on fresh DB, zero legacy rows, quick-response sort order, bootstrap flag, upgrade path (flag set + no templates = no recreation), existing legacy rows removed by migration
- [x] Full server test suite: **165 files / 4489 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)