### PR TITLE
Default auto-retry on for API-created sessions

### DIFF
--- a/docs/agent-system-prompt.md
+++ b/docs/agent-system-prompt.md
@@ -53,6 +53,8 @@ The prompt provides the agent with its own session ID and project ID. All endpoi
 
 **Optional fields for session creation:** `name`, `mode`, `thinkingEnabled` (boolean), `effortLevel` (low/medium/high/max/auto), `model`, `providerId`, `gitBranch`, `gitMode`, `templateId`, `nextTemplateId`, `parentSessionId` (to create a related follow-up session from the current session), `startImmediately`, `scheduledAt` (ISO 8601 date-time string with timezone, e.g. `"2026-06-12T14:00:00Z"`), `autoRescheduleEnabled`, `rescheduleDelayMinutes`, `rescheduleOnTokenLimit`, `rescheduleOnServiceError`, `maxRescheduleCount`, `maxTotalTokens`, `rescheduleAtTokenCount`.
 
+**Auto-retry defaults:** API-created sessions automatically retry on token-limit exhaustion and provider outages. `autoRescheduleEnabled` defaults to `true` (pass `false` to opt out), `rescheduleOnTokenLimit` and `rescheduleOnServiceError` both default to `true`, and `maxRescheduleCount` defaults to `24` (≈ one day of hourly retries). Pass an explicit `maxRescheduleCount` to adjust the cap.
+
 ### Project Operations (always included)
 
 | Method | Endpoint | Description |

--- a/packages/server/src/api/projects-session-helpers.js
+++ b/packages/server/src/api/projects-session-helpers.js
@@ -4,7 +4,7 @@ import { setupGitForSession } from '../services/gitSessionSetup.js';
 import { resolveProviderMetadataFromModel } from '../services/sessionProvider.js';
 import { executeHookAsync } from '../services/hookService.js';
 import { broadcastToProject } from '../websocket.js';
