### PR TITLE
Harden package publish artifacts

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -11,9 +11,6 @@ node scripts/build-package.js --version=0.2.0 --posthog-key=phc_xxxxx
 # Build for publishing — environment variables (for CI/CD)
 POSTHOG_KEY=phc_xxxxx node scripts/build-package.js --version=0.2.0
 
-# Build for local testing (no analytics)
-node scripts/build-package.js --version=0.2.0
-
 # Run E2E tests against the built package
 ./scripts/pw.sh test-package
 
@@ -23,8 +20,8 @@ cd /tmp && mkdir test && cd test
 npm install /path/to/dist-package/circuschief-0.2.0.tgz
 npx circuschief
 
-# Publish
-cd dist-package && npm publish
+# Publish through the wrapper
+./scripts/publish.sh 0.2.0 123456
 ```
 
 ## PostHog Analytics Configuration
@@ -35,7 +32,7 @@ The PostHog API key is a **public client-side key** (always visible in the brows
 
 | Value | CLI flag | Environment variable | `.env.production` | Default |
 |-------|----------|---------------------|-------------------|---------|
-| API key | `--posthog-key=<key>` | `POSTHOG_KEY` | `VITE_POSTHOG_KEY` | empty (analytics disabled) |
+| API key | `--posthog-key=<key>` | `POSTHOG_KEY` | `VITE_POSTHOG_KEY` | required |
 | API host | `--posthog-host=<host>` | `POSTHOG_HOST` | `VITE_POSTHOG_HOST` | `https://us.i.posthog.com` |
 
 CLI flags take precedence over environment variables, which take precedence over `.env.production`.
@@ -59,9 +56,10 @@ The build script reads `.env.production` automatically and injects the key into 
 
 ### Notes
 
-- Omitting the key from all sources produces a working package with analytics disabled
-- `scripts/start-package-server.sh` intentionally provides no key since E2E tests don't need analytics
-- After the Vite build, the script verifies the key appears in the output bundle (if one was provided)
+- Omitting the key from all sources fails package builds and makes `scripts/publish.sh` abort before `npm publish`
+- `scripts/start-package-server.sh` provides `phc_test_package_key` by default so E2E package tests do not depend on a local `.env.production`
+- After the Vite build, the script verifies the configured key appears in the output bundle
+- The PostHog client key is public, but it must be intentionally configured before publishing
 
 ### GitHub Actions
 
@@ -82,8 +80,9 @@ The app is a monorepo with three packages (`server`, `web`, `shared`) that use Y
 1. **Building the frontend** — runs `vite build` to produce static HTML/CSS/JS in `packages/web/dist/`
 2. **Copying the source tree** — copies `packages/server/src/`, `packages/shared/src/`, and `packages/web/dist/` into `dist-package/`, preserving the same directory structure
 3. **Rewriting imports** — transforms `@circuschief/shared` imports into relative paths (e.g., `../../shared/src/index.js`)
-4. **Generating package.json** — merges runtime dependencies from `server` and `shared` into a single flat `package.json`
+4. **Generating package.json** — merges runtime dependencies from `server` and `shared` into a single flat `package.json`, then writes sanitized internal `server` and `shared` manifests at the publish version
 5. **Writing the CLI entry point** — produces a `bin/cli.js` that sets `NODE_ENV=production` before starting the server
+6. **Verifying the artifact** — checks manifest versions, generated CLI `--version`, and stale workspace dependency metadata before the artifact is considered publishable
 
 ## Why This Approach
 
@@ -120,8 +119,10 @@ dist-package/
   packages/
     server/
       bin/cli.js
+      package.json  (sanitized, publish version)
       src/          (server source, imports rewritten)
     shared/
+      package.json  (sanitized, publish version)
       src/          (shared source, copied as-is)
     web/
       dist/         (pre-built frontend)
@@ -159,7 +160,7 @@ The build script filters out `*.test.js` files from both `server` and `shared` p
 
 ### What it does
 
-1. **Builds the package** — runs `scripts/build-package.js` to produce `dist-package/`
+1. **Builds the package** — runs `scripts/build-package.js` with a fake test PostHog key to produce `dist-package/`
 2. **Packs a tarball** — runs `npm pack` inside `dist-package/`, producing a `.tgz` identical to what `npm publish` would upload
 3. **Installs in an isolated directory** — creates `.package-test/` with a fresh `package.json` and installs the tarball via `npm install`, simulating a real user install
 4. **Symlinks test cassettes** — links `tests/` into the install directory so VCR replay cassettes are reachable at the expected relative path

--- a/docs/build-and-distribution.md
+++ b/docs/build-and-distribution.md
@@ -6,8 +6,8 @@ Circus Chief is distributed as an npm package named `circuschief`. End users run
 
 The build/publish/run flow:
 
-1. **Build** (`node scripts/build-package.js`): Vite compiles the Vue.js frontend into static assets, then the script assembles a publish-ready tree under `dist-package/`. Server-side code requires no compilation — the JS sources are copied as-is and `@circuschief/shared` imports are rewritten to relative paths so the package can run without workspace tooling.
-2. **Publish** (`scripts/publish.sh`): Runs the build, then `npm publish` from `dist-package/`. The package ships with the pre-built frontend included.
+1. **Build** (`node scripts/build-package.js`): Verifies PostHog publish configuration, Vite compiles the Vue.js frontend into static assets, then the script assembles a publish-ready tree under `dist-package/`. Server-side code requires no compilation — the JS sources are copied as-is and `@circuschief/shared` imports are rewritten to relative paths so the package can run without workspace tooling.
+2. **Publish** (`scripts/publish.sh`): Verifies PostHog publish configuration before npm login or build, runs the build, then `npm publish` from `dist-package/`. The package ships with the pre-built frontend included.
 3. **Run** (`npx circuschief`): The `bin/cli.js` shim sets `NODE_ENV=production` and starts the Express server, which serves the pre-built frontend as static files.
 
 ## Build-time vs runtime variables
