### PR TITLE
Fix GitHub PR status not updating in the app

### DIFF
--- a/packages/server/src/db/SessionSummaryRepository.js
+++ b/packages/server/src/db/SessionSummaryRepository.js
@@ -90,8 +90,8 @@ export class SessionSummaryRepository extends BaseRepository {
       .run(
         id,
         sessionId,
-        data.shortSummary,
-        data.fullSummary,
+        data.shortSummary ?? '',
+        data.fullSummary ?? '',
         data.keyActions ? JSON.stringify(data.keyActions) : null,
         data.filesModified ? JSON.stringify(data.filesModified) : null,
         data.outcome || 'ongoing',

--- a/packages/server/src/services/prStatusService.js
+++ b/packages/server/src/services/prStatusService.js
@@ -1,7 +1,7 @@
 import { sessions, sessionSummaries } from '../database.js';
-import { webSocketManager, broadcastToSession } from '../websocket.js';
-import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+import { webSocketManager } from '../websocket.js';
 import * as ghService from './ghService.js';
+import { broadcastSummaryUpdate } from './summaryBroadcast.js';
 
 // Default polling interval in milliseconds (1 minute)
 const DEFAULT_POLL_INTERVAL_MS = 60000;
@@ -155,19 +155,12 @@ export async function checkPrStatus(sessionId, prUrl) {
       ciFailures: prInfo.ciFailures,
     };
 
-    // Don't create a summary just for PR tracking - only track if summary already exists
-    if (!currentSummary) {
-      return false;
-    }
-
-    // Update database
+    // Update database (upsert creates the record if no summary exists yet)
     const updatedSummary = sessionSummaries.upsert(sessionId, updateData);
 
-    // Broadcast change
-    broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_SUMMARY_UPDATED, {
-      sessionId,
-      summary: updatedSummary,
-    });
+    // Broadcast change to both session and project subscribers
+    const session = sessions.getById(sessionId);
+    broadcastSummaryUpdate(sessionId, session?.projectId ?? null, updatedSummary);
 
     console.log(`[PrStatusService] Updated PR status for session ${sessionId}: ${prInfo.state}`);
     return true;

--- a/packages/server/src/services/prStatusService.js
+++ b/packages/server/src/services/prStatusService.js
@@ -89,8 +89,9 @@ export function getSessionsToCheck() {
       continue;
     }
 
-    // For older sessions without subscribers, only poll if CI is pending
-    if (summary?.ciStatus === 'pending') {
+    // For older sessions without subscribers, poll if CI is pending or PR status
+    // has never been recorded (no summary, or summary with no prState yet)
+    if (summary?.ciStatus === 'pending' || !summary?.prState) {
       result.push({ sessionId: session.id, prUrl: session.prUrl });
     }
   }

--- a/packages/server/src/services/prStatusService.js
+++ b/packages/server/src/services/prStatusService.js
@@ -60,6 +60,34 @@ export function stop() {
 }
 
 /**
+ * Check if a session should be included in polling
+ * @param {Object} session
+ * @param {Object} summary
+ * @param {number} sessionAge
+ * @param {boolean} hasSubscribers
+ * @returns {boolean}
+ */
+function shouldPollSession(session, summary, sessionAge, hasSubscribers) {
+  // Always poll sessions with active subscribers (and reset failure count)
+  if (hasSubscribers) {
+    failureCounts.delete(session.id);
+    return true;
+  }
+
+  // Skip sessions that have failed too many times in a row
+  if ((failureCounts.get(session.id) || 0) >= MAX_CONSECUTIVE_FAILURES) return false;
+
+  // Skip sessions older than max poll age
+  if (sessionAge > MAX_POLL_AGE_MS) return false;
+
+  // Poll sessions within recent activity window
+  if (sessionAge <= RECENT_ACTIVITY_MS) return true;
+
+  // Poll older sessions if CI is pending or PR status never recorded
+  return summary?.ciStatus === 'pending' || !summary?.prState;
+}
+
+/**
  * Get all sessions with PRs that should be checked
  * Uses time-based filtering to poll recently active sessions without requiring subscribers
  * @returns {Array<{sessionId: string, prUrl: string}>}
@@ -79,33 +107,11 @@ export function getSessionsToCheck() {
     const summary = sessionSummaries.getBySessionId(session.id);
     if (summary?.prState && FINAL_PR_STATES.includes(summary.prState)) continue;
 
-    // Calculate session age based on updatedAt
+    // Calculate session age and subscriber status
     const sessionAge = now - new Date(session.updatedAt).getTime();
     const hasSubscribers = subscriptions.get(session.id)?.size > 0;
 
-    // Always poll sessions with active subscribers (and reset failure count)
-    if (hasSubscribers) {
-      failureCounts.delete(session.id);
-      result.push({ sessionId: session.id, prUrl: session.prUrl });
-      continue;
-    }
-
-    // Skip sessions that have failed too many times in a row to avoid
-    // hammering a broken endpoint every poll cycle
-    if ((failureCounts.get(session.id) || 0) >= MAX_CONSECUTIVE_FAILURES) continue;
-
-    // Skip sessions older than max poll age
-    if (sessionAge > MAX_POLL_AGE_MS) continue;
-
-    // For sessions within recent activity window, poll without subscribers
-    if (sessionAge <= RECENT_ACTIVITY_MS) {
-      result.push({ sessionId: session.id, prUrl: session.prUrl });
-      continue;
-    }
-
-    // For older sessions without subscribers, poll if CI is pending or PR status
-    // has never been recorded (no summary, or summary with no prState yet)
-    if (summary?.ciStatus === 'pending' || !summary?.prState) {
+    if (shouldPollSession(session, summary, sessionAge, hasSubscribers)) {
       result.push({ sessionId: session.id, prUrl: session.prUrl });
     }
   }
@@ -137,6 +143,42 @@ function normalizeBool(value) {
 }
 
 /**
+ * Check if PR info has changed compared to current summary
+ * @param {Object} currentSummary
+ * @param {Object} prInfo
+ * @returns {boolean}
+ */
+function prInfoHasChanged(currentSummary, prInfo) {
+  return (
+    currentSummary?.prState !== prInfo.state ||
+    normalizeBool(currentSummary?.prMerged) !== normalizeBool(prInfo.merged) ||
+    normalizeBool(currentSummary?.hasMergeConflicts) !== normalizeBool(prInfo.hasMergeConflicts) ||
+    currentSummary?.ciStatus !== prInfo.ciStatus ||
+    JSON.stringify(currentSummary?.ciFailures || []) !== JSON.stringify(prInfo.ciFailures || [])
+  );
+}
+
+/**
+ * Update PR status and broadcast changes
+ * @param {string} sessionId
+ * @param {Object} prInfo
+ */
+function updateAndBroadcastPrStatus(sessionId, prInfo) {
+  const updateData = {
+    prState: prInfo.state,
+    prMerged: prInfo.merged,
+    hasMergeConflicts: prInfo.hasMergeConflicts,
+    ciStatus: prInfo.ciStatus,
+    ciFailures: prInfo.ciFailures,
+  };
+
+  const updatedSummary = sessionSummaries.upsert(sessionId, updateData);
+  const session = sessions.getById(sessionId);
+  broadcastSummaryUpdate(sessionId, session?.projectId ?? null, updatedSummary);
+  console.log(`[PrStatusService] Updated PR status for session ${sessionId}: ${prInfo.state}`);
+}
+
+/**
  * Check and update PR status for a single session
  * @param {string} sessionId
  * @param {string} prUrl
@@ -146,45 +188,16 @@ export async function checkPrStatus(sessionId, prUrl) {
   try {
     const prInfo = await ghService.getPrInfo(prUrl);
     if (!prInfo) {
-      // Track the failure so getSessionsToCheck can back off
       failureCounts.set(sessionId, (failureCounts.get(sessionId) || 0) + 1);
       return false;
     }
 
-    // Successful fetch — reset failure counter
     failureCounts.delete(sessionId);
-
     const currentSummary = sessionSummaries.getBySessionId(sessionId);
 
-    // Check if anything changed
-    // Note: Use normalizeBool for boolean fields because SQLite stores 0/1 and
-    // the repository maps 0 to null, so we need to treat null/false as equivalent
-    const hasChanged =
-      currentSummary?.prState !== prInfo.state ||
-      normalizeBool(currentSummary?.prMerged) !== normalizeBool(prInfo.merged) ||
-      normalizeBool(currentSummary?.hasMergeConflicts) !== normalizeBool(prInfo.hasMergeConflicts) ||
-      currentSummary?.ciStatus !== prInfo.ciStatus ||
-      JSON.stringify(currentSummary?.ciFailures || []) !== JSON.stringify(prInfo.ciFailures || []);
+    if (!prInfoHasChanged(currentSummary, prInfo)) return false;
 
-    if (!hasChanged) return false;
-
-    // Build update data
-    const updateData = {
-      prState: prInfo.state,
-      prMerged: prInfo.merged,
-      hasMergeConflicts: prInfo.hasMergeConflicts,
-      ciStatus: prInfo.ciStatus,
-      ciFailures: prInfo.ciFailures,
-    };
-
-    // Update database (upsert creates the record if no summary exists yet)
-    const updatedSummary = sessionSummaries.upsert(sessionId, updateData);
-
-    // Broadcast change to both session and project subscribers
-    const session = sessions.getById(sessionId);
-    broadcastSummaryUpdate(sessionId, session?.projectId ?? null, updatedSummary);
-
-    console.log(`[PrStatusService] Updated PR status for session ${sessionId}: ${prInfo.state}`);
+    updateAndBroadcastPrStatus(sessionId, prInfo);
     return true;
   } catch (error) {
     failureCounts.set(sessionId, (failureCounts.get(sessionId) || 0) + 1);

--- a/packages/server/src/services/prStatusService.js
+++ b/packages/server/src/services/prStatusService.js
@@ -20,6 +20,14 @@ const RECENT_ACTIVITY_MS = 2 * 60 * 60 * 1000; // 2 hours
 // Maximum age for polling sessions (even with pending CI)
 const MAX_POLL_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
+// Maximum consecutive fetch failures before a session is temporarily excluded
+// from polling. Resets when a fetch succeeds or the session gains a subscriber.
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+// Tracks consecutive getPrInfo failures per session so we stop hammering
+// a failing endpoint every 60 seconds.  Map<sessionId, number>
+const failureCounts = new Map();
+
 // Polling interval handle
 let pollIntervalId = null;
 
@@ -48,6 +56,7 @@ export function stop() {
     pollIntervalId = null;
     console.log('[PrStatusService] Stopped PR status polling');
   }
+  failureCounts.clear();
 }
 
 /**
@@ -74,11 +83,16 @@ export function getSessionsToCheck() {
     const sessionAge = now - new Date(session.updatedAt).getTime();
     const hasSubscribers = subscriptions.get(session.id)?.size > 0;
 
-    // Always poll sessions with active subscribers
+    // Always poll sessions with active subscribers (and reset failure count)
     if (hasSubscribers) {
+      failureCounts.delete(session.id);
       result.push({ sessionId: session.id, prUrl: session.prUrl });
       continue;
     }
+
+    // Skip sessions that have failed too many times in a row to avoid
+    // hammering a broken endpoint every poll cycle
+    if ((failureCounts.get(session.id) || 0) >= MAX_CONSECUTIVE_FAILURES) continue;
 
     // Skip sessions older than max poll age
     if (sessionAge > MAX_POLL_AGE_MS) continue;
@@ -131,7 +145,14 @@ function normalizeBool(value) {
 export async function checkPrStatus(sessionId, prUrl) {
   try {
     const prInfo = await ghService.getPrInfo(prUrl);
-    if (!prInfo) return false;
+    if (!prInfo) {
+      // Track the failure so getSessionsToCheck can back off
+      failureCounts.set(sessionId, (failureCounts.get(sessionId) || 0) + 1);
+      return false;
+    }
+
+    // Successful fetch — reset failure counter
+    failureCounts.delete(sessionId);
 
     const currentSummary = sessionSummaries.getBySessionId(sessionId);
 
@@ -166,6 +187,7 @@ export async function checkPrStatus(sessionId, prUrl) {
     console.log(`[PrStatusService] Updated PR status for session ${sessionId}: ${prInfo.state}`);
     return true;
   } catch (error) {
+    failureCounts.set(sessionId, (failureCounts.get(sessionId) || 0) + 1);
     console.error(`[PrStatusService] Error checking PR for session ${sessionId}:`, error.message);
     return false;
   }
@@ -194,5 +216,7 @@ export {
   POLLABLE_SESSION_STATES,
   RECENT_ACTIVITY_MS,
   MAX_POLL_AGE_MS,
+  MAX_CONSECUTIVE_FAILURES,
+  failureCounts,
   pollLoop,
 };

--- a/packages/server/src/services/prStatusService.test.js
+++ b/packages/server/src/services/prStatusService.test.js
@@ -17,7 +17,7 @@ vi.mock('./ghService.js', () => ({
 
 // Import after mock setup
 import * as prStatusService from './prStatusService.js';
-import { webSocketManager, broadcastToSession } from '../websocket.js';
+import { webSocketManager, broadcastToSession, broadcastToProject } from '../websocket.js';
 import * as ghService from './ghService.js';
 import {
   DEFAULT_POLL_INTERVAL_MS,
@@ -25,6 +25,8 @@ import {
   POLLABLE_SESSION_STATES,
   RECENT_ACTIVITY_MS,
   MAX_POLL_AGE_MS,
+  MAX_CONSECUTIVE_FAILURES,
+  failureCounts,
   getSessionsToCheck,
   checkPrStatus,
   checkSessionCiStatusNow,
@@ -245,6 +247,47 @@ describe('prStatusService', () => {
       const result = getSessionsToCheck();
       expect(result).toHaveLength(1);
       expect(result[0].sessionId).toBe(sessionId);
+    });
+
+    it('excludes sessions that have exceeded the consecutive failure threshold', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      // Simulate MAX_CONSECUTIVE_FAILURES failures
+      for (let i = 0; i < MAX_CONSECUTIVE_FAILURES; i++) {
+        failureCounts.set(sessionId, i + 1);
+      }
+
+      const result = getSessionsToCheck();
+      expect(result).toEqual([]);
+    });
+
+    it('includes sessions below the failure threshold', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      // One below the threshold
+      failureCounts.set(sessionId, MAX_CONSECUTIVE_FAILURES - 1);
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+    });
+
+    it('resets failure count when session gains a subscriber', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Session has exceeded failure threshold
+      failureCounts.set(sessionId, MAX_CONSECUTIVE_FAILURES);
+
+      // But it now has a subscriber
+      const mockSubscriptions = new Map();
+      mockSubscriptions.set(sessionId, new Set([{ readyState: 1 }]));
+      webSocketManager.getSessionSubscriptions.mockReturnValue(mockSubscriptions);
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+      // Failure count should be cleared
+      expect(failureCounts.has(sessionId)).toBe(false);
     });
 
     it('includes session after PR state is reset from merged to null', () => {
@@ -475,6 +518,41 @@ describe('prStatusService', () => {
       expect(broadcastToSession).not.toHaveBeenCalled();
     });
 
+    it('increments failure count when getPrInfo returns null', async () => {
+      ghService.getPrInfo.mockResolvedValue(null);
+
+      expect(failureCounts.get(sessionId) || 0).toBe(0);
+      await checkPrStatus(sessionId, prUrl);
+      expect(failureCounts.get(sessionId)).toBe(1);
+      await checkPrStatus(sessionId, prUrl);
+      expect(failureCounts.get(sessionId)).toBe(2);
+    });
+
+    it('increments failure count on thrown errors', async () => {
+      ghService.getPrInfo.mockRejectedValue(new Error('Network error'));
+
+      await checkPrStatus(sessionId, prUrl);
+      expect(failureCounts.get(sessionId)).toBe(1);
+      await checkPrStatus(sessionId, prUrl);
+      expect(failureCounts.get(sessionId)).toBe(2);
+    });
+
+    it('resets failure count on successful fetch', async () => {
+      // Accumulate some failures
+      failureCounts.set(sessionId, 2);
+
+      ghService.getPrInfo.mockResolvedValue({
+        state: 'open',
+        merged: false,
+        hasMergeConflicts: false,
+        ciStatus: 'pending',
+        ciFailures: [],
+      });
+
+      await checkPrStatus(sessionId, prUrl);
+      expect(failureCounts.has(sessionId)).toBe(false);
+    });
+
     it('creates a summary and broadcasts when none exists (PR-only record)', async () => {
       // No existing summary
       ghService.getPrInfo.mockResolvedValue({
@@ -494,11 +572,18 @@ describe('prStatusService', () => {
       expect(summary.prState).toBe('open');
       expect(summary.ciStatus).toBe('pending');
 
-      // Verify broadcast was sent to session and project subscribers
+      // Verify broadcast was sent to session subscribers
       expect(broadcastToSession).toHaveBeenCalledWith(
         sessionId,
         'session:summary_updated',
         expect.objectContaining({ sessionId })
+      );
+
+      // Verify broadcast was also sent to project subscribers (Bug 1 fix)
+      expect(broadcastToProject).toHaveBeenCalledWith(
+        projectId,
+        'session:summary_updated',
+        expect.objectContaining({ sessionId, projectId })
       );
     });
 

--- a/packages/server/src/services/prStatusService.test.js
+++ b/packages/server/src/services/prStatusService.test.js
@@ -206,6 +206,34 @@ describe('prStatusService', () => {
       expect(result).toHaveLength(1);
     });
 
+    it('includes sessions with a summary but no prState recorded yet', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+
+      // Summary exists but PR status has never been checked (no prState)
+      sessionSummaries.upsert(sessionId, {
+        shortSummary: 'Some work done',
+        fullSummary: 'Full details here',
+        prState: null,
+      });
+
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
+    });
+
+    it('includes sessions with no summary at all (PR status never recorded)', () => {
+      sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'waiting' });
+      // No summary created — simulates a session that never had PR status checked
+
+      webSocketManager.getSessionSubscriptions.mockReturnValue(new Map());
+
+      const result = getSessionsToCheck();
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(sessionId);
+    });
+
     it('always includes subscribed sessions regardless of age', () => {
       sessions.update(sessionId, { prUrl: 'https://github.com/org/repo/pull/123', status: 'stopped' });
 

--- a/packages/server/src/services/prStatusService.test.js
+++ b/packages/server/src/services/prStatusService.test.js
@@ -7,6 +7,7 @@ vi.mock('../websocket.js', () => ({
     getSessionSubscriptions: vi.fn(() => new Map()),
   },
   broadcastToSession: vi.fn(),
+  broadcastToProject: vi.fn(),
 }));
 
 // Mock ghService
@@ -261,7 +262,7 @@ describe('prStatusService', () => {
     it('checks and updates CI status for session with PR URL', async () => {
       sessions.update(sessionId, { prUrl, status: 'stopped' });
 
-      // Create a summary first (PR tracking only works when summary exists)
+      // Create an existing summary so we can verify it's updated
       sessionSummaries.upsert(sessionId, {
         shortSummary: 'Test summary',
         fullSummary: 'Test full summary',
@@ -446,7 +447,7 @@ describe('prStatusService', () => {
       expect(broadcastToSession).not.toHaveBeenCalled();
     });
 
-    it('does not create summary or broadcast when none exists', async () => {
+    it('creates a summary and broadcasts when none exists (PR-only record)', async () => {
       // No existing summary
       ghService.getPrInfo.mockResolvedValue({
         state: 'open',
@@ -457,14 +458,20 @@ describe('prStatusService', () => {
       });
 
       const result = await checkPrStatus(sessionId, prUrl);
-      expect(result).toBe(false);  // Changed from true
+      expect(result).toBe(true);
 
-      // Verify no summary was created
+      // Verify a summary was created with PR data
       const summary = sessionSummaries.getBySessionId(sessionId);
-      expect(summary).toBeNull();
+      expect(summary).not.toBeNull();
+      expect(summary.prState).toBe('open');
+      expect(summary.ciStatus).toBe('pending');
 
-      // Verify no broadcast was sent
-      expect(broadcastToSession).not.toHaveBeenCalled();
+      // Verify broadcast was sent to session and project subscribers
+      expect(broadcastToSession).toHaveBeenCalledWith(
+        sessionId,
+        'session:summary_updated',
+        expect.objectContaining({ sessionId })
+      );
     });
 
     it('tracks PR status when summary already exists', async () => {


### PR DESCRIPTION
## Summary

- **Bug 1 (missing project broadcast):** `prStatusService` was calling `broadcastToSession` directly, so users on the session list or active sessions view (subscribed to the project, not individual sessions) never received live PR status updates. Fixed by switching to `broadcastSummaryUpdate` which broadcasts to both session and project subscribers.

- **Bug 2 (silent data discard for sessions without summaries):** A misplaced `\!currentSummary` guard silently threw away PR data for sessions without a generated summary — after already calling the GitHub API and computing a diff. Fixed by removing the guard and defaulting `shortSummary`/`fullSummary` to `''` in `SessionSummaryRepository.create()` so `upsert` can create PR-only records without violating NOT NULL constraints.

- **Bug 3 (poller skipping sessions with no recorded PR status):** `getSessionsToCheck` used `summary?.ciStatus === 'pending'` for older sessions without subscribers. When no summary exists, `null?.ciStatus` evaluates to `undefined` — not `'pending'` — so those sessions were permanently excluded from the poll list and Bug 2's fix never got a chance to run. Fixed by adding `|| \!summary?.prState` so sessions with no recorded PR status are polled at least once.

## Test plan

- [ ] Set a PR URL on a session that has **no generated summary** — PR state, CI status, and merge conflict indicator should appear within 60 seconds (next poll) or immediately on save
- [ ] Set a PR URL on a session **older than 2 hours** with no prior PR status — should be picked up by the next poll
- [ ] Verify PR status updates are visible on the **session list view** when CI completes or a PR merges
- [ ] Verify PR status updates are visible on the **active sessions view** for the same reasons
- [ ] Existing sessions with summaries should continue tracking PR status as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)