### PR TITLE
Trigger kanban lane automation when adding cards

### DIFF
--- a/packages/server/src/api/kanban.js
+++ b/packages/server/src/api/kanban.js
@@ -10,7 +10,10 @@ import {
   MoveKanbanCardRequest,
   ReorderKanbanCardsRequest,
 } from '@circuschief/shared/contracts/kanban';
-import { moveCard as moveCardService } from '../services/kanbanService.js';
+import {
+  addSessionToBoard,
+  moveCard as moveCardService,
+} from '../services/kanbanService.js';
 import { resolveBodyRootSessionForProject } from '../middleware/sessionLookup.js';
 
 const router = Router({ mergeParams: true });
@@ -216,9 +219,7 @@ router.put('/lanes/reorder', (req, res) => {
  * POST /api/projects/:projectId/kanban/cards
  * Add a session to the board (create card in a lane)
  */
-router.post('/cards', resolveBodyRootSessionForProject('projectId'), (req, res) => {
-  const { projectId } = req.params;
-
+router.post('/cards', resolveBodyRootSessionForProject('projectId'), async (req, res) => {
   const result = CreateKanbanCardRequest.safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.issues[0].message });
@@ -239,15 +240,15 @@ router.post('/cards', resolveBodyRootSessionForProject('projectId'), (req, res) 
     return res.status(404).json({ error: 'Lane not found' });
   }
 
-  const card = kanbanCards.create(laneId, sessionId);
-
-  broadcastToProject(projectId, WS_MESSAGE_TYPES.KANBAN_CARD_ADDED, {
-    projectId,
-    card,
-    laneId,
-  });
-
-  res.status(201).json(card);
+  try {
+    const card = await addSessionToBoard(sessionId, laneId);
+    res.status(201).json(card);
+  } catch (error) {
+    if (error.message === 'Session already has a card on the board') {
+      return res.status(409).json({ error: error.message });
+    }
+    res.status(500).json({ error: error.message });
+  }
 });
 
 /**

--- a/packages/server/src/api/kanban.test.js
+++ b/packages/server/src/api/kanban.test.js
@@ -14,10 +14,14 @@ vi.mock('../websocket.js', () => ({
   broadcastToProject: vi.fn(),
 }));
 
-// Mock kanbanService before importing the router
-vi.mock('../services/kanbanService.js', () => ({
-  moveCard: vi.fn(),
-}));
+// Mock card moves while keeping card creation behavior real.
+vi.mock('../services/kanbanService.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    moveCard: vi.fn(),
+  };
+});
 
 import kanbanRouter from './kanban.js';
 import { broadcastToProject } from '../websocket.js';

--- a/packages/server/src/services/kanbanService.js
+++ b/packages/server/src/services/kanbanService.js
@@ -64,6 +64,21 @@ export function getFullBoard(projectId) {
   return buildFullBoardResponse(board);
 }
 
+async function triggerLaneEntryAutomation(sessionId, laneId, options = {}) {
+  const { runOnEnterTemplate = true, depth = 0 } = options;
+
+  if (!runOnEnterTemplate) {
+    return;
+  }
+
+  const lane = kanbanLanes.getByIdWithTemplate(laneId);
+  if (lane?.onEnterTemplateId) {
+    await triggerOnEnterTemplate(sessionId, lane, { depth });
+  } else if (lane?.onEnterPrompt) {
+    await triggerOnEnterPrompt(sessionId, lane, { depth });
+  }
+}
+
 /**
  * Add a session to the kanban board.
  *
@@ -71,17 +86,21 @@ export function getFullBoard(projectId) {
  * @param {string} laneId - The lane to add the session to
  * @param {Object} [options] - Options
  * @param {number} [options.sortOrder] - Optional sort order
+ * @param {boolean} [options.runOnEnterTemplate=true] - Whether to run lane on-enter automation
+ * @param {number} [options.depth=0] - Current recursion depth for template triggers
  * @returns {Object} The created card
  * @throws {Error} If session already has a card on the board
  */
-export function addSessionToBoard(sessionId, laneId, options = {}) {
+export async function addSessionToBoard(sessionId, laneId, options = {}) {
+  const { sortOrder, runOnEnterTemplate = true, depth = 0 } = options;
+
   // Check if session already has a card
   const existingCard = kanbanCards.getBySessionId(sessionId);
   if (existingCard) {
     throw new Error('Session already has a card on the board');
   }
 
-  const card = kanbanCards.create(laneId, sessionId, options);
+  const card = kanbanCards.create(laneId, sessionId, { sortOrder });
 
   // Get session to find project ID for broadcast
   const session = sessions.getById(sessionId);
@@ -91,6 +110,8 @@ export function addSessionToBoard(sessionId, laneId, options = {}) {
       card,
       laneId,
     });
+
+    await triggerLaneEntryAutomation(sessionId, laneId, { runOnEnterTemplate, depth });
   }
 
   return card;
@@ -133,15 +154,7 @@ export async function moveCard(cardId, targetLaneId, options = {}) {
       card: movedCard,
     });
 
-    // Trigger on-enter automation if configured (template or custom prompt)
-    if (runOnEnterTemplate) {
-      const targetLane = kanbanLanes.getByIdWithTemplate(targetLaneId);
-      if (targetLane?.onEnterTemplateId) {
-        await triggerOnEnterTemplate(sessionId, targetLane, { depth });
-      } else if (targetLane?.onEnterPrompt) {
-        await triggerOnEnterPrompt(sessionId, targetLane, { depth });
-      }
-    }
+    await triggerLaneEntryAutomation(sessionId, targetLaneId, { runOnEnterTemplate, depth });
   }
 
   return movedCard;
