### PR TITLE
Add running spinner to kanban cards and extract SessionRunningSpinner component

### DIFF
--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -115,7 +115,11 @@
                 class="card-link"
               >
                 <div class="card-header">
+                  <SessionRunningSpinner
+                    :active="isCardEffectivelyRunning(card.sessions[0])"
+                  />
                   <span
+                    v-if="!isCardEffectivelyRunning(card.sessions[0])"
                     class="card-status"
                     :class="`status-${card.sessions[0].status}`"
                   >
@@ -335,9 +339,11 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue';
 import { useKanbanStore } from '../stores/kanban.js';
+import { useSessionsStore } from '../stores/sessions.js';
 import AddSessionToLaneModal from './AddSessionToLaneModal.vue';
 import LaneSettingsModal from './LaneSettingsModal.vue';
 import MoveCardModal from './MoveCardModal.vue';
+import SessionRunningSpinner from './SessionRunningSpinner.vue';
 import './KanbanBoard.css';
 
 const props = defineProps({
@@ -348,6 +354,7 @@ const props = defineProps({
 });
 
 const kanbanStore = useKanbanStore();
+const sessionsStore = useSessionsStore();
 
 // Local state
 const showAddLane = ref(false);
@@ -402,6 +409,14 @@ const getStatusIndicator = (status) => {
     default:
       return '○';
   }
+};
+
+const isCardEffectivelyRunning = (session) => {
+  if (!session?.id) return false;
+  if (sessionsStore.getWorkflowEffectiveStatus(session.id) === 'running') {
+    return true;
+  }
+  return ['running', 'starting'].includes(session.status);
 };
 
 // --- Card drag-and-drop ---

--- a/packages/web/src/components/SessionChatHandle.vue
+++ b/packages/web/src/components/SessionChatHandle.vue
@@ -31,15 +31,16 @@
         stroke-linejoin="round"
       />
     </svg>
-    <span
-      v-if="isSessionActive"
-      class="active-spinner"
+    <SessionRunningSpinner
+      :active="isSessionActive"
       :title="sessionStatus === 'starting' ? 'Session starting...' : 'Session running...'"
     />
   </div>
 </template>
 
 <script setup>
+import SessionRunningSpinner from './SessionRunningSpinner.vue';
+
 const emit = defineEmits(['open']);
 
 defineProps({
@@ -97,21 +98,6 @@ function handleOpen() {
 
 .session-chat-handle:hover .handle-icon {
   color: #fff;
-}
-
-.active-spinner {
-  width: 0.75rem;
-  height: 0.75rem;
-  border: 2px solid rgba(6, 182, 212, 0.3);
-  border-top-color: #06b6d4;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 @media (min-width: 641px) {

--- a/packages/web/src/components/SessionRunningSpinner.vue
+++ b/packages/web/src/components/SessionRunningSpinner.vue
@@ -1,0 +1,40 @@
+<template>
+  <span
+    v-if="active"
+    class="session-running-spinner active-spinner"
+    :title="title"
+    aria-label="Session running"
+  />
+</template>
+
+<script setup>
+defineProps({
+  active: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: 'Session running...',
+  },
+});
+</script>
+
+<style scoped>
+.session-running-spinner {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid rgba(6, 182, 212, 0.3);
+  border-top-color: #06b6d4;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/packages/web/src/composables/useProjectSessionSubscription.js
+++ b/packages/web/src/composables/useProjectSessionSubscription.js
@@ -135,7 +135,10 @@ export function useProjectSessionSubscription(projectId, summaryCallbacks) {
     const handlers = [];
 
     handlers.push(onSessionCreated((session) => { stores.sessionsStore.addSessionToList(session); }));
-    handlers.push(onSessionUpdated((session) => { stores.sessionsStore.updateSession(session); }));
+    handlers.push(onSessionUpdated((session) => {
+      stores.sessionsStore.updateSession(session);
+      stores.kanbanStore.handleSessionUpdated(session);
+    }));
     handlers.push(onSessionDeleted((sid) => {
       stores.sessionsStore.removeSessionFromList(sid);
       callbacks.cleanupSummary(sid);

--- a/packages/web/src/composables/useProjectSessionSubscription.test.js
+++ b/packages/web/src/composables/useProjectSessionSubscription.test.js
@@ -33,6 +33,7 @@ const mockKanbanStore = {
   handleCardMoved: vi.fn(),
   handleCardAdded: vi.fn(),
   handleCardRemoved: vi.fn(),
+  handleSessionUpdated: vi.fn(),
 };
 
 // Mock useProjectSubscription - all "on" handlers must return a cleanup function
@@ -132,6 +133,7 @@ describe('useProjectSessionSubscription', () => {
     mockKanbanStore.handleCardMoved.mockReset();
     mockKanbanStore.handleCardAdded.mockReset();
     mockKanbanStore.handleCardRemoved.mockReset();
+    mockKanbanStore.handleSessionUpdated.mockReset();
 
     mockSubscribe.mockReset();
     mockUnsubscribe.mockReset();
@@ -287,6 +289,7 @@ describe('useProjectSessionSubscription', () => {
       handler(updatedSession);
 
       expect(mockSessionsStore.updateSession).toHaveBeenCalledWith(updatedSession);
+      expect(mockKanbanStore.handleSessionUpdated).toHaveBeenCalledWith(updatedSession);
     });
 
     it('registers session deleted handler', async () => {


### PR DESCRIPTION
## Summary

- **Extract `SessionRunningSpinner`** — Pull the inline spinner CSS/HTML from `SessionChatHandle.vue` into a reusable `SessionRunningSpinner.vue` component
- **Show running spinner on kanban cards** — Kanban board cards now display an animated spinner when the associated session is running or starting, using `isCardEffectivelyRunning()` which checks both raw session status and workflow effective status
- **Keep kanban in sync via WebSocket** — Forward session updates from `useProjectSessionSubscription` to `kanbanStore.handleSessionUpdated()` so the board reflects status changes in real time

## Changed files

| File | Change |
|------|--------|
| `SessionRunningSpinner.vue` | **New** — reusable spinner component |
| `KanbanBoard.vue` | Add spinner to cards + `isCardEffectivelyRunning()` helper |
| `SessionChatHandle.vue` | Replace inline spinner with shared component |
| `useProjectSessionSubscription.js` | Forward session updates to kanban store |
| `useProjectSessionSubscription.test.js` | Test for kanban store forwarding |

## Test plan

- [ ] Verify spinner appears on kanban cards for running/starting sessions
- [ ] Verify spinner disappears when session stops
- [ ] Verify SessionChatHandle spinner still works as before
- [ ] Confirm kanban cards update in real time when session status changes via WebSocket
- [ ] Run unit tests: `yarn workspace @circuschief/web test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)