### PR TITLE
Link agent log rows to root sessions

### DIFF
--- a/packages/server/src/db/AgentCallLogRepository.js
+++ b/packages/server/src/db/AgentCallLogRepository.js
@@ -202,9 +202,19 @@ export class AgentCallLogRepository extends BaseRepository {
 
     const rows = this.db
       .prepare(
-        `SELECT acl.*, s.name AS session_name
+        `WITH RECURSIVE session_roots(id, root_id, root_name) AS (
+           SELECT id, id, name
+           FROM sessions
+           WHERE parent_session_id IS NULL
+           UNION ALL
+           SELECT child.id, session_roots.root_id, session_roots.root_name
+           FROM sessions child
+           JOIN session_roots ON child.parent_session_id = session_roots.id
+         )
+         SELECT acl.*, s.name AS session_name, sr.root_id AS root_session_id, sr.root_name AS root_session_name
          FROM agent_call_logs acl
          LEFT JOIN sessions s ON acl.session_id = s.id
+         LEFT JOIN session_roots sr ON acl.session_id = sr.id
          ${whereClause}
          ORDER BY acl.${safeSortBy} ${safeSortOrder}
          LIMIT ? OFFSET ?`
@@ -214,7 +224,11 @@ export class AgentCallLogRepository extends BaseRepository {
     const mappedRows = rows
       .map((row) => {
         const mapped = mapRow(row);
-        if (mapped) mapped.sessionName = row.session_name || null;
+        if (mapped) {
+          mapped.sessionName = row.session_name || null;
+          mapped.rootSessionId = row.root_session_id || row.session_id;
+          mapped.rootSessionName = row.root_session_name || row.session_name || null;
+        }
         return mapped;
       })
       .filter(Boolean);

--- a/packages/server/src/db/AgentCallLogRepository.test.js
+++ b/packages/server/src/db/AgentCallLogRepository.test.js
@@ -518,6 +518,27 @@ describe('AgentCallLogRepository', () => {
       // sessionName comes from the sessions table 'name' column
       expect(result.rows[0]).toHaveProperty('sessionName');
     });
+
+    it('includes root session fields for child session call logs', () => {
+      const now = Date.now();
+      const childSessionId = databaseManager.generateId();
+      databaseManager.get().prepare(
+        'INSERT INTO sessions (id, project_id, name, status, mode, parent_session_id, created_at, updated_at) SELECT ?, project_id, ?, ?, ?, ?, ?, ? FROM sessions WHERE id = ?'
+      ).run(childSessionId, 'Child Session', 'running', 'standard', sessionId, now, now, sessionId);
+
+      repo.create({
+        id: databaseManager.generateId(),
+        sessionId: childSessionId,
+        agentType: 'claude-code',
+        callType: 'runSession',
+        promptLength: 10,
+      });
+
+      const result = repo.getAll({ sessionId: childSessionId });
+      expect(result.rows[0].sessionName).toBe('Child Session');
+      expect(result.rows[0].rootSessionId).toBe(sessionId);
+      expect(result.rows[0].rootSessionName).toBe('Test Session');
+    });
   });
 
   describe('getFilterOptions', () => {

--- a/packages/web/src/components/AgentLogTable.vue
+++ b/packages/web/src/components/AgentLogTable.vue
@@ -59,7 +59,7 @@
           <td class="td">
             <router-link
               v-if="log.sessionId"
-              :to="`/sessions/${log.sessionId}`"
+              :to="`/sessions/${log.rootSessionId || log.sessionId}`"
               class="session-link"
             >
               {{ log.sessionName || log.sessionId }}

--- a/tests/e2e/agent-logs.spec.ts
+++ b/tests/e2e/agent-logs.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import {
   seedProject,
   seedSession,
+  seedChildSession,
   seedAgentCallLog,
   cleanupCreatedResources,
 } from './helpers';
@@ -139,6 +140,25 @@ test.describe('Agent Logs - Settings Tab', () => {
     await expect(link).toBeVisible();
     const href = await link.getAttribute('href');
     expect(href).toContain(`/sessions/${session.id}`);
+  });
+
+  test('session column links child session logs to the root session detail page', async ({ page }) => {
+    const child = await seedChildSession(project.id, session.id, {
+      prompt: 'child session for agent logs',
+      name: 'Child Logs Test Session',
+    });
+    await seedAgentCallLog(child.id);
+
+    await scopeLogsToSession(page, child.id);
+    await page.goto('/settings/logs');
+    await page.waitForLoadState('networkidle');
+
+    const link = page.locator('a.session-link').first();
+    await expect(link).toBeVisible();
+    await expect(link).toHaveText('Child Logs Test Session');
+    const href = await link.getAttribute('href');
+    expect(href).toContain(`/sessions/${session.id}`);
+    expect(href).not.toContain(`/sessions/${child.id}`);
   });
 
   test('tokens column displays locale-formatted total token count', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add root session metadata to agent call log rows
- update settings log session links to navigate to the root session while preserving the displayed logged session name
- cover child-session log links in repository and Playwright tests

## Session goal
Ensure links on the settings view logs tab point to the root session instead of the child session when a log row belongs to a child session.

## Verification
- yarn workspace @circuschief/server test src/db/AgentCallLogRepository.test.js
- yarn test:e2e agent-logs.spec.ts --project=chromium
- yarn lint (passed with an existing unrelated warning in ConversationPanel.vue)