@@ -181,12 +194,9 @@ export async function handleTurnCompletion(sessionId) {
       return;
     }
 
-    card = kanbanCards.create(session.targetLaneId, sessionId);
-
-    broadcastToProject(session.projectId, WS_MESSAGE_TYPES.KANBAN_CARD_ADDED, {
-      projectId: session.projectId,
-      card,
-      laneId: session.targetLaneId,
+    card = await addSessionToBoard(sessionId, session.targetLaneId, {
+      runOnEnterTemplate: true,
+      depth: session.laneTriggerDepth || 0,
     });
   } else {
     // Move existing card to target lane
@@ -237,7 +247,7 @@ export function removeSessionFromBoard(sessionId) {
  * @param {string} sessionId - The newly created session ID
  * @param {string} templateId - The template ID used to create the session
  */
-export function addSessionToTemplateTargetLane(sessionId, templateId) {
+export async function addSessionToTemplateTargetLane(sessionId, templateId) {
   const template = sessionTemplates.getById(templateId);
   if (!template?.targetLaneId) {
     return;
@@ -252,7 +262,7 @@ export function addSessionToTemplateTargetLane(sessionId, templateId) {
   }
 
   try {
-    addSessionToBoard(sessionId, template.targetLaneId);
+    await addSessionToBoard(sessionId, template.targetLaneId);
     console.log(
       `Kanban: Added session ${sessionId} to lane "${lane.name}" based on template target`
     );

--- a/packages/server/src/services/kanbanService.test.js
+++ b/packages/server/src/services/kanbanService.test.js
@@ -116,18 +116,18 @@ describe('kanbanService', () => {
   // ── addSessionToBoard ──────────────────────────────────────────────
 
   describe('addSessionToBoard', () => {
-    it('adds a session to a lane', () => {
+    it('adds a session to a lane', async () => {
       const session = createSession();
-      const card = addSessionToBoard(session.id, lanes[0].id);
+      const card = await addSessionToBoard(session.id, lanes[0].id);
 
       expect(card).not.toBeNull();
       expect(card.laneId).toBe(lanes[0].id);
       expect(card.sessions[0].id).toBe(session.id);
     });
 
-    it('broadcasts KANBAN_CARD_ADDED', () => {
+    it('broadcasts KANBAN_CARD_ADDED', async () => {
       const session = createSession();
-      addSessionToBoard(session.id, lanes[0].id);
+      await addSessionToBoard(session.id, lanes[0].id);
 
       expect(broadcastToProject).toHaveBeenCalledWith(
         projectId,
@@ -139,13 +139,38 @@ describe('kanbanService', () => {
       );
     });
 
-    it('throws when session already has a card', () => {
+    it('throws when session already has a card', async () => {
       const session = createSession();
-      addSessionToBoard(session.id, lanes[0].id);
+      await addSessionToBoard(session.id, lanes[0].id);
 
-      expect(() => addSessionToBoard(session.id, lanes[1].id)).toThrow(
+      await expect(addSessionToBoard(session.id, lanes[1].id)).rejects.toThrow(
         'Session already has a card on the board'
       );
+    });
+
+    it('triggers lane on-enter prompt when creating a card in a lane', async () => {
+      kanbanLanes.update(lanes[0].id, { onEnterPrompt: 'do something' });
+      const session = createSession();
+
+      await addSessionToBoard(session.id, lanes[0].id);
+
+      const allSessions = sessions.getByProjectId(projectId);
+      const childSession = allSessions.find((s) => s.id !== session.id);
+      expect(childSession).toBeDefined();
+      expect(childSession.parentSessionId).toBe(session.id);
+      expect(childSession.laneTriggerDepth).toBe(1);
+      expect(runSession).toHaveBeenCalled();
+    });
+
+    it('skips lane on-enter prompt when runOnEnterTemplate is false', async () => {
+      kanbanLanes.update(lanes[0].id, { onEnterPrompt: 'do something' });
+      const session = createSession();
+
+      await addSessionToBoard(session.id, lanes[0].id, { runOnEnterTemplate: false });
+
+      const allSessions = sessions.getByProjectId(projectId);
+      expect(allSessions).toHaveLength(1);
+      expect(runSession).not.toHaveBeenCalled();
     });
   });
 
@@ -154,7 +179,7 @@ describe('kanbanService', () => {
   describe('moveCard', () => {
     it('moves a card to a different lane', async () => {
       const session = createSession();
-      const card = addSessionToBoard(session.id, lanes[0].id);
+      const card = await addSessionToBoard(session.id, lanes[0].id);
       vi.clearAllMocks();
 
       const moved = await moveCard(card.id, lanes[1].id);
@@ -168,7 +193,7 @@ describe('kanbanService', () => {
 
     it('broadcasts KANBAN_CARD_MOVED', async () => {
       const session = createSession();
-      const card = addSessionToBoard(session.id, lanes[0].id);
+      const card = await addSessionToBoard(session.id, lanes[0].id);
       vi.clearAllMocks();
 
       await moveCard(card.id, lanes[1].id);
@@ -199,7 +224,7 @@ describe('kanbanService', () => {
       kanbanLanes.update(lanes[1].id, { onEnterTemplateId: template.id });
 
       const session = createSession();
-      const card = addSessionToBoard(session.id, lanes[0].id);
+      const card = await addSessionToBoard(session.id, lanes[0].id);
       vi.clearAllMocks();
 
       await moveCard(card.id, lanes[1].id, { runOnEnterTemplate: false });
@@ -351,7 +376,7 @@ describe('kanbanService', () => {
   // ── addSessionToTemplateTargetLane ─────────────────────────────────
 
   describe('addSessionToTemplateTargetLane', () => {
-    it('adds session to the lane specified in the template', () => {
+    it('adds session to the lane specified in the template', async () => {
       const template = sessionTemplates.create({
         projectId,
         name: 'Template',
@@ -360,14 +385,14 @@ describe('kanbanService', () => {
       });
 
       const session = createSession();
-      addSessionToTemplateTargetLane(session.id, template.id);
+      await addSessionToTemplateTargetLane(session.id, template.id);
 
       const card = kanbanCards.getBySessionId(session.id);
       expect(card).not.toBeNull();
       expect(card.laneId).toBe(lanes[2].id);
     });
 
-    it('does nothing when template has no targetLaneId', () => {
+    it('does nothing when template has no targetLaneId', async () => {
       const template = sessionTemplates.create({
         projectId,
         name: 'Template',
@@ -375,21 +400,21 @@ describe('kanbanService', () => {
       });
 
       const session = createSession();
-      addSessionToTemplateTargetLane(session.id, template.id);
+      await addSessionToTemplateTargetLane(session.id, template.id);
 
       const card = kanbanCards.getBySessionId(session.id);
       expect(card).toBeNull();
     });
 
-    it('does nothing when template does not exist', () => {
+    it('does nothing when template does not exist', async () => {
       const session = createSession();
-      addSessionToTemplateTargetLane(session.id, 'non-existent');
+      await addSessionToTemplateTargetLane(session.id, 'non-existent');
 
       const card = kanbanCards.getBySessionId(session.id);
       expect(card).toBeNull();
     });
 
-    it('does not throw when target lane has been deleted', () => {
+    it('does not throw when target lane has been deleted', async () => {
       // Create a real lane, assign it to template, then delete the lane
       const tempLane = kanbanLanes.create(boardId, { name: 'Temp Lane' });
       const template = sessionTemplates.create({
@@ -404,14 +429,14 @@ describe('kanbanService', () => {
 
       const session = createSession();
       // Template's targetLaneId is now null, so should do nothing
-      expect(() => addSessionToTemplateTargetLane(session.id, template.id)).not.toThrow();
+      await expect(addSessionToTemplateTargetLane(session.id, template.id)).resolves.toBeUndefined();
 
       // Session should not have a card on the board
       const card = kanbanCards.getBySessionId(session.id);
       expect(card).toBeNull();
     });
 
-    it('does not throw when session already has a card', () => {
+    it('does not throw when session already has a card', async () => {
       const template = sessionTemplates.create({
         projectId,
         name: 'Template',
@@ -423,7 +448,7 @@ describe('kanbanService', () => {
       kanbanCards.create(lanes[1].id, session.id);
 
       // Should not throw - should log a warning
-      expect(() => addSessionToTemplateTargetLane(session.id, template.id)).not.toThrow();
+      await expect(addSessionToTemplateTargetLane(session.id, template.id)).resolves.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- route kanban card creation through addSessionToBoard so direct adds can run lane-entry automation
- share the on-enter trigger helper between card adds, moves, and target-lane completion
- add service coverage for triggering and opt-out behavior on card add

## Tests
- yarn workspace @circuschief/server test src/services/kanbanService.test.js src/api/kanban.test.js
- yarn workspace @circuschief/server test
- git diff --check