### PR TITLE
fix: extract wrapCommandForPlatform, redirect stdin on macOS to avoid socket error

### DIFF
--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { platform } from 'os';
+import * as osModule from 'os';
 import { commandRuns } from '../database.js';
 import { createRobustEnv } from './nodeSpawnHelper.js';
 import { TerminalOutputProcessor } from './terminalOutput.js';
@@ -11,6 +11,13 @@ export function createCommandRunnerEnv(baseEnv = process.env) {
   const env = createRobustEnv(baseEnv);
   delete env.CIRCUSCHIEF_COMMIT_ATTRIBUTION;
   return env;
+}
+
+export function wrapCommandForPlatform(command, currentPlatform = osModule.platform()) {
+  const cmd = JSON.stringify(command);
+  return currentPlatform === 'linux'
+    ? `script -q -e -c ${cmd} /dev/null`
+    : `script -q /dev/null sh -c ${cmd} < /dev/null`;
 }
 
 /**
@@ -33,16 +40,6 @@ export class CommandRunner {
     } catch (dbErr) {
       console.warn(`[commandRunner.run] Warning: Failed to create database record for runId: ${runId}`, dbErr.message);
     }
-  }
-
-  /**
-   * Wrap command with platform-specific TTY allocation.
-   */
-  #wrapCommandForPlatform(command) {
-    const cmd = JSON.stringify(command);
-    return platform() === 'linux'
-      ? `script -q -e -c ${cmd} /dev/null`
-      : `script -q /dev/null sh -c ${cmd}`;
   }
 
   /**
@@ -141,11 +138,11 @@ export class CommandRunner {
     return new Promise((resolve) => {
       try {
         this.#createDatabaseRecord(runId, sessionId, buttonId);
-        const wrappedCommand = this.#wrapCommandForPlatform(command);
+        const wrappedCommand = wrapCommandForPlatform(command);
 
         const child = spawn('sh', ['-c', wrappedCommand], {
           cwd: workingDirectory,
-          stdio: ['pipe', 'pipe', 'pipe'],
+          stdio: ['ignore', 'pipe', 'pipe'],
           detached: true,
           env: createCommandRunnerEnv(),
         });

--- a/packages/server/src/services/commandRunner.test.js
+++ b/packages/server/src/services/commandRunner.test.js
@@ -4,6 +4,7 @@ import {
   createCommandRunnerEnv,
   stripAnsiCodes,
   TerminalOutputProcessor,
+  wrapCommandForPlatform,
 } from './commandRunner.js';
 import * as osModule from 'os';
 
@@ -1004,7 +1005,7 @@ describe('CommandRunner', () => {
       // This test verifies the logic without actually executing commands
       // The key fix: script command is wrapped with platform-specific flags
       // - Linux: script -q -e -c [command] /dev/null (includes -e for exit code)
-      // - macOS/Darwin: script -q -c [command] /dev/null (no -e, uses close event instead)
+      // - macOS/Darwin: script -q /dev/null sh -c [command] < /dev/null (stdin redirected to avoid socket error)
       const currentPlatform = osModule.platform();
 
       // Verify that os.platform() is callable
@@ -1034,6 +1035,21 @@ describe('CommandRunner', () => {
 
       expect(exitCode).toBe(0);
       expect(output.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('wrapCommandForPlatform', () => {
+    it('macOS: redirects script stdin from /dev/null to avoid socket error', () => {
+      const wrapped = wrapCommandForPlatform('echo hello', 'darwin');
+
+      expect(wrapped).toContain('< /dev/null');
+    });
+
+    it('linux: uses -e flag and does not add stdin redirect', () => {
+      const wrapped = wrapCommandForPlatform('echo hello', 'linux');
+
+      expect(wrapped).toContain('-e');
+      expect(wrapped).not.toContain('< /dev/null');
     });
   });
 


### PR DESCRIPTION
## Summary

Extracts `wrapCommandForPlatform` from a private method to a standalone export, and fixes a socket error on macOS by redirecting script stdin from `/dev/null`.

## Changes

- **Extract `wrapCommandForPlatform`** from private `#wrapCommandForPlatform` method to a standalone exportable function for better testability
- **Redirect stdin on macOS**: Added `< /dev/null` to the macOS script command to prevent "socket is not connected" error
- **Change spawn stdio**: Changed stdin from `'pipe'` to `'ignore'` since stdin is now redirected via the shell command
- **Add unit tests** for `wrapCommandForPlatform` covering both Linux and macOS platforms

## Testing

- ✅ All 1130 Playwright E2E tests passed (2 flaky but passed, 18 skipped)
- ✅ Unit tests added for the extracted function

🤖 Generated with [Claude Code](https://claude.com/claude-code)