### PR TITLE
Remove duplicate refresh button from ChangesTab

### DIFF
--- a/packages/web/src/components/ChangesTab.test.js
+++ b/packages/web/src/components/ChangesTab.test.js
@@ -467,11 +467,11 @@ describe('ChangesTab', () => {
       const toolbar = wrapper.find('.changes-toolbar');
       expect(toolbar.exists()).toBe(true);
 
-      // Should have mode toggle buttons + Expand/Collapse button
+      // Should have mode toggle button + Expand/Collapse button
       const buttons = toolbar.findAll('button');
-      // At least 3 buttons: Local Changes + Expand/Collapse All + Refresh
+      // At least 2 buttons: Local Changes + Expand/Collapse All
       // (Compare to branch button only shows if defaultBranch is set)
-      expect(buttons.length).toBeGreaterThanOrEqual(3);
+      expect(buttons.length).toBeGreaterThanOrEqual(2);
       expect(toolbar.text()).toContain('Local Changes');
       expect(toolbar.text()).toMatch(/Expand All|Collapse All/);
     });
@@ -507,16 +507,16 @@ describe('ChangesTab', () => {
       const toolbar = wrapper.find('.changes-toolbar');
       expect(toolbar.exists()).toBe(true);
 
-      // Should have both mode toggle buttons + refresh button
+      // Should have both mode toggle buttons
       const buttons = toolbar.findAll('button');
-      expect(buttons.length).toBeGreaterThanOrEqual(3);
+      expect(buttons.length).toBe(2);
       expect(toolbar.text()).toContain('Local Changes');
       expect(toolbar.text()).toContain('Compare to main');
-      expect(toolbar.text()).toContain('Refresh');
 
       // Should NOT show the Expand/Collapse button when there are no changes
       expect(toolbar.text()).not.toContain('Expand All');
       expect(toolbar.text()).not.toContain('Collapse All');
+      expect(wrapper.find('.toolbar-actions').exists()).toBe(false);
     });
 
     it('allows switching to branch compare mode when no local changes', async () => {
@@ -1145,7 +1145,7 @@ index 1234567..abcdefg 100644
     });
   });
 
