### PR TITLE
Pass Claude MCP config to SDK sessions

### DIFF
--- a/packages/server/src/services/claudeMcpConfigResolver.js
+++ b/packages/server/src/services/claudeMcpConfigResolver.js
@@ -1,0 +1,218 @@
+import os from 'os';
+import path from 'path';
+import fsModule from 'fs';
+
+const defaultFs = {
+  existsSync: fsModule.existsSync,
+  readFileSync: fsModule.readFileSync,
+  statSync: fsModule.statSync,
+};
+
+export function resolveClaudeMcpServers({
+  workingDirectory,
+  homeDirectory = os.homedir(),
+  fs = defaultFs,
+} = {}) {
+  const diagnostics = { included: [], skipped: [] };
+  const mcpServers = {};
+
+  if (!workingDirectory || typeof workingDirectory !== 'string') {
+    diagnostics.skipped.push({ name: null, source: 'input', reason: 'missing-working-directory' });
+    return { mcpServers, diagnostics };
+  }
+
+  const resolvedWorkingDirectory = path.resolve(workingDirectory);
+  const claudeConfigPath = path.join(homeDirectory, '.claude.json');
+  const claudeConfig = readJsonFile(claudeConfigPath, fs);
+  const projectMatch = findClaudeProjectMatch({
+    workingDirectory: resolvedWorkingDirectory,
+    projects: claudeConfig?.projects,
+    fs,
+  });
+  const projectEntry = projectMatch ? claudeConfig.projects[projectMatch.key] : null;
+
+  mergeServers({
+    target: mcpServers,
+    servers: claudeConfig?.mcpServers,
+    source: 'user',
+    diagnostics,
+  });
+
+  mergeServers({
+    target: mcpServers,
+    servers: projectEntry?.mcpServers,
+    source: 'local',
+    diagnostics,
+  });
+
+  const projectMcpPath = path.join(resolvedWorkingDirectory, '.mcp.json');
+  const projectMcpConfig = readJsonFile(projectMcpPath, fs);
+  const projectApproval = getProjectMcpApproval({
+    projectEntry,
+    workingDirectory: resolvedWorkingDirectory,
+    fs,
+  });
+
+  mergeProjectMcpServers({
+    target: mcpServers,
+    servers: projectMcpConfig?.mcpServers,
+    approval: projectApproval,
+    diagnostics,
+  });
+
+  return { mcpServers, diagnostics };
+}
+
+function mergeServers({ target, servers, source, diagnostics }) {
+  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return;
+
+  for (const [name, config] of Object.entries(servers)) {
+    const normalized = normalizeServerConfig(config);
+    if (!normalized) {
+      diagnostics.skipped.push({ name, source, reason: 'unsupported-or-malformed-server' });
+      continue;
+    }
+    target[name] = normalized.server;
+    diagnostics.included.push({ name, source, transport: normalized.transport });
+  }
+}
+
+function mergeProjectMcpServers({ target, servers, approval, diagnostics }) {
+  if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return;
+
+  for (const [name, config] of Object.entries(servers)) {
+    if (approval.disabled.has(name)) {
+      diagnostics.skipped.push({ name, source: 'project', reason: 'disabled' });
+      continue;
+    }
+    if (!approval.enableAll && !approval.enabled.has(name)) {
+      diagnostics.skipped.push({ name, source: 'project', reason: 'not-approved' });
+      continue;
+    }
+
+    const normalized = normalizeServerConfig(config);
+    if (!normalized) {
+      diagnostics.skipped.push({ name, source: 'project', reason: 'unsupported-or-malformed-server' });
+      continue;
+    }
+    target[name] = normalized.server;
+    diagnostics.included.push({ name, source: 'project', transport: normalized.transport });
+  }
+}
+
+function normalizeServerConfig(config) {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return null;
+
+  if (config.type === 'sse' || config.type === 'http') {
+    if (typeof config.url !== 'string' || config.url.length === 0) return null;
+    if (config.headers !== undefined && !isPlainObject(config.headers)) return null;
+    return {
+      transport: config.type,
+      server: {
+        type: config.type,
+        url: config.url,
+        ...(config.headers !== undefined ? { headers: config.headers } : {}),
+      },
+    };
+  }
+
+  if (config.type === undefined || config.type === 'stdio') {
+    if (typeof config.command !== 'string' || config.command.length === 0) return null;
+    if (config.args !== undefined && !Array.isArray(config.args)) return null;
+    if (config.env !== undefined && !isPlainObject(config.env)) return null;
+    return {
+      transport: 'stdio',
+      server: {
+        ...(config.type === 'stdio' ? { type: 'stdio' } : {}),
+        command: config.command,
+        ...(config.args !== undefined ? { args: config.args } : {}),
+        ...(config.env !== undefined ? { env: config.env } : {}),
+      },
+    };
+  }
+
+  return null;
+}
+
+function getProjectMcpApproval({ projectEntry, workingDirectory, fs }) {
+  const localSettings = readJsonFile(path.join(workingDirectory, '.claude', 'settings.local.json'), fs);
+  const sources = [projectEntry, localSettings].filter(Boolean);
+
+  return {
+    enableAll: sources.some((source) => source.enableAllProjectMcpServers === true),
+    enabled: new Set(sources.flatMap((source) => asStringArray(source.enabledMcpjsonServers))),
+    disabled: new Set(sources.flatMap((source) => asStringArray(source.disabledMcpjsonServers))),
+  };
+}
+
+function findClaudeProjectMatch({ workingDirectory, projects, fs }) {
+  if (!projects || typeof projects !== 'object' || Array.isArray(projects)) return null;
+
+  const normalizedWorkingDirectory = normalizePath(workingDirectory);
+  const normalizedGitRoot = findGitRoot(workingDirectory, fs);
+
+  const candidates = Object.keys(projects).map((key) => {
+    const normalizedKey = normalizePath(key);
+    if (normalizedKey === normalizedWorkingDirectory) {
+      return { key, score: 4, length: normalizedKey.length };
+    }
+    if (normalizedGitRoot && normalizedKey === normalizePath(normalizedGitRoot)) {
+      return { key, score: 3, length: normalizedKey.length };
+    }
+    if (
+      isSameOrAncestor(normalizedKey, normalizedWorkingDirectory)
+      || isSameOrAncestor(normalizedWorkingDirectory, normalizedKey)
+    ) {
+      return { key, score: 2, length: normalizedKey.length };
+    }
+    return { key, score: 0, length: normalizedKey.length };
+  }).filter((candidate) => candidate.score > 0);
+
+  candidates.sort((a, b) => b.score - a.score || b.length - a.length || a.key.localeCompare(b.key));
+  return candidates[0] ?? null;
+}
+
+function findGitRoot(startDirectory, fs) {
+  let current = path.resolve(startDirectory);
+  while (true) {
+    const gitPath = path.join(current, '.git');
+    if (pathExists(gitPath, fs)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function readJsonFile(filePath, fs) {
+  try {
+    if (!pathExists(filePath, fs)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function pathExists(filePath, fs) {
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+function normalizePath(value) {
+  return path.resolve(value).split(path.sep).join('/');
+}
+
+function isSameOrAncestor(maybeAncestor, child) {
+  if (maybeAncestor === child) return true;
+  return child.startsWith(`${maybeAncestor.replace(/\/$/, '')}/`);
+}
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asStringArray(value) {
+  return Array.isArray(value) ? value.filter((item) => typeof item === 'string') : [];
+}

--- a/packages/server/src/services/claudeMcpConfigResolver.js
+++ b/packages/server/src/services/claudeMcpConfigResolver.js
@@ -72,7 +72,7 @@ function mergeServers({ target, servers, source, diagnostics }) {
       diagnostics.skipped.push({ name, source, reason: 'unsupported-or-malformed-server' });
       continue;
     }
-    target[name] = normalized.server;
+    Object.assign(target, { [name]: normalized.server });
     diagnostics.included.push({ name, source, transport: normalized.transport });
   }
 }
@@ -95,7 +95,7 @@ function mergeProjectMcpServers({ target, servers, approval, diagnostics }) {
       diagnostics.skipped.push({ name, source: 'project', reason: 'unsupported-or-malformed-server' });
       continue;
     }
-    target[name] = normalized.server;
+    Object.assign(target, { [name]: normalized.server });
     diagnostics.included.push({ name, source: 'project', transport: normalized.transport });
   }
 }
@@ -103,35 +103,40 @@ function mergeProjectMcpServers({ target, servers, approval, diagnostics }) {
 function normalizeServerConfig(config) {
   if (!config || typeof config !== 'object' || Array.isArray(config)) return null;
 
-  if (config.type === 'sse' || config.type === 'http') {
-    if (typeof config.url !== 'string' || config.url.length === 0) return null;
-    if (config.headers !== undefined && !isPlainObject(config.headers)) return null;
-    return {
-      transport: config.type,
-      server: {
-        type: config.type,
-        url: config.url,
-        ...(config.headers !== undefined ? { headers: config.headers } : {}),
-      },
-    };
-  }
-
-  if (config.type === undefined || config.type === 'stdio') {
-    if (typeof config.command !== 'string' || config.command.length === 0) return null;
-    if (config.args !== undefined && !Array.isArray(config.args)) return null;
-    if (config.env !== undefined && !isPlainObject(config.env)) return null;
-    return {
-      transport: 'stdio',
-      server: {
-        ...(config.type === 'stdio' ? { type: 'stdio' } : {}),
-        command: config.command,
-        ...(config.args !== undefined ? { args: config.args } : {}),
-        ...(config.env !== undefined ? { env: config.env } : {}),
-      },
-    };
-  }
+  if (config.type === 'sse' || config.type === 'http') return normalizeRemoteServerConfig(config);
+  if (config.type === undefined || config.type === 'stdio') return normalizeStdioServerConfig(config);
 
   return null;
+}
+
+function normalizeRemoteServerConfig(config) {
+  if (typeof config.url !== 'string' || config.url.length === 0) return null;
+  if (config.headers !== undefined && !isPlainObject(config.headers)) return null;
+
+  return {
+    transport: config.type,
+    server: {
+      type: config.type,
+      url: config.url,
+      ...(config.headers !== undefined ? { headers: config.headers } : {}),
+    },
+  };
+}
+
+function normalizeStdioServerConfig(config) {
+  if (typeof config.command !== 'string' || config.command.length === 0) return null;
+  if (config.args !== undefined && !Array.isArray(config.args)) return null;
+  if (config.env !== undefined && !isPlainObject(config.env)) return null;
+
+  return {
+    transport: 'stdio',
+    server: {
+      ...(config.type === 'stdio' ? { type: 'stdio' } : {}),
+      command: config.command,
+      ...(config.args !== undefined ? { args: config.args } : {}),
+      ...(config.env !== undefined ? { env: config.env } : {}),
+    },
+  };
 }
 
 function getProjectMcpApproval({ projectEntry, workingDirectory, fs }) {
@@ -174,13 +179,14 @@ function findClaudeProjectMatch({ workingDirectory, projects, fs }) {
 
 function findGitRoot(startDirectory, fs) {
   let current = path.resolve(startDirectory);
-  while (true) {
+  while (current) {
     const gitPath = path.join(current, '.git');
     if (pathExists(gitPath, fs)) return current;
     const parent = path.dirname(current);
     if (parent === current) return null;
     current = parent;
   }
+  return null;
 }
 
 function readJsonFile(filePath, fs) {

--- a/packages/server/src/services/claudeMcpConfigResolver.test.js
+++ b/packages/server/src/services/claudeMcpConfigResolver.test.js
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { resolveClaudeMcpServers } from './claudeMcpConfigResolver.js';
+
+describe('resolveClaudeMcpServers', () => {
+  let tempDir;
+  let homeDirectory;
+  let workingDirectory;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'claude-mcp-config-resolver-test-'));
+    homeDirectory = join(tempDir, 'home');
+    workingDirectory = join(tempDir, 'workspace');
+    mkdirSync(homeDirectory, { recursive: true });
+    mkdirSync(workingDirectory, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('includes user-level Claude MCP servers', () => {
+    writeJson(join(homeDirectory, '.claude.json'), {
+      mcpServers: {
+        userServer: { command: 'node', args: ['server.js'], env: { TOKEN: 'secret' } },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers).toEqual({
+      userServer: { command: 'node', args: ['server.js'], env: { TOKEN: 'secret' } },
+    });
+    expect(result.diagnostics.included).toContainEqual({
+      name: 'userServer',
+      source: 'user',
+      transport: 'stdio',
+    });
+  });
+
+  it('includes matching directory-scoped local project MCP servers', () => {
+    writeJson(join(homeDirectory, '.claude.json'), {
+      projects: {
+        [workingDirectory]: {
+          mcpServers: {
+            localServer: { type: 'http', url: 'https://example.test/mcp' },
+          },
+        },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers).toEqual({
+      localServer: { type: 'http', url: 'https://example.test/mcp' },
+    });
+  });
+
+  it('ignores unrelated project entries', () => {
+    writeJson(join(homeDirectory, '.claude.json'), {
+      projects: {
+        [join(tempDir, 'other')]: {
+          mcpServers: {
+            unrelated: { command: 'node' },
+          },
+        },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers).toEqual({});
+  });
+
+  it('matches a normalized git repository root project entry', () => {
+    const repoRoot = join(tempDir, 'repo');
+    const nestedDirectory = join(repoRoot, 'packages', 'server');
+    mkdirSync(join(repoRoot, '.git'), { recursive: true });
+    mkdirSync(nestedDirectory, { recursive: true });
+    writeJson(join(homeDirectory, '.claude.json'), {
+      projects: {
+        [repoRoot]: {
+          mcpServers: {
+            repoServer: { command: 'node' },
+          },
+        },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({
+      workingDirectory: nestedDirectory,
+      homeDirectory,
+    });
+
+    expect(result.mcpServers.repoServer).toEqual({ command: 'node' });
+  });
+
+  it('includes .mcp.json servers when explicitly enabled', () => {
+    writeJson(join(workingDirectory, '.mcp.json'), {
+      mcpServers: {
+        projectServer: { command: 'node', args: ['project.js'] },
+      },
+    });
+    writeJson(join(homeDirectory, '.claude.json'), {
+      projects: {
+        [workingDirectory]: {
+          enabledMcpjsonServers: ['projectServer'],
+        },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers.projectServer).toEqual({ command: 'node', args: ['project.js'] });
+  });
+
+  it('includes .mcp.json servers when enableAllProjectMcpServers is true', () => {
+    writeJson(join(workingDirectory, '.mcp.json'), {
+      mcpServers: {
+        projectServer: { type: 'sse', url: 'https://example.test/sse' },
+      },
+    });
+    writeJson(join(homeDirectory, '.claude.json'), {
+      projects: {
+        [workingDirectory]: {
+          enableAllProjectMcpServers: true,
+        },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers.projectServer).toEqual({
+      type: 'sse',
+      url: 'https://example.test/sse',
+    });
+  });
+
+  it('excludes .mcp.json servers when disabled', () => {
+    writeJson(join(workingDirectory, '.mcp.json'), {
+      mcpServers: {
+        enabledServer: { command: 'node' },
+        disabledServer: { command: 'node' },
+      },
+    });
+    writeJson(join(homeDirectory, '.claude.json'), {
+      projects: {
+        [workingDirectory]: {
+          enableAllProjectMcpServers: true,
+          disabledMcpjsonServers: ['disabledServer'],
+        },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers).toEqual({ enabledServer: { command: 'node' } });
+    expect(result.diagnostics.skipped).toContainEqual({
+      name: 'disabledServer',
+      source: 'project',
+      reason: 'disabled',
+    });
+  });
+
+  it('reads .mcp.json approval from .claude/settings.local.json', () => {
+    mkdirSync(join(workingDirectory, '.claude'), { recursive: true });
+    writeJson(join(workingDirectory, '.mcp.json'), {
+      mcpServers: {
+        projectServer: { command: 'node' },
+      },
+    });
+    writeJson(join(workingDirectory, '.claude', 'settings.local.json'), {
+      enabledMcpjsonServers: ['projectServer'],
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers.projectServer).toEqual({ command: 'node' });
+  });
+
+  it('merges sources by server name with project .mcp.json taking precedence', () => {
+    writeJson(join(homeDirectory, '.claude.json'), {
+      mcpServers: {
+        shared: { command: 'user-command' },
+      },
+      projects: {
+        [workingDirectory]: {
+          mcpServers: {
+            shared: { command: 'local-command' },
+          },
+          enabledMcpjsonServers: ['shared'],
+        },
+      },
+    });
+    writeJson(join(workingDirectory, '.mcp.json'), {
+      mcpServers: {
+        shared: { command: 'project-command' },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers.shared).toEqual({ command: 'project-command' });
+  });
+
+  it('does not throw on malformed or missing config files', () => {
+    writeFileSync(join(homeDirectory, '.claude.json'), '{bad json', 'utf8');
+
+    expect(() => resolveClaudeMcpServers({ workingDirectory, homeDirectory })).not.toThrow();
+    expect(resolveClaudeMcpServers({ workingDirectory, homeDirectory }).mcpServers).toEqual({});
+  });
+
+  it('skips unsupported server shapes', () => {
+    writeJson(join(homeDirectory, '.claude.json'), {
+      mcpServers: {
+        sdkServer: { type: 'sdk', name: 'sdkServer' },
+        missingCommand: { args: ['server.js'] },
+        validServer: { command: 'node', extra: 'ignored' },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers).toEqual({
+      validServer: { command: 'node' },
+    });
+    expect(result.diagnostics.skipped).toEqual([
+      { name: 'sdkServer', source: 'user', reason: 'unsupported-or-malformed-server' },
+      { name: 'missingCommand', source: 'user', reason: 'unsupported-or-malformed-server' },
+    ]);
+  });
+
+  it('leaves unapproved .mcp.json servers out', () => {
+    writeJson(join(workingDirectory, '.mcp.json'), {
+      mcpServers: {
+        projectServer: { command: 'node' },
+      },
+    });
+
+    const result = resolveClaudeMcpServers({ workingDirectory, homeDirectory });
+
+    expect(result.mcpServers).toEqual({});
+    expect(result.diagnostics.skipped).toContainEqual({
+      name: 'projectServer',
+      source: 'project',
+      reason: 'not-approved',
+    });
+  });
+});
+
+function writeJson(filePath, value) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}

--- a/packages/server/src/services/claudeMcpConfigResolver.test.js
+++ b/packages/server/src/services/claudeMcpConfigResolver.test.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { resolveClaudeMcpServers } from './claudeMcpConfigResolver.js';

--- a/packages/server/src/services/e2eSpawnCapture.js
+++ b/packages/server/src/services/e2eSpawnCapture.js
@@ -13,7 +13,7 @@ export function captureSpawnAttempt(agentType, spawnOptions) {
   const record = {
     agentType,
     command: spawnOptions.command,
-    args: spawnOptions.args || [],
+    args: sanitizeSpawnArgs(agentType, spawnOptions.args || []),
     cwd: spawnOptions.cwd || null,
     env: summarizeSpawnEnv(spawnOptions.env),
     options: summarizeSpawnOptions(agentType, spawnOptions),
@@ -61,6 +61,17 @@ export function createCapturedSpawnProcess(agentType) {
   return processStub;
 }
 
+function sanitizeSpawnArgs(agentType, args) {
+  if (agentType !== 'claude-code') return args;
+  const sanitized = [...args];
+  for (let index = 0; index < sanitized.length; index += 1) {
+    if (sanitized[index] === '--mcp-config' && sanitized[index + 1] !== undefined) {
+      sanitized[index + 1] = '[redacted]';
+    }
+  }
+  return sanitized;
+}
+
 function summarizeSpawnEnv(env = {}) {
   const summary = {};
   if (Object.prototype.hasOwnProperty.call(env, 'CIRCUSCHIEF_COMMIT_ATTRIBUTION')) {
@@ -81,6 +92,7 @@ function summarizeSpawnOptions(agentType, spawnOptions) {
       settings: valueAfter(args, '--settings'),
       permissionMode: valueAfter(args, '--permission-mode'),
       settingSources: valueAfter(args, '--setting-sources'),
+      mcpServers: summarizeMcpConfig(valueAfter(args, '--mcp-config')),
     };
   }
 
@@ -122,6 +134,28 @@ function valuesAfter(args, flag) {
     }
   }
   return values;
+}
+
+function summarizeMcpConfig(rawConfig) {
+  if (!rawConfig) return [];
+  try {
+    const parsed = JSON.parse(rawConfig);
+    const servers = parsed?.mcpServers;
+    if (!servers || typeof servers !== 'object' || Array.isArray(servers)) return [];
+    return Object.entries(servers).map(([name, config]) => ({
+      name,
+      transport: summarizeMcpTransport(config),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function summarizeMcpTransport(config) {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return 'unknown';
+  if (config.type === 'sse' || config.type === 'http') return config.type;
+  if (config.type === 'stdio' || config.type === undefined) return 'stdio';
+  return String(config.type);
 }
 
 function writeCapturedAgentEvents(agentType, stdout) {

--- a/packages/server/src/services/e2eSpawnCapture.test.js
+++ b/packages/server/src/services/e2eSpawnCapture.test.js
@@ -53,6 +53,13 @@ describe('e2eSpawnCapture', () => {
         'acceptEdits',
         '--setting-sources',
         'user,project,local',
+        '--mcp-config',
+        JSON.stringify({
+          mcpServers: {
+            safeName: { command: 'node', args: ['secret.js'], env: { TOKEN: 'secret' } },
+            remoteName: { type: 'http', url: 'https://secret.example.test/mcp', headers: { Authorization: 'Bearer secret' } },
+          },
+        }),
       ],
       cwd: tempDir,
     });
@@ -67,9 +74,16 @@ describe('e2eSpawnCapture', () => {
         settings: '{"attribution":{"commit":"Claude"}}',
         permissionMode: 'acceptEdits',
         settingSources: 'user,project,local',
+        mcpServers: [
+          { name: 'safeName', transport: 'stdio' },
+          { name: 'remoteName', transport: 'http' },
+        ],
       },
     });
     expect(record.args).toContain('--model');
+    expect(record.args).toContain('[redacted]');
+    expect(JSON.stringify(record)).not.toContain('secret.js');
+    expect(JSON.stringify(record)).not.toContain('Bearer secret');
     expect(record.capturedAt).toEqual(expect.any(String));
   });
 

--- a/packages/server/src/services/nodeSpawnHelper.test.js
+++ b/packages/server/src/services/nodeSpawnHelper.test.js
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { dirname, isAbsolute, join } from 'path';
 import { tmpdir } from 'os';
-import path from 'path';
 import { getNodeBinDir, createRobustEnv, createClaudeCodeSpawner } from './nodeSpawnHelper.js';
 
 describe('nodeSpawnHelper', () => {
@@ -34,12 +33,12 @@ describe('nodeSpawnHelper', () => {
       expect(typeof nodeBinDir).toBe('string');
 
       // Should be the parent directory of process.execPath
-      expect(nodeBinDir).toBe(path.dirname(process.execPath));
+      expect(nodeBinDir).toBe(dirname(process.execPath));
     });
 
     it('returns absolute path', () => {
       const nodeBinDir = getNodeBinDir();
-      expect(path.isAbsolute(nodeBinDir)).toBe(true);
+      expect(isAbsolute(nodeBinDir)).toBe(true);
     });
   });
 

--- a/packages/server/src/services/nodeSpawnHelper.test.js
+++ b/packages/server/src/services/nodeSpawnHelper.test.js
@@ -1,8 +1,30 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import path from 'path';
 import { getNodeBinDir, createRobustEnv, createClaudeCodeSpawner } from './nodeSpawnHelper.js';
 
 describe('nodeSpawnHelper', () => {
+  const originalCaptureFile = process.env.E2E_AGENT_SPAWN_CAPTURE_FILE;
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'node-spawn-helper-test-'));
+    delete process.env.E2E_AGENT_SPAWN_CAPTURE_FILE;
+  });
+
+  afterEach(() => {
+    if (originalCaptureFile === undefined) {
+      delete process.env.E2E_AGENT_SPAWN_CAPTURE_FILE;
+    } else {
+      process.env.E2E_AGENT_SPAWN_CAPTURE_FILE = originalCaptureFile;
+    }
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   describe('getNodeBinDir', () => {
     it('returns the directory containing the Node binary', () => {
       const nodeBinDir = getNodeBinDir();
@@ -95,5 +117,46 @@ describe('nodeSpawnHelper', () => {
         });
       }).not.toThrow(); // The spawn itself might fail, but the function should execute
     });
+
+    it('captures Claude SDK launches with sanitized MCP config when E2E capture is enabled', async () => {
+      const captureFile = join(tempDir, 'capture.jsonl');
+      process.env.E2E_AGENT_SPAWN_CAPTURE_FILE = captureFile;
+
+      const spawner = createClaudeCodeSpawner();
+      const processStub = spawner({
+        command: 'claude',
+        args: [
+          '--model',
+          'claude-sonnet-4-20250514',
+          '--setting-sources',
+          'user,project,local',
+          '--mcp-config',
+          JSON.stringify({
+            mcpServers: {
+              testServer: { command: 'node', args: ['secret-server.js'] },
+            },
+          }),
+        ],
+        cwd: tempDir,
+        env: {},
+        signal: new AbortController().signal,
+      });
+
+      await collectProcessClose(processStub);
+
+      const record = JSON.parse(readFileSync(captureFile, 'utf8').trim());
+      expect(record.options.settingSources).toBe('user,project,local');
+      expect(record.options.mcpServers).toEqual([
+        { name: 'testServer', transport: 'stdio' },
+      ]);
+      expect(record.args).toContain('[redacted]');
+      expect(JSON.stringify(record)).not.toContain('secret-server.js');
+    });
   });
 });
+
+function collectProcessClose(processStub) {
+  return new Promise((resolve) => {
+    processStub.once('close', resolve);
+  });
+}

--- a/packages/server/src/services/queryParamBuilder.js
+++ b/packages/server/src/services/queryParamBuilder.js
@@ -1,4 +1,5 @@
 import { createClaudeCodeSpawner } from './nodeSpawnHelper.js';
+import { resolveClaudeMcpServers } from './claudeMcpConfigResolver.js';
 import {
   buildSystemPromptConfig,
   getGeminiApprovalModeForSession,
@@ -12,10 +13,14 @@ import {
  */
 function buildClaudeCodeQueryParams({
   prompt, workingDirectory, controller, session, sessionId, systemPrompt,
-  model, sessionEnv, resumeSessionId = null,
+  model, sessionEnv, resumeSessionId = null, claudeMcpConfigHomeDirectory,
 }) {
   const isVCR = Boolean(process.env.VCR_MODE);
   const effectiveModel = isVCR ? 'claude-haiku-4-5-20251001' : model;
+  const { mcpServers } = resolveClaudeMcpServers({
+    workingDirectory,
+    ...(claudeMcpConfigHomeDirectory ? { homeDirectory: claudeMcpConfigHomeDirectory } : {}),
+  });
 
   return {
     prompt,
@@ -32,6 +37,7 @@ function buildClaudeCodeQueryParams({
       spawnClaudeCodeProcess: createClaudeCodeSpawner(),
       model: effectiveModel,
       systemPrompt: buildSystemPromptConfig(sessionId, session.projectId, systemPrompt, session.mode),
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
     },
   };
 }

--- a/packages/server/src/services/sessionExecution.test.js
+++ b/packages/server/src/services/sessionExecution.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, existsSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -90,6 +90,34 @@ describe('buildQueryParams', () => {
     expect(result.options.settingSources).toEqual(['user', 'project', 'local']);
   });
 
+  it('includes resolved Claude MCP servers without changing setting sources', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'query-param-mcp-test-'));
+    try {
+      const homeDirectory = join(tempDir, 'home');
+      const workingDirectory = join(tempDir, 'workspace');
+      mkdirSync(homeDirectory, { recursive: true });
+      mkdirSync(workingDirectory, { recursive: true });
+      writeFileSync(join(homeDirectory, '.claude.json'), JSON.stringify({
+        mcpServers: {
+          localTool: { command: 'node', args: ['server.js'] },
+        },
+      }), 'utf8');
+
+      const result = buildQueryParams({
+        ...baseArgs(),
+        workingDirectory,
+        claudeMcpConfigHomeDirectory: homeDirectory,
+      });
+
+      expect(result.options.settingSources).toEqual(['user', 'project', 'local']);
+      expect(result.options.mcpServers).toEqual({
+        localTool: { command: 'node', args: ['server.js'] },
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('propagates effortLevel into Codex query options', () => {
     const args = {
       ...baseArgs(),
@@ -104,6 +132,7 @@ describe('buildQueryParams', () => {
     expect(result.options.model).toBe('gpt-5.5');
     expect(result.options.permissionMode).toBeUndefined();
     expect(result.options.settingSources).toBeUndefined();
+    expect(result.options.mcpServers).toBeUndefined();
     expect(result.options.includePartialMessages).toBeUndefined();
     expect(result.options.resume).toBeUndefined();
     expect(result.options.spawnClaudeCodeProcess).toBeUndefined();
@@ -429,6 +458,7 @@ describe('buildQueryParams agent-aware', () => {
     expect(result.options.sandboxMode).toBe('workspace-write');
 
     expect(result.options.settingSources).toBeUndefined();
+    expect(result.options.mcpServers).toBeUndefined();
     expect(result.options.spawnClaudeCodeProcess).toBeUndefined();
     expect(result.options.includePartialMessages).toBeUndefined();
     expect(result.options.permissionMode).toBeUndefined();
@@ -518,6 +548,7 @@ describe('buildQueryParams agent-aware', () => {
 
     expect(result.options.permissionMode).toBeUndefined();
     expect(result.options.settingSources).toBeUndefined();
+    expect(result.options.mcpServers).toBeUndefined();
     expect(result.options.includePartialMessages).toBeUndefined();
     expect(result.options.spawnClaudeCodeProcess).toBeUndefined();
     expect(result.options.resume).toBeUndefined();


### PR DESCRIPTION
## Summary
- resolve Claude MCP servers from user config, matched project-local config, and approved `.mcp.json` entries
- pass resolved `mcpServers` into Claude SDK query options while preserving existing setting sources
- sanitize E2E spawn capture so raw `--mcp-config` JSON is redacted while retaining MCP server name/transport summaries

## Verification
- `yarn test` from `packages/server`: 164 files passed, 1 skipped; 4486 tests passed, 19 skipped
- live smoke: direct Claude CLI returned `CC_MCP_SMOKE_OK direct-178052 direct`
- live smoke: app-launched Circus Chief session returned `CC_MCP_SMOKE_OK app-178052 app`
