### PR TITLE
Kanban board: card drag-and-drop + schedule info utils

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@circuschief/shared": "1.0.0",
     "ansi-to-html": "^0.7.2",
+    "date-fns": "^2.30.0",
     "dompurify": "^3.4.0",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.1.0",

--- a/packages/web/src/components/KanbanBoard.css
+++ b/packages/web/src/components/KanbanBoard.css
@@ -242,6 +242,24 @@
   color: var(--color-text-soft);
 }
 
+.card-scheduled-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+}
+
+.card-scheduled-info .schedule-icon-inline {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.25rem;
+}
+
+.card-scheduled-info .scheduled-time {
+  font-size: 0.7rem;
+  color: var(--color-text-soft);
+}
+
 .card-mode {
   text-transform: capitalize;
 }

--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import KanbanBoard from './KanbanBoard.vue';
+import { useSessionsStore } from '../stores/sessions.js';
 
 vi.mock('../stores/kanban.js', () => ({
   useKanbanStore: vi.fn(() => ({
@@ -44,6 +45,7 @@ vi.mock('../stores/kanban.js', () => ({
     error: null,
     fetchBoard: vi.fn().mockResolvedValue({}),
     removeCard: vi.fn().mockResolvedValue({}),
+    reorderCards: vi.fn().mockResolvedValue({}),
     moveCard: vi.fn().mockResolvedValue({}),
   })),
 }));
@@ -84,9 +86,14 @@ describe('KanbanBoard.vue', () => {
   beforeEach(() => {
     pinia = createPinia();
     setActivePinia(pinia);
+    vi.useRealTimers();
     vi.clearAllMocks();
 
     mockKanbanStore = useKanbanStore();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function mountBoard(props = {}) {
@@ -163,6 +170,43 @@ describe('KanbanBoard.vue', () => {
       const moveButton = wrapper.find('.card-move-btn');
       expect(moveButton.exists()).toBe(true);
       // Click handler testing skipped - covered by E2E tests
+    });
+  });
+
+  describe('Scheduled session indicator', () => {
+    it('shows scheduled badge and relative time for a scheduled workflow session', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-10T12:00:00-06:00'));
+      const sessionsStore = useSessionsStore();
+      sessionsStore.sessions = [
+        { id: 'session-1', name: 'Session 1', status: 'waiting', scheduledAt: null },
+        {
+          id: 'session-1-child',
+          parentSessionId: 'session-1',
+          name: 'Scheduled child',
+          status: 'scheduled',
+          scheduledAt: '2026-01-10T14:00:00-06:00',
+        },
+      ];
+
+      const wrapper = mountBoard();
+
+      const scheduledInfo = wrapper.find('.card-scheduled-info');
+      expect(scheduledInfo.exists()).toBe(true);
+      expect(scheduledInfo.text()).toContain('scheduled');
+      expect(scheduledInfo.text()).toContain('in about 2 hours');
+      expect(scheduledInfo.find('.scheduled-time').attributes('title')).toBe('Jan 10, 2:00 PM');
+    });
+
+    it('does not show scheduled badge when the workflow has no scheduled time', () => {
+      const sessionsStore = useSessionsStore();
+      sessionsStore.sessions = [
+        { id: 'session-1', name: 'Session 1', status: 'waiting', scheduledAt: null },
+      ];
+
+      const wrapper = mountBoard();
+
+      expect(wrapper.find('.card-scheduled-info').exists()).toBe(false);
     });
   });
 

--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
+import { format } from 'date-fns';
 import KanbanBoard from './KanbanBoard.vue';
 import { useSessionsStore } from '../stores/sessions.js';
 
@@ -195,7 +196,8 @@ describe('KanbanBoard.vue', () => {
       expect(scheduledInfo.exists()).toBe(true);
       expect(scheduledInfo.text()).toContain('scheduled');
       expect(scheduledInfo.text()).toContain('in about 2 hours');
-      expect(scheduledInfo.find('.scheduled-time').attributes('title')).toBe('Jan 10, 2:00 PM');
+      const expectedTitle = format(new Date('2026-01-10T14:00:00-06:00'), 'MMM d, h:mm a');
+      expect(scheduledInfo.find('.scheduled-time').attributes('title')).toBe(expectedTitle);
     });
 
     it('does not show scheduled badge when the workflow has no scheduled time', () => {

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -137,6 +137,40 @@
                     {{ card.sessions[0].mode }}
                   </span>
                 </div>
+                <div
+                  v-if="cardsScheduledInfo[card.id]?.showBadge"
+                  class="card-scheduled-info"
+                >
+                  <span class="status-badge status-scheduled">
+                    <svg
+                      class="schedule-icon-inline"
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                      />
+                      <polyline points="12 6 12 12 16 14" />
+                    </svg>
+                    scheduled
+                  </span>
+                  <span
+                    v-if="cardsScheduledInfo[card.id].timeDisplay"
+                    class="scheduled-time"
+                    :title="cardsScheduledInfo[card.id].absoluteTime"
+                  >
+                    {{ cardsScheduledInfo[card.id].timeDisplay }}
+                  </span>
+                </div>
               </router-link>
               <!-- Card reorder arrows -->
               <div class="card-reorder-arrows">
@@ -337,9 +371,12 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, watch, toRef } from 'vue';
+import { formatDistanceToNow, format } from 'date-fns';
 import { useKanbanStore } from '../stores/kanban.js';
 import { useSessionsStore } from '../stores/sessions.js';
+import { findNearestScheduledTime } from '../utils/scheduleInfo.js';
+import { useCardDragDrop } from '../composables/useCardDragDrop.js';
 import AddSessionToLaneModal from './AddSessionToLaneModal.vue';
 import LaneSettingsModal from './LaneSettingsModal.vue';
 import MoveCardModal from './MoveCardModal.vue';
@@ -360,13 +397,44 @@ const sessionsStore = useSessionsStore();
 const showAddLane = ref(false);
 const newLaneName = ref('');
 
-// Drag state (cards only)
-const dragType = ref(null); // 'card'
-const draggedCard = ref(null);
-const draggedCardLaneId = ref(null);
-const draggedCardIndex = ref(-1);
-const dropCardLaneId = ref(null);
-const dropCardIndex = ref(-1);
+// Computed
+const board = computed(() => kanbanStore.board);
+const loading = computed(() => kanbanStore.loading);
+const error = computed(() => kanbanStore.error);
+const cardsScheduledInfo = computed(() => {
+  const map = {};
+  if (!board.value?.lanes) return map;
+
+  for (const lane of board.value.lanes) {
+    for (const card of lane.cards || []) {
+      const session = card.sessions?.[0];
+      if (!session?.id) continue;
+
+      const nearest = findNearestScheduledTime(session.id);
+
+      if (nearest === null) {
+        map[card.id] = { showBadge: false, timeDisplay: null, absoluteTime: null };
+        continue;
+      }
+
+      const scheduledTime = new Date(nearest);
+      map[card.id] = {
+        showBadge: true,
+        timeDisplay: formatDistanceToNow(scheduledTime, { addSuffix: true }),
+        absoluteTime: format(scheduledTime, 'MMM d, h:mm a'),
+      };
+    }
+  }
+
+  return map;
+});
+
+// Drag-and-drop
+const {
+  dragType, draggedCard, dropCardLaneId, dropCardIndex,
+  handleCardDragStart, handleCardDragOver, handleDragEnd,
+  handleDrop, moveCardInLane,
+} = useCardDragDrop(board, kanbanStore.reorderCards, kanbanStore.moveCard, toRef(props, 'projectId'));
 
 // Modal state
 const showAddSessionModal = ref(false);
@@ -376,11 +444,6 @@ const selectedLaneForSettings = ref(null);
 const showMoveCardModal = ref(false);
 const selectedCardForMove = ref(null);
 const selectedCardCurrentLaneId = ref(null);
-
-// Computed
-const board = computed(() => kanbanStore.board);
-const loading = computed(() => kanbanStore.loading);
-const error = computed(() => kanbanStore.error);
 
 // Methods
 const fetchBoard = async () => {
@@ -417,126 +480,6 @@ const isCardEffectivelyRunning = (session) => {
     return true;
   }
   return ['running', 'starting'].includes(session.status);
-};
-
-// --- Card drag-and-drop ---
-const handleCardDragStart = (event, card, laneId, cardIndex) => {
-  dragType.value = 'card';
-  draggedCard.value = card;
-  draggedCardLaneId.value = laneId;
-  draggedCardIndex.value = cardIndex;
-  const dt = event.dataTransfer;
-  dt.effectAllowed = 'move';
-  dt.setData('text/plain', card.id);
-};
-
-const handleCardDragOver = (event, laneId, cardIndex) => {
-  if (dragType.value !== 'card') return;
-  // Determine if above or below midpoint
-  const rect = event.currentTarget.getBoundingClientRect();
-  const midY = rect.top + rect.height / 2;
-  const index = event.clientY < midY ? cardIndex : cardIndex + 1;
-
-  // Don't show indicator at the card's current position
-  if (laneId === draggedCardLaneId.value &&
-      (index === draggedCardIndex.value || index === draggedCardIndex.value + 1)) {
-    dropCardLaneId.value = null;
-    dropCardIndex.value = -1;
-  } else {
-    dropCardLaneId.value = laneId;
-    dropCardIndex.value = index;
-  }
-};
-
-// --- Drag end ---
-const handleDragEnd = () => {
-  dragType.value = null;
-  draggedCard.value = null;
-  draggedCardLaneId.value = null;
-  draggedCardIndex.value = -1;
-  dropCardLaneId.value = null;
-  dropCardIndex.value = -1;
-};
-
-/**
- * Reorder cards within the same lane.
- * @param {string} laneId - The lane ID
- * @param {number} sourceIndex - Original card index
- * @param {number} dropIndex - Where the card was dropped
- */
-const reorderCardsInLane = async (laneId, sourceIndex, dropIndex) => {
-  const lane = board.value?.lanes?.find((l) => l.id === laneId);
-  if (!lane?.cards) return;
-
-  let targetIndex = dropIndex >= 0 ? dropIndex : lane.cards.length;
-  // Adjust for removal of source card
-  if (targetIndex > sourceIndex) targetIndex--;
-  if (targetIndex === sourceIndex) return;
-
-  const newOrder = lane.cards.map((c) => c.id);
-  const [movedId] = newOrder.splice(sourceIndex, 1);
-  newOrder.splice(targetIndex, 0, movedId);
-
-  try {
-    await kanbanStore.reorderCards(props.projectId, laneId, newOrder);
-  } catch (err) {
-    console.error('Failed to reorder cards:', err);
-  }
-};
-
-/**
- * Move a card to a different lane.
- * @param {string} cardId - The card ID
- * @param {string} targetLaneId - The target lane ID
- */
-const moveCardToLane = async (cardId, targetLaneId) => {
-  try {
-    await kanbanStore.moveCard(props.projectId, cardId, targetLaneId, {
-      runOnEnterTemplate: true,
-    });
-  } catch (err) {
-    console.error('Failed to move card:', err);
-  }
-};
-
-// --- Drop handler (card drops only) ---
-const handleDrop = async (event, targetLaneId) => {
-  event.preventDefault();
-
-  if (dragType.value !== 'card' || !draggedCard.value) {
-    handleDragEnd();
-    return;
-  }
-
-  const cardId = event.dataTransfer.getData('text/plain');
-  if (!cardId) {
-    handleDragEnd();
-    return;
-  }
-
-  const sourceLaneId = draggedCardLaneId.value;
-
-  if (sourceLaneId === targetLaneId) {
-    await reorderCardsInLane(targetLaneId, draggedCardIndex.value, dropCardIndex.value);
-  } else {
-    await moveCardToLane(cardId, targetLaneId);
-  }
-
-  handleDragEnd();
-};
-
-// --- Card reorder arrow handler ---
-const moveCardInLane = async (laneId, fromIndex, toIndex) => {
-  const lane = board.value?.lanes?.find((l) => l.id === laneId);
-  if (!lane?.cards) return;
-  const newOrder = lane.cards.map((c) => c.id);
-  const [movedId] = newOrder.splice(fromIndex, 1);
-  newOrder.splice(toIndex, 0, movedId);
-  try {
-    await kanbanStore.reorderCards(props.projectId, laneId, newOrder);
-  } catch (err) {
-    console.error('Failed to reorder cards:', err);
-  }
 };
 
 const handleRemoveCard = async (cardId) => {

--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -37,6 +37,7 @@ const mockSessionsStoreData = {
   activeSessions: [],
   commandRunVersion: 0,
   toggleSessionStar: vi.fn(),
+  getSessionById: vi.fn((id) => mockSessionsStoreData.sessions.find((s) => s.id === id) || null),
   getWorkflowSessions: vi.fn((sessionId) => {
     // Default implementation: search both sessions and activeSessions
     const root = mockSessionsStoreData.sessions.find(s => s.id === sessionId)
@@ -139,6 +140,9 @@ describe('SessionCard', () => {
     mockSessionsStoreData.activeSessions = [];
     mockSessionsStoreData.commandRunVersion = 0;
     mockSessionsStoreData._currentSession = null;
+    mockSessionsStoreData.getSessionById.mockImplementation(
+      (id) => mockSessionsStoreData.sessions.find((s) => s.id === id) || null,
+    );
 
     // Reset commandButtons store mock data
     mockCommandButtonsData.buttons = [];

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -177,6 +177,7 @@ import { formatDistanceToNow, format } from 'date-fns';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useKanbanStore } from '../stores/kanban.js';
+import { findNearestScheduledTime } from '../utils/scheduleInfo.js';
 import { getStatusIconSvg } from './statusIcons';
 import ButtonStatusModal from './ButtonStatusModal.vue';
 import PrIndicators from './PrIndicators.vue';
@@ -289,34 +290,7 @@ const runningSessionIds = computed(() => {
 
 const hasRunningSession = computed(() => runningSessionIds.value.length > 0);
 
-/** Find the nearest upcoming scheduledAt from any session in the workflow tree. */
-const nearestScheduledAt = computed(() => {
-  const now = Date.now();
-
-  // Check the session itself first (most relevant).
-  // Note: For self-scheduled sessions, we show the time even if it's in the past —
-  // this preserves backward compatibility and signals a potential scheduling issue.
-  if (props.session.status === 'scheduled' && props.session.scheduledAt) {
-    return props.session.scheduledAt;
-  }
-
-  // Find the earliest future scheduled time among children.
-  // Only future times are shown for children (past scheduled times mean the
-  // session should have already been triggered).
-  const allSessions = getWorkflowSessions();
-  let earliest = null;
-  for (const s of allSessions) {
-    // Skip the root session (already checked above)
-    if (s.id === props.session.id) continue;
-    if (s.status === 'scheduled' && s.scheduledAt) {
-      const t = new Date(s.scheduledAt).getTime();
-      if (t >= now && (earliest === null || t < earliest)) {
-        earliest = t;
-      }
-    }
-  }
-  return earliest;
-});
+const nearestScheduledAt = computed(() => findNearestScheduledTime(props.session.id));
 
 const scheduledTimeDisplay = computed(() => {
   if (!nearestScheduledAt.value) return null;

--- a/packages/web/src/composables/useCardDragDrop.js
+++ b/packages/web/src/composables/useCardDragDrop.js
@@ -1,0 +1,134 @@
+import { ref } from 'vue';
+
+/**
+ * Composable for card drag-and-drop in the kanban board.
+ * Manages drag state, drop indicators, and reorder/move operations.
+ *
+ * @param {import('vue').Ref<object>} board - Reactive reference to the kanban board
+ * @param {Function} reorderCardsFn - Function to call for card reordering: (projectId, laneId, cardOrder) => Promise
+ * @param {Function} moveCardFn - Function to call for cross-lane card moves: (projectId, cardId, targetLaneId, opts) => Promise
+ * @param {import('vue').Ref<string>} projectId - Reactive reference to the project ID
+ */
+export function useCardDragDrop(board, reorderCardsFn, moveCardFn, projectId) {
+  // Drag state
+  const dragType = ref(null);
+  const draggedCard = ref(null);
+  const draggedCardLaneId = ref(null);
+  const draggedCardIndex = ref(-1);
+  const dropCardLaneId = ref(null);
+  const dropCardIndex = ref(-1);
+
+  const handleCardDragStart = (event, card, laneId, cardIndex) => {
+    dragType.value = 'card';
+    draggedCard.value = card;
+    draggedCardLaneId.value = laneId;
+    draggedCardIndex.value = cardIndex;
+    const dt = event.dataTransfer;
+    dt.effectAllowed = 'move';
+    dt.setData('text/plain', card.id);
+  };
+
+  const handleCardDragOver = (event, laneId, cardIndex) => {
+    if (dragType.value !== 'card') return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    const index = event.clientY < midY ? cardIndex : cardIndex + 1;
+
+    if (laneId === draggedCardLaneId.value &&
+        (index === draggedCardIndex.value || index === draggedCardIndex.value + 1)) {
+      dropCardLaneId.value = null;
+      dropCardIndex.value = -1;
+    } else {
+      dropCardLaneId.value = laneId;
+      dropCardIndex.value = index;
+    }
+  };
+
+  const handleDragEnd = () => {
+    dragType.value = null;
+    draggedCard.value = null;
+    draggedCardLaneId.value = null;
+    draggedCardIndex.value = -1;
+    dropCardLaneId.value = null;
+    dropCardIndex.value = -1;
+  };
+
+  const reorderCardsInLane = async (laneId, sourceIndex, dropIndex) => {
+    const lane = board.value?.lanes?.find((l) => l.id === laneId);
+    if (!lane?.cards) return;
+
+    let targetIndex = dropIndex >= 0 ? dropIndex : lane.cards.length;
+    if (targetIndex > sourceIndex) targetIndex--;
+    if (targetIndex === sourceIndex) return;
+
+    const newOrder = lane.cards.map((c) => c.id);
+    const [movedId] = newOrder.splice(sourceIndex, 1);
+    newOrder.splice(targetIndex, 0, movedId);
+
+    try {
+      await reorderCardsFn(projectId.value, laneId, newOrder);
+    } catch (err) {
+      console.error('Failed to reorder cards:', err);
+    }
+  };
+
+  const moveCardToLane = async (cardId, targetLaneId) => {
+    try {
+      await moveCardFn(projectId.value, cardId, targetLaneId, {
+        runOnEnterTemplate: true,
+      });
+    } catch (err) {
+      console.error('Failed to move card:', err);
+    }
+  };
+
+  const handleDrop = async (event, targetLaneId) => {
+    event.preventDefault();
+
+    if (dragType.value !== 'card' || !draggedCard.value) {
+      handleDragEnd();
+      return;
+    }
+
+    const cardId = event.dataTransfer.getData('text/plain');
+    if (!cardId) {
+      handleDragEnd();
+      return;
+    }
+
+    const sourceLaneId = draggedCardLaneId.value;
+
+    if (sourceLaneId === targetLaneId) {
+      await reorderCardsInLane(targetLaneId, draggedCardIndex.value, dropCardIndex.value);
+    } else {
+      await moveCardToLane(cardId, targetLaneId);
+    }
+
+    handleDragEnd();
+  };
+
+  const moveCardInLane = async (laneId, fromIndex, toIndex) => {
+    const lane = board.value?.lanes?.find((l) => l.id === laneId);
+    if (!lane?.cards) return;
+    const newOrder = lane.cards.map((c) => c.id);
+    const [movedId] = newOrder.splice(fromIndex, 1);
+    newOrder.splice(toIndex, 0, movedId);
+    try {
+      await reorderCardsFn(projectId.value, laneId, newOrder);
+    } catch (err) {
+      console.error('Failed to reorder cards:', err);
+    }
+  };
+
+  return {
+    dragType,
+    draggedCard,
+    dropCardLaneId,
+    dropCardIndex,
+    handleCardDragStart,
+    handleCardDragOver,
+    handleDragEnd,
+    handleDrop,
+    moveCardInLane,
+  };
+}

--- a/packages/web/src/utils/scheduleInfo.js
+++ b/packages/web/src/utils/scheduleInfo.js
@@ -1,0 +1,41 @@
+import { useSessionsStore } from '../stores/sessions.js';
+
+/**
+ * Find the nearest scheduled time across all sessions in a workflow tree.
+ *
+ * The root session's scheduled time is returned even when it is in the past,
+ * which preserves the existing session-card behavior and surfaces stale
+ * scheduling state. Descendant sessions only count when scheduled in the
+ * future.
+ *
+ * @param {string} rootSessionId
+ * @returns {string|number|null}
+ */
+export function findNearestScheduledTime(rootSessionId) {
+  const sessionsStore = useSessionsStore();
+  const allSessions = sessionsStore.getWorkflowSessions(rootSessionId);
+  const rootSession =
+    sessionsStore.getSessionById?.(rootSessionId) ||
+    allSessions.find((session) => session.id === rootSessionId);
+  if (!rootSession) return null;
+
+  if (rootSession.status === 'scheduled' && rootSession.scheduledAt) {
+    return rootSession.scheduledAt;
+  }
+
+  const now = Date.now();
+  let earliest = null;
+
+  for (const session of allSessions) {
+    if (session.id === rootSessionId) continue;
+
+    if (session.status === 'scheduled' && session.scheduledAt) {
+      const scheduledTime = new Date(session.scheduledAt).getTime();
+      if (scheduledTime >= now && (earliest === null || scheduledTime < earliest)) {
+        earliest = scheduledTime;
+      }
+    }
+  }
+
+  return earliest;
+}

--- a/packages/web/src/utils/scheduleInfo.js
+++ b/packages/web/src/utils/scheduleInfo.js
@@ -15,7 +15,7 @@ export function findNearestScheduledTime(rootSessionId) {
   const sessionsStore = useSessionsStore();
   const allSessions = sessionsStore.getWorkflowSessions(rootSessionId);
   const rootSession =
-    sessionsStore.getSessionById?.(rootSessionId) ||
+    sessionsStore.getSessionById(rootSessionId) ||
     allSessions.find((session) => session.id === rootSessionId);
   if (!rootSession) return null;
 

--- a/packages/web/src/utils/scheduleInfo.test.js
+++ b/packages/web/src/utils/scheduleInfo.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useSessionsStore } from '../stores/sessions.js';
+import { findNearestScheduledTime } from './scheduleInfo.js';
+
+describe('findNearestScheduledTime', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the root scheduled time even when it is in the past', () => {
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+    const sessionsStore = useSessionsStore();
+    const scheduledAt = '2026-01-10T10:00:00Z';
+
+    sessionsStore.sessions = [
+      { id: 'root', status: 'scheduled', scheduledAt },
+      { id: 'child', parentSessionId: 'root', status: 'scheduled', scheduledAt: '2026-01-10T13:00:00Z' },
+    ];
+
+    expect(findNearestScheduledTime('root')).toBe(scheduledAt);
+  });
+
+  it('returns the nearest future scheduled descendant when the root is not scheduled', () => {
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+    const sessionsStore = useSessionsStore();
+
+    sessionsStore.sessions = [
+      { id: 'root', status: 'waiting', scheduledAt: null },
+      { id: 'past-child', parentSessionId: 'root', status: 'scheduled', scheduledAt: '2026-01-10T11:00:00Z' },
+      { id: 'later-child', parentSessionId: 'root', status: 'scheduled', scheduledAt: '2026-01-10T15:00:00Z' },
+      { id: 'soon-child', parentSessionId: 'root', status: 'scheduled', scheduledAt: '2026-01-10T13:00:00Z' },
+    ];
+
+    expect(findNearestScheduledTime('root')).toBe(new Date('2026-01-10T13:00:00Z').getTime());
+  });
+
+  it('finds active-session roots through workflow traversal', () => {
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+    const sessionsStore = useSessionsStore();
+    const scheduledAt = '2026-01-10T14:00:00Z';
+
+    sessionsStore.activeSessions = [
+      { id: 'active-root', status: 'scheduled', scheduledAt },
+    ];
+
+    expect(findNearestScheduledTime('active-root')).toBe(scheduledAt);
+  });
+});

--- a/tests/e2e/session-name-editing.spec.ts
+++ b/tests/e2e/session-name-editing.spec.ts
@@ -99,6 +99,7 @@ test.describe('Session Name Editing', () => {
 
     // Click the edit pencil icon
     await page.click('button.name-edit-trigger');
+    await page.waitForSelector('input.name-edit-input', { state: 'visible' });
 
     // Enter a new name
     await page.fill('input.name-edit-input', 'This Should Not Save');
@@ -129,6 +130,7 @@ test.describe('Session Name Editing', () => {
 
     // Click the edit pencil icon
     await page.click('button.name-edit-trigger');
+    await page.waitForSelector('input.name-edit-input', { state: 'visible' });
 
     // Enter a new name
     await page.fill('input.name-edit-input', 'This Should Not Save');
@@ -158,6 +160,7 @@ test.describe('Session Name Editing', () => {
 
     // Click the edit pencil icon
     await page.click('button.name-edit-trigger');
+    await page.waitForSelector('input.name-edit-input', { state: 'visible' });
 
     // Enter a new name and press Enter
     await page.fill('input.name-edit-input', 'Name Saved Via Enter');

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -197,11 +197,13 @@ test.describe('Settings', () => {
 
   test.describe('Category 4: Summary Settings — Reset', () => {
     test.beforeEach(async () => {
-      // Pre-set non-default values via API
-      await updateSummarySettings({
+      // Pre-set non-default values via API and verify they persisted
+      const result = await updateSummarySettings({
         disableSessionSummaries: true,
         sessionTitlePrompt: 'Custom title prompt for testing',
       });
+      // Verify the API actually saved the settings before navigating
+      expect(result.disableSessionSummaries).toBe(true);
     });
 
     test('reset to defaults shows confirmation dialog', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Extract card drag-and-drop logic into a composable (`useCardDragDrop.js`) to reduce `KanbanBoard.vue` below 600 lines and improve maintainability
- Add `scheduleInfo` utility module with tests for scheduling display on session cards
- Simplify `SessionCard.vue` component by removing redundant code
- Update E2E test configs for session-name-editing and settings specs
- Declare `date-fns` in `packages/web/package.json` (corrects a previously-undeclared-but-used dependency — latent-bug fix)

## Test plan

- [x] All unit tests pass (`yarn test`)
- [x] `TZ=UTC yarn test` passes (timezone-independent)
- [x] All Playwright E2E tests pass (1132 passed, 18 skipped)
- [x] Lint passes (`yarn lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)