@@ -40,26 +40,28 @@ NODE_ENV=production yarn workspace @circuschief/server start
 
 ```bash
 # Build the publishable package (defaults to version 0.1.0 if --version is omitted)
-node scripts/build-package.js --version=0.2.0
+POSTHOG_KEY=phc_xxxxx node scripts/build-package.js --version=0.2.0
 ```
 
 What the script does:
 
 1. Cleans and recreates `dist-package/`.
 2. Builds the frontend with `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` injected.
-3. If a PostHog key was provided, **verifies** the key appears in one of the built JS bundles and fails the build if it doesn't.
-4. Copies `packages/web/dist/`, `packages/server/src/` (minus `*.test.js`), `packages/server/bin/`, and `packages/shared/src/` + `package.json` into `dist-package/packages/...`.
+3. Requires a PostHog key and **verifies** the key appears in one of the built JS bundles, failing the build if it doesn't.
+4. Copies `packages/web/dist/`, `packages/server/src/` (minus `*.test.js`), `packages/server/bin/`, and `packages/shared/src/` into `dist-package/packages/...`.
 5. Rewrites all `from '@circuschief/shared'` / `from '@circuschief/shared/...'` imports in the copied server code to relative paths into `packages/shared/src/`. **Only static `import ... from '...'` syntax is handled** — `require()` and dynamic `import()` of `@circuschief/shared` would need script changes.
 6. Writes a publish-ready `dist-package/package.json` with:
    - `name: circuschief`, the given `--version`, `type: module`, `bin.circuschief`, `engines.node: >=18`
    - Merged runtime deps from `server` + `shared` (workspace reference to `@circuschief/shared` removed)
-   - A `files` array limiting the published tarball to `packages/server/bin/`, `packages/server/src/`, `packages/shared/src/`, `packages/shared/package.json`, and `packages/web/dist/`
-7. Overwrites `packages/server/bin/cli.js` with a production shim that sets `NODE_ENV=production` and imports `../src/index.js`.
+   - A `files` array limiting the published tarball to `packages/server/bin/`, `packages/server/src/`, `packages/server/package.json`, `packages/shared/src/`, `packages/shared/package.json`, and `packages/web/dist/`
+7. Writes sanitized internal `packages/server/package.json` and `packages/shared/package.json` manifests with the publish version and no workspace-only scripts or dependency metadata.
+8. Overwrites `packages/server/bin/cli.js` with a production shim that sets `NODE_ENV=production` and imports `../src/index.js`.
+9. Verifies the generated artifact versions, internal manifests, CLI `--version` output, and absence of stale internal workspace references.
 
 ### Testing the package locally
 
 ```bash
-node scripts/build-package.js --version=0.0.0-test
+POSTHOG_KEY=phc_test_publish_key node scripts/build-package.js --version=0.0.0-test
 cd dist-package
 npm pack
 # Then from any directory:
@@ -85,7 +87,7 @@ VCR_MODE=record ./scripts/pw.sh test-package
 
 Under the hood, `pw.sh test-package` sets `USE_PACKAGE_SERVER=true` and delegates server startup to `scripts/start-package-server.sh`, which reproduces a realistic end-user install. The key difference is that the server is launched from an installed tarball, not from the repo checkout.
 
-1. Runs `node scripts/build-package.js` to produce `dist-package/`.
+1. Runs `scripts/build-package.js` with `POSTHOG_KEY=phc_test_package_key` by default to produce `dist-package/`.
 2. `cd dist-package && npm pack` to produce a `circuschief-<version>.tgz` tarball.
 3. Creates an isolated temp install directory (`$TMPDIR/circuschief-package-test.XXXXXX`) with a minimal `package.json`.
 4. `npm install`s the tarball into that directory — this is the same path `npx circuschief` takes for real users.
@@ -135,13 +137,14 @@ Arguments:
 
 What the script does:
 
-1. Verifies you're logged in (`npm whoami`) and aborts with an error if not.
-2. If `version` is omitted, queries npm for the latest published version and auto-bumps the minor version (e.g. `1.4.2` → `1.5.0`).
-3. Runs `node scripts/build-package.js --version=$VERSION`.
-4. Runs `npm publish --otp=$OTP` from inside `dist-package/`.
-5. Prints install/run hints (`npx circuschief`, `npx circuschief@<version>`).
+1. If `version` is omitted, queries npm for the latest published version and auto-bumps the minor version (e.g. `1.4.2` → `1.5.0`).
+2. Verifies a PostHog key is configured and aborts before npm login, build, or `npm publish` when absent.
+3. Verifies you're logged in (`npm whoami`) and aborts with an error if not.
+4. Runs `node scripts/build-package.js --version=$VERSION`.
+5. Runs `npm publish --otp=$OTP` from inside `dist-package/`.
+6. Prints install/run hints (`npx circuschief`, `npx circuschief@<version>`).
 
-Before publishing, make sure `VITE_POSTHOG_KEY` is available via one of the sources listed below so analytics actually ship in the bundle.
+Before publishing, make sure `POSTHOG_KEY` or `VITE_POSTHOG_KEY` is available via one of the sources listed below. The PostHog client key is public, but publishing requires it to be intentionally configured.
 
 ## Analytics
 
@@ -153,7 +156,7 @@ This application uses [PostHog](https://posthog.com) for anonymous usage analyti
   2. `POSTHOG_KEY` environment variable
   3. `VITE_POSTHOG_KEY` from `.env.production` in the repo root
 - The PostHog host is resolved the same way (`--posthog-host=...` / `POSTHOG_HOST` / `VITE_POSTHOG_HOST`) and defaults to `https://us.i.posthog.com`.
