### PR TITLE
Add git status visibility to session detail view

### DIFF
--- a/packages/server/src/api/sessions.gitStatus.test.js
+++ b/packages/server/src/api/sessions.gitStatus.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { projects, sessions } from '../database.js';
+
+vi.mock('../services/gitService.js', () => ({
+  getSessionGitStatus: vi.fn(),
+}));
+
+import sessionsRouter from './sessions.js';
+import * as gitService from '../services/gitService.js';
+
+describe('Sessions API - Git Status Endpoint', () => {
+  let app;
+  let project;
+  let session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/sessions', sessionsRouter);
+
+    project = projects.create('Test Project', '/tmp/test-repo');
+    session = sessions.create(project.id, 'Test Session', 'Test prompt');
+  });
+
+  it('returns git status for the project working directory', async () => {
+    gitService.getSessionGitStatus.mockResolvedValue({
+      currentBranch: 'feature',
+      upstreamBranch: 'origin/feature',
+      hasUpstream: true,
+      localChangeCount: 0,
+      aheadCount: 0,
+      behindCount: 0,
+      syncStatus: 'clean',
+      fetched: false,
+    });
+
+    const res = await request(app)
+      .get(`/api/sessions/${session.id}/git-status`)
+      .expect(200);
+
+    expect(gitService.getSessionGitStatus).toHaveBeenCalledWith('/tmp/test-repo', { fetch: false });
+    expect(res.body.workingDirectory).toBe('/tmp/test-repo');
+    expect(res.body.syncStatus).toBe('clean');
+  });
+
+  it('passes fetch=true when requested', async () => {
+    gitService.getSessionGitStatus.mockResolvedValue({ syncStatus: 'behind', fetched: true });
+
+    await request(app)
+      .get(`/api/sessions/${session.id}/git-status?fetch=true`)
+      .expect(200);
+
+    expect(gitService.getSessionGitStatus).toHaveBeenCalledWith('/tmp/test-repo', { fetch: true });
+  });
+
+  it('uses the session worktree when available', async () => {
+    sessions.update(session.id, { gitWorktree: '/tmp/session-worktree' });
+    gitService.getSessionGitStatus.mockResolvedValue({ syncStatus: 'clean', fetched: false });
+
+    const res = await request(app)
+      .get(`/api/sessions/${session.id}/git-status`)
+      .expect(200);
+
+    expect(gitService.getSessionGitStatus).toHaveBeenCalledWith('/tmp/session-worktree', { fetch: false });
+    expect(res.body.workingDirectory).toBe('/tmp/session-worktree');
+  });
+
+  it('returns a controlled error when git status fails', async () => {
+    gitService.getSessionGitStatus.mockRejectedValue(new Error('Not a git repository'));
+
+    const res = await request(app)
+      .get(`/api/sessions/${session.id}/git-status`)
+      .expect(500);
+
+    expect(res.body.error).toBe('Not a git repository');
+  });
+});

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -234,6 +234,23 @@ router.get('/:id/default-branch', requireSessionAndProject, async (req, res) => 
   }
 });
 
