### PR TITLE
Fix WebSocket subscription race condition in multi-turn tests

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -2502,6 +2502,46 @@ export function subscribeToSession(ws: any, sessionId: string): void {
   ws.send(JSON.stringify({ type: 'subscribe:session', sessionId }));
 }
 
+/**
+ * Subscribe to a session and verify the subscription is active via an existing
+ * session-scoped broadcast. This avoids fixed sleeps before tests trigger
+ * transient WebSocket events.
+ */
+export async function subscribeToSessionAndVerify(
+  ws: any,
+  sessionId: string,
+  timeout = 5000
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  const session = await getSession(sessionId);
+  const manuallyNamed = Boolean(session?.manuallyNamed);
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    subscribeToSession(ws, sessionId);
+
+    const markerPromise = waitForWSMessage(
+      ws,
+      'session:updated',
+      Math.min(1000, Math.max(100, deadline - Date.now())),
+      (data: any) => data.sessionId === sessionId || data.session?.id === sessionId
+    );
+
+    await updateSessionFields(sessionId, { manuallyNamed });
+
+    try {
+      await markerPromise;
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Timeout verifying WS session subscription for ${sessionId}`);
+}
+
 /** Unsubscribe from a session via WebSocket */
 export function unsubscribeFromSession(ws: any, sessionId: string): void {
   ws.send(JSON.stringify({ type: 'unsubscribe:session', sessionId }));

--- a/tests/e2e/websocket.spec.ts
+++ b/tests/e2e/websocket.spec.ts
@@ -19,6 +19,7 @@ import { test, expect } from '@playwright/test';
 import {
   connectWebSocket,
   subscribeToSession,
+  subscribeToSessionAndVerify,
   unsubscribeFromSession,
   subscribeToProject,
   unsubscribeFromProject,
@@ -73,6 +74,24 @@ test.describe('WebSocket Communication', () => {
   async function connect(): Promise<any> {
     const ws = await connectWebSocket();
     wsConnections.push(ws);
+    return ws;
+  }
+
+  async function connectAfterInitialTurnSettles(sessionId: string): Promise<any> {
+    const ws = await connect();
+    await subscribeToSessionAndVerify(ws, sessionId);
+
+    const changesPromise = waitForWSMessage(
+      ws,
+      'changes:update',
+      45000,
+      (data: any) => data.sessionId === sessionId
+    );
+
+    await waitForStatus(sessionId, 'waiting', 45000);
+    await changesPromise;
+    await getSession(sessionId);
+
     return ws;
   }
 
@@ -1053,13 +1072,9 @@ test.describe('WebSocket Communication', () => {
       test.setTimeout(60000);
       const project = await seedProject('WS MultiTurn User Msg', process.cwd());
       const session = await seedSession(project.id, { prompt: 'First message' });
-      await waitForStatus(session.id, 'waiting', 45000);
+      const ws = await connectAfterInitialTurnSettles(session.id);
 
-      const ws = await connect();
-      subscribeToSession(ws, session.id);
-      await new Promise(r => setTimeout(r, 100));
-
-      const msgPromise = waitForWSMessage(ws, 'session:message', 15000, (d) => {
+      const msgPromise = waitForWSMessage(ws, 'session:message', 45000, (d) => {
         return (d.message?.role === 'user' || d.role === 'user');
       });
 
@@ -1075,11 +1090,7 @@ test.describe('WebSocket Communication', () => {
       test.setTimeout(90000);
       const project = await seedProject('WS MultiTurn Stream', process.cwd());
       const session = await seedSession(project.id, { prompt: 'First turn' });
-      await waitForStatus(session.id, 'waiting', 45000);
-
-      const ws = await connect();
-      subscribeToSession(ws, session.id);
-      await new Promise(r => setTimeout(r, 100));
+      const ws = await connectAfterInitialTurnSettles(session.id);
 
       // Send follow-up and collect messages until session is waiting again
       const messagesPromise = collectWSMessagesUntil(
@@ -1107,11 +1118,7 @@ test.describe('WebSocket Communication', () => {
       test.setTimeout(90000);
       const project = await seedProject('WS MultiTurn Conv Updated', process.cwd());
       const session = await seedSession(project.id, { prompt: 'Hello' });
-      await waitForStatus(session.id, 'waiting', 45000);
-
-      const ws = await connect();
-      subscribeToSession(ws, session.id);
-      await new Promise(r => setTimeout(r, 100));
+      const ws = await connectAfterInitialTurnSettles(session.id);
 
       // Collect all messages until session reaches 'waiting' or 'error' status
       const messagesPromise = collectWSMessagesUntil(
@@ -1125,9 +1132,6 @@ test.describe('WebSocket Communication', () => {
 
       const messages = await messagesPromise;
 
-      // Debug: what messages did we receive?
-      console.log(`[TEST 46] Received ${messages.length} messages`);
-      console.log(`[TEST 46] Message types:`, [...new Set(messages.map((m: any) => m.type))]);
       const errorMessages = messages.filter((m: any) => m.type === 'session:error');
       if (errorMessages.length > 0) {
         console.log(`[TEST 46] Received error:`, errorMessages[0]);
@@ -1135,7 +1139,6 @@ test.describe('WebSocket Communication', () => {
 
       // Check that we received conversation:updated
       const convUpdatedMessages = messages.filter((m: any) => m.type === 'conversation:updated');
-      console.log(`[TEST 46] conversation:updated messages: ${convUpdatedMessages.length}`);
       expect(convUpdatedMessages.length).toBeGreaterThan(0);
 
       const msg = convUpdatedMessages[convUpdatedMessages.length - 1]; // Get the last one


### PR DESCRIPTION
## Summary

Fixed WebSocket subscription race condition in multi-turn Playwright tests (tests 44-46). The issue occurred when the WebSocket client subscription happened after the initial agent turn completed, causing intermediate WebSocket events to be missed.

## Changes

- **Added `subscribeToSessionAndVerify()` helper** in `tests/e2e/helpers.ts` that establishes subscription and verifies it's active by waiting for a `session:updated` broadcast
- **Added `connectAfterInitialTurnSettles()` helper** to establish WebSocket connection with verified subscription after initial turn completes
- **Updated three multi-turn tests** to use new helpers instead of manual wait patterns and arbitrary 100ms sleeps
- **Removed debug logging** from test 46 to clean up test output
- **Adjusted timeouts** in test 44 to match real event timing under parallel load

## Details

The fix is test-side only—no production code changes. The WebSocket subscription now happens early and verifies active subscription before proceeding, ensuring tests observe events as they're broadcast. This eliminates race conditions and improves test reliability.

## Test Plan

- [x] Full WebSocket specification passes cleanly without flakes
- [x] Multi-turn tests (44-46) now reliably receive intermediate WebSocket events

🤖 Generated with [Claude Code](https://claude.com/claude-code)