### PR TITLE
Fix child sessions incorrectly creating git worktrees when parent has none

### DIFF
--- a/packages/server/src/api/projects-session-helpers.js
+++ b/packages/server/src/api/projects-session-helpers.js
@@ -294,16 +294,34 @@ export function buildSchedulingUpdate(config, initialStatus) {
 
 /**
  * Resolve working directory and optional worktree for a new session.
- * Inherits the parent's worktree when applicable.
+ *
+ * Child session inheritance rules:
+ * - If the parent session has a real gitWorktree, the child inherits it (same
+ *   worktree path is used for both workingDirectory and gitWorktree).
+ * - If the parent session exists but its gitWorktree is null, the child is
+ *   pinned to the project's working directory with gitWorktree: null — no new
+ *   worktree is created, regardless of the resolved gitMode/gitBranch config.
+ *
+ * Root sessions (no parentSessionId) go through the normal setupGitForSession
+ * path, which honours gitMode/gitBranch and may create a worktree.
+ *
  * @param {object} params
  * @returns {Promise<{ workingDirectory: string, gitWorktree: string|null }>}
  */
 async function resolveSessionWorkingDirectory({ session, config, project }) {
   const parentSession = config.parentSessionId ? sessions.getById(config.parentSessionId) : null;
-  if (parentSession?.gitWorktree) {
+  if (parentSession) {
+    if (parentSession.gitWorktree) {
+      return {
+        workingDirectory: parentSession.gitWorktree,
+        gitWorktree: parentSession.gitWorktree,
+      };
+    }
+    // Parent exists but is not in a worktree — pin the child to the plain
+    // project checkout so it never accidentally creates its own worktree.
     return {
-      workingDirectory: parentSession.gitWorktree,
-      gitWorktree: parentSession.gitWorktree,
+      workingDirectory: project.workingDirectory,
+      gitWorktree: null,
     };
   }
 

--- a/packages/server/src/api/projects-session-helpers.test.js
+++ b/packages/server/src/api/projects-session-helpers.test.js
@@ -771,15 +771,13 @@ describe('setupAndStartSession', () => {
       files: [],
     });
 
-    expect(setupGitForSession).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        gitMode: 'worktree',
-      })
-    );
+    // No git setup of any kind should happen — the child returns early and
+    // is pinned to the parent's plain project checkout.
+    expect(setupGitForSession).not.toHaveBeenCalled();
     expect(sessions.update).not.toHaveBeenCalledWith(
       childSession.id,
       expect.objectContaining({
-        gitWorktree: expect.stringContaining('/.worktrees/'),
+        gitWorktree: expect.anything(),
       })
     );
   });

--- a/packages/server/src/api/projects-session-helpers.test.js
+++ b/packages/server/src/api/projects-session-helpers.test.js
@@ -727,4 +727,60 @@ describe('setupAndStartSession', () => {
     );
     expect(result).toHaveProperty('updatedSession');
   });
+
+  it('keeps child sessions on the project directory when the parent is not in a worktree', async () => {
+    vi.clearAllMocks();
+
+    const { sessions } = await import('../database.js');
+    const { setupGitForSession } = await import('../services/gitSessionSetup.js');
+    const { resolvePromptSkillOrCommand } = await import('../services/slashCommandService.js');
+
+    const parentSession = {
+      id: 'parent-current',
+      gitBranch: null,
+      gitWorktree: null,
+    };
+    const childSession = { id: 'child-current' };
+    sessions.getById.mockImplementation((id) => (
+      id === parentSession.id ? parentSession : childSession
+    ));
+    sessions.update.mockReturnValue(childSession);
+    setupGitForSession.mockResolvedValue({
+      workingDirectory: '/tmp/project/.worktrees/child-current',
+      gitWorktree: '/tmp/project/.worktrees/child-current',
+    });
+    resolvePromptSkillOrCommand.mockResolvedValue(null);
+
+    vi.doMock('../services/sessionManager.js', () => ({
+      runSession: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    await setupAndStartSession({
+      session: childSession,
+      config: {
+        prompt: 'child prompt',
+        startImmediately: true,
+        scheduledAt: null,
+        parentSessionId: parentSession.id,
+        gitMode: 'worktree',
+        gitBranch: 'circus-chief/generated-child-branch',
+        model: 'sonnet',
+      },
+      project: { workingDirectory: '/tmp/project', systemPrompt: null },
+      projectId: 'proj-1',
+      files: [],
+    });
+
+    expect(setupGitForSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        gitMode: 'worktree',
+      })
+    );
+    expect(sessions.update).not.toHaveBeenCalledWith(
+      childSession.id,
+      expect.objectContaining({
+        gitWorktree: expect.stringContaining('/.worktrees/'),
+      })
+    );
+  });
 });

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -1768,7 +1768,7 @@ describe('Projects API', () => {
       expect(childSession.gitWorktree).toBe('/tmp/parent-worktree');
     });
 