+// GET /api/sessions/:id/git-status - Get compact upstream/local git status
+// Query params:
+//   fetch: 'true' to fetch origin before computing status
+router.get('/:id/git-status', requireSessionAndProject, async (req, res) => {
+  try {
+    const status = await gitService.getSessionGitStatus(req.workingDirectory, {
+      fetch: req.query.fetch === 'true',
+    });
+    res.json({
+      workingDirectory: req.workingDirectory,
+      ...status,
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // GET /api/sessions/:id/files-count - Get count of modified files
 // Uses a 60-second TTL cache to avoid expensive git operations on every request
 router.get('/:id/files-count', requireSession, async (req, res) => {

--- a/packages/server/src/services/gitService.js
+++ b/packages/server/src/services/gitService.js
@@ -251,6 +251,126 @@ export async function getCurrentBranch(directory) {
 }
 
 /**
+ * Get the configured upstream branch for HEAD.
+ * @param {string} directory
+ * @returns {Promise<string|null>}
+ */
+export async function getBranchUpstream(directory) {
+  try {
+    return await git(directory, 'rev-parse --abbrev-ref --symbolic-full-name @{u}');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get ahead/behind counts relative to an upstream branch.
+ * @param {string} directory
+ * @param {string} upstreamBranch
+ * @returns {Promise<{aheadCount: number, behindCount: number}>}
+ */
+export async function getAheadBehindCounts(directory, upstreamBranch) {
+  const output = await git(directory, `rev-list --left-right --count ${shellQuote(upstreamBranch)}...HEAD`);
+  const [behindRaw = '0', aheadRaw = '0'] = output.split(/\s+/);
+  return {
+    behindCount: Number.parseInt(behindRaw, 10) || 0,
+    aheadCount: Number.parseInt(aheadRaw, 10) || 0,
+  };
+}
+
+function parsePorcelainPath(line) {
+  const rawPath = line.slice(3).trim();
+  if (!rawPath) return null;
+
+  const renameSeparator = ' -> ';
+  if (rawPath.includes(renameSeparator)) {
+    return rawPath.split(renameSeparator).pop();
+  }
+
+  return rawPath;
+}
+
+/**
+ * Count unique paths with uncommitted local changes.
+ * @param {string} directory
+ * @returns {Promise<number>}
+ */
+export async function getLocalChangeCount(directory) {
+  const output = await git(directory, 'status --porcelain=v1');
+  if (!output) return 0;
+
+  const paths = new Set();
+  for (const line of output.split('\n')) {
+    const path = parsePorcelainPath(line);
+    if (path) paths.add(path);
+  }
+  return paths.size;
+}
+
+/**
+ * Fetch origin with pruning. Intended for explicit user refreshes, not polling.
+ * @param {string} directory
+ * @returns {Promise<void>}
+ */
+export async function fetchOrigin(directory) {
+  await git(directory, 'fetch origin --prune', { timeout: 10_000 });
+}
+
+function computeSyncStatus({ currentBranch, upstreamBranch, aheadCount, behindCount, localChangeCount }) {
+  if (!currentBranch) return 'unknown';
+  if (!upstreamBranch) return 'unpublished';
+  if (aheadCount > 0 && behindCount > 0) return 'diverged';
+  if (behindCount > 0) return 'behind';
+  if (aheadCount > 0) return 'ahead';
+  if (localChangeCount > 0) return 'dirty';
+  return 'clean';
+}
+
+/**
+ * Get compact Git repository status for a session worktree.
+ * @param {string} directory
+ * @param {Object} [options]
+ * @param {boolean} [options.fetch=false]
+ * @returns {Promise<Object>}
+ */
+export async function getSessionGitStatus(directory, options = {}) {
+  const fetched = options.fetch === true;
+  if (fetched) {
+    await fetchOrigin(directory);
+  }
+
+  const currentBranch = await getCurrentBranch(directory);
+  const localChangeCount = await getLocalChangeCount(directory);
+  const upstreamBranch = currentBranch ? await getBranchUpstream(directory) : null;
+  const counts = upstreamBranch
+    ? await getAheadBehindCounts(directory, upstreamBranch)
+    : { aheadCount: 0, behindCount: 0 };
+  const syncStatus = computeSyncStatus({
+    currentBranch,
+    upstreamBranch,
+    aheadCount: counts.aheadCount,
+    behindCount: counts.behindCount,
+    localChangeCount,
+  });
+
+  return {
+    currentBranch,
+    upstreamBranch,
+    hasUpstream: Boolean(upstreamBranch),
+    hasUncommittedChanges: localChangeCount > 0,
+    localChangeCount,
+    aheadCount: counts.aheadCount,
+    behindCount: counts.behindCount,
+    isDiverged: counts.aheadCount > 0 && counts.behindCount > 0,
+    isUnpushed: counts.aheadCount > 0 || syncStatus === 'unpublished',
+    isBehind: counts.behindCount > 0,
+    syncStatus,
+    lastCheckedAt: new Date().toISOString(),
+    fetched,
+  };
+}
+
+/**
  * Get the git author info from the global config (~/.gitconfig).
  * Uses `--global` so that a contaminated local config is bypassed.
  * @param {string} directory

--- a/packages/server/src/services/gitService.test.js
+++ b/packages/server/src/services/gitService.test.js
@@ -13,12 +13,17 @@ import {
   createWorktree,
   createWorktreeForBranch,
   detectWorktreePath,
+  fetchOrigin,
+  getAheadBehindCounts,
+  getBranchUpstream,
   getCacheSize,
   getCurrentBranch,
   getGitAuthor,
+  getLocalChangeCount,
   getManagedHooksPath,
   getOriginDefaultBranch,
   getRepositoryUrl,
+  getSessionGitStatus,
   getUntrackedFiles,
   git,
   ensureWorktreeCommitAttributionHook,
@@ -1292,6 +1297,110 @@ describe('gitService', () => {
 
       // Clean up worktree before the shared afterEach deletes testDir
       execSync(`git worktree remove --force "${worktreePath}"`, { cwd: testDir });
+    });
+  });
+
+  describe('session git status helpers', () => {
+    async function commitFile(directory, filename, content, message) {
+      await writeFile(join(directory, filename), content);
+      execSync(`git add "${filename}"`, { cwd: directory });
+      execSync(`git commit -m "${message}"`, { cwd: directory });
+    }
+
+    async function cloneOrigin() {
+      const cloneDir = await mkdtemp(join(tmpdir(), 'git-clone-'));
+      execSync(`git clone "${bareRepoDir}" "${cloneDir}"`);
+      execSync('git config user.email "other@test.com"', { cwd: cloneDir });
+      execSync('git config user.name "Other"', { cwd: cloneDir });
+      return cloneDir;
+    }
+
+    it('reports a clean branch with upstream', async () => {
+      const status = await getSessionGitStatus(testDir);
+
+      expect(status.syncStatus).toBe('clean');
+      expect(status.hasUpstream).toBe(true);
+      expect(status.aheadCount).toBe(0);
+      expect(status.behindCount).toBe(0);
+      expect(status.localChangeCount).toBe(0);
+    });
+
+    it('counts unique local changed paths including renames', async () => {
+      execSync('git mv README.md README-renamed.md', { cwd: testDir });
+      await writeFile(join(testDir, 'new-file.txt'), 'new');
+
+      const count = await getLocalChangeCount(testDir);
+      const status = await getSessionGitStatus(testDir);
+
+      expect(count).toBe(2);
+      expect(status.syncStatus).toBe('dirty');
+      expect(status.hasUncommittedChanges).toBe(true);
+    });
+
+    it('reports ahead commits', async () => {
+      await commitFile(testDir, 'ahead.txt', 'ahead', 'Ahead');
+
+      const status = await getSessionGitStatus(testDir);
+
+      expect(status.syncStatus).toBe('ahead');
+      expect(status.aheadCount).toBe(1);
+      expect(status.isUnpushed).toBe(true);
+    });
+
+    it('reports behind commits after fetching remote refs', async () => {
+      const cloneDir = await cloneOrigin();
+      try {
+        await commitFile(cloneDir, 'remote.txt', 'remote', 'Remote');
+        execSync('git push', { cwd: cloneDir });
+        await fetchOrigin(testDir);
+
+        const status = await getSessionGitStatus(testDir);
+
+        expect(status.syncStatus).toBe('behind');
+        expect(status.behindCount).toBe(1);
+        expect(status.isBehind).toBe(true);
+      } finally {
+        await rm(cloneDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports diverged branches', async () => {
+      const cloneDir = await cloneOrigin();
+      try {
+        await commitFile(cloneDir, 'remote.txt', 'remote', 'Remote');
+        execSync('git push', { cwd: cloneDir });
+        await fetchOrigin(testDir);
+        await commitFile(testDir, 'local.txt', 'local', 'Local');
+
+        const counts = await getAheadBehindCounts(testDir, await getBranchUpstream(testDir));
+        const status = await getSessionGitStatus(testDir);
+
+        expect(counts).toEqual({ behindCount: 1, aheadCount: 1 });
+        expect(status.syncStatus).toBe('diverged');
+        expect(status.isDiverged).toBe(true);
+      } finally {
+        await rm(cloneDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports branches without upstream as unpublished', async () => {
+      execSync('git checkout -b no-upstream', { cwd: testDir });
+
+      const status = await getSessionGitStatus(testDir);
+
+      expect(status.syncStatus).toBe('unpublished');
+      expect(status.upstreamBranch).toBeNull();
+      expect(status.hasUpstream).toBe(false);
+    });
+
+    it('reports detached HEAD as unknown', async () => {
+      const head = execSync('git rev-parse HEAD', { cwd: testDir }).toString().trim();
+      execSync(`git checkout ${head}`, { cwd: testDir });
+
+      const status = await getSessionGitStatus(testDir);
+
+      expect(status.currentBranch).toBeNull();
+      expect(status.syncStatus).toBe('unknown');
     });
   });
 });

--- a/packages/web/src/api/resources/SessionsApi.js
+++ b/packages/web/src/api/resources/SessionsApi.js
@@ -221,6 +221,21 @@ export function SessionsApi(ApiClient) {
     },
 
     /**
+     * Get compact git status for a session.
+     * @param {string} sessionId
+     * @param {Object} [options]
+     * @param {boolean} [options.fetch=false] - Fetch origin before computing status
+     * @returns {Promise<Object>}
+     */
+    async getSessionGitStatus(sessionId, options = {}) {
+      const params = {};
+      if (options.fetch === true) {
+        params.fetch = true;
+      }
+      return this._get(this._buildQueryPath(`/sessions/${sessionId}/git-status`, params));
+    },
+
+    /**
      * Get count of files modified compared to the default branch
      * @param {string} sessionId - Session ID
      * @returns {Promise<{count: number}>}

--- a/packages/web/src/api/resources/SessionsApi.test.js
+++ b/packages/web/src/api/resources/SessionsApi.test.js
@@ -33,6 +33,24 @@ describe('SessionsApi', () => {
     });
   });
 
+  describe('getSessionGitStatus', () => {
+    it('fetches git status without fetch by default', async () => {
+      mockFetch.mockReturnValue(mockResponse({ syncStatus: 'clean' }));
+
+      await client.getSessionGitStatus('sess-123');
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/sessions/sess-123/git-status', expect.any(Object));
+    });
+
+    it('adds fetch=true only when requested', async () => {
+      mockFetch.mockReturnValue(mockResponse({ syncStatus: 'behind', fetched: true }));
+
+      await client.getSessionGitStatus('sess-123', { fetch: true });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/sessions/sess-123/git-status?fetch=true', expect.any(Object));
+    });
+  });
+
   describe('getProjectSessions', () => {
     it('fetches sessions for project without filters', async () => {
       mockFetch.mockReturnValue(mockResponse([]));

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -16,6 +16,14 @@
     </div>
 
     <template v-else>
+      <GitStatusSummary
+        :status="gitStatus"
+        :summary-text="gitStatusSummary"
+        :loading="gitStatusLoading"
+        :error="gitStatusError"
+        @refresh-origin="handleRefreshOrigin"
+      />
+
       <!-- Toolbar: Show when there are changes OR a default branch exists -->
       <div
         v-if="hasChanges || defaultBranch"
@@ -159,12 +167,18 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { api } from '../api/ApiClient.js';
 import { parseDiff } from '../utils/diffParser.js';
 import DiffViewer from './DiffViewer.vue';
+import GitStatusSummary from './GitStatusSummary.vue';
 
 const props = defineProps({
   sessionId: { type: String, required: true },
+  gitStatus: { type: Object, default: null },
+  gitStatusSummary: { type: String, default: 'Git status unknown' },
+  gitStatusLoading: { type: Boolean, default: false },
+  gitStatusError: { type: [Object, String], default: null },
+  refreshGitStatus: { type: Function, default: null },
 });
 
-const emit = defineEmits(['update:fileCount']);
+const emit = defineEmits(['update:fileCount', 'refreshGitStatus']);
 
 const branchDiff = ref('');
 const staged = ref('');
@@ -346,6 +360,14 @@ async function fetchChanges() {
   } finally {
     loading.value = false;
   }
+}
+
+async function handleRefreshOrigin() {
+  emit('refreshGitStatus');
+  if (props.refreshGitStatus) {
+    await props.refreshGitStatus({ fetch: true });
+  }
+  await fetchChanges();
 }
 
 // Fetch the default branch for comparison

--- a/packages/web/src/components/GitStatusChip.test.js
+++ b/packages/web/src/components/GitStatusChip.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import GitStatusChip from './GitStatusChip.vue';
+
+describe('GitStatusChip', () => {
+  let router;
+
+  beforeEach(async () => {
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/sessions/:id/:tab?', component: { template: '<div />' } }],
+    });
+    await router.push('/sessions/sess-1/summary');
+    await router.isReady();
+  });
+
+  it('renders actionable status styling', () => {
+    const wrapper = mount(GitStatusChip, {
+      global: { plugins: [router] },
+      props: {
+        sessionId: 'sess-1',
+        summaryText: '2 unpushed commits',
+        hasActionableStatus: true,
+      },
+    });
+
+    expect(wrapper.text()).toContain('2 unpushed commits');
+    expect(wrapper.classes()).toContain('is-actionable');
+  });
+
+  it('navigates to the Changes tab on click', async () => {
+    const pushSpy = vi.spyOn(router, 'push');
+    const wrapper = mount(GitStatusChip, {
+      global: { plugins: [router] },
+      props: { sessionId: 'sess-1', summaryText: 'Git clean' },
+    });
+
+    await wrapper.trigger('click');
+
+    expect(pushSpy).toHaveBeenCalledWith('/sessions/sess-1/changes');
+  });
+});

--- a/packages/web/src/components/GitStatusChip.vue
+++ b/packages/web/src/components/GitStatusChip.vue
@@ -1,0 +1,102 @@
+<template>
+  <button
+    type="button"
+    class="git-status-chip"
+    :class="{
+      'is-actionable': hasActionableStatus,
+      'is-loading': loading,
+      'is-unknown': error && !hasActionableStatus,
+    }"
+    :title="summaryText"
+    @click="goToChanges"
+  >
+    <span
+      class="git-status-dot"
+      aria-hidden="true"
+    />
+    <span class="git-status-text">{{ displayText }}</span>
+  </button>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+
+const props = defineProps({
+  sessionId: { type: String, required: true },
+  summaryText: { type: String, default: 'Git status unknown' },
+  loading: { type: Boolean, default: false },
+  error: { type: [Object, String], default: null },
+  hasActionableStatus: { type: Boolean, default: false },
+});
+
+const router = useRouter();
+
+const displayText = computed(() => {
+  if (props.loading && !props.summaryText) return 'Checking Git...';
+  return props.summaryText || 'Git status unknown';
+});
+
+function goToChanges() {
+  router.push(`/sessions/${props.sessionId}/changes`);
+}
+</script>
+
+<style scoped>
+.git-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-height: 1.5rem;
+  max-width: min(100%, 28rem);
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg-soft, rgba(255, 255, 255, 0.05));
+  color: var(--color-text-soft);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  line-height: 1;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.git-status-chip:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text, #e0e0e0);
+}
+
+.git-status-chip.is-actionable {
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
+}
+
+.git-status-chip.is-unknown {
+  border-color: rgba(156, 163, 175, 0.35);
+}
+
+.git-status-dot {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.65;
+  flex-shrink: 0;
+}
+
+.git-status-chip.is-loading .git-status-dot {
+  animation: git-status-pulse 1s ease-in-out infinite;
+}
+
+.git-status-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes git-status-pulse {
+  50% { opacity: 0.3; }
+}
+</style>

--- a/packages/web/src/components/GitStatusSummary.test.js
+++ b/packages/web/src/components/GitStatusSummary.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import GitStatusSummary from './GitStatusSummary.vue';
+
+describe('GitStatusSummary', () => {
+  it('renders status copy, branch mapping, and refresh event', async () => {
+    const onRefreshOrigin = vi.fn();
+    const wrapper = mount(GitStatusSummary, {
+      props: {
+        status: {
+          currentBranch: 'feature/session-detail',
+          upstreamBranch: 'origin/feature/session-detail',
+          lastCheckedAt: '2026-06-05T18:12:30.000Z',
+          localChangeCount: 3,
+        },
+        summaryText: '3 local files',
+        onRefreshOrigin,
+      },
+    });
+
+    expect(wrapper.text()).toContain('Git attention');
+    expect(wrapper.text()).toContain('3 local files');
+    expect(wrapper.text()).toContain('feature/session-detail -> origin/feature/session-detail');
+
+    const button = wrapper.find('.refresh-origin-button');
+    expect(button.exists()).toBe(true);
+    expect(button.attributes('disabled')).toBeUndefined();
+    await button.trigger('click');
+
+    expect(onRefreshOrigin).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders inline error text', () => {
+    const wrapper = mount(GitStatusSummary, {
+      props: {
+        summaryText: 'Git status unknown',
+        error: new Error('Not a git repository'),
+      },
+    });
+
+    expect(wrapper.text()).toContain('Not a git repository');
+  });
+});

--- a/packages/web/src/components/GitStatusSummary.vue
+++ b/packages/web/src/components/GitStatusSummary.vue
@@ -1,0 +1,163 @@
+<template>
+  <section
+    class="git-status-summary"
+    :class="{ 'is-muted': !hasAttention }"
+  >
+    <div class="git-status-copy">
+      <div class="git-status-title">
+        {{ title }}
+      </div>
+      <div class="git-status-counts">
+        {{ summaryText }}
+      </div>
+      <div
+        v-if="branchMapping"
+        class="git-status-branch"
+      >
+        {{ branchMapping }}
+      </div>
+      <div
+        v-if="lastCheckedText"
+        class="git-status-checked"
+      >
+        Last checked {{ lastCheckedText }}
+      </div>
+      <div
+        v-if="error"
+        class="git-status-error"
+      >
+        {{ errorMessage }}
+      </div>
+    </div>
+    <button
+      type="button"
+      class="btn-secondary refresh-origin-button"
+      :disabled="loading"
+      @click="refreshOrigin"
+    >
+      <span
+        v-if="loading"
+        class="loading-spinner"
+      />
+      Refresh from origin
+    </button>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  status: { type: Object, default: null },
+  summaryText: { type: String, default: 'Git status unknown' },
+  loading: { type: Boolean, default: false },
+  error: { type: [Object, String], default: null },
+});
+
+const emit = defineEmits(['refreshOrigin']);
+
+function refreshOrigin() {
+  emit('refreshOrigin');
+}
+
+const hasAttention = computed(() => {
+  const status = props.status;
+  return Boolean(
+    props.error ||
+    status?.localChangeCount > 0 ||
+    status?.aheadCount > 0 ||
+    status?.behindCount > 0 ||
+    status?.syncStatus === 'unpublished'
+  );
+});
+
+const title = computed(() => hasAttention.value ? 'Git attention' : 'Git status');
+
+const branchMapping = computed(() => {
+  if (!props.status?.currentBranch) return null;
+  if (!props.status.upstreamBranch) return `${props.status.currentBranch} has no upstream`;
+  return `${props.status.currentBranch} -> ${props.status.upstreamBranch}`;
+});
+
+const lastCheckedText = computed(() => {
+  if (!props.status?.lastCheckedAt) return null;
+  return new Date(props.status.lastCheckedAt).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+});
+
+const errorMessage = computed(() => {
+  if (!props.error) return null;
+  return typeof props.error === 'string' ? props.error : props.error.message || 'Git status lookup failed';
+});
+</script>
+
+<style scoped>
+.git-status-summary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  border-radius: 6px;
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.git-status-summary.is-muted {
+  border-color: var(--color-border);
+  background: var(--color-bg-soft, rgba(255, 255, 255, 0.04));
+}
+
+.git-status-copy {
+  min-width: 0;
+}
+
+.git-status-title {
+  color: var(--color-text, #e0e0e0);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.git-status-counts {
+  margin-top: 0.25rem;
+  color: var(--color-text, #e0e0e0);
+  font-size: 0.8125rem;
+}
+
+.git-status-branch,
+.git-status-checked {
+  margin-top: 0.25rem;
+  color: var(--color-text-soft, #9ca3af);
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.git-status-error {
+  margin-top: 0.375rem;
+  color: var(--color-error, #f87171);
+  font-size: 0.75rem;
+}
+
+.refresh-origin-button {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .git-status-summary {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .refresh-origin-button {
+    width: 100%;
+  }
+}
+</style>

--- a/packages/web/src/components/SessionHeaderPanel.vue
+++ b/packages/web/src/components/SessionHeaderPanel.vue
@@ -240,6 +240,13 @@
           </svg>
           {{ sessionLane.name }}
         </button>
+        <GitStatusChip
+          :session-id="sessionId"
+          :summary-text="gitStatusSummary"
+          :loading="gitStatusLoading"
+          :error="gitStatusError"
+          :has-actionable-status="hasActionableGitStatus"
+        />
         <PrUrlEditor
           :session-id="sessionId"
           :pr-url="session.prUrl"
@@ -274,6 +281,7 @@ import OverflowMenu from './OverflowMenu.vue';
 import PrUrlEditor from './PrUrlEditor.vue';
 import CommandButtonStatusBar from './CommandButtonStatusBar.vue';
 import MoveCardModal from './MoveCardModal.vue';
+import GitStatusChip from './GitStatusChip.vue';
 import { useUiStore } from '../stores/ui.js';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useKanbanStore } from '../stores/kanban.js';
@@ -305,6 +313,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  gitStatusSummary: { type: String, default: 'Git status unknown' },
+  gitStatusLoading: { type: Boolean, default: false },
+  gitStatusError: { type: [Object, String], default: null },
+  hasActionableGitStatus: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['duplicate', 'copySessionId', 'archive', 'delete', 'star']);

--- a/packages/web/src/components/SessionTabsPanel.test.js
+++ b/packages/web/src/components/SessionTabsPanel.test.js
@@ -123,6 +123,17 @@ describe('SessionTabsPanel', () => {
       const wrapper = mountPanel({ hasChanges: false });
       expect(wrapper.find('.changes-indicator').exists()).toBe(false);
     });
+
+    it('shows changes indicator when git status has a warning', () => {
+      const wrapper = mountPanel({
+        hasChanges: false,
+        hasGitStatusWarning: true,
+        gitStatusTitle: '2 unpushed commits',
+      });
+      const indicator = wrapper.find('.changes-indicator');
+      expect(indicator.exists()).toBe(true);
+      expect(indicator.attributes('title')).toBe('2 unpushed commits');
+    });
   });
 
   describe('canvas indicator', () => {
@@ -194,6 +205,12 @@ describe('SessionTabsPanel', () => {
       const wrapper = mountPanel({ hasChanges: true });
       const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Changes'));
       expect(option.text()).toContain('\u2022');
+    });
+
+    it('shows git attention text for changes in mobile', () => {
+      const wrapper = mountPanel({ hasGitStatusWarning: true });
+      const option = wrapper.findAll('.tab-select option').find(o => o.text().includes('Changes'));
+      expect(option.text()).toContain('Changes · Git attention');
     });
 
     it('shows dot indicator for canvas items in mobile', () => {

--- a/packages/web/src/components/SessionTabsPanel.vue
+++ b/packages/web/src/components/SessionTabsPanel.vue
@@ -98,9 +98,9 @@
             :title="sessionStatus === 'starting' ? 'Session starting...' : 'Session running...'"
           />
           <span
-            v-if="tab.id === 'changes' && hasChanges"
+            v-if="tab.id === 'changes' && hasChangesAttention"
             class="changes-indicator"
-            title="Uncommitted changes"
+            :title="gitStatusTitle || 'Uncommitted changes'"
           />
           <span
             v-if="tab.id === 'canvas' && canvasCount > 0"
@@ -123,7 +123,7 @@
           :key="tab.id"
           :value="tab.id"
         >
-          {{ tab.label }}{{ tab.id === 'changes' && hasChanges ? ' \u2022' : '' }}{{ tab.id === 'canvas' && canvasCount > 0 ? ' \u2022' : '' }}
+          {{ mobileTabLabel(tab) }}{{ tab.id === 'canvas' && canvasCount > 0 ? ' \u2022' : '' }}
         </option>
       </select>
     </div>
@@ -175,11 +175,27 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  hasGitStatusWarning: {
+    type: Boolean,
+    default: false,
+  },
+  gitStatusTitle: {
+    type: String,
+    default: '',
+  },
 });
 
 const router = useRouter();
 
 const mobileTabs = computed(() => props.tabs.filter(tab => tab.desktopOnly !== true));
+const hasChangesAttention = computed(() => props.hasGitStatusWarning || props.hasChanges);
+
+function mobileTabLabel(tab) {
+  if (tab.id !== 'changes') return tab.label;
+  if (props.hasGitStatusWarning) return `${tab.label} · Git attention`;
+  if (props.hasChanges) return `${tab.label} \u2022`;
+  return tab.label;
+}
 
 function navigateToTab(tabId) {
   router.push(`/sessions/${props.sessionId}/${tabId}`);

--- a/packages/web/src/composables/useSessionGitStatus.js
+++ b/packages/web/src/composables/useSessionGitStatus.js
@@ -1,0 +1,117 @@
+import { computed, ref } from 'vue';
+import { api } from './useApi.js';
+
+function pluralize(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function buildFragments(status) {
+  if (!status) return [];
+
+  const fragments = [];
+  if (status.localChangeCount > 0) {
+    fragments.push(pluralize(status.localChangeCount, 'local file'));
+  }
+  if (status.aheadCount > 0) {
+    fragments.push(pluralize(status.aheadCount, 'unpushed commit'));
+  }
+  if (status.behindCount > 0) {
+    fragments.push(`${pluralize(status.behindCount, 'commit')} to pull`);
+  }
+  if (status.syncStatus === 'unpublished') {
+    fragments.push('Branch not pushed');
+  }
+  return fragments;
+}
+
+function hasUsableStatus(status) {
+  return status && status.syncStatus !== 'unknown';
+}
+
+export function formatGitStatusSummary(status, fallback = 'Git status unknown') {
+  if (!status) return fallback;
+  const fragments = buildFragments(status);
+  if (fragments.length > 0) return fragments.join(' · ');
+  if (status.syncStatus === 'clean') return 'Git clean';
+  return fallback;
+}
+
+export function useSessionGitStatus({ getSessionId }) {
+  const gitStatus = ref(null);
+  const loading = ref(false);
+  const error = ref(null);
+  let requestToken = 0;
+
+  const hasActionableGitStatus = computed(() => {
+    if (hasUsableStatus(gitStatus.value)) {
+      return (
+        gitStatus.value.localChangeCount > 0 ||
+        gitStatus.value.aheadCount > 0 ||
+        gitStatus.value.behindCount > 0 ||
+        gitStatus.value.syncStatus === 'unpublished'
+      );
+    }
+    return Boolean(error.value);
+  });
+
+  const summaryText = computed(() => {
+    if (error.value && !gitStatus.value) return 'Git status unknown';
+    return formatGitStatusSummary(gitStatus.value, loading.value ? 'Checking Git...' : 'Git status unknown');
+  });
+
+  const shortSummaryText = computed(() => summaryText.value);
+
+  const indicatorTitle = computed(() => {
+    if (error.value && !gitStatus.value) return error.value.message || 'Git status unknown';
+    const status = gitStatus.value;
+    if (!status) return summaryText.value;
+    const fragments = buildFragments(status);
+    if (fragments.length > 0) return fragments.join(', ');
+    return summaryText.value;
+  });
+
+  async function refresh(options = {}) {
+    const sessionId = getSessionId();
+    if (!sessionId) return null;
+
+    const token = ++requestToken;
+    loading.value = true;
+    try {
+      const status = await api.getSessionGitStatus(sessionId, { fetch: options.fetch === true });
+      if (token !== requestToken || getSessionId() !== sessionId) {
+        return gitStatus.value;
+      }
+      gitStatus.value = status;
+      error.value = null;
+      return status;
+    } catch (err) {
+      if (token === requestToken && getSessionId() === sessionId) {
+        error.value = err;
+      }
+      return gitStatus.value;
+    } finally {
+      if (token === requestToken) {
+        loading.value = false;
+      }
+    }
+  }
+
+  function reset() {
+    requestToken += 1;
+    gitStatus.value = null;
+    loading.value = false;
+    error.value = null;
+  }
+
+  return {
+    gitStatus,
+    loading,
+    error,
+    summaryText,
+    shortSummaryText,
+    indicatorTitle,
+    hasActionableGitStatus,
+    refresh,
+    reset,
+  };
+}

--- a/packages/web/src/composables/useSessionGitStatus.test.js
+++ b/packages/web/src/composables/useSessionGitStatus.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSessionGitStatus } from './useSessionGitStatus.js';
+
+vi.mock('./useApi.js', () => ({
+  api: {
+    getSessionGitStatus: vi.fn(),
+  },
+}));
+
+import { api } from './useApi.js';
+
+describe('useSessionGitStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('formats actionable status summaries', async () => {
+    api.getSessionGitStatus.mockResolvedValue({
+      syncStatus: 'diverged',
+      localChangeCount: 3,
+      aheadCount: 2,
+      behindCount: 1,
+    });
+
+    const status = useSessionGitStatus({ getSessionId: () => 'sess-1' });
+    await status.refresh();
+
+    expect(status.summaryText.value).toBe('3 local files · 2 unpushed commits · 1 commit to pull');
+    expect(status.indicatorTitle.value).toBe('3 local files, 2 unpushed commits, 1 commit to pull');
+    expect(status.hasActionableGitStatus.value).toBe(true);
+  });
+
+  it('keeps the last successful status after refresh failure', async () => {
+    api.getSessionGitStatus
+      .mockResolvedValueOnce({ syncStatus: 'clean', localChangeCount: 0, aheadCount: 0, behindCount: 0 })
+      .mockRejectedValueOnce(new Error('Git failed'));
+
+    const status = useSessionGitStatus({ getSessionId: () => 'sess-1' });
+    await status.refresh();
+    await status.refresh({ fetch: true });
+
+    expect(status.summaryText.value).toBe('Git clean');
+    expect(status.error.value.message).toBe('Git failed');
+  });
+
+  it('ignores stale responses when the session changes', async () => {
+    let resolveFirst;
+    let currentSessionId = 'sess-1';
+    api.getSessionGitStatus
+      .mockReturnValueOnce(new Promise(resolve => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce({ syncStatus: 'ahead', localChangeCount: 0, aheadCount: 1, behindCount: 0 });
+
+    const status = useSessionGitStatus({ getSessionId: () => currentSessionId });
+    const first = status.refresh();
+    currentSessionId = 'sess-2';
+    await status.refresh();
+    resolveFirst({ syncStatus: 'dirty', localChangeCount: 5, aheadCount: 0, behindCount: 0 });
+    await first;
+
+    expect(status.summaryText.value).toBe('1 unpushed commit');
+  });
+});

--- a/packages/web/src/composables/useSessionInitializer.js
+++ b/packages/web/src/composables/useSessionInitializer.js
@@ -89,6 +89,7 @@ function registerCommandHandlers(subscription, sessionId, stores) {
  * @param {Function} options.startPolling - Function to start status polling
  * @param {Function} options.stopPolling - Function to stop status polling
  * @param {Function} options.resetPolling - Function to reset polling state
+ * @param {Function} [options.refreshGitStatus] - Optional git status refresh hook
  * @param {Function} [options.onReconnectCallback] - Optional callback invoked after WebSocket reconnection (e.g., to rebuild session chain)
  * @returns {Object} Session initializer utilities
  */
@@ -100,6 +101,7 @@ export function useSessionInitializer({
   startPolling,
   stopPolling,
   resetPolling,
+  refreshGitStatus,
   onReconnectCallback,
 }) {
   const summary = summaryRef;
@@ -203,7 +205,9 @@ export function useSessionInitializer({
         } else {
           stopPolling();
           if (status === 'waiting' || status === 'completed') {
-            checkForChanges();
+            Promise.resolve(checkForChanges()).then(() => {
+              if (refreshGitStatus) refreshGitStatus({ fetch: false });
+            });
           }
         }
       })
@@ -265,6 +269,7 @@ export function useSessionInitializer({
         } else {
           hasChanges.value = changeCount > 0;
         }
+        if (refreshGitStatus) refreshGitStatus({ fetch: false });
       })
     );
 
@@ -294,7 +299,9 @@ export function useSessionInitializer({
       // Ignore errors - summary may not exist yet
     });
 
-    checkForChanges();
+    Promise.resolve(checkForChanges()).then(() => {
+      if (refreshGitStatus) refreshGitStatus({ fetch: false });
+    });
 
     const { onReconnect } = useWebSocket();
     reconnectCleanups.push(
@@ -304,7 +311,10 @@ export function useSessionInitializer({
         await sessionsStore.fetchMessages(sessionId, false, sessionsStore.activeConversationId);
         await sessionsStore.fetchWorkLogs(sessionId);
         await canvasStore.fetchItems(sessionId);
-        checkForChanges();
+        await checkForChanges();
+        if (refreshGitStatus) {
+          refreshGitStatus({ fetch: false });
+        }
         // Rebuild session chain so descendant statuses are fresh (fixes stale spinner bug)
         if (onReconnectCallback) {
           await onReconnectCallback();

--- a/packages/web/src/composables/useSessionPolling.js
+++ b/packages/web/src/composables/useSessionPolling.js
@@ -11,9 +11,10 @@ import { parseDiff } from '../utils/diffParser.js';
  * @param {Function} options.getSessionStatus - Function that returns the current session status
  * @param {Object} options.sessionsStore - The sessions Pinia store
  * @param {number} [options.pollInterval=3000] - Polling interval in milliseconds
+ * @param {Function} [options.refreshGitStatus] - Optional git status refresh hook
  * @returns {Object} Polling and changes utilities
  */
-export function useSessionPolling({ getSessionId, getSessionStatus, sessionsStore, pollInterval = 3000 }) {
+export function useSessionPolling({ getSessionId, getSessionStatus, sessionsStore, pollInterval = 3000, refreshGitStatus }) {
   const pollIntervalId = ref(null);
   const hasChanges = ref(false);
   const changesFileCount = ref(0);
@@ -66,7 +67,10 @@ export function useSessionPolling({ getSessionId, getSessionStatus, sessionsStor
           return;
         }
         // Check for file changes during active session
-        checkForChanges();
+        await checkForChanges();
+        if (refreshGitStatus) {
+          refreshGitStatus({ fetch: false });
+        }
       } else {
         // Session no longer actively processing, stop polling
         stopPolling();

--- a/packages/web/src/views/SessionDetailView.vue
+++ b/packages/web/src/views/SessionDetailView.vue
@@ -31,6 +31,10 @@
         :summary="summary"
         :is-deleting="isDeleting"
         :button-statuses="buttonStatusesToDisplay"
+        :git-status-summary="shortGitStatusSummary"
+        :git-status-loading="gitStatusLoading"
+        :git-status-error="gitStatusError"
+        :has-actionable-git-status="hasActionableGitStatus"
         @duplicate="handleDuplicate"
         @copy-session-id="handleCopySessionId"
         @archive="handleArchive"
@@ -44,6 +48,8 @@
         :active-tab="activeTab"
         :tabs="tabs"
         :has-changes="hasChanges"
+        :has-git-status-warning="hasActionableGitStatus"
+        :git-status-title="gitStatusIndicatorTitle"
         :canvas-count="canvasStore.groupedItems.length"
         :is-session-active="isSessionActive"
         :session-status="activeSessionStatus"
@@ -62,6 +68,11 @@
           v-else-if="activeTab === 'changes'"
           :key="route.params.id"
           :session-id="route.params.id"
+          :git-status="gitStatus"
+          :git-status-summary="gitStatusSummary"
+          :git-status-loading="gitStatusLoading"
+          :git-status-error="gitStatusError"
+          :refresh-git-status="refreshGitStatus"
           @update:file-count="changesFileCount = $event"
         />
         <CanvasTab
@@ -128,6 +139,7 @@ import { useKanbanStore } from '../stores/kanban.js';
 import { useSessionPolling } from '../composables/useSessionPolling.js';
 import { useSessionInitializer } from '../composables/useSessionInitializer.js';
 import { useSessionTree } from '../composables/useSessionTree.js';
+import { useSessionGitStatus } from '../composables/useSessionGitStatus.js';
 import ChangesTab from '../components/ChangesTab.vue';
 import CanvasTab from '../components/CanvasTab.vue';
 import SummaryTab from '../components/SummaryTab.vue';
@@ -160,6 +172,20 @@ const currentSessionId = ref(route.params.id);
 sessionsStore.viewedSessionId = route.params.id;
 
 const {
+  gitStatus,
+  loading: gitStatusLoading,
+  error: gitStatusError,
+  summaryText: gitStatusSummary,
+  shortSummaryText: shortGitStatusSummary,
+  indicatorTitle: gitStatusIndicatorTitle,
+  hasActionableGitStatus,
+  refresh: refreshGitStatus,
+  reset: resetGitStatus,
+} = useSessionGitStatus({
+  getSessionId: () => currentSessionId.value,
+});
+
+const {
   hasChanges,
   changesFileCount,
   checkForChanges,
@@ -170,6 +196,7 @@ const {
   getSessionId: () => currentSessionId.value,
   getSessionStatus: () => sessionsStore.currentSession?.status,
   sessionsStore,
+  refreshGitStatus,
 });
 
 const summary = ref(null);
@@ -213,6 +240,7 @@ const { cleanup, initializeSession } = useSessionInitializer({
   startPolling,
   stopPolling,
   resetPolling,
+  refreshGitStatus,
   onReconnectCallback: buildSessionChain,
 });
 
@@ -301,6 +329,7 @@ watch(
       resetPreferred();
       cleanup();
       currentSessionId.value = newSessionId;
+      resetGitStatus();
       await initializeSession(newSessionId);
 
       const newProjectId = sessionsStore.currentSession?.projectId;
@@ -354,6 +383,7 @@ onActivated(() => {
 
 onUnmounted(() => {
   cleanup();
+  resetGitStatus();
   if (currentProjectSubscriptionId) {
     send(WS_MESSAGE_TYPES.UNSUBSCRIBE_PROJECT, { projectId: currentProjectSubscriptionId });
     currentProjectSubscriptionId = null;

--- a/tests/e2e/ui-ux.spec.ts
+++ b/tests/e2e/ui-ux.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect, Page } from '@playwright/test';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
   seedProject,
   seedSession,
@@ -1199,14 +1203,18 @@ test.describe('Pagination / Load More', () => {
 test.describe('Tab Indicators', () => {
   let project: any;
   let session: any;
+  let tmpDir: string;
 
   test.beforeEach(async () => {
-    project = await seedProject('Indicators', '/tmp/test');
+    tmpDir = mkdtempSync(join(tmpdir(), 'e2e-indicators-'));
+    execSync('git init', { cwd: tmpDir });
+    project = await seedProject('Indicators', tmpDir);
     session = await seedSession(project.id, { prompt: 'test', name: 'Indicator Test', startImmediately: false });
   });
 
   test.afterEach(async () => {
     await cleanupCreatedResources();
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test('canvas tab shows indicator dot when items exist', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **New server endpoint** `GET /sessions/:id/git-status` computes compact git sync status (clean/dirty/ahead/behind/diverged/unpublished) from porcelain output and ahead/behind counts. Supports `?fetch=true` to fetch origin before computing.
- **New frontend composable** `useSessionGitStatus` manages fetching, lifecycle, and derived state (actionable flags, summary text, indicator title).
- **GitStatusChip** component shows a compact colored indicator in the session header bar — clickable to navigate to the Changes tab.
- **GitStatusSummary** banner at the top of the Changes tab displays branch mapping, change counts, and a "Refresh from origin" button.
- Changes tab indicator and mobile tab label now reflect git attention state (uncommitted changes, unpushed commits, behind origin, unpublished branch).

## Test plan

- [ ] Verify git status chip appears in session header with correct state (clean/dirty/ahead/behind/unpublished)
- [ ] Verify Changes tab shows GitStatusSummary banner with correct branch info and counts
- [ ] Verify "Refresh from origin" button fetches and updates status
- [ ] Verify status updates automatically when session stops/waiting
- [ ] Verify mobile tab label shows "Git attention" when actionable
- [ ] Run existing unit tests: `yarn workspace @circuschief/server test` and `yarn workspace @circuschief/web test`
- [ ] Run new test files: `sessions.gitStatus.test.js`, `GitStatusChip.test.js`, `GitStatusSummary.test.js`, `useSessionGitStatus.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)