### PR TITLE
Fix summaries still failing after PR #977 (maxTurns: 1 → 2)

### DIFF
--- a/packages/server/src/services/summaryClaudeClient.js
+++ b/packages/server/src/services/summaryClaudeClient.js
@@ -66,7 +66,10 @@ function buildClaudeRequest(prompt, options) {
     options: {
       cwd: process.cwd(),
       permissionMode: 'bypassPermissions',
-      maxTurns: 1,
+      // outputFormat uses an SDK-internal StructuredOutput tool that requires one model
+      // turn to call the tool. maxTurns must be >= 2 so the SDK can complete the tool-use
+      // cycle (call → result) without emitting "Reached maximum number of turns (1)".
+      maxTurns: 2,
       model,
       // Summary generation is a pure text->JSON task: it must never load tools,
       // MCP servers, or filesystem settings (CLAUDE.md, hooks, user/project MCP).

--- a/packages/server/src/services/summaryClaudeClient.test.js
+++ b/packages/server/src/services/summaryClaudeClient.test.js
@@ -143,6 +143,16 @@ describe('summaryClaudeClient', () => {
       expect(callArgs.options.allowedTools).toEqual([]);
     });
 
+    it('uses maxTurns >= 2 to allow the SDK-internal StructuredOutput tool-use cycle', async () => {
+      await callClaude('Test prompt', [], 'running');
+
+      const callArgs = query.mock.calls[0][0];
+      // outputFormat injects a StructuredOutput tool internally. The model calls it on
+      // turn 1; the SDK needs at least one more turn to process the tool result.
+      // maxTurns: 1 causes "Reached maximum number of turns (1)" errors for ALL summaries.
+      expect(callArgs.options.maxTurns).toBeGreaterThanOrEqual(2);
+    });
+
     it('starts agent call logging when logMeta provided', async () => {
       await callClaude('Test prompt', [], 'running', {
         logMeta: {


### PR DESCRIPTION
## Problem

Session summaries continued failing with `Reached maximum number of turns (1)` even after PR #977 was merged.

## Why #977 didn't fully fix it

PR #977 correctly identified that MCP servers and the agentic toolbelt were loading into summary calls and consuming the single allowed turn. Its fix — `settingSources: []`, `allowedTools: []`, `mcpServers: {}` — removed all *externally configured* tools.

What it missed: **`outputFormat: { type: 'json_schema', schema }`** causes the Claude Code SDK to inject a `StructuredOutput` tool **internally**. This tool is added by the SDK itself — it bypasses every isolation setting PR #977 added.

After #977, the summary call still had one tool available: `StructuredOutput`. The model calls it on turn 1, the SDK needs another turn to complete the tool-use cycle, but `maxTurns: 1` means there is no turn 2. Same error, same failure.

Agent call logs confirm every summary attempt after #977 landed still shows:
```
error  Claude Code returned an error result: Reached maximum number of turns (1)
```

## Fix

Increase `maxTurns` from `1` to `2` in `buildClaudeRequest`. This gives the SDK the room it needs to complete the StructuredOutput tool-use cycle (call → result). The isolation settings from #977 remain intact — no other tool can consume those turns.

## Test

Added a regression test asserting `maxTurns >= 2` with a comment explaining why. PR #977's test suite had no assertion on `maxTurns`, which is why the regression wasn't caught.

- `summaryClaudeClient.test.js`: 23 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)