-  describe('refresh button', () => {
+  describe('unified refresh button', () => {
     const stagedDiffFixture = `diff --git a/file1.js b/file1.js
 index 1234567..abcdefg 100644
 --- a/file1.js
@@ -1154,49 +1154,34 @@ index 1234567..abcdefg 100644
  const x = 1;
 +const y = 2;`;
 
-    it('renders refresh button in toolbar when changes are present', async () => {
+    it('renders exactly one refresh control on the tab', async () => {
       api.getSessionChanges.mockResolvedValue({
         staged: stagedDiffFixture,
         unstaged: '',
         untracked: '',
       });
-
-      const wrapper = mountComponent();
-      await flushAll(wrapper);
-
-      const refreshButton = wrapper.find('.refresh-button');
-      expect(refreshButton.exists()).toBe(true);
-      expect(refreshButton.text()).toContain('Refresh');
-    });
-
-    it('renders refresh button when no changes but defaultBranch exists', async () => {
-      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
-      api.getSessionDefaultBranch.mockResolvedValue({ branch: 'origin/main' });
-
-      const wrapper = mountComponent();
-      await flushAll(wrapper);
-
-      expect(wrapper.find('.refresh-button').exists()).toBe(true);
-    });
-
-    it('does not render refresh button when toolbar is hidden', async () => {
-      api.getSessionChanges.mockResolvedValue({ staged: '', unstaged: '', untracked: '' });
-      api.getSessionDefaultBranch.mockResolvedValue({ branch: null });
 
       const wrapper = mountComponent();
       await flushAll(wrapper);
 
       expect(wrapper.find('.refresh-button').exists()).toBe(false);
+      const refreshButtons = wrapper.findAll('button').filter(button => button.text().includes('Refresh'));
+      expect(refreshButtons).toHaveLength(1);
+      expect(refreshButtons[0].classes()).toContain('refresh-origin-button');
     });
 
-    it('calls fetchChanges when clicked', async () => {
+    it('banner refresh triggers git status refresh and changes refresh', async () => {
+      const refreshGitStatus = vi.fn().mockResolvedValue();
       api.getSessionChanges.mockResolvedValue({
         staged: stagedDiffFixture,
         unstaged: '',
         untracked: '',
       });
 
-      const wrapper = mountComponent();
+      const wrapper = mountComponent({
+        sessionId: 'test-session',
+        refreshGitStatus,
+      });
       await flushAll(wrapper);
 
       api.getSessionChanges.mockClear();
@@ -1206,22 +1191,28 @@ index 1234567..abcdefg 100644
         untracked: '',
       });
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-origin-button');
       await refreshButton.trigger('click');
       await flushAll(wrapper);
 
+      expect(refreshGitStatus).toHaveBeenCalledWith({ fetch: true });
+      expect(refreshGitStatus).toHaveBeenCalledTimes(1);
       expect(api.getSessionChanges).toHaveBeenCalledWith('test-session', 'local', null);
       expect(api.getSessionChanges).toHaveBeenCalledTimes(1);
     });
 
-    it('is disabled and shows spinner while refreshing', async () => {
+    it('banner refresh button is disabled and shows spinner while changes refresh is pending', async () => {
+      const refreshGitStatus = vi.fn().mockResolvedValue();
       api.getSessionChanges.mockResolvedValue({
         staged: stagedDiffFixture,
         unstaged: '',
         untracked: '',
       });
 
-      const wrapper = mountComponent();
+      const wrapper = mountComponent({
+        sessionId: 'test-session',
+        refreshGitStatus,
+      });
       await flushAll(wrapper);
 
       // Make next API call return a pending promise
@@ -1230,7 +1221,7 @@ index 1234567..abcdefg 100644
         resolveRefresh = resolve;
       }));
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-origin-button');
       await refreshButton.trigger('click');
       await nextTick();
       await wrapper.vm.$forceUpdate();
@@ -1240,17 +1231,14 @@ index 1234567..abcdefg 100644
       expect(refreshButton.attributes('disabled')).toBeDefined();
       // Spinner should be visible
       expect(refreshButton.find('.loading-spinner').exists()).toBe(true);
-      // Static icon should not be present
-      expect(refreshButton.text()).not.toContain('↻');
 
       // Resolve the pending promise
       resolveRefresh({ staged: stagedDiffFixture, unstaged: '', untracked: '' });
       await flushAll(wrapper);
 
-      // After loading completes, spinner should be gone and static icon should return
-      const refreshedButton = wrapper.find('.refresh-button');
+      // After loading completes, spinner should be gone
+      const refreshedButton = wrapper.find('.refresh-origin-button');
       expect(refreshedButton.find('.loading-spinner').exists()).toBe(false);
-      expect(refreshedButton.text()).toContain('↻');
     });
 
     it('updates data after refresh completes', async () => {
@@ -1280,11 +1268,36 @@ index 1234567..abcdefg 100644
         untracked: '',
       });
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-origin-button');
       await refreshButton.trigger('click');
       await flushAll(wrapper);
 
       expect(wrapper.vm.stagedFiles[0].displayPath).toBe('file2.js');
+    });
+
+    it('banner refresh button is disabled and shows spinner when git status loading is true', async () => {
+      api.getSessionChanges.mockResolvedValue({
+        staged: stagedDiffFixture,
+        unstaged: '',
+        untracked: '',
+      });
+
+      const wrapper = mountComponent({
+        sessionId: 'test-session',
+        gitStatusLoading: true,
+      });
+      await flushAll(wrapper);
+
+      const refreshButton = wrapper.find('.refresh-origin-button');
+      expect(refreshButton.attributes('disabled')).toBeDefined();
+      expect(refreshButton.find('.loading-spinner').exists()).toBe(true);
+
+      await wrapper.setProps({ gitStatusLoading: false });
+      await flushAll(wrapper);
+
+      const refreshedButton = wrapper.find('.refresh-origin-button');
+      expect(refreshedButton.attributes('disabled')).toBeUndefined();
+      expect(refreshedButton.find('.loading-spinner').exists()).toBe(false);
     });
 
     it('shows initial loading state on first mount', async () => {
@@ -1313,14 +1326,18 @@ index 1234567..abcdefg 100644
       expect(wrapper.find('.loading-state').exists()).toBe(false);
     });
 
-    it('keeps toolbar visible during refresh after initial load', async () => {
+    it('keeps toolbar visible during banner refresh after initial load', async () => {
+      const refreshGitStatus = vi.fn().mockResolvedValue();
       api.getSessionChanges.mockResolvedValue({
         staged: stagedDiffFixture,
         unstaged: '',
         untracked: '',
       });
 
-      const wrapper = mountComponent();
+      const wrapper = mountComponent({
+        sessionId: 'test-session',
+        refreshGitStatus,
+      });
       await flushAll(wrapper);
 
       // Toolbar should be visible after initial load
@@ -1332,7 +1349,7 @@ index 1234567..abcdefg 100644
         resolveRefresh = resolve;
       }));
 
-      const refreshButton = wrapper.find('.refresh-button');
+      const refreshButton = wrapper.find('.refresh-origin-button');
       await refreshButton.trigger('click');
       await nextTick();
       await wrapper.vm.$forceUpdate();

--- a/packages/web/src/components/ChangesTab.vue
+++ b/packages/web/src/components/ChangesTab.vue
@@ -19,7 +19,7 @@
       <GitStatusSummary
         :status="gitStatus"
         :summary-text="gitStatusSummary"
-        :loading="gitStatusLoading"
+        :loading="loading || gitStatusLoading"
         :error="gitStatusError"
         @refresh-origin="handleRefreshOrigin"
       />
@@ -51,27 +51,16 @@
             Compare to {{ branchLabel }}
           </button>
         </div>
-        <div class="toolbar-actions">
+        <div
+          v-if="hasChanges"
+          class="toolbar-actions"
+        >
           <button
-            v-if="hasChanges"
             class="btn-link"
             :disabled="loading"
             @click="toggleAllFiles"
           >
             {{ allExpanded ? 'Collapse All' : 'Expand All' }}
-          </button>
-          <button
-            class="btn-link refresh-button"
-            :disabled="loading"
-            title="Refresh changes"
-            @click="fetchChanges"
-          >
-            <span
-              v-if="loading"
-              class="loading-spinner"
-            />
-            <span v-else>↻</span>
-            Refresh
           </button>
         </div>
       </div>
@@ -364,10 +353,10 @@ async function fetchChanges() {
 
 async function handleRefreshOrigin() {
   emit('refreshGitStatus');
-  if (props.refreshGitStatus) {
-    await props.refreshGitStatus({ fetch: true });
-  }
-  await fetchChanges();
+  await Promise.all([
+    props.refreshGitStatus ? props.refreshGitStatus({ fetch: true }) : null,
+    fetchChanges(),
+  ]);
 }
 
 // Fetch the default branch for comparison
@@ -552,9 +541,4 @@ defineExpose({
   gap: 0.5rem;
 }
 
-.refresh-button .loading-spinner {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-width: 1.5px;
-}
 </style>

--- a/packages/web/src/components/GitStatusSummary.test.js
+++ b/packages/web/src/components/GitStatusSummary.test.js
@@ -24,6 +24,8 @@ describe('GitStatusSummary', () => {
 
     const button = wrapper.find('.refresh-origin-button');
     expect(button.exists()).toBe(true);
+    expect(button.text()).toContain('Refresh');
+    expect(button.text()).not.toContain('from origin');
     expect(button.attributes('disabled')).toBeUndefined();
     await button.trigger('click');
 
@@ -39,5 +41,17 @@ describe('GitStatusSummary', () => {
     });
 
     expect(wrapper.text()).toContain('Not a git repository');
+  });
+
+  it('disables the refresh button and shows a spinner while loading', () => {
+    const wrapper = mount(GitStatusSummary, {
+      props: {
+        loading: true,
+      },
+    });
+
+    const button = wrapper.find('.refresh-origin-button');
+    expect(button.attributes('disabled')).toBeDefined();
+    expect(button.find('.loading-spinner').exists()).toBe(true);
   });
 });

--- a/packages/web/src/components/GitStatusSummary.vue
+++ b/packages/web/src/components/GitStatusSummary.vue
@@ -39,7 +39,7 @@
         v-if="loading"
         class="loading-spinner"
       />
-      Refresh from origin
+      Refresh
     </button>
   </section>
 </template>


### PR DESCRIPTION
## Summary

The Changes tab had **two refresh buttons**: one in the GitStatusSummary banner ("Refresh from origin") and one in the toolbar ("Refresh"). This removes the toolbar refresh and consolidates all refresh behavior into the banner button.

## Changes

- **Remove** the toolbar `Refresh` button and its CSS styles
- **Consolidate** refresh behavior: the banner button now runs `git status fetch` and `changes refresh` in parallel via `Promise.all`
- **Show** `toolbar-actions` div only when there are changes (contains Expand/Collapse All)
- **Combine** loading states: pass `loading || gitStatusLoading` to GitStatusSummary so the banner button is disabled during either operation
- **Rename** "Refresh from origin" → "Refresh" since it now refreshes everything
- **Update** all related tests to reflect the new single-refresh-button behavior

## Test plan

- [x] Unit tests pass (`yarn workspace @circuschief/web test`)
- [ ] Manual: verify the Changes tab has exactly one Refresh button in the banner
- [ ] Manual: clicking Refresh triggers both a git fetch and a changes reload
- [ ] Manual: button shows spinner while either operation is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)