### PR TITLE
Remove 'Start session or send a message' hint from summary empty states

### DIFF
--- a/packages/web/src/components/SessionOverviewCard.test.js
+++ b/packages/web/src/components/SessionOverviewCard.test.js
@@ -129,7 +129,6 @@ describe('SessionOverviewCard.vue', () => {
       expect(wrapper.find('.session-overview').exists()).toBe(true);
       expect(wrapper.find('.overview-summary-empty').exists()).toBe(true);
       expect(wrapper.text()).toContain("This session hasn't started yet.");
-      expect(wrapper.text()).toContain('Start the session or send a message to see a summary here.');
       expect(wrapper.find('.overview-summary-empty button').exists()).toBe(false);
       expect(wrapper.find('.overview-summary-empty').text()).not.toContain('Generate summary');
     });

--- a/packages/web/src/components/SessionOverviewCard.vue
+++ b/packages/web/src/components/SessionOverviewCard.vue
@@ -33,9 +33,6 @@
       <p class="summary-empty-text">
         This session hasn't started yet.
       </p>
-      <p class="summary-empty-hint">
-        Start the session or send a message to see a summary here.
-      </p>
     </div>
 
     <!-- Overview Metrics -->
@@ -270,13 +267,6 @@ defineEmits(['open-session-overlay']);
   font-weight: 500;
   color: var(--color-text);
   margin: 0 0 0.5rem;
-}
-
-.summary-empty-hint {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  margin: 0;
-  line-height: 1.4;
 }
 
 .overview-metrics {

--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -965,7 +965,6 @@ describe('SummaryTab', () => {
 
       expect(wrapper.find('.summary-empty-state').exists()).toBe(true);
       expect(wrapper.text()).toContain("This session hasn't started yet.");
-      expect(wrapper.text()).toContain('Start the session or send a message to see a summary here.');
       expect(wrapper.find('.summary-empty-state button').exists()).toBe(false);
       expect(wrapper.find('.summary-empty-state').text()).not.toContain('Generate summary');
     });

--- a/packages/web/src/components/SummaryTab.vue
+++ b/packages/web/src/components/SummaryTab.vue
@@ -61,9 +61,6 @@
         <p class="summary-empty-state-text">
           This session hasn't started yet.
         </p>
-        <p class="summary-empty-state-hint">
-          Start the session or send a message to see a summary here.
-        </p>
       </div>
     </div>
 
@@ -306,13 +303,6 @@ async function handleRegenerate() {
   font-weight: 500;
   color: var(--color-text);
   margin: 0 0 0.5rem;
-}
-
-.summary-empty-state-hint {
-  font-size: 0.875rem;
-  color: var(--color-text-soft);
-  margin: 0;
-  line-height: 1.4;
 }
 
 .missing-summary-action {


### PR DESCRIPTION
## Summary

Removes the hint text **"Start the session or send a message to see a summary here."** from the empty/starting state of both:

- **SessionOverviewCard** (canvas overview card)
- **SummaryTab** (session detail summary tab)

## Changes

- Remove the `<p class="summary-empty-hint">` element and its CSS from `SessionOverviewCard.vue`
- Remove the `<p class="summary-empty-state-hint">` element and its CSS from `SummaryTab.vue`
- Update corresponding test assertions in both `SessionOverviewCard.test.js` and `SummaryTab.test.js`

## Why

The hint text is no longer needed — users already understand they need to start a session to see a summary. Removing it simplifies the empty state UI.

## Testing

- Unit tests updated and passing for both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)