### PR TITLE
Add lane completion move settings

### DIFF
--- a/packages/server/src/api/kanban.js
+++ b/packages/server/src/api/kanban.js
@@ -146,10 +146,28 @@ router.patch('/lanes/:laneId', (req, res) => {
     return res.status(404).json({ error: 'Lane not found' });
   }
 
+  const board = kanbanBoards.getByProjectId(projectId);
+  if (!board || board.id !== lane.boardId) {
+    return res.status(404).json({ error: 'Lane not found' });
+  }
+
+  if (result.data.completionTargetLaneId !== undefined && result.data.completionTargetLaneId !== null) {
+    if (result.data.completionTargetLaneId === laneId) {
+      return res.status(400).json({ error: 'Completion target lane cannot be the same lane' });
+    }
+
+    const targetLane = kanbanLanes.getById(result.data.completionTargetLaneId);
+    if (!targetLane) {
+      return res.status(404).json({ error: 'Completion target lane not found' });
+    }
+    if (targetLane.boardId !== lane.boardId) {
+      return res.status(400).json({ error: 'Completion target lane must be on the same board' });
+    }
+  }
+
   const updated = kanbanLanes.update(laneId, result.data);
 
   // Broadcast updated board
-  const board = kanbanBoards.getByProjectId(projectId);
   const fullBoard = buildFullBoardResponse(board);
   broadcastToProject(projectId, WS_MESSAGE_TYPES.KANBAN_BOARD_UPDATED, {
     projectId,

--- a/packages/server/src/api/kanban.js
+++ b/packages/server/src/api/kanban.js
@@ -17,6 +17,7 @@ import {
 import { resolveBodyRootSessionForProject } from '../middleware/sessionLookup.js';
 
 const router = Router({ mergeParams: true });
+const LANE_NOT_FOUND_ERROR = 'Lane not found';
 
 /**
  * Helper to build full board response with lanes and cards
@@ -143,12 +144,12 @@ router.patch('/lanes/:laneId', (req, res) => {
 
   const lane = kanbanLanes.getById(laneId);
   if (!lane) {
-    return res.status(404).json({ error: 'Lane not found' });
+    return res.status(404).json({ error: LANE_NOT_FOUND_ERROR });
   }
 
   const board = kanbanBoards.getByProjectId(projectId);
   if (!board || board.id !== lane.boardId) {
-    return res.status(404).json({ error: 'Lane not found' });
+    return res.status(404).json({ error: LANE_NOT_FOUND_ERROR });
   }
 
   if (result.data.completionTargetLaneId !== undefined && result.data.completionTargetLaneId !== null) {

--- a/packages/server/src/api/kanban.test.js
+++ b/packages/server/src/api/kanban.test.js
@@ -198,6 +198,67 @@ describe('Kanban API', () => {
       expect(res.body.name).toBe('Renamed');
     });
 
+    it('accepts completionTargetLaneId null', async () => {
+      setupBoard();
+      kanbanLanes.update(lanes[0].id, { completionTargetLaneId: lanes[1].id });
+
+      const res = await request(app)
+        .patch(`/api/projects/${projectId}/kanban/lanes/${lanes[0].id}`)
+        .send({ completionTargetLaneId: null });
+
+      expect(res.status).toBe(200);
+      expect(res.body.completionTargetLaneId).toBeNull();
+    });
+
+    it('accepts completionTargetLaneId for another lane on the same board', async () => {
+      setupBoard();
+
+      const res = await request(app)
+        .patch(`/api/projects/${projectId}/kanban/lanes/${lanes[0].id}`)
+        .send({ completionTargetLaneId: lanes[1].id });
+
+      expect(res.status).toBe(200);
+      expect(res.body.completionTargetLaneId).toBe(lanes[1].id);
+    });
+
+    it('rejects completionTargetLaneId equal to the source lane', async () => {
+      setupBoard();
+
+      const res = await request(app)
+        .patch(`/api/projects/${projectId}/kanban/lanes/${lanes[0].id}`)
+        .send({ completionTargetLaneId: lanes[0].id });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Completion target lane cannot be the same lane');
+    });
+
+    it('rejects completionTargetLaneId from another board', async () => {
+      setupBoard();
+      const otherProject = projects.create('Other Project', '/tmp/other', null, { kanbanEnabled: true });
+      const otherBoard = kanbanBoards.getOrCreateForProject(otherProject.id);
+      const otherLanes = kanbanLanes.getByBoardId(otherBoard.id);
+
+      const res = await request(app)
+        .patch(`/api/projects/${projectId}/kanban/lanes/${lanes[0].id}`)
+        .send({ completionTargetLaneId: otherLanes[0].id });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Completion target lane must be on the same board');
+    });
+
+    it('rejects updating a lane through a project route whose board does not own it', async () => {
+      setupBoard();
+      const otherProject = projects.create('Other Project', '/tmp/other', null, { kanbanEnabled: true });
+      kanbanBoards.getOrCreateForProject(otherProject.id);
+
+      const res = await request(app)
+        .patch(`/api/projects/${otherProject.id}/kanban/lanes/${lanes[0].id}`)
+        .send({ name: 'Wrong Project' });
+
+      expect(res.status).toBe(404);
+      expect(kanbanLanes.getById(lanes[0].id).name).not.toBe('Wrong Project');
+    });
+
     it('returns 404 for non-existent lane', async () => {
       setupBoard();
 

--- a/packages/server/src/db/KanbanLaneRepository.js
+++ b/packages/server/src/db/KanbanLaneRepository.js
@@ -92,6 +92,7 @@ export class KanbanLaneRepository extends BaseRepository {
       onEnterMaxRescheduleCount: row.on_enter_max_reschedule_count,
       onEnterMaxTotalTokens: row.on_enter_max_total_tokens,
       onEnterRescheduleAtTokenCount: row.on_enter_reschedule_at_token_count,
+      completionTargetLaneId: row.completion_target_lane_id,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -186,6 +187,7 @@ export class KanbanLaneRepository extends BaseRepository {
       onEnterMaxRescheduleCount: 'on_enter_max_reschedule_count',
       onEnterMaxTotalTokens: 'on_enter_max_total_tokens',
       onEnterRescheduleAtTokenCount: 'on_enter_reschedule_at_token_count',
+      completionTargetLaneId: 'completion_target_lane_id',
     };
 
     const updates = [];

--- a/packages/server/src/db/KanbanLaneRepository.test.js
+++ b/packages/server/src/db/KanbanLaneRepository.test.js
@@ -99,6 +99,12 @@ describe('KanbanLaneRepository', () => {
 
       expect(lane.onEnterTemplateId).toBeNull();
     });
+
+    it('maps completionTargetLaneId as null by default', () => {
+      const lane = laneRepo.create(boardId, { name: 'Plain Lane' });
+
+      expect(lane.completionTargetLaneId).toBeNull();
+    });
   });
 
   describe('update', () => {
@@ -141,6 +147,25 @@ describe('KanbanLaneRepository', () => {
 
       const updated = laneRepo.update(lane.id, { onEnterTemplateId: null });
       expect(updated.onEnterTemplateId).toBeNull();
+    });
+
+    it('updates completionTargetLaneId', () => {
+      const source = laneRepo.create(boardId, { name: 'Source' });
+      const target = laneRepo.create(boardId, { name: 'Target' });
+
+      const updated = laneRepo.update(source.id, { completionTargetLaneId: target.id });
+
+      expect(updated.completionTargetLaneId).toBe(target.id);
+    });
+
+    it('clears completionTargetLaneId when set to null', () => {
+      const source = laneRepo.create(boardId, { name: 'Source' });
+      const target = laneRepo.create(boardId, { name: 'Target' });
+      laneRepo.update(source.id, { completionTargetLaneId: target.id });
+
+      const updated = laneRepo.update(source.id, { completionTargetLaneId: null });
+
+      expect(updated.completionTargetLaneId).toBeNull();
     });
 
     it('returns unchanged lane when no updates provided', () => {

--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -239,6 +239,7 @@ export const allMigrations = validateMigrations([
   k.get('session_templates-add-target_lane_id'),
   k.get('kanban_lanes-add-on_enter_prompt'),
   k.get('kanban_lanes-add-agent-settings'),
+  k.get('kanban_lanes-add-completion_target_lane_id'),
 
   // --- Sessions default mode / thinking defaults (table recreation) ---
   s.get('sessions-migrate-default-mode-thinking'),

--- a/packages/server/src/db/migrations/kanbanMigrations.js
+++ b/packages/server/src/db/migrations/kanbanMigrations.js
@@ -96,4 +96,10 @@ export const kanbanMigrations = [
       addColumnIfMissing(db, 'kanban_lanes', 'on_enter_reschedule_at_token_count', 'INTEGER');
     },
   },
+  {
+    name: 'kanban_lanes-add-completion_target_lane_id',
+    up(db) {
+      addColumnIfMissing(db, 'kanban_lanes', 'completion_target_lane_id', 'TEXT REFERENCES kanban_lanes(id) ON DELETE SET NULL');
+    },
+  },
 ];

--- a/packages/server/src/db/schemaBaseline.test.js
+++ b/packages/server/src/db/schemaBaseline.test.js
@@ -127,7 +127,7 @@ describe('schema baseline', () => {
       expect(columnNames(db, 'conversations')).toEqual(expect.arrayContaining(['model', 'parent_conversation_id', 'branch_from_message_id']));
       expect(columnNames(db, 'session_summaries')).toEqual(expect.arrayContaining(['last_summarized_message_id', 'workflow_fingerprint']));
       expect(columnNames(db, 'message_attachments')).toEqual(expect.arrayContaining(['file_path']));
-      expect(columnNames(db, 'kanban_lanes')).toEqual(expect.arrayContaining(['on_enter_reschedule_delay_minutes']));
+      expect(columnNames(db, 'kanban_lanes')).toEqual(expect.arrayContaining(['on_enter_reschedule_delay_minutes', 'completion_target_lane_id']));
     });
   });
 
@@ -145,6 +145,7 @@ describe('schema baseline', () => {
       expect(byName.get('on_enter_max_reschedule_count')).toBeTruthy();
       expect(byName.get('on_enter_max_total_tokens')).toBeTruthy();
       expect(byName.get('on_enter_reschedule_at_token_count')).toBeTruthy();
+      expect(byName.get('completion_target_lane_id')).toBeTruthy();
     });
   });
 

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -324,6 +324,7 @@ CREATE TABLE IF NOT EXISTS kanban_lanes (
   on_enter_max_reschedule_count INTEGER,
   on_enter_max_total_tokens INTEGER,
   on_enter_reschedule_at_token_count INTEGER,
+  completion_target_lane_id TEXT REFERENCES kanban_lanes(id) ON DELETE SET NULL,
   created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );

--- a/packages/server/src/services/kanbanService.js
+++ b/packages/server/src/services/kanbanService.js
@@ -160,6 +160,17 @@ export async function moveCard(cardId, targetLaneId, options = {}) {
   return movedCard;
 }
 
+async function moveExistingSessionCard(session, card, targetLaneId) {
+  if (card.laneId === targetLaneId) {
+    return card;
+  }
+
+  return moveCard(card.id, targetLaneId, {
+    runOnEnterTemplate: true,
+    depth: session.laneTriggerDepth || 0,
+  });
+}
+
 /**
  * Handle turn completion for a session.
  * If the session has a target_lane_id set, move its card to that lane.
@@ -200,18 +211,45 @@ export async function handleTurnCompletion(sessionId) {
     });
   } else {
     // Move existing card to target lane
-    const fromLaneId = card.laneId;
-
-    if (fromLaneId !== session.targetLaneId) {
-      await moveCard(card.id, session.targetLaneId, {
-        runOnEnterTemplate: true,
-        depth: session.laneTriggerDepth || 0,
-      });
-    }
+    await moveExistingSessionCard(session, card, session.targetLaneId);
   }
 
   // Clear the target lane now that we've processed it
   sessions.update(sessionId, { targetLaneId: null });
+}
+
+/**
+ * Move an existing card based on the current lane's completion target.
+ *
+ * @param {string} sessionId - The session that just completed its turn
+ */
+export async function handleCompletionMove(sessionId) {
+  const session = sessions.getById(sessionId);
+  if (!session) {
+    return;
+  }
+
+  const card = kanbanCards.getBySessionId(sessionId);
+  if (!card) {
+    return;
+  }
+
+  const currentLane = kanbanLanes.getById(card.laneId);
+  if (!currentLane?.completionTargetLaneId) {
+    return;
+  }
+
+  const targetLaneId = currentLane.completionTargetLaneId;
+  if (targetLaneId === currentLane.id) {
+    return;
+  }
+
+  const targetLane = kanbanLanes.getById(targetLaneId);
+  if (!targetLane || targetLane.boardId !== currentLane.boardId) {
+    return;
+  }
+
+  await moveExistingSessionCard(session, card, targetLaneId);
 }
 
 /**

--- a/packages/server/src/services/kanbanService.test.js
+++ b/packages/server/src/services/kanbanService.test.js
@@ -37,6 +37,7 @@ import {
   addSessionToBoard,
   moveCard,
   handleTurnCompletion,
+  handleCompletionMove,
   removeSessionFromBoard,
   addSessionToTemplateTargetLane,
 } from './kanbanService.js';
@@ -333,6 +334,89 @@ describe('kanbanService', () => {
       // Card should still be in the same lane
       const card = kanbanCards.getBySessionId(session.id);
       expect(card.laneId).toBe(lanes[0].id);
+    });
+  });
+
+  // ── handleCompletionMove ──────────────────────────────────────────
+
+  describe('handleCompletionMove', () => {
+    it('moves an existing card to the current lane completion target', async () => {
+      const session = createSession();
+      kanbanCards.create(lanes[0].id, session.id);
+      kanbanLanes.update(lanes[0].id, { completionTargetLaneId: lanes[1].id });
+
+      await handleCompletionMove(session.id);
+
+      const card = kanbanCards.getBySessionId(session.id);
+      expect(card.laneId).toBe(lanes[1].id);
+      expect(broadcastToProject).toHaveBeenCalledWith(
+        projectId,
+        WS_MESSAGE_TYPES.KANBAN_CARD_MOVED,
+        expect.objectContaining({
+          fromLaneId: lanes[0].id,
+          toLaneId: lanes[1].id,
+        })
+      );
+    });
+
+    it('does nothing when the session has no card', async () => {
+      const session = createSession();
+
+      await handleCompletionMove(session.id);
+
+      expect(kanbanCards.getBySessionId(session.id)).toBeNull();
+      expect(broadcastToProject).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the current lane has no completion target', async () => {
+      const session = createSession();
+      kanbanCards.create(lanes[0].id, session.id);
+
+      await handleCompletionMove(session.id);
+
+      const card = kanbanCards.getBySessionId(session.id);
+      expect(card.laneId).toBe(lanes[0].id);
+      expect(broadcastToProject).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the completion target equals the current lane', async () => {
+      const session = createSession();
+      kanbanCards.create(lanes[0].id, session.id);
+      kanbanLanes.update(lanes[0].id, { completionTargetLaneId: lanes[0].id });
+
+      await handleCompletionMove(session.id);
+
+      const card = kanbanCards.getBySessionId(session.id);
+      expect(card.laneId).toBe(lanes[0].id);
+      expect(broadcastToProject).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the completion target is on another board', async () => {
+      const session = createSession();
+      kanbanCards.create(lanes[0].id, session.id);
+      const otherProject = projects.create('Other Project', '/tmp/other', null, { kanbanEnabled: true });
+      const otherBoard = kanbanBoards.create(otherProject.id);
+      const otherLanes = kanbanLanes.getByBoardId(otherBoard.id);
+      kanbanLanes.update(lanes[0].id, { completionTargetLaneId: otherLanes[0].id });
+
+      await handleCompletionMove(session.id);
+
+      const card = kanbanCards.getBySessionId(session.id);
+      expect(card.laneId).toBe(lanes[0].id);
+      expect(broadcastToProject).not.toHaveBeenCalled();
+    });
+
+    it('composes with per-session targetLaneId moves', async () => {
+      const session = createSession();
+      kanbanCards.create(lanes[0].id, session.id);
+      sessions.update(session.id, { targetLaneId: lanes[1].id });
+      kanbanLanes.update(lanes[1].id, { completionTargetLaneId: lanes[2].id });
+
+      await handleTurnCompletion(session.id);
+      await handleCompletionMove(session.id);
+
+      const card = kanbanCards.getBySessionId(session.id);
+      expect(card.laneId).toBe(lanes[2].id);
     });
   });
 

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -59,6 +59,7 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
 
   // Handle kanban lane movements based on targetLaneId
   await kanbanService.handleTurnCompletion(sessionId);
+  await kanbanService.handleCompletionMove(sessionId);
 
   // Auto-send queued prompt if enabled (runs BEFORE template trigger)
   const { handleAutoSendIfNeeded, handleTemplateTriggerIfNeeded } = callbacks;

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -59,6 +59,7 @@ vi.mock('./usageTracker.js', () => ({
 
 vi.mock('./kanbanService.js', () => ({
   handleTurnCompletion: vi.fn().mockResolvedValue(undefined),
+  handleCompletionMove: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { sessions, messages, workLogs, conversations } from '../database.js';
@@ -463,7 +464,7 @@ describe('streamEventHandler', () => {
       expect(summaryService.extractPrUrlIfNeeded).toHaveBeenCalledWith('sess-1');
     });
 
-    it('calls kanbanService.handleTurnCompletion with sessionId', async () => {
+    it('calls kanban completion hooks with sessionId', async () => {
       activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
       workLogs.associatePendingLogs.mockReturnValue(0);
       sessions.getById.mockReturnValue({ projectId: 'proj-1' });
@@ -475,6 +476,7 @@ describe('streamEventHandler', () => {
       await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
 
       expect(kanbanService.handleTurnCompletion).toHaveBeenCalledWith('sess-1');
+      expect(kanbanService.handleCompletionMove).toHaveBeenCalledWith('sess-1');
     });
 
     it('does not call kanbanService.handleTurnCompletion when session was aborted', async () => {
@@ -487,6 +489,7 @@ describe('streamEventHandler', () => {
       await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
 
       expect(kanbanService.handleTurnCompletion).not.toHaveBeenCalled();
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
     });
 
     it('does not call kanbanService.handleTurnCompletion when rescheduled', async () => {
@@ -499,6 +502,7 @@ describe('streamEventHandler', () => {
       await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
 
       expect(kanbanService.handleTurnCompletion).not.toHaveBeenCalled();
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
     });
 
     it('skips template trigger when auto-send fires', async () => {

--- a/packages/shared/src/contracts/kanban.js
+++ b/packages/shared/src/contracts/kanban.js
@@ -55,6 +55,7 @@ export const UpdateKanbanLaneRequest = z.object({
   onEnterMaxRescheduleCount: z.number().nullable().optional(),
   onEnterMaxTotalTokens: z.number().nullable().optional(),
   onEnterRescheduleAtTokenCount: z.number().nullable().optional(),
+  completionTargetLaneId: z.string().uuid().nullable().optional(),
 }).refine(
   (data) => {
     // Mutual exclusivity: can't have both template and prompt set
@@ -88,6 +89,7 @@ export const KanbanLaneResponse = z.object({
   onEnterMaxRescheduleCount: z.number().nullable(),
   onEnterMaxTotalTokens: z.number().nullable(),
   onEnterRescheduleAtTokenCount: z.number().nullable(),
+  completionTargetLaneId: z.string().uuid().nullable(),
   createdAt: z.number(),
   updatedAt: z.number(),
 });

--- a/packages/shared/src/contracts/kanban.test.js
+++ b/packages/shared/src/contracts/kanban.test.js
@@ -15,6 +15,7 @@ import {
 
 const UUID = '550e8400-e29b-41d4-a716-446655440000';
 const UUID2 = '550e8400-e29b-41d4-a716-446655440001';
+const UUID3 = '550e8400-e29b-41d4-a716-446655440002';
 
 describe('Kanban Contracts', () => {
   // ── CreateKanbanLaneRequest ──────────────────────────────────────
@@ -125,6 +126,21 @@ describe('Kanban Contracts', () => {
     it('allows partial update with sortOrder', () => {
       const result = UpdateKanbanLaneRequest.safeParse({ sortOrder: 5 });
       expect(result.success).toBe(true);
+    });
+
+    it('allows completionTargetLaneId with a valid UUID', () => {
+      const result = UpdateKanbanLaneRequest.safeParse({ completionTargetLaneId: UUID3 });
+      expect(result.success).toBe(true);
+    });
+
+    it('allows null completionTargetLaneId', () => {
+      const result = UpdateKanbanLaneRequest.safeParse({ completionTargetLaneId: null });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid completionTargetLaneId', () => {
+      const result = UpdateKanbanLaneRequest.safeParse({ completionTargetLaneId: 'not-a-uuid' });
+      expect(result.success).toBe(false);
     });
 
     it('rejects empty name', () => {
@@ -303,10 +319,63 @@ describe('Kanban Contracts', () => {
         onEnterMaxRescheduleCount: null,
         onEnterMaxTotalTokens: null,
         onEnterRescheduleAtTokenCount: null,
+        completionTargetLaneId: null,
         createdAt: 1234567890,
         updatedAt: 1234567890,
       });
       expect(result.success).toBe(true);
+    });
+
+    it('allows completionTargetLaneId with a valid UUID', () => {
+      const result = KanbanLaneResponse.safeParse({
+        id: UUID,
+        boardId: UUID2,
+        name: 'To Do',
+        sortOrder: 0,
+        onEnterTemplateId: null,
+        onEnterPrompt: null,
+        onEnterMode: null,
+        onEnterModel: null,
+        onEnterEffortLevel: null,
+        onEnterThinkingEnabled: null,
+        onEnterAutoRescheduleEnabled: false,
+        onEnterRescheduleDelayMinutes: null,
+        onEnterRescheduleOnTokenLimit: null,
+        onEnterRescheduleOnServiceError: null,
+        onEnterMaxRescheduleCount: null,
+        onEnterMaxTotalTokens: null,
+        onEnterRescheduleAtTokenCount: null,
+        completionTargetLaneId: UUID3,
+        createdAt: 1234567890,
+        updatedAt: 1234567890,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects invalid completionTargetLaneId', () => {
+      const result = KanbanLaneResponse.safeParse({
+        id: UUID,
+        boardId: UUID2,
+        name: 'To Do',
+        sortOrder: 0,
+        onEnterTemplateId: null,
+        onEnterPrompt: null,
+        onEnterMode: null,
+        onEnterModel: null,
+        onEnterEffortLevel: null,
+        onEnterThinkingEnabled: null,
+        onEnterAutoRescheduleEnabled: false,
+        onEnterRescheduleDelayMinutes: null,
+        onEnterRescheduleOnTokenLimit: null,
+        onEnterRescheduleOnServiceError: null,
+        onEnterMaxRescheduleCount: null,
+        onEnterMaxTotalTokens: null,
+        onEnterRescheduleAtTokenCount: null,
+        completionTargetLaneId: 'not-a-uuid',
+        createdAt: 1234567890,
+        updatedAt: 1234567890,
+      });
+      expect(result.success).toBe(false);
     });
 
     it('allows null onEnterTemplateId', () => {
@@ -328,6 +397,7 @@ describe('Kanban Contracts', () => {
         onEnterMaxRescheduleCount: null,
         onEnterMaxTotalTokens: null,
         onEnterRescheduleAtTokenCount: null,
+        completionTargetLaneId: null,
         createdAt: 1234567890,
         updatedAt: 1234567890,
       });
@@ -433,6 +503,7 @@ describe('Kanban Contracts', () => {
             onEnterMaxRescheduleCount: null,
             onEnterMaxTotalTokens: null,
             onEnterRescheduleAtTokenCount: null,
+            completionTargetLaneId: null,
             createdAt: 1234567890,
             updatedAt: 1234567890,
           },
@@ -481,6 +552,7 @@ describe('Kanban Contracts', () => {
             onEnterMaxRescheduleCount: null,
             onEnterMaxTotalTokens: null,
             onEnterRescheduleAtTokenCount: null,
+            completionTargetLaneId: null,
             createdAt: 1234567890,
             updatedAt: 1234567890,
             cards: [

--- a/packages/web/src/components/LaneSettingsModal.test.js
+++ b/packages/web/src/components/LaneSettingsModal.test.js
@@ -102,6 +102,7 @@ describe('LaneSettingsModal.vue', () => {
     onEnterMaxRescheduleCount: null,
     onEnterMaxTotalTokens: null,
     onEnterRescheduleAtTokenCount: null,
+    completionTargetLaneId: null,
   };
 
   const laneWithTemplate = {
@@ -276,6 +277,29 @@ describe('LaneSettingsModal.vue', () => {
       // lane-2 is at index 1, should show "2 of 3"
       expect(wrapper.find('.lane-position-label').text()).toBe('2 of 3');
     });
+
+    it('excludes the current lane from completion target options', () => {
+      const wrapper = mountModal({ lane: baseLane });
+      const optionValues = wrapper.findAll('#completion-target-lane-select option').map((option) => option.element.value);
+
+      expect(optionValues).not.toContain('lane-2');
+    });
+
+    it('includes other lanes in completion target options', () => {
+      const wrapper = mountModal({ lane: baseLane });
+      const optionValues = wrapper.findAll('#completion-target-lane-select option').map((option) => option.element.value);
+
+      expect(optionValues).toContain('lane-1');
+      expect(optionValues).toContain('lane-3');
+    });
+
+    it('populates the completion target select from lane data', () => {
+      const wrapper = mountModal({
+        lane: { ...baseLane, completionTargetLaneId: 'lane-3' },
+      });
+
+      expect(wrapper.find('#completion-target-lane-select').element.value).toBe('lane-3');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -372,6 +396,60 @@ describe('LaneSettingsModal.vue', () => {
       expect(data.onEnterEffortLevel).toBeNull();
       expect(data.onEnterThinkingEnabled).toBeNull();
       expect(data.onEnterAutoRescheduleEnabled).toBe(false);
+      expect(data.completionTargetLaneId).toBeNull();
+    });
+
+    it('saves the selected completion target', async () => {
+      const wrapper = mountModal({ lane: baseLane });
+      await wrapper.find('#completion-target-lane-select').setValue('lane-3');
+      await wrapper.find('.btn-primary').trigger('click');
+      await flushPromises();
+
+      const [, , data] = mockKanbanStore.updateLane.mock.calls[0];
+      expect(data.completionTargetLaneId).toBe('lane-3');
+    });
+
+    it('clears the completion target with null', async () => {
+      const wrapper = mountModal({
+        lane: { ...baseLane, completionTargetLaneId: 'lane-3' },
+      });
+      await wrapper.find('#completion-target-lane-select').setValue('');
+      await wrapper.find('.btn-primary').trigger('click');
+      await flushPromises();
+
+      const [, , data] = mockKanbanStore.updateLane.mock.calls[0];
+      expect(data.completionTargetLaneId).toBeNull();
+    });
+
+    it('offers only no automatic move for a one-lane board', async () => {
+      mockKanbanStore.board = { lanes: [{ id: 'lane-2', name: 'In Progress' }] };
+      const wrapper = mountModal({ lane: baseLane });
+
+      const options = wrapper.findAll('#completion-target-lane-select option');
+      expect(options).toHaveLength(1);
+      expect(options[0].text()).toBe('Do not move automatically');
+
+      await wrapper.find('.btn-primary').trigger('click');
+      await flushPromises();
+
+      const [, , data] = mockKanbanStore.updateLane.mock.calls[0];
+      expect(data.completionTargetLaneId).toBeNull();
+    });
+
+    it('does not clear completionTargetLaneId when automation type changes', async () => {
+      mockTemplatesStore.projectTemplates = [{ id: 'template-42', name: 'Test Template' }];
+      const wrapper = mountModal({
+        lane: { ...baseLane, completionTargetLaneId: 'lane-3' },
+      });
+
+      await wrapper.find('input[type="radio"][value="template"]').setValue(true);
+      await wrapper.find('#template-select').setValue('template-42');
+      await wrapper.find('.btn-primary').trigger('click');
+      await flushPromises();
+
+      const [, , data] = mockKanbanStore.updateLane.mock.calls[0];
+      expect(data.onEnterTemplateId).toBe('template-42');
+      expect(data.completionTargetLaneId).toBe('lane-3');
     });
 
     it('shows success toast on success', async () => {

--- a/packages/web/src/components/LaneSettingsModal.vue
+++ b/packages/web/src/components/LaneSettingsModal.vue
@@ -471,9 +471,9 @@ const laneIndex = computed(() => currentLaneIndex.value);
 
 const totalLanes = computed(() => kanbanStore.board?.lanes?.length || 0);
 
-const completionTargetLanes = computed(() => {
-  return (kanbanStore.board?.lanes || []).filter((lane) => lane.id !== props.lane?.id);
-});
+const completionTargetLanes = computed(() =>
+  (kanbanStore.board?.lanes || []).filter((lane) => lane.id !== props.lane?.id)
+);
 
 const isValid = computed(() => {
   if (!form.name.trim()) return false;

--- a/packages/web/src/components/LaneSettingsModal.vue
+++ b/packages/web/src/components/LaneSettingsModal.vue
@@ -85,6 +85,30 @@
           </div>
         </div>
 
+        <!-- On Completion -->
+        <div class="form-group">
+          <label
+            for="completion-target-lane-select"
+            class="form-label"
+          >On Completion</label>
+          <select
+            id="completion-target-lane-select"
+            v-model="form.completionTargetLaneId"
+            class="form-input"
+          >
+            <option :value="null">
+              Do not move automatically
+            </option>
+            <option
+              v-for="targetLane in completionTargetLanes"
+              :key="targetLane.id"
+              :value="targetLane.id"
+            >
+              {{ targetLane.name }}
+            </option>
+          </select>
+        </div>
+
         <!-- Automation Type -->
         <div class="form-group">
           <label class="form-label">On-Enter Automation</label>
@@ -432,6 +456,7 @@ const form = reactive({
   onEnterMaxRescheduleCount: null,
   onEnterMaxTotalTokens: null,
   onEnterRescheduleAtTokenCount: null,
+  completionTargetLaneId: null,
 });
 
 const projectTemplates = computed(() => templatesStore.projectTemplates);
@@ -445,6 +470,10 @@ const workingDirectory = computed(() => {
 const laneIndex = computed(() => currentLaneIndex.value);
 
 const totalLanes = computed(() => kanbanStore.board?.lanes?.length || 0);
+
+const completionTargetLanes = computed(() => {
+  return (kanbanStore.board?.lanes || []).filter((lane) => lane.id !== props.lane?.id);
+});
 
 const isValid = computed(() => {
   if (!form.name.trim()) return false;
@@ -484,6 +513,7 @@ function buildFormFromLane(lane) {
     onEnterModel: lane.onEnterModel || null,
     onEnterEffortLevel: lane.onEnterEffortLevel || null,
     onEnterThinkingEnabled: lane.onEnterThinkingEnabled ?? null,
+    completionTargetLaneId: lane.completionTargetLaneId || null,
     ...buildRescheduleFields(lane),
   };
 }
@@ -654,6 +684,7 @@ async function handleSave() {
     } else {
       Object.assign(data, buildSaveDataForNone());
     }
+    data.completionTargetLaneId = form.completionTargetLaneId || null;
 
     await handleLanePositionChange(props.lane, initialLaneIndex.value, currentLaneIndex.value, props.projectId);
     await kanbanStore.updateLane(props.projectId, props.lane.id, data);
@@ -724,6 +755,11 @@ watch(
       if (currentIndex >= 0) {
         initialLaneIndex.value = currentIndex;
         currentLaneIndex.value = currentIndex;
+      }
+
+      const targetStillValid = newLanes.some((l) => l.id === form.completionTargetLaneId && l.id !== props.lane.id);
+      if (form.completionTargetLaneId && !targetStillValid) {
+        form.completionTargetLaneId = null;
       }
     }
   },

--- a/tests/e2e/git-session-creation.spec.ts
+++ b/tests/e2e/git-session-creation.spec.ts
@@ -8,8 +8,9 @@ import {
 } from './helpers';
 
 test.describe('Git-backed project session creation', () => {
-  // Session creation can be slow under load
-  test.describe.configure({ timeout: 60000 });
+  // These tests create and remove git worktrees in the same repository.
+  // Keep them serial so cleanup and git worktree operations do not race.
+  test.describe.configure({ mode: 'serial', timeout: 60000 });
 
   let project: any;
 

--- a/tests/e2e/kanban-completion-move.spec.ts
+++ b/tests/e2e/kanban-completion-move.spec.ts
@@ -4,25 +4,34 @@ import {
   BASE_URL,
   seedProject,
   seedSession,
+  seedProjectTemplate,
   cleanupCreatedResources,
   navigateAndWait,
   openSessionOverlay,
   waitForStatus,
+  waitForChildSession,
+  getProjectSessions,
 } from './helpers';
 
 /**
  * UI-driven E2E coverage for the lane "On Completion" move feature.
  *
- * Implements the plan on the canvas (kanban-completion-move-e2e-plan.md):
- *  - Test 1: configure + persist the completion target through the UI.
- *  - Test 2: clearing the target through the UI prevents an auto move.
- *  - Test 3 (+4 folded in): a real session lifecycle moves the card from the
- *    source lane to the configured destination, exercised through the UI and
- *    backed by the existing VCR cassette system (no Playwright route mocking).
+ *  - Test 1: configure / change / clear the completion target through the UI and
+ *    assert each variation persists across reload AND server-side.
+ *  - Test 2: clearing the target prevents an auto move — proven by running a REAL
+ *    session lifecycle (VCR replay) so the production completion hook actually
+ *    fires and decides not to move (no direct status PATCH shortcut).
+ *  - Test 3: a real session lifecycle moves the card from the source lane to the
+ *    configured destination, through the UI and backed by the VCR cassette system.
+ *  - Test 4: completing into a destination lane that has an on-enter CUSTOM PROMPT
+ *    creates a child session (the automation runs as part of the completion move).
+ *  - Test 5: same as Test 4 but the destination lane runs an on-enter TEMPLATE.
  *
- * No REST mocking. The REST API is used only for seeding setup and for final
- * state verification — every user-observable action (configuring the lane,
- * adding the card, starting the session) happens through the UI.
+ * No REST mocking. The REST API is used only for seeding setup (sessions,
+ * templates, destination-lane on-enter automation) and for final state
+ * verification. Every user-observable action for the feature under test —
+ * configuring the completion target, adding the card, starting the session —
+ * happens through the UI.
  */
 
 // ============================================================
@@ -30,15 +39,15 @@ import {
 // ============================================================
 
 /**
- * The completion-move lifecycle test (Test 3) starts a draft session through
- * the chat input. To keep it deterministic and runnable in the default
- * `VCR_MODE=replay`, it reuses the prompt of an already-committed cassette
- * (runSession-ec0df80145f024e5.json). The cassette key is callType + a hash of
- * this exact prompt, so the text MUST match byte-for-byte.
+ * The lifecycle tests start a draft session through the chat input. To keep
+ * them deterministic and runnable in the default `VCR_MODE=replay`, they reuse
+ * the prompt of an already-committed cassette (runSession-ec0df80145f024e5.json).
+ * The cassette key is callType + a hash of this exact prompt, so the text MUST
+ * match byte-for-byte. The same prompt is reused for the on-enter automation in
+ * Tests 4/5 so the spawned child session also replays cleanly from that cassette.
  *
  * If you ever change this prompt, re-record with:
- *   VCR_MODE=record ./scripts/pw.sh test tests/e2e/kanban-completion-move.spec.ts \
- *     --grep "Session completion moves card"
+ *   VCR_MODE=record ./scripts/pw.sh test tests/e2e/kanban-completion-move.spec.ts
  * and commit the new cassette under tests/e2e/cassettes/.
  */
 const VCR_PROMPT = 'Claude E2E regression: reply with exactly "Claude E2E response."';
@@ -66,6 +75,25 @@ function findLaneOfSession(board: any, sessionId: string): string | null {
   return null;
 }
 
+/** Configure a destination lane's on-enter automation via the REST API (test setup). */
+async function setLaneOnEnter(projectId: string, laneId: string, settings: object) {
+  const response = await fetch(`${API_URL}/api/projects/${projectId}/kanban/lanes/${laneId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to set lane on-enter automation: ${response.status} ${await response.text()}`);
+  }
+  return response.json();
+}
+
+/** Count child sessions of a parent (used for negative assertions). */
+async function countChildSessions(parentSessionId: string, projectId: string): Promise<number> {
+  const all = await getProjectSessions(projectId);
+  return all.filter((s: any) => s.parentSessionId === parentSessionId).length;
+}
+
 /** Locate a kanban lane by its exact title (avoids matching card text). */
 function laneByTitle(page: Page, title: string): Locator {
   return page.locator('.kanban-lane').filter({
@@ -89,6 +117,13 @@ async function saveLaneSettings(page: Page) {
   await expect(page.locator('.modal-backdrop')).toBeHidden({ timeout: 5000 });
 }
 
+/** Open "In Progress" lane settings, pick a completion target by label, and save. */
+async function configureCompletionTarget(page: Page, sourceLane: string, targetLabel: string) {
+  await openLaneSettings(page, sourceLane);
+  await page.selectOption('#completion-target-lane-select', { label: targetLabel });
+  await saveLaneSettings(page);
+}
+
 /** Add a (draft) session to a lane via the lane's "Add Session" modal. */
 async function addSessionToLaneViaUI(page: Page, laneTitle: string, sessionName: string) {
   await laneByTitle(page, laneTitle).locator('.add-session-btn').click();
@@ -97,6 +132,27 @@ async function addSessionToLaneViaUI(page: Page, laneTitle: string, sessionName:
   await page.locator('.session-item').filter({ hasText: sessionName }).first().click();
   await page.click('.modal-footer .btn-primary');
   await expect(page.locator('.modal-backdrop')).toBeHidden({ timeout: 5000 });
+}
+
+/**
+ * Drive a real agent turn through the UI: open the session, type the VCR prompt
+ * into the visible chat input, send, and wait for the turn to settle to
+ * 'waiting' (VCR replay). This is what triggers the production completion hook.
+ */
+async function runSessionTurnViaUI(page: Page, sessionId: string) {
+  await navigateAndWait(page, `${BASE_URL}/sessions/${sessionId}/summary`);
+  await openSessionOverlay(page);
+  const textarea = page.locator('.input-form textarea');
+  await textarea.fill(VCR_PROMPT);
+  await page.locator('.btn-send-full').first().click();
+  await waitForStatus(sessionId, 'waiting', 60000);
+}
+
+/** Poll the board until the given session's card lands in the expected lane. */
+async function expectCardSettlesInLane(projectId: string, sessionId: string, laneName: string) {
+  await expect
+    .poll(async () => findLaneOfSession(await getBoard(projectId), sessionId), { timeout: 15000 })
+    .toBe(laneName);
 }
 
 // ============================================================
@@ -122,11 +178,16 @@ test.describe('Kanban lane completion move', () => {
   });
 
   // ----------------------------------------------------------------
-  // Test 1: configure + persist completion target through the UI
+  // Test 1: configure / change / clear the completion target through the UI
   // ----------------------------------------------------------------
-  test('configures and persists the completion target through the UI', async ({ page }) => {
+  test('configures, changes, and clears the completion target through the UI', async ({ page }) => {
     const board = await getBoard(project.id);
     const doneLane = getLaneByName(board, 'Done');
+    const reviewLane = getLaneByName(board, 'Review');
+    const otherLaneNames = board.lanes
+      .filter((l: any) => l.name !== 'In Progress')
+      .map((l: any) => l.name)
+      .sort();
 
     await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
       waitFor: '.kanban-board',
@@ -134,19 +195,16 @@ test.describe('Kanban lane completion move', () => {
 
     await openLaneSettings(page, 'In Progress');
 
-    // The select should list "do not move" plus every OTHER lane, but never
-    // the lane being configured.
-    const optionTexts = await page
-      .locator('#completion-target-lane-select option')
-      .allTextContents();
-    const trimmed = optionTexts.map((t) => t.trim());
-    expect(trimmed).toContain('Do not move automatically');
-    expect(trimmed).toContain('To Do');
-    expect(trimmed).toContain('Review');
-    expect(trimmed).toContain('Done');
-    expect(trimmed).not.toContain('In Progress');
+    // The select lists "do not move" + every OTHER lane, and never the lane
+    // being configured. Assert the exact set, not just a few members.
+    const optionTexts = (
+      await page.locator('#completion-target-lane-select option').allTextContents()
+    ).map((t) => t.trim());
+    expect(optionTexts[0]).toBe('Do not move automatically');
+    expect(optionTexts.slice(1).sort()).toEqual(otherLaneNames);
+    expect(optionTexts).not.toContain('In Progress');
 
-    // Configure the move to "Done" and save through the real API.
+    // (a) Configure the move to "Done" and save through the real API.
     await page.selectOption('#completion-target-lane-select', { label: 'Done' });
     await saveLaneSettings(page);
 
@@ -154,25 +212,47 @@ test.describe('Kanban lane completion move', () => {
     await page.reload();
     await expect(page.locator('.kanban-board')).toBeVisible();
     await openLaneSettings(page, 'In Progress');
-
-    const select = page.locator('#completion-target-lane-select');
-    await expect(select).toHaveValue(doneLane.id);
+    await expect(page.locator('#completion-target-lane-select')).toHaveValue(doneLane.id);
     await expect(page.locator('#completion-target-lane-select option:checked')).toHaveText('Done');
+    expect(getLaneByName(await getBoard(project.id), 'In Progress').completionTargetLaneId).toBe(
+      doneLane.id
+    );
+    await page.click('.modal-footer .btn-secondary'); // Cancel out
 
-    // Persisted server-side too.
-    const afterBoard = await getBoard(project.id);
-    const inProgress = getLaneByName(afterBoard, 'In Progress');
-    expect(inProgress.completionTargetLaneId).toBe(doneLane.id);
+    // (b) Change the target to a DIFFERENT lane ("Review") and confirm it updates.
+    await configureCompletionTarget(page, 'In Progress', 'Review');
+    await page.reload();
+    await expect(page.locator('.kanban-board')).toBeVisible();
+    await openLaneSettings(page, 'In Progress');
+    await expect(page.locator('#completion-target-lane-select')).toHaveValue(reviewLane.id);
+    expect(getLaneByName(await getBoard(project.id), 'In Progress').completionTargetLaneId).toBe(
+      reviewLane.id
+    );
+    await page.click('.modal-footer .btn-secondary');
+
+    // (c) Clear it back to "do not move" and confirm it persists as null.
+    await configureCompletionTarget(page, 'In Progress', 'Do not move automatically');
+    await page.reload();
+    await expect(page.locator('.kanban-board')).toBeVisible();
+    await openLaneSettings(page, 'In Progress');
+    await expect(page.locator('#completion-target-lane-select option:checked')).toHaveText(
+      'Do not move automatically'
+    );
+    expect(getLaneByName(await getBoard(project.id), 'In Progress').completionTargetLaneId).toBeNull();
   });
 
   // ----------------------------------------------------------------
-  // Test 2: clearing the completion target through the UI prevents auto move
+  // Test 2: clearing the completion target prevents an auto move — proven by a
+  // REAL session lifecycle so the completion hook actually runs and declines.
   // ----------------------------------------------------------------
-  test('clearing the completion target through the UI prevents auto move', async ({ page }) => {
-    const sessionName = 'Completion Clear Session';
+  test('clearing the completion target prevents auto move across a real session lifecycle', async ({
+    page,
+  }) => {
+    const sessionName = 'Completion Clear VCR Session';
     const session = await seedSession(project.id, {
-      prompt: 'Draft for clear test',
+      prompt: VCR_PROMPT,
       name: sessionName,
+      model: VCR_MODEL,
       startImmediately: false,
     });
 
@@ -180,46 +260,44 @@ test.describe('Kanban lane completion move', () => {
       waitFor: '.kanban-board',
     });
 
-    // First set a target...
-    await openLaneSettings(page, 'In Progress');
-    await page.selectOption('#completion-target-lane-select', { label: 'Done' });
-    await saveLaneSettings(page);
+    // First set a target, then clear it back to "do not move" — both via the UI.
+    await configureCompletionTarget(page, 'In Progress', 'Done');
+    await configureCompletionTarget(page, 'In Progress', 'Do not move automatically');
 
-    // ...then clear it back to "do not move".
-    await openLaneSettings(page, 'In Progress');
-    await page.selectOption('#completion-target-lane-select', { label: 'Do not move automatically' });
-    await saveLaneSettings(page);
+    // The cleared setting is persisted as null.
+    expect(getLaneByName(await getBoard(project.id), 'In Progress').completionTargetLaneId).toBeNull();
 
     // Add the draft to "In Progress" through the UI.
     await addSessionToLaneViaUI(page, 'In Progress', sessionName);
     await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
 
-    // The cleared setting is persisted as null.
-    const board = await getBoard(project.id);
-    const inProgress = getLaneByName(board, 'In Progress');
-    expect(inProgress.completionTargetLaneId).toBeNull();
+    // Run a REAL agent turn. The completion hook fires for this session, but with
+    // the target cleared it must leave the card exactly where it is.
+    await runSessionTurnViaUI(page, session.id);
 
-    // Simulate the session settling into the natural-completion status. With the
-    // target cleared, the card must stay put. (No LLM lifecycle is spent here.)
-    await fetch(`${API_URL}/api/sessions/${session.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: 'waiting' }),
+    // Give the completion hook (which runs just after status flips to 'waiting')
+    // time to run, then assert the card never moved — live and after reload.
+    await expect
+      .poll(async () => findLaneOfSession(await getBoard(project.id), session.id), { timeout: 8000 })
+      .toBe('In Progress');
+
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
     });
+    await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
+    await expect(cardInLane(page, 'Done', sessionName)).toHaveCount(0);
 
     await page.reload();
     await expect(page.locator('.kanban-board')).toBeVisible();
     await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
     await expect(cardInLane(page, 'Done', sessionName)).toHaveCount(0);
 
-    // And server-side the card never left "In Progress".
-    const afterBoard = await getBoard(project.id);
-    expect(findLaneOfSession(afterBoard, session.id)).toBe('In Progress');
+    // Server-side, the card never left "In Progress".
+    expect(findLaneOfSession(await getBoard(project.id), session.id)).toBe('In Progress');
   });
 
   // ----------------------------------------------------------------
-  // Test 3 (+ Test 4): a real session lifecycle moves the card via the
-  // completion hook, driven through the UI and replayed via VCR.
+  // Test 3: a real session lifecycle moves the card from source to target.
   // ----------------------------------------------------------------
   test('Session completion moves card from source lane to completion target', async ({ page }) => {
     const sessionName = 'Completion Move VCR Session';
@@ -238,34 +316,21 @@ test.describe('Kanban lane completion move', () => {
     });
 
     // Configure "In Progress" → "Done" on completion, through the UI.
-    await openLaneSettings(page, 'In Progress');
-    await page.selectOption('#completion-target-lane-select', { label: 'Done' });
-    await saveLaneSettings(page);
+    await configureCompletionTarget(page, 'In Progress', 'Done');
 
     // Add the draft session to "In Progress" through the UI.
     await addSessionToLaneViaUI(page, 'In Progress', sessionName);
     await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
 
     // Start the session via the visible chat input (no direct /message call).
-    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
-    await openSessionOverlay(page);
-    const textarea = page.locator('.input-form textarea');
-    await textarea.fill(VCR_PROMPT);
-    await page.locator('.btn-send-full').first().click();
-
-    // Wait for the agent turn to complete naturally (VCR replay → 'waiting').
-    await waitForStatus(session.id, 'waiting', 60000);
+    await runSessionTurnViaUI(page, session.id);
 
     // The completion hook runs right after the status flips to 'waiting', so
     // poll the API until the card lands in "Done" (avoids the status/hook race).
-    await expect
-      .poll(async () => findLaneOfSession(await getBoard(project.id), session.id), {
-        timeout: 15000,
-      })
-      .toBe('Done');
+    await expectCardSettlesInLane(project.id, session.id, 'Done');
 
     // Back on the board, the card is shown in "Done" and gone from "In Progress"
-    // — first live (no manual reload), then again after a reload (Test 4).
+    // — first live (no manual reload), then again after a reload.
     await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
       waitFor: '.kanban-board',
     });
@@ -277,11 +342,104 @@ test.describe('Kanban lane completion move', () => {
     await expect(cardInLane(page, 'Done', sessionName)).toBeVisible();
     await expect(cardInLane(page, 'In Progress', sessionName)).toHaveCount(0);
 
+    // "Done" has no on-enter automation, so no child session should be spawned.
+    expect(await countChildSessions(session.id, project.id)).toBe(0);
+
     // Final server-side verification.
     const finalBoard = await getBoard(project.id);
     const done = getLaneByName(finalBoard, 'Done');
     const card = done.cards.find((c: any) => (c.sessions || []).some((s: any) => s.id === session.id));
     expect(card).toBeTruthy();
     expect(card.laneId).toBe(doneLane.id);
+  });
+
+  // ----------------------------------------------------------------
+  // Test 4: completing into a destination lane with an on-enter CUSTOM PROMPT
+  // moves the card AND runs the automation (spawns a child session).
+  // ----------------------------------------------------------------
+  test('completion move runs the destination lane on-enter prompt (spawns child session)', async ({
+    page,
+  }) => {
+    const sessionName = 'Completion Prompt Parent';
+    const board = await getBoard(project.id);
+    const doneLane = getLaneByName(board, 'Done');
+
+    // Destination lane runs a custom prompt on entry (test setup via API).
+    // Reuse VCR_PROMPT so the spawned child also replays from the cassette.
+    await setLaneOnEnter(project.id, doneLane.id, { onEnterPrompt: VCR_PROMPT });
+
+    const session = await seedSession(project.id, {
+      prompt: VCR_PROMPT,
+      name: sessionName,
+      model: VCR_MODEL,
+      startImmediately: false,
+    });
+
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
+    });
+
+    await configureCompletionTarget(page, 'In Progress', 'Done');
+    await addSessionToLaneViaUI(page, 'In Progress', sessionName);
+    await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
+
+    await runSessionTurnViaUI(page, session.id);
+
+    // Card moves to Done...
+    await expectCardSettlesInLane(project.id, session.id, 'Done');
+
+    // ...and the on-enter prompt automation spawns a child session.
+    const child = await waitForChildSession(session.id, 15000);
+    expect(child).toBeTruthy();
+    expect(child.parentSessionId).toBe(session.id);
+    expect(child.name).toContain('Lane prompt (lane: Done)');
+  });
+
+  // ----------------------------------------------------------------
+  // Test 5: completing into a destination lane with an on-enter TEMPLATE moves
+  // the card AND runs the template (spawns a child session named after it).
+  // ----------------------------------------------------------------
+  test('completion move runs the destination lane on-enter template (spawns child session)', async ({
+    page,
+  }) => {
+    const sessionName = 'Completion Template Parent';
+    const board = await getBoard(project.id);
+    const doneLane = getLaneByName(board, 'Done');
+
+    // Seed a project template and attach it as the destination lane's on-enter
+    // automation. Reuse VCR_PROMPT so the spawned child replays from the cassette.
+    const template = await seedProjectTemplate(project.id, {
+      name: 'Completion Template',
+      prompt: VCR_PROMPT,
+      model: VCR_MODEL,
+    });
+    await setLaneOnEnter(project.id, doneLane.id, { onEnterTemplateId: template.id });
+
+    const session = await seedSession(project.id, {
+      prompt: VCR_PROMPT,
+      name: sessionName,
+      model: VCR_MODEL,
+      startImmediately: false,
+    });
+
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
+    });
+
+    await configureCompletionTarget(page, 'In Progress', 'Done');
+    await addSessionToLaneViaUI(page, 'In Progress', sessionName);
+    await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
+
+    await runSessionTurnViaUI(page, session.id);
+
+    // Card moves to Done...
+    await expectCardSettlesInLane(project.id, session.id, 'Done');
+
+    // ...and the on-enter template automation spawns a child session named after
+    // the template.
+    const child = await waitForChildSession(session.id, 15000);
+    expect(child).toBeTruthy();
+    expect(child.parentSessionId).toBe(session.id);
+    expect(child.name).toContain('Completion Template (lane: Done)');
   });
 });

--- a/tests/e2e/kanban-completion-move.spec.ts
+++ b/tests/e2e/kanban-completion-move.spec.ts
@@ -1,0 +1,287 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+import {
+  API_URL,
+  BASE_URL,
+  seedProject,
+  seedSession,
+  cleanupCreatedResources,
+  navigateAndWait,
+  openSessionOverlay,
+  waitForStatus,
+} from './helpers';
+
+/**
+ * UI-driven E2E coverage for the lane "On Completion" move feature.
+ *
+ * Implements the plan on the canvas (kanban-completion-move-e2e-plan.md):
+ *  - Test 1: configure + persist the completion target through the UI.
+ *  - Test 2: clearing the target through the UI prevents an auto move.
+ *  - Test 3 (+4 folded in): a real session lifecycle moves the card from the
+ *    source lane to the configured destination, exercised through the UI and
+ *    backed by the existing VCR cassette system (no Playwright route mocking).
+ *
+ * No REST mocking. The REST API is used only for seeding setup and for final
+ * state verification — every user-observable action (configuring the lane,
+ * adding the card, starting the session) happens through the UI.
+ */
+
+// ============================================================
+// Helpers (scoped to this spec)
+// ============================================================
+
+/**
+ * The completion-move lifecycle test (Test 3) starts a draft session through
+ * the chat input. To keep it deterministic and runnable in the default
+ * `VCR_MODE=replay`, it reuses the prompt of an already-committed cassette
+ * (runSession-ec0df80145f024e5.json). The cassette key is callType + a hash of
+ * this exact prompt, so the text MUST match byte-for-byte.
+ *
+ * If you ever change this prompt, re-record with:
+ *   VCR_MODE=record ./scripts/pw.sh test tests/e2e/kanban-completion-move.spec.ts \
+ *     --grep "Session completion moves card"
+ * and commit the new cassette under tests/e2e/cassettes/.
+ */
+const VCR_PROMPT = 'Claude E2E regression: reply with exactly "Claude E2E response."';
+const VCR_MODEL = 'claude-haiku-4-5-20251001';
+
+async function getBoard(projectId: string) {
+  const response = await fetch(`${API_URL}/api/projects/${projectId}/kanban`);
+  if (!response.ok) throw new Error(`Failed to fetch board: ${response.status}`);
+  return response.json();
+}
+
+function getLaneByName(board: any, name: string) {
+  return board.lanes.find((lane: any) => lane.name === name);
+}
+
+/** Return the name of the lane that currently holds the given session's card, or null. */
+function findLaneOfSession(board: any, sessionId: string): string | null {
+  for (const lane of board.lanes) {
+    for (const card of lane.cards || []) {
+      if ((card.sessions || []).some((s: any) => s.id === sessionId)) {
+        return lane.name;
+      }
+    }
+  }
+  return null;
+}
+
+/** Locate a kanban lane by its exact title (avoids matching card text). */
+function laneByTitle(page: Page, title: string): Locator {
+  return page.locator('.kanban-lane').filter({
+    has: page.locator('.lane-title', { hasText: new RegExp(`^${title}$`) }),
+  });
+}
+
+/** Locate a card (by session name) inside a specific lane. */
+function cardInLane(page: Page, laneTitle: string, sessionName: string): Locator {
+  return laneByTitle(page, laneTitle).locator('.kanban-card').filter({ hasText: sessionName });
+}
+
+async function openLaneSettings(page: Page, laneTitle: string) {
+  await laneByTitle(page, laneTitle).locator('.lane-settings-btn').click();
+  await expect(page.locator('.modal-content')).toBeVisible();
+  await expect(page.locator('#completion-target-lane-select')).toBeVisible();
+}
+
+async function saveLaneSettings(page: Page) {
+  await page.click('.modal-footer .btn-primary');
+  await expect(page.locator('.modal-backdrop')).toBeHidden({ timeout: 5000 });
+}
+
+/** Add a (draft) session to a lane via the lane's "Add Session" modal. */
+async function addSessionToLaneViaUI(page: Page, laneTitle: string, sessionName: string) {
+  await laneByTitle(page, laneTitle).locator('.add-session-btn').click();
+  await expect(page.locator('.modal-content')).toBeVisible();
+  await page.waitForSelector('.session-item', { timeout: 10000 });
+  await page.locator('.session-item').filter({ hasText: sessionName }).first().click();
+  await page.click('.modal-footer .btn-primary');
+  await expect(page.locator('.modal-backdrop')).toBeHidden({ timeout: 5000 });
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+test.describe('Kanban lane completion move', () => {
+  test.describe.configure({ timeout: 120000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+    project = await seedProject('Kanban Completion Move Test', '/tmp/test-kanban-completion', {
+      kanbanEnabled: true,
+    });
+    // Force board + default lanes to exist before the UI loads.
+    await getBoard(project.id);
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  // ----------------------------------------------------------------
+  // Test 1: configure + persist completion target through the UI
+  // ----------------------------------------------------------------
+  test('configures and persists the completion target through the UI', async ({ page }) => {
+    const board = await getBoard(project.id);
+    const doneLane = getLaneByName(board, 'Done');
+
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
+    });
+
+    await openLaneSettings(page, 'In Progress');
+
+    // The select should list "do not move" plus every OTHER lane, but never
+    // the lane being configured.
+    const optionTexts = await page
+      .locator('#completion-target-lane-select option')
+      .allTextContents();
+    const trimmed = optionTexts.map((t) => t.trim());
+    expect(trimmed).toContain('Do not move automatically');
+    expect(trimmed).toContain('To Do');
+    expect(trimmed).toContain('Review');
+    expect(trimmed).toContain('Done');
+    expect(trimmed).not.toContain('In Progress');
+
+    // Configure the move to "Done" and save through the real API.
+    await page.selectOption('#completion-target-lane-select', { label: 'Done' });
+    await saveLaneSettings(page);
+
+    // Survives a full reload + reopen.
+    await page.reload();
+    await expect(page.locator('.kanban-board')).toBeVisible();
+    await openLaneSettings(page, 'In Progress');
+
+    const select = page.locator('#completion-target-lane-select');
+    await expect(select).toHaveValue(doneLane.id);
+    await expect(page.locator('#completion-target-lane-select option:checked')).toHaveText('Done');
+
+    // Persisted server-side too.
+    const afterBoard = await getBoard(project.id);
+    const inProgress = getLaneByName(afterBoard, 'In Progress');
+    expect(inProgress.completionTargetLaneId).toBe(doneLane.id);
+  });
+
+  // ----------------------------------------------------------------
+  // Test 2: clearing the completion target through the UI prevents auto move
+  // ----------------------------------------------------------------
+  test('clearing the completion target through the UI prevents auto move', async ({ page }) => {
+    const sessionName = 'Completion Clear Session';
+    const session = await seedSession(project.id, {
+      prompt: 'Draft for clear test',
+      name: sessionName,
+      startImmediately: false,
+    });
+
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
+    });
+
+    // First set a target...
+    await openLaneSettings(page, 'In Progress');
+    await page.selectOption('#completion-target-lane-select', { label: 'Done' });
+    await saveLaneSettings(page);
+
+    // ...then clear it back to "do not move".
+    await openLaneSettings(page, 'In Progress');
+    await page.selectOption('#completion-target-lane-select', { label: 'Do not move automatically' });
+    await saveLaneSettings(page);
+
+    // Add the draft to "In Progress" through the UI.
+    await addSessionToLaneViaUI(page, 'In Progress', sessionName);
+    await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
+
+    // The cleared setting is persisted as null.
+    const board = await getBoard(project.id);
+    const inProgress = getLaneByName(board, 'In Progress');
+    expect(inProgress.completionTargetLaneId).toBeNull();
+
+    // Simulate the session settling into the natural-completion status. With the
+    // target cleared, the card must stay put. (No LLM lifecycle is spent here.)
+    await fetch(`${API_URL}/api/sessions/${session.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'waiting' }),
+    });
+
+    await page.reload();
+    await expect(page.locator('.kanban-board')).toBeVisible();
+    await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
+    await expect(cardInLane(page, 'Done', sessionName)).toHaveCount(0);
+
+    // And server-side the card never left "In Progress".
+    const afterBoard = await getBoard(project.id);
+    expect(findLaneOfSession(afterBoard, session.id)).toBe('In Progress');
+  });
+
+  // ----------------------------------------------------------------
+  // Test 3 (+ Test 4): a real session lifecycle moves the card via the
+  // completion hook, driven through the UI and replayed via VCR.
+  // ----------------------------------------------------------------
+  test('Session completion moves card from source lane to completion target', async ({ page }) => {
+    const sessionName = 'Completion Move VCR Session';
+    const board = await getBoard(project.id);
+    const doneLane = getLaneByName(board, 'Done');
+
+    const session = await seedSession(project.id, {
+      prompt: VCR_PROMPT,
+      name: sessionName,
+      model: VCR_MODEL,
+      startImmediately: false,
+    });
+
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
+    });
+
+    // Configure "In Progress" → "Done" on completion, through the UI.
+    await openLaneSettings(page, 'In Progress');
+    await page.selectOption('#completion-target-lane-select', { label: 'Done' });
+    await saveLaneSettings(page);
+
+    // Add the draft session to "In Progress" through the UI.
+    await addSessionToLaneViaUI(page, 'In Progress', sessionName);
+    await expect(cardInLane(page, 'In Progress', sessionName)).toBeVisible();
+
+    // Start the session via the visible chat input (no direct /message call).
+    await navigateAndWait(page, `${BASE_URL}/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
+    const textarea = page.locator('.input-form textarea');
+    await textarea.fill(VCR_PROMPT);
+    await page.locator('.btn-send-full').first().click();
+
+    // Wait for the agent turn to complete naturally (VCR replay → 'waiting').
+    await waitForStatus(session.id, 'waiting', 60000);
+
+    // The completion hook runs right after the status flips to 'waiting', so
+    // poll the API until the card lands in "Done" (avoids the status/hook race).
+    await expect
+      .poll(async () => findLaneOfSession(await getBoard(project.id), session.id), {
+        timeout: 15000,
+      })
+      .toBe('Done');
+
+    // Back on the board, the card is shown in "Done" and gone from "In Progress"
+    // — first live (no manual reload), then again after a reload (Test 4).
+    await navigateAndWait(page, `${BASE_URL}/projects/${project.id}/kanban`, {
+      waitFor: '.kanban-board',
+    });
+    await expect(cardInLane(page, 'Done', sessionName)).toBeVisible({ timeout: 15000 });
+    await expect(cardInLane(page, 'In Progress', sessionName)).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.locator('.kanban-board')).toBeVisible();
+    await expect(cardInLane(page, 'Done', sessionName)).toBeVisible();
+    await expect(cardInLane(page, 'In Progress', sessionName)).toHaveCount(0);
+
+    // Final server-side verification.
+    const finalBoard = await getBoard(project.id);
+    const done = getLaneByName(finalBoard, 'Done');
+    const card = done.cards.find((c: any) => (c.sessions || []).some((s: any) => s.id === session.id));
+    expect(card).toBeTruthy();
+    expect(card.laneId).toBe(doneLane.id);
+  });
+});


### PR DESCRIPTION
## Summary
- add lane-level completion destination persistence and API validation
- move completed sessions to the configured lane after turn completion
- expose the setting in the lane settings modal with focused coverage

## Tests
- yarn workspace @circuschief/shared vitest run src/contracts/kanban.test.js
- yarn workspace @circuschief/server vitest run src/db/KanbanLaneRepository.test.js src/db/schemaBaseline.test.js src/api/kanban.test.js src/services/kanbanService.test.js
- yarn workspace @circuschief/web vitest run src/components/LaneSettingsModal.test.js