### PR TITLE
Fix PostHog localhost classification for npm users

### DIFF
--- a/packages/web/src/plugins/posthog.js
+++ b/packages/web/src/plugins/posthog.js
@@ -27,6 +27,11 @@ export function initPostHog(options = {}) {
     // router.afterEach hook needed.
     defaults: '2026-01-30',
 
+    // The npm app is intentionally served from localhost for every real user.
+    // PostHog's 2026 defaults classify localhost as internal/test traffic,
+    // which hides normal npx usage in projects with internal-user filters.
+    internal_or_test_user_hostname: undefined,
+
     // DISABLE SESSION RECORDING
     disable_session_recording: true,
 

--- a/packages/web/src/plugins/posthog.test.js
+++ b/packages/web/src/plugins/posthog.test.js
@@ -21,6 +21,7 @@ describe('PostHog Plugin', () => {
         api_host: 'https://us.i.posthog.com',
         disable_session_recording: true,
         defaults: '2026-01-30',
+        internal_or_test_user_hostname: undefined,
         respect_dnt: true,
         persistence: 'localStorage',
         autocapture: true,
@@ -65,6 +66,23 @@ describe('PostHog Plugin', () => {
         expect.any(String),
         expect.objectContaining({
           disable_session_recording: true,
+        })
+      );
+
+      vi.unstubAllEnvs();
+    });
+
+    it('does not classify localhost npx users as internal/test users', async () => {
+      vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test_key');
+
+      const { initPostHog } = await import('./posthog.js');
+      initPostHog();
+
+      expect(posthog.init).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          defaults: '2026-01-30',
+          internal_or_test_user_hostname: undefined,
         })
       );
 


### PR DESCRIPTION
## Summary
Fixed PostHog analytics configuration to prevent localhost npx users from being classified as internal/test traffic.

## Changes
- Updated PostHog initialization config to set `internal_or_test_user_hostname: undefined`
- Added a new test case to verify localhost users are not classified as internal/test users
- Added explanatory comments about why this configuration is necessary

## Context
The npm app is intentionally served from localhost for every real user. However, PostHog's 2026 defaults classify localhost as internal/test traffic, which hides normal npx usage in projects with internal-user filters. This change explicitly overrides that behavior to ensure legitimate analytics are captured.

## Test Plan
- ✅ New test case validates the configuration
- Run `yarn test` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)