### PR TITLE
Fix session summaries failing with "Reached maximum number of turns (1)"

### DIFF
--- a/packages/server/src/services/summaryClaudeClient.js
+++ b/packages/server/src/services/summaryClaudeClient.js
@@ -68,6 +68,16 @@ function buildClaudeRequest(prompt, options) {
       permissionMode: 'bypassPermissions',
       maxTurns: 1,
       model,
+      // Summary generation is a pure text->JSON task: it must never load tools,
+      // MCP servers, or filesystem settings (CLAUDE.md, hooks, user/project MCP).
+      // Without this isolation the model is handed the full agentic toolbelt and
+      // spends its single allowed turn invoking a tool/MCP, which makes the SDK
+      // return "Reached maximum number of turns (1)" and the summary fails.
+      // Scoped to this summary call only — agent sessions use their own adapters.
+      settingSources: [],
+      strictMcpConfig: true,
+      mcpServers: {},
+      allowedTools: [],
       ...(env && { env }),
       ...(systemPrompt && { systemPrompt }),
       outputFormat: {

--- a/packages/server/src/services/summaryClaudeClient.test.js
+++ b/packages/server/src/services/summaryClaudeClient.test.js
@@ -131,6 +131,18 @@ describe('summaryClaudeClient', () => {
       expect(callArgs.options.outputFormat.schema).toEqual(customSchema);
     });
 
+    it('isolates the summary call from tools, MCP servers, and filesystem settings', async () => {
+      await callClaude('Test prompt', [], 'running');
+
+      const callArgs = query.mock.calls[0][0];
+      // Summary generation must be a pure text->JSON task. Inheriting the
+      // agentic toolbelt/MCP caused "Reached maximum number of turns (1)".
+      expect(callArgs.options.settingSources).toEqual([]);
+      expect(callArgs.options.strictMcpConfig).toBe(true);
+      expect(callArgs.options.mcpServers).toEqual({});
+      expect(callArgs.options.allowedTools).toEqual([]);
+    });
+
     it('starts agent call logging when logMeta provided', async () => {
       await callClaude('Test prompt', [], 'running', {
         logMeta: {


### PR DESCRIPTION
## Problem

Session summaries stopped working — every generation attempt fails and the UI/API falls back to the generic `"Session in progress"` / `"Session with N messages"` placeholder.

The `agent_call_logs` table tells the story:

```
2026-06-05 21:50  claude-haiku-4-5  error  Reached maximum number of turns (1)
2026-06-05 21:48  GLM-4.7           error  Reached maximum number of turns (1)
2026-06-05 21:46  GLM-5-turbo       error  Reached maximum number of turns (1)
```

- Summaries completed fine through **2026-06-04 23:04**; **100% of calls fail on 06-05**.
- The identical error hit **both** the Anthropic (`claude-haiku-4-5`) and z.ai (`GLM-*`) model paths at the same time — pointing to a **local-config trigger**, not a model-server change.
- No code or SDK change occurred between the last success and the failures.

## Root cause

`buildClaudeRequest` in `summaryClaudeClient.js` issued the summary query without restricting `settingSources` / `strictMcpConfig`. Per the SDK, when `settingSources` is omitted **all** sources load — so the summary call inherited user/project settings, **all configured MCP servers**, and the full agentic toolbelt. Captured from a real summary call's `init` event:

```
tools = Task, AskUserQuestion, Bash, CronCreate, ...
mcp_servers = [{"puppeteer": connected}, {"clickup": disabled}]
```

The trigger: a global `puppeteer` MCP server (in `~/.claude.json`) plus a project `clickup` server were added around 06-05. With `maxTurns: 1`, the model now spends its single allowed turn engaging a tool/MCP instead of returning the JSON, so the SDK returns `Reached maximum number of turns (1)`, which is thrown and swallowed into the placeholder fallback.

## Fix

Make the summary call hermetic — it's a pure text→JSON task that needs no tools, MCP, or project context:

```js
settingSources: [],
strictMcpConfig: true,
mcpServers: {},
allowedTools: [],
```

**Tightly scoped:** the change is confined to `buildClaudeRequest`, which is used **only** by summary generation. Agent sessions go through their own adapters and retain full MCP/tool access — nothing else is affected.

## Testing

- Added a regression test asserting all four isolation options are set on the summary call.
- `summaryClaudeClient.test.js`: 22 passed
- `summaryService.test.js` + `summaryModelClient.test.js`: 267 passed

## Note (out of scope)

The OpenAI `gpt-5.4-mini` summary failures are a separate `429 quota` (billing) issue, unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)