### PR TITLE
Suppress empty panel-header in ConversationPanel when there's nothing to show

### DIFF
--- a/packages/web/src/components/ConversationPanel.vue
+++ b/packages/web/src/components/ConversationPanel.vue
@@ -4,7 +4,7 @@
     class="conversation-panel"
   >
     <!-- Compact header: conversation selector + new button -->
-    <div class="panel-header">
+    <div v-if="conversations.length > 1 || !hideNewConversation" class="panel-header">
       <div class="header-row">
         <!-- Conversation dropdown -->
         <div


### PR DESCRIPTION
## Summary

- The `panel-header` div in `ConversationPanel.vue` was always rendered, even when both of its children were hidden (no multiple conversations, and `hideNewConversation` is true), resulting in an empty padded div at the top of the conversation panel
- Added a `v-if="conversations.length > 1 || !hideNewConversation"` guard to the `panel-header` div so it only renders when there's actually content to display

## Test plan

- [ ] Verify the conversation panel header is hidden when there is only one conversation and the "New Conversation" button is not shown
- [ ] Verify the conversation selector dropdown still appears when there are multiple conversations
- [ ] Verify the "New Conversation" button still appears when `hideNewConversation` is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)