-import { WS_MESSAGE_TYPES, DEFAULT_RESCHEDULE_DELAY_MINUTES } from '@circuschief/shared';
+import { WS_MESSAGE_TYPES, DEFAULT_RESCHEDULE_DELAY_MINUTES, DEFAULT_MAX_RESCHEDULE_COUNT } from '@circuschief/shared';
 
 const SCHEDULED_AT_FORMAT_MESSAGE = 'scheduledAt must be a valid ISO 8601 date-time string with a timezone, for example "2026-06-12T14:00:00Z".';
 const ISO_8601_DATE_TIME_WITH_TIMEZONE = /^(\d{4})-(\d{2})-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d+)?(Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
@@ -137,11 +137,11 @@ export function parseSchedulingConfig(body) {
   return {
     scheduledAt: scheduledAt.value,
     schedulingError: scheduledAt.error,
-    autoRescheduleEnabled: body.autoRescheduleEnabled === true || body.autoRescheduleEnabled === 'true',
+    autoRescheduleEnabled: body.autoRescheduleEnabled !== false && body.autoRescheduleEnabled !== 'false',
     rescheduleDelayMinutes: body.rescheduleDelayMinutes ? parseInt(body.rescheduleDelayMinutes, 10) : DEFAULT_RESCHEDULE_DELAY_MINUTES,
     rescheduleOnTokenLimit: body.rescheduleOnTokenLimit !== false && body.rescheduleOnTokenLimit !== 'false',
     rescheduleOnServiceError: body.rescheduleOnServiceError !== false && body.rescheduleOnServiceError !== 'false',
-    maxRescheduleCount: body.maxRescheduleCount ? parseInt(body.maxRescheduleCount, 10) : null,
+    maxRescheduleCount: body.maxRescheduleCount ? parseInt(body.maxRescheduleCount, 10) : DEFAULT_MAX_RESCHEDULE_COUNT,
     maxTotalTokens: body.maxTotalTokens ? parseInt(body.maxTotalTokens, 10) : null,
     rescheduleAtTokenCount: body.rescheduleAtTokenCount ? parseInt(body.rescheduleAtTokenCount, 10) : null,
   };

--- a/packages/server/src/api/projects-session-helpers.test.js
+++ b/packages/server/src/api/projects-session-helpers.test.js
@@ -14,7 +14,7 @@ import {
   buildSchedulingUpdate,
   setupAndStartSession,
 } from './projects-session-helpers.js';
-import { DEFAULT_RESCHEDULE_DELAY_MINUTES } from '@circuschief/shared';
+import { DEFAULT_RESCHEDULE_DELAY_MINUTES, DEFAULT_MAX_RESCHEDULE_COUNT } from '@circuschief/shared';
 
 // Mock all external dependencies
 vi.mock('../database.js', () => ({
@@ -307,7 +307,9 @@ describe('parseSchedulingConfig', () => {
   it('coerces autoRescheduleEnabled boolean', () => {
     expect(parseSchedulingConfig({ autoRescheduleEnabled: true }).autoRescheduleEnabled).toBe(true);
     expect(parseSchedulingConfig({ autoRescheduleEnabled: 'true' }).autoRescheduleEnabled).toBe(true);
-    expect(parseSchedulingConfig({}).autoRescheduleEnabled).toBe(false);
+    expect(parseSchedulingConfig({}).autoRescheduleEnabled).toBe(true);
+    expect(parseSchedulingConfig({ autoRescheduleEnabled: false }).autoRescheduleEnabled).toBe(false);
+    expect(parseSchedulingConfig({ autoRescheduleEnabled: 'false' }).autoRescheduleEnabled).toBe(false);
   });
 
   it('defaults rescheduleDelayMinutes to DEFAULT_RESCHEDULE_DELAY_MINUTES', () => {
@@ -322,17 +324,18 @@ describe('parseSchedulingConfig', () => {
 
   it('parses maxRescheduleCount', () => {
     expect(parseSchedulingConfig({ maxRescheduleCount: '5' }).maxRescheduleCount).toBe(5);
-    expect(parseSchedulingConfig({}).maxRescheduleCount).toBeNull();
+    expect(parseSchedulingConfig({}).maxRescheduleCount).toBe(DEFAULT_MAX_RESCHEDULE_COUNT);
   });
 
   it('returns defaults for null/empty body', () => {
     const result = parseSchedulingConfig({});
     expect(result.scheduledAt).toBeUndefined();
     expect(result.schedulingError).toBeNull();
-    expect(result.autoRescheduleEnabled).toBe(false);
+    expect(result.autoRescheduleEnabled).toBe(true);
     expect(result.rescheduleDelayMinutes).toBe(DEFAULT_RESCHEDULE_DELAY_MINUTES);
     expect(result.rescheduleOnTokenLimit).toBe(true);
-    expect(result.maxRescheduleCount).toBeNull();
+    expect(result.rescheduleOnServiceError).toBe(true);
+    expect(result.maxRescheduleCount).toBe(DEFAULT_MAX_RESCHEDULE_COUNT);
   });
 });
 

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -23,6 +23,9 @@ export const TOAST_DURATION = 5000;
 /** Default delay (in minutes) before auto-rescheduling a session. */
 export const DEFAULT_RESCHEDULE_DELAY_MINUTES = 60;
 
+/** Default maximum number of automatic reschedules for an API-created session. */
+export const DEFAULT_MAX_RESCHEDULE_COUNT = 24;
+
 export const DEFAULT_SYSTEM_PROMPT = `You are an AI coding assistant. You help users with software engineering tasks including writing code, debugging, refactoring, and explaining code. You have full access to the shell and can execute any commands needed to assist the user. Be helpful, accurate, and thorough.
 
 IMPORTANT: Your working directory is already set correctly for this session. NEVER use \`cd\` to change to a hardcoded project path before running commands (e.g., \`cd /path/to/project && git status\`). This bypasses git worktree isolation and causes commands to run in the wrong directory. Always run commands directly without changing directory.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -524,7 +524,7 @@ export async function seedProject(
 
 export async function seedSession(
   projectId: string,
-  data: { prompt: string; name?: string; mode?: string; model?: string; startImmediately?: boolean; gitMode?: string; gitBranch?: string; parentSessionId?: string; effortLevel?: string; scheduledAt?: string | number | Date }
+  data: { prompt: string; name?: string; mode?: string; model?: string; startImmediately?: boolean; gitMode?: string; gitBranch?: string; parentSessionId?: string; effortLevel?: string; scheduledAt?: string | number | Date; autoRescheduleEnabled?: boolean }
 ) {
   const scheduledAt =
     data.scheduledAt instanceof Date
@@ -534,9 +534,12 @@ export async function seedSession(
         : data.scheduledAt;
 
   // Default gitMode/gitBranch so tests pass for git-repo-backed projects
+  // Default autoRescheduleEnabled to false so tests get deterministic panel behavior
+  // (the REST API now defaults it to true for agent convenience)
   const payload = {
     gitMode: 'none',
     gitBranch: 'main',
+    autoRescheduleEnabled: false,
     ...data,
     ...(scheduledAt !== undefined ? { scheduledAt } : {}),
   };


### PR DESCRIPTION
## Summary

- Added `DEFAULT_MAX_RESCHEDULE_COUNT = 24` constant to `@circuschief/shared` (≈ one day of hourly retries)
- Changed `autoRescheduleEnabled` to default to `true` for API-created sessions — opt-out instead of opt-in
- Changed `maxRescheduleCount` to default to `24` instead of `null` for API-created sessions
- Updated docs to document the new auto-retry defaults

API-created sessions now automatically retry on token-limit exhaustion and provider outages by default. Pass `autoRescheduleEnabled: false` to opt out.

## Test plan

- [ ] Verify `parseSchedulingConfig({})` returns `autoRescheduleEnabled: true` and `maxRescheduleCount: 24`
- [ ] Verify passing `autoRescheduleEnabled: false` correctly disables auto-retry
- [ ] Verify passing an explicit `maxRescheduleCount` overrides the default
- [ ] Run unit tests: `yarn workspace @circuschief/server test src/api/projects-session-helpers.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)