-- When no key is provided (local dev, CI, contributor forks), analytics are completely disabled — no PostHog code loads, no network requests are made, and the build prints a warning instead of failing.
-- When a key is provided, the build **fails** if the key is not found in the generated JS bundle, so you can't accidentally ship a build with analytics missing.
+- Package builds and publishing fail when no key is provided. Package E2E startup provides a fake test key by default so tests do not depend on a developer machine's `.env.production`.
+- The build **fails** if the key is not found in the generated JS bundle, so you can't accidentally ship a build with analytics missing.
 - The PostHog client API key is a public key (like a Google Analytics tracking ID), not a secret.
 - Browser Do Not Track (`respect_dnt: true`) is honored.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:integration": "vitest run --config tests/integration/vitest.config.js",
     "test:coverage": "yarn workspaces run test:coverage",
     "test:e2e": "./scripts/pw.sh test",
-    "test:publish-script": "bash scripts/publish.test.sh",
+    "test:publish-script": "bash scripts/publish.test.sh && bash scripts/package-artifact.test.sh",
     "lint": "npx eslint packages/*/src"
   },
   "devDependencies": {

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -9,55 +9,28 @@
  * The only transform: rewrite `@circuschief/shared` imports to relative paths.
  */
 
-import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+import { requirePostHogKey, resolvePostHogConfig } from './posthog-publish-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = dirname(dirname(__filename));
 const DIST = join(ROOT, 'dist-package');
 const version = process.argv.find(a => a.startsWith('--version='))?.split('=')[1] || '0.1.0';
 
-// --- Read .env.production if it exists ---
-// Parses KEY=VALUE lines (ignoring comments and blank lines) as a fallback
-// source for PostHog configuration. CLI flags and env vars take precedence.
-const dotenvVars = {};
-const envProdPath = join(ROOT, '.env.production');
-if (existsSync(envProdPath)) {
-  const lines = readFileSync(envProdPath, 'utf-8').split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eqIndex = trimmed.indexOf('=');
-    if (eqIndex === -1) continue;
-    const key = trimmed.slice(0, eqIndex).trim();
-    let value = trimmed.slice(eqIndex + 1).trim();
-    // Strip surrounding quotes (single or double)
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    dotenvVars[key] = value;
-  }
+const posthogConfig = resolvePostHogConfig({
+  root: ROOT,
+  argv: process.argv.slice(2),
+  env: process.env,
+});
+
+if (posthogConfig.loadedEnvProduction) {
   console.log('Loaded .env.production');
 }
 
-// --- PostHog configuration ---
-// Resolution order (first non-empty wins): CLI flag → env var → .env.production
-const posthogKey = process.argv.find(a => a.startsWith('--posthog-key='))?.split('=')[1]
-  || process.env.POSTHOG_KEY
-  || dotenvVars.VITE_POSTHOG_KEY
-  || '';
-const posthogHost = process.argv.find(a => a.startsWith('--posthog-host='))?.split('=')[1]
-  || process.env.POSTHOG_HOST
-  || dotenvVars.VITE_POSTHOG_HOST
-  || 'https://us.i.posthog.com';
-
-if (!posthogKey) {
-  console.error('ERROR: PostHog key is required to publish.');
-  console.error('  Provide it via --posthog-key=<key>, POSTHOG_KEY env var, or VITE_POSTHOG_KEY in .env.production');
-  process.exit(1);
-}
+requirePostHogKey(posthogConfig, 'build');
 
 /** cpSync filter: exclude test files but always keep directories */
 const excludeTests = (src) => {
@@ -79,8 +52,8 @@ execSync('yarn workspace @circuschief/web build', {
   stdio: 'inherit',
   env: {
     ...process.env,
-    VITE_POSTHOG_KEY: posthogKey,
-    VITE_POSTHOG_HOST: posthogHost,
+    VITE_POSTHOG_KEY: posthogConfig.key,
+    VITE_POSTHOG_HOST: posthogConfig.host,
   },
 });
 
@@ -88,7 +61,7 @@ execSync('yarn workspace @circuschief/web build', {
 const assetsDir = join(ROOT, 'packages/web/dist/assets');
 const jsFiles = readdirSync(assetsDir).filter(f => f.endsWith('.js'));
 const found = jsFiles.some(f =>
-  readFileSync(join(assetsDir, f), 'utf-8').includes(posthogKey)
+  readFileSync(join(assetsDir, f), 'utf-8').includes(posthogConfig.key)
 );
 if (!found) {
   console.error('ERROR: PostHog key was not found in the built frontend bundle');
@@ -111,9 +84,6 @@ cpSync(join(ROOT, 'packages/shared/src'), join(DIST, 'packages/shared/src'), {
   recursive: true,
   filter: excludeTests,
 });
-
-// Copy shared package.json (needed for exports resolution)
-cpSync(join(ROOT, 'packages/shared/package.json'), join(DIST, 'packages/shared/package.json'));
 
 console.log('Copying packages/server/bin...');
 cpSync(join(ROOT, 'packages/server/bin'), join(DIST, 'packages/server/bin'), { recursive: true });
@@ -198,6 +168,7 @@ const publishPkg = {
   files: [
     'packages/server/bin/',
     'packages/server/src/',
+    'packages/server/package.json',
     'packages/shared/src/',
     'packages/shared/package.json',
     'packages/web/dist/',
@@ -209,6 +180,31 @@ const publishPkg = {
 };
 
 writeFileSync(join(DIST, 'package.json'), JSON.stringify(publishPkg, null, 2) + '\n');
+
+const internalServerPkg = {
+  name: '@circuschief/server',
+  version,
+  type: 'module',
+};
+
+const internalSharedPkg = {
+  name: '@circuschief/shared',
+  version,
+  type: 'module',
+  main: 'src/index.js',
+  exports: {
+    '.': './src/index.js',
+    './types': './src/types.js',
+    './protocol': './src/protocol.js',
+    './constants': './src/constants.js',
+    './contracts/*': './src/contracts/*.js',
+    './utils': './src/utils.js',
+    './routeParams': './src/routeParams.js',
+  },
+};
+
+writeFileSync(join(DIST, 'packages/server/package.json'), JSON.stringify(internalServerPkg, null, 2) + '\n');
+writeFileSync(join(DIST, 'packages/shared/package.json'), JSON.stringify(internalSharedPkg, null, 2) + '\n');
 
 // --- 6. Write CLI entry point ---
 // This intentionally overwrites the dev cli.js copied in step 3 with a
@@ -222,6 +218,51 @@ await import('../src/index.js');
 `;
 
 writeFileSync(join(DIST, 'packages/server/bin/cli.js'), cli);
+
+// --- 7. Verify generated artifact metadata ---
+console.log('Verifying package artifact...');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    console.error(`ERROR: ${label} expected '${expected}', got '${actual}'`);
+    process.exit(1);
+  }
+}
+
+function assertNoInternalWorkspaceReference(pkg, label) {
+  const serialized = JSON.stringify({
+    dependencies: pkg.dependencies,
+    devDependencies: pkg.devDependencies,
+    peerDependencies: pkg.peerDependencies,
+    optionalDependencies: pkg.optionalDependencies,
+  });
+  if (serialized.includes('"@circuschief/shared"')) {
+    console.error(`ERROR: ${label} contains stale @circuschief/shared dependency metadata`);
+    process.exit(1);
+  }
+}
+
+const generatedRootPkg = readJson(join(DIST, 'package.json'));
+const generatedServerPkg = readJson(join(DIST, 'packages/server/package.json'));
+const generatedSharedPkg = readJson(join(DIST, 'packages/shared/package.json'));
+
+assertEqual(generatedRootPkg.version, version, 'dist-package/package.json version');
+assertEqual(generatedServerPkg.version, version, 'dist-package/packages/server/package.json version');
+assertEqual(generatedSharedPkg.version, version, 'dist-package/packages/shared/package.json version');
+assertNoInternalWorkspaceReference(generatedRootPkg, 'dist-package/package.json');
+assertNoInternalWorkspaceReference(generatedServerPkg, 'dist-package/packages/server/package.json');
+assertNoInternalWorkspaceReference(generatedSharedPkg, 'dist-package/packages/shared/package.json');
+
+const cliVersion = execSync(`node ${JSON.stringify(join(DIST, 'packages/server/bin/cli.js'))} --version`, {
+  cwd: DIST,
+  encoding: 'utf-8',
+}).trim();
+assertEqual(cliVersion, version, 'generated CLI --version output');
+console.log('✓ Package artifact metadata verified');
 
 // --- Done ---
 console.log('');

--- a/scripts/check-posthog-publish-config.js
+++ b/scripts/check-posthog-publish-config.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { requirePostHogKey, resolvePostHogConfig } from './posthog-publish-config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = dirname(dirname(__filename));
+
+const config = resolvePostHogConfig({
+  root: ROOT,
+  argv: process.argv.slice(2),
+  env: process.env,
+});
+
+requirePostHogKey(config, 'publish');

--- a/scripts/package-artifact.test.sh
+++ b/scripts/package-artifact.test.sh
@@ -6,15 +6,12 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSION="0.2.0"
-ENV_PROD="$ROOT/.env.production"
-ENV_PROD_BACKUP=""
 MISSING_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/circuschief-missing-posthog.XXXXXX")
+MISSING_ENV_PROD=$(mktemp "${TMPDIR:-/tmp}/circuschief-env-production-missing.XXXXXX")
+rm -f "$MISSING_ENV_PROD"
 
 cleanup() {
-  if [ -n "$ENV_PROD_BACKUP" ] && [ -f "$ENV_PROD_BACKUP" ]; then
-    mv "$ENV_PROD_BACKUP" "$ENV_PROD"
-  fi
-  rm -f "$MISSING_OUTPUT"
+  rm -f "$MISSING_OUTPUT" "$MISSING_ENV_PROD"
 }
 trap cleanup EXIT
 
@@ -22,19 +19,12 @@ echo "=== Package artifact checks ==="
 
 echo "Checking missing PostHog key fails before artifact build..."
 rm -rf "$ROOT/dist-package"
-if [ -f "$ENV_PROD" ]; then
-  ENV_PROD_BACKUP=$(mktemp "${TMPDIR:-/tmp}/circuschief-env-production.XXXXXX")
-  mv "$ENV_PROD" "$ENV_PROD_BACKUP"
-fi
 if env -u POSTHOG_KEY -u VITE_POSTHOG_KEY -u POSTHOG_HOST -u VITE_POSTHOG_HOST \
+  POSTHOG_ENV_PRODUCTION_PATH="$MISSING_ENV_PROD" \
   node "$ROOT/scripts/build-package.js" --version=0.0.0-test >"$MISSING_OUTPUT" 2>&1; then
   echo "FAIL: build succeeded without PostHog key"
   cat "$MISSING_OUTPUT"
   exit 1
-fi
-if [ -n "$ENV_PROD_BACKUP" ] && [ -f "$ENV_PROD_BACKUP" ]; then
-  mv "$ENV_PROD_BACKUP" "$ENV_PROD"
-  ENV_PROD_BACKUP=""
 fi
 
 if [ -d "$ROOT/dist-package" ]; then
@@ -44,7 +34,9 @@ if [ -d "$ROOT/dist-package" ]; then
 fi
 
 echo "Building package with test PostHog key..."
-POSTHOG_KEY=phc_test_publish_key node "$ROOT/scripts/build-package.js" --version="$VERSION"
+POSTHOG_KEY=phc_test_publish_key \
+  POSTHOG_ENV_PRODUCTION_PATH="$MISSING_ENV_PROD" \
+  node "$ROOT/scripts/build-package.js" --version="$VERSION"
 
 echo "Checking generated manifests and CLI version..."
 node --input-type=module <<'NODE'

--- a/scripts/package-artifact.test.sh
+++ b/scripts/package-artifact.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+##
+# Focused checks for the generated dist-package artifact.
+##
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="0.2.0"
+ENV_PROD="$ROOT/.env.production"
+ENV_PROD_BACKUP=""
+MISSING_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/circuschief-missing-posthog.XXXXXX")
+
+cleanup() {
+  if [ -n "$ENV_PROD_BACKUP" ] && [ -f "$ENV_PROD_BACKUP" ]; then
+    mv "$ENV_PROD_BACKUP" "$ENV_PROD"
+  fi
+  rm -f "$MISSING_OUTPUT"
+}
+trap cleanup EXIT
+
+echo "=== Package artifact checks ==="
+
+echo "Checking missing PostHog key fails before artifact build..."
+rm -rf "$ROOT/dist-package"
+if [ -f "$ENV_PROD" ]; then
+  ENV_PROD_BACKUP=$(mktemp "${TMPDIR:-/tmp}/circuschief-env-production.XXXXXX")
+  mv "$ENV_PROD" "$ENV_PROD_BACKUP"
+fi
+if env -u POSTHOG_KEY -u VITE_POSTHOG_KEY -u POSTHOG_HOST -u VITE_POSTHOG_HOST \
+  node "$ROOT/scripts/build-package.js" --version=0.0.0-test >"$MISSING_OUTPUT" 2>&1; then
+  echo "FAIL: build succeeded without PostHog key"
+  cat "$MISSING_OUTPUT"
+  exit 1
+fi
+if [ -n "$ENV_PROD_BACKUP" ] && [ -f "$ENV_PROD_BACKUP" ]; then
+  mv "$ENV_PROD_BACKUP" "$ENV_PROD"
+  ENV_PROD_BACKUP=""
+fi
+
+if [ -d "$ROOT/dist-package" ]; then
+  echo "FAIL: dist-package was produced without PostHog key"
+  cat "$MISSING_OUTPUT"
+  exit 1
+fi
+
+echo "Building package with test PostHog key..."
+POSTHOG_KEY=phc_test_publish_key node "$ROOT/scripts/build-package.js" --version="$VERSION"
+
+echo "Checking generated manifests and CLI version..."
+node --input-type=module <<'NODE'
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+
+const expected = '0.2.0';
+const readJson = path => JSON.parse(readFileSync(path, 'utf-8'));
+const rootPkg = readJson('dist-package/package.json');
+const serverPkg = readJson('dist-package/packages/server/package.json');
+const sharedPkg = readJson('dist-package/packages/shared/package.json');
+
+for (const [label, pkg] of [
+  ['root', rootPkg],
+  ['server', serverPkg],
+  ['shared', sharedPkg],
+]) {
+  if (pkg.version !== expected) {
+    throw new Error(`${label} version expected ${expected}, got ${pkg.version}`);
+  }
+}
+
+if (rootPkg.dependencies?.['@circuschief/shared']) {
+  throw new Error('root manifest contains @circuschief/shared dependency');
+}
+
+for (const [label, pkg] of [
+  ['server', serverPkg],
+  ['shared', sharedPkg],
+]) {
+  const serializedDeps = JSON.stringify({
+    dependencies: pkg.dependencies,
+    devDependencies: pkg.devDependencies,
+  });
+  if (serializedDeps.includes('@circuschief/')) {
+    throw new Error(`${label} manifest contains stale workspace dependency metadata`);
+  }
+}
+
+const cliVersion = execSync('node dist-package/packages/server/bin/cli.js --version', {
+  encoding: 'utf-8',
+}).trim();
+if (cliVersion !== expected) {
+  throw new Error(`CLI version expected ${expected}, got ${cliVersion}`);
+}
+NODE
+
+echo "Package artifact checks passed."

--- a/scripts/posthog-publish-config.js
+++ b/scripts/posthog-publish-config.js
@@ -1,15 +1,14 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
-export function loadEnvProduction(root) {
+export function loadEnvProduction(root, envProductionPath = join(root, '.env.production')) {
   const vars = {};
-  const envProdPath = join(root, '.env.production');
 
-  if (!existsSync(envProdPath)) {
+  if (!existsSync(envProductionPath)) {
     return vars;
   }
 
-  const lines = readFileSync(envProdPath, 'utf-8').split('\n');
+  const lines = readFileSync(envProductionPath, 'utf-8').split('\n');
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
@@ -33,7 +32,7 @@ function getArgValue(argv, flag) {
 }
 
 export function resolvePostHogConfig({ root, argv = [], env = process.env }) {
-  const dotenvVars = loadEnvProduction(root);
+  const dotenvVars = loadEnvProduction(root, env.POSTHOG_ENV_PRODUCTION_PATH);
 
   return {
     key: getArgValue(argv, '--posthog-key')

--- a/scripts/posthog-publish-config.js
+++ b/scripts/posthog-publish-config.js
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export function loadEnvProduction(root) {
+  const vars = {};
+  const envProdPath = join(root, '.env.production');
+
+  if (!existsSync(envProdPath)) {
+    return vars;
+  }
+
+  const lines = readFileSync(envProdPath, 'utf-8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    let value = trimmed.slice(eqIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    vars[key] = value;
+  }
+
+  return vars;
+}
+
+function getArgValue(argv, flag) {
+  return argv.find(arg => arg.startsWith(`${flag}=`))?.split('=')[1] || '';
+}
+
+export function resolvePostHogConfig({ root, argv = [], env = process.env }) {
+  const dotenvVars = loadEnvProduction(root);
+
+  return {
+    key: getArgValue(argv, '--posthog-key')
+      || env.POSTHOG_KEY
+      || dotenvVars.VITE_POSTHOG_KEY
+      || '',
+    host: getArgValue(argv, '--posthog-host')
+      || env.POSTHOG_HOST
+      || dotenvVars.VITE_POSTHOG_HOST
+      || 'https://us.i.posthog.com',
+    loadedEnvProduction: Object.keys(dotenvVars).length > 0,
+  };
+}
+
+export function requirePostHogKey(config, context = 'build') {
+  if (config.key) {
+    return;
+  }
+
+  if (context === 'publish') {
+    console.error('ERROR: npm publish aborted because PostHog key is missing.');
+    console.error('Provide it via POSTHOG_KEY or VITE_POSTHOG_KEY in .env.production.');
+  } else {
+    console.error('ERROR: PostHog key is required to build a publishable package.');
+    console.error('  Provide it via --posthog-key=<key>, POSTHOG_KEY env var, or VITE_POSTHOG_KEY in .env.production');
+  }
+  process.exit(1);
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -117,7 +117,10 @@ echo " Publishing circuschief v${VERSION}"
 echo "========================================"
 echo ""
 
-# --- 1. Verify npm login ---
+# --- 1. Verify PostHog publish configuration ---
+node "$SCRIPT_DIR/check-posthog-publish-config.js"
+
+# --- 2. Verify npm login ---
 echo "Checking npm login..."
 NPM_USER=$(npm whoami 2>/dev/null || true)
 if [ -z "$NPM_USER" ]; then
@@ -127,12 +130,12 @@ fi
 echo "Logged in as: $NPM_USER"
 echo ""
 
-# --- 2. Build the package ---
+# --- 3. Build the package ---
 echo "Building package..."
 node "$SCRIPT_DIR/build-package.js" --version="$VERSION"
 echo ""
 
-# --- 3. Publish ---
+# --- 4. Publish ---
 echo "Publishing to npm..."
 cd "$ROOT/dist-package"
 npm publish --otp="$OTP"

--- a/scripts/publish.test.sh
+++ b/scripts/publish.test.sh
@@ -11,6 +11,10 @@
 set -euo pipefail
 
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/publish.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_PROD="$REPO_ROOT/.env.production"
+ENV_PROD_BACKUP=""
+REAL_NODE="$(command -v node)"
 PASS=0
 FAIL=0
 
@@ -66,9 +70,24 @@ assert_output_not_includes() {
 # --- Setup: create a temp mock npm directory ---
 MOCK_DIR=$(mktemp -d)
 cleanup() {
+  restore_env_production
   rm -rf "$MOCK_DIR"
 }
 trap cleanup EXIT
+
+hide_env_production() {
+  if [ -f "$ENV_PROD" ] && [ -z "$ENV_PROD_BACKUP" ]; then
+    ENV_PROD_BACKUP="$MOCK_DIR/env.production.backup"
+    mv "$ENV_PROD" "$ENV_PROD_BACKUP"
+  fi
+}
+
+restore_env_production() {
+  if [ -n "$ENV_PROD_BACKUP" ] && [ -f "$ENV_PROD_BACKUP" ]; then
+    mv "$ENV_PROD_BACKUP" "$ENV_PROD"
+    ENV_PROD_BACKUP=""
+  fi
+}
 
 # Helper: write a mock npm script and run the publish script with it on PATH
 run_with_mock() {
@@ -79,6 +98,19 @@ run_with_mock() {
 $mock_body
 MOCK_EOF
   chmod +x "$MOCK_DIR/npm"
+  cat > "$MOCK_DIR/node" <<MOCK_EOF
+#!/usr/bin/env bash
+FIRST="\${1:-}"
+if [[ "\$FIRST" == */check-posthog-publish-config.js ]]; then
+  exec "$REAL_NODE" "\$@"
+elif [[ "\$FIRST" == */build-package.js ]]; then
+  echo "mock build \$*"
+  exit 0
+else
+  exec "$REAL_NODE" "\$@"
+fi
+MOCK_EOF
+  chmod +x "$MOCK_DIR/node"
   PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" "$@" 2>&1
 }
 
@@ -138,7 +170,7 @@ assert_output_includes "Usage:" "$OUTPUT" "zero args prints usage"
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 2: Two args (9.9.9 000000) → fails at npm whoami, not at parsing"
-OUTPUT=$(run_with_mock "$MOCK_NOT_LOGGED_IN" 9.9.9 000000 2>&1) && RC=$? || RC=$?
+OUTPUT=$(POSTHOG_KEY=phc_test_publish_key run_with_mock "$MOCK_NOT_LOGGED_IN" 9.9.9 000000 2>&1) && RC=$? || RC=$?
 assert_exit 1 "$RC" "two args fails (expected: npm whoami)"
 assert_output_includes "Publishing circuschief v9.9.9" "$OUTPUT" "two args sets VERSION=9.9.9"
 assert_output_not_includes "Usage:" "$OUTPUT" "two args does not print usage"
@@ -157,7 +189,7 @@ assert_output_includes "OTP is required" "$OUTPUT" "one-arg version mentions mis
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 4: One arg (OTP 123456) → auto-bump minor"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_VIEW" 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(POSTHOG_KEY=phc_test_publish_key run_with_mock "$MOCK_LOGGED_IN_VIEW" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 0 "$RC" "auto-bump succeeds"
 assert_output_includes "Next: 1.5.0" "$OUTPUT" "auto-bump from 1.4.2 → 1.5.0"
 assert_output_includes "Publishing circuschief v1.5.0" "$OUTPUT" "VERSION set to 1.5.0"
@@ -176,7 +208,7 @@ assert_output_includes "version must be semver" "$OUTPUT" "-y rejected"
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 6: Pre-release latest → error"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_PRERELEASE" 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(POSTHOG_KEY=phc_test_publish_key run_with_mock "$MOCK_LOGGED_IN_PRERELEASE" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 1 "$RC" "pre-release latest exits 1"
 assert_output_includes "pre-release" "$OUTPUT" "pre-release error message"
 
@@ -185,7 +217,7 @@ assert_output_includes "pre-release" "$OUTPUT" "pre-release error message"
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 7: Never published → 0.1.0"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_EMPTY" 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(POSTHOG_KEY=phc_test_publish_key run_with_mock "$MOCK_LOGGED_IN_EMPTY" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 0 "$RC" "never-published succeeds"
 assert_output_includes "Next: 0.1.0" "$OUTPUT" "never-published starts at 0.1.0"
 assert_output_includes "Publishing circuschief v0.1.0" "$OUTPUT" "VERSION set to 0.1.0"
@@ -195,7 +227,7 @@ assert_output_includes "Publishing circuschief v0.1.0" "$OUTPUT" "VERSION set to
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 8: Unparseable npm output → error"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_GARBAGE" 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(POSTHOG_KEY=phc_test_publish_key run_with_mock "$MOCK_LOGGED_IN_GARBAGE" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 1 "$RC" "unparseable npm output exits 1"
 assert_output_includes "could not parse" "$OUTPUT" "unparseable error message"
 
@@ -222,10 +254,42 @@ assert_output_includes "version must be semver" "$OUTPUT" "--yes rejected"
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 11: One arg (OTP 123456) → auto-bump without prompt"
-OUTPUT=$(run_with_mock "$MOCK_LOGGED_IN_VIEW" 123456 2>&1) && RC=$? || RC=$?
+OUTPUT=$(POSTHOG_KEY=phc_test_publish_key run_with_mock "$MOCK_LOGGED_IN_VIEW" 123456 2>&1) && RC=$? || RC=$?
 assert_exit 0 "$RC" "auto-bump succeeds"
 assert_output_includes "Next: 1.5.0" "$OUTPUT" "auto-bump still calculates next version"
 assert_output_not_includes "Proceed?" "$OUTPUT" "auto-bump does not prompt"
+
+# --------------------------------------------------------------------------------
+# Test 12: Missing PostHog key aborts before npm login/build/publish
+# --------------------------------------------------------------------------------
+echo ""
+echo "Test 12: Missing PostHog key → aborts before publish"
+hide_env_production
+OUTPUT=$(
+  unset POSTHOG_KEY VITE_POSTHOG_KEY POSTHOG_HOST VITE_POSTHOG_HOST
+  run_with_mock "$MOCK_LOGGED_IN_VIEW" 9.9.9 000000 2>&1
+) && RC=$? || RC=$?
+restore_env_production
+assert_exit 1 "$RC" "missing PostHog key exits 1"
+assert_output_includes "PostHog key is missing" "$OUTPUT" "missing key mentions PostHog configuration"
+assert_output_not_includes "published" "$OUTPUT" "missing key does not call npm publish"
+assert_output_not_includes "Checking npm login" "$OUTPUT" "missing key aborts before npm login"
+
+# --------------------------------------------------------------------------------
+# Test 13: .env.production satisfies PostHog preflight
+# --------------------------------------------------------------------------------
+echo ""
+echo "Test 13: .env.production key → preflight passes"
+hide_env_production
+printf '%s\n' 'VITE_POSTHOG_KEY=phc_test_env_publish_key' > "$ENV_PROD"
+OUTPUT=$(
+  unset POSTHOG_KEY VITE_POSTHOG_KEY
+  run_with_mock "$MOCK_LOGGED_IN_VIEW" 9.9.9 000000 2>&1
+) && RC=$? || RC=$?
+rm -f "$ENV_PROD"
+restore_env_production
+assert_exit 0 "$RC" ".env.production satisfies preflight"
+assert_output_includes "published" "$OUTPUT" ".env.production flow reaches npm publish"
 
 # --- Summary ---
 echo ""

--- a/scripts/publish.test.sh
+++ b/scripts/publish.test.sh
@@ -11,9 +11,6 @@
 set -euo pipefail
 
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/publish.sh"
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ENV_PROD="$REPO_ROOT/.env.production"
-ENV_PROD_BACKUP=""
 REAL_NODE="$(command -v node)"
 PASS=0
 FAIL=0
@@ -69,25 +66,12 @@ assert_output_not_includes() {
 
 # --- Setup: create a temp mock npm directory ---
 MOCK_DIR=$(mktemp -d)
+MISSING_ENV_PROD="$MOCK_DIR/env.production.missing"
+TEST_ENV_PROD="$MOCK_DIR/env.production"
 cleanup() {
-  restore_env_production
   rm -rf "$MOCK_DIR"
 }
 trap cleanup EXIT
-
-hide_env_production() {
-  if [ -f "$ENV_PROD" ] && [ -z "$ENV_PROD_BACKUP" ]; then
-    ENV_PROD_BACKUP="$MOCK_DIR/env.production.backup"
-    mv "$ENV_PROD" "$ENV_PROD_BACKUP"
-  fi
-}
-
-restore_env_production() {
-  if [ -n "$ENV_PROD_BACKUP" ] && [ -f "$ENV_PROD_BACKUP" ]; then
-    mv "$ENV_PROD_BACKUP" "$ENV_PROD"
-    ENV_PROD_BACKUP=""
-  fi
-}
 
 # Helper: write a mock npm script and run the publish script with it on PATH
 run_with_mock() {
@@ -111,7 +95,8 @@ else
 fi
 MOCK_EOF
   chmod +x "$MOCK_DIR/node"
-  PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" "$@" 2>&1
+  POSTHOG_ENV_PRODUCTION_PATH="${POSTHOG_ENV_PRODUCTION_PATH:-$MISSING_ENV_PROD}" \
+    PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" "$@" 2>&1
 }
 
 # --- Syntax check first ---
@@ -264,12 +249,11 @@ assert_output_not_includes "Proceed?" "$OUTPUT" "auto-bump does not prompt"
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 12: Missing PostHog key → aborts before publish"
-hide_env_production
 OUTPUT=$(
   unset POSTHOG_KEY VITE_POSTHOG_KEY POSTHOG_HOST VITE_POSTHOG_HOST
+  export POSTHOG_ENV_PRODUCTION_PATH="$MISSING_ENV_PROD"
   run_with_mock "$MOCK_LOGGED_IN_VIEW" 9.9.9 000000 2>&1
 ) && RC=$? || RC=$?
-restore_env_production
 assert_exit 1 "$RC" "missing PostHog key exits 1"
 assert_output_includes "PostHog key is missing" "$OUTPUT" "missing key mentions PostHog configuration"
 assert_output_not_includes "published" "$OUTPUT" "missing key does not call npm publish"
@@ -280,14 +264,12 @@ assert_output_not_includes "Checking npm login" "$OUTPUT" "missing key aborts be
 # --------------------------------------------------------------------------------
 echo ""
 echo "Test 13: .env.production key → preflight passes"
-hide_env_production
-printf '%s\n' 'VITE_POSTHOG_KEY=phc_test_env_publish_key' > "$ENV_PROD"
+printf '%s\n' 'VITE_POSTHOG_KEY=phc_test_env_publish_key' > "$TEST_ENV_PROD"
 OUTPUT=$(
   unset POSTHOG_KEY VITE_POSTHOG_KEY
+  export POSTHOG_ENV_PRODUCTION_PATH="$TEST_ENV_PROD"
   run_with_mock "$MOCK_LOGGED_IN_VIEW" 9.9.9 000000 2>&1
 ) && RC=$? || RC=$?
-rm -f "$ENV_PROD"
-restore_env_production
 assert_exit 0 "$RC" ".env.production satisfies preflight"
 assert_output_includes "published" "$OUTPUT" ".env.production flow reaches npm publish"
 

--- a/scripts/start-package-server.sh
+++ b/scripts/start-package-server.sh
@@ -70,7 +70,7 @@ else
 fi
 
 echo "=== Building package ==="
-node "$SCRIPT_DIR/build-package.js"
+POSTHOG_KEY="${POSTHOG_KEY:-phc_test_package_key}" node "$SCRIPT_DIR/build-package.js"
 
 echo ""
 echo "=== Packing tarball ==="


### PR DESCRIPTION
## Summary
- require intentional PostHog configuration before package builds and npm publishing
- add shared PostHog publish config helpers and preflight checks
- generate sanitized internal package manifests and verify artifact versions/CLI metadata
- expand publish/package artifact tests and update distribution docs

## Tests
- yarn test:publish-script