-    it('calls setupGitForSession when parent has no gitWorktree', async () => {
+    it('does not call setupGitForSession when parent has no gitWorktree, pins child to project directory', async () => {
       // Create a parent session WITHOUT a gitWorktree
       const parentSession = sessions.create(projectId, 'Parent Session', 'running');
       sessions.update(parentSession.id, { gitWorktree: null });
@@ -1782,15 +1782,13 @@ describe('Projects API', () => {
 
       expect(res.status).toBe(201);
 
-      // setupGitForSession SHOULD have been called because parent has no worktree
-      expect(setupGitForSession).toHaveBeenCalledWith({
-        projectDir: tempDir,
-        gitMode: 'worktree',
-        gitBranch: 'test-branch',
-        sessionId: res.body.id,
-        worktreeBasePath: null,
-        commitAttributionOverride: null,
-      });
+      // setupGitForSession should NOT be called — child is pinned to the
+      // parent's plain project checkout, no new worktree is created.
+      expect(setupGitForSession).not.toHaveBeenCalled();
+
+      // The child session's gitWorktree should remain null
+      const childSession = sessions.getById(res.body.id);
+      expect(childSession.gitWorktree).toBeNull();
     });
 
     it('calls setupGitForSession when no parentSessionId is provided', async () => {
@@ -1813,8 +1811,8 @@ describe('Projects API', () => {
       });
     });
 
-    it('calls setupGitForSession when parent session has no gitWorktree field set', async () => {
-      // Create a parent session that exists but has no gitWorktree at all (undefined/falsy)
+    it('does not call setupGitForSession when parent session has no gitWorktree field set, pins child to project directory', async () => {
+      // Create a parent session that exists but has no gitWorktree at all (defaults to null)
       const parentSession = sessions.create(projectId, 'Parent No Worktree', 'running');
       // Don't set gitWorktree - it defaults to null
 
@@ -1827,8 +1825,13 @@ describe('Projects API', () => {
 
       expect(res.status).toBe(201);
 
-      // setupGitForSession should be called because parent has no gitWorktree
-      expect(setupGitForSession).toHaveBeenCalled();
+      // setupGitForSession should NOT be called — child is pinned to the
+      // parent's plain project checkout, no new worktree is created.
+      expect(setupGitForSession).not.toHaveBeenCalled();
+
+      // The child session's gitWorktree should remain null
+      const childSession = sessions.getById(res.body.id);
+      expect(childSession.gitWorktree).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- Child sessions now correctly inherit their parent's git isolation mode: if the parent has no `gitWorktree` (i.e. it runs in the plain project checkout), the child is pinned to the same plain checkout with `gitWorktree: null` — `setupGitForSession` is never called, so no spurious worktree is created even when the resolved `gitMode` is `"worktree"`.
- Parents with a real `gitWorktree` continue to work exactly as before (child inherits the same worktree path).
- Root sessions (no `parentSessionId`) are completely unaffected.

## Changes

**`packages/server/src/api/projects-session-helpers.js`**
- Updated `resolveSessionWorkingDirectory` to distinguish three cases: parent-with-worktree, parent-without-worktree, and root session. Added JSDoc describing both child inheritance paths.

**`packages/server/src/api/projects.test.js`**
- Updated two tests in `child session git worktree inheritance` that encoded the old (broken) behavior to assert the new correct behavior: `setupGitForSession` is not called and the child's `gitWorktree` stays `null`.

**`packages/server/src/api/projects-session-helpers.test.js`**
- Kept the regression test (`keeps child sessions on the project directory when the parent is not in a worktree`) added as part of the planning phase.

## Test plan

- [x] `yarn workspace @circuschief/server test src/api/projects-session-helpers.test.js` — 78/78 pass
- [x] `yarn workspace @circuschief/server test src/api/projects.test.js` — 109/109 pass
- [ ] Smoke-test: create a session with `gitMode: "worktree"`, then create a child session of it — verify the child runs in the project checkout, not a new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)