### PR TITLE
feat: model validation, kanban/PR cross-links, and E2E test fixes

### DIFF
--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
+import { defineComponent, h } from 'vue';
 import KanbanBoard from './KanbanBoard.vue';
 
 vi.mock('../stores/kanban.js', () => ({
@@ -16,7 +17,12 @@ vi.mock('../stores/kanban.js', () => ({
             {
               id: 'card-1',
               laneId: 'lane-1',
-              sessions: [{ id: 'session-1', name: 'Session 1', status: 'waiting' }],
+              sessions: [{
+                id: 'session-1',
+                name: 'Session 1',
+                status: 'waiting',
+                prUrl: 'https://github.com/owner/repo/pull/123',
+              }],
             },
             {
               id: 'card-2',
@@ -73,6 +79,16 @@ vi.mock('./MoveCardModal.vue', () => ({
     props: ['isOpen', 'projectId', 'cardId', 'currentLaneId', 'sessionName'],
     emits: ['update:isOpen', 'close', 'moved'],
   },
+}));
+
+vi.mock('./PrIndicators.vue', () => ({
+  default: defineComponent({
+    name: 'PrIndicators',
+    props: ['prUrl'],
+    setup(props) {
+      return () => h('span', { class: 'pr-indicators', 'data-pr-url': props.prUrl }, 'PR');
+    },
+  }),
 }));
 
 import { useKanbanStore } from '../stores/kanban.js';
@@ -163,6 +179,16 @@ describe('KanbanBoard.vue', () => {
       const moveButton = wrapper.find('.card-move-btn');
       expect(moveButton.exists()).toBe(true);
       // Click handler testing skipped - covered by E2E tests
+    });
+  });
+
+  describe('PR indicators', () => {
+    it('shows a PR indicator for kanban cards whose session has a PR URL', () => {
+      const wrapper = mountBoard();
+
+      const prIndicators = wrapper.findAll('.pr-indicators');
+      expect(prIndicators).toHaveLength(1);
+      expect(prIndicators[0].attributes('data-pr-url')).toBe('https://github.com/owner/repo/pull/123');
     });
   });
 

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -136,6 +136,10 @@
                   >
                     {{ card.sessions[0].mode }}
                   </span>
+                  <PrIndicators
+                    v-if="card.sessions[0].prUrl"
+                    :pr-url="card.sessions[0].prUrl"
+                  />
                 </div>
               </router-link>
               <!-- Card reorder arrows -->
@@ -343,6 +347,7 @@ import { useSessionsStore } from '../stores/sessions.js';
 import AddSessionToLaneModal from './AddSessionToLaneModal.vue';
 import LaneSettingsModal from './LaneSettingsModal.vue';
 import MoveCardModal from './MoveCardModal.vue';
+import PrIndicators from './PrIndicators.vue';
 import SessionRunningSpinner from './SessionRunningSpinner.vue';
 import './KanbanBoard.css';
 

--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -69,10 +69,13 @@ vi.mock('../stores/sessions.js', () => ({
 }));
 
 // Mock kanban store
+const mockKanbanStoreData = {
+  isSessionOnBoard: vi.fn(() => false),
+  getCardBySessionId: vi.fn(() => null),
+  getLaneById: vi.fn(() => null),
+};
 vi.mock('../stores/kanban.js', () => ({
-  useKanbanStore: vi.fn(() => ({
-    isSessionOnBoard: vi.fn(() => false),
-  })),
+  useKanbanStore: vi.fn(() => mockKanbanStoreData),
 }));
 
 
@@ -83,6 +86,17 @@ vi.mock('./ButtonStatusModal.vue', () => ({
     props: ['button', 'latestRun', 'isOpen'],
     setup() {
       return () => h('div', { class: 'button-status-modal-mock' });
+    },
+  }),
+}));
+
+// Mock MoveCardModal component
+vi.mock('./MoveCardModal.vue', () => ({
+  default: defineComponent({
+    name: 'MoveCardModal',
+    props: ['isOpen', 'projectId', 'cardId', 'currentLaneId', 'sessionName'],
+    setup() {
+      return () => h('div', { class: 'move-card-modal-mock' });
     },
   }),
 }));
@@ -144,6 +158,11 @@ describe('SessionCard', () => {
     mockCommandButtonsData.buttons = [];
     mockCommandButtonsData.getButtonsByProjectId.mockImplementation(() => mockCommandButtonsData.buttons);
     mockCommandButtonsData.getLatestRunForButton.mockReturnValue(null);
+
+    // Reset kanban store mock data
+    mockKanbanStoreData.isSessionOnBoard.mockReturnValue(false);
+    mockKanbanStoreData.getCardBySessionId.mockReturnValue(null);
+    mockKanbanStoreData.getLaneById.mockReturnValue(null);
   });
   const baseSession = {
     id: 'session-123',
@@ -268,6 +287,58 @@ describe('SessionCard', () => {
       const html = wrapper.html();
       // Should still render PrIndicators even if summary is null
       expect(html).toContain('pr-indicators');
+    });
+  });
+
+  describe('kanban lane chip', () => {
+    it('does not render a lane chip when session is not on the board', () => {
+      const wrapper = mountComponent();
+      expect(wrapper.find('.lane-chip').exists()).toBe(false);
+    });
+
+    it('renders lane chip for root sessions on the board', () => {
+      mockKanbanStoreData.getCardBySessionId.mockReturnValue({ id: 'card-1', laneId: 'lane-1' });
+      mockKanbanStoreData.getLaneById.mockReturnValue({ id: 'lane-1', name: 'Implementation' });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, projectId: 'proj-1' },
+      });
+
+      const chip = wrapper.find('.lane-chip');
+      expect(chip.exists()).toBe(true);
+      expect(chip.text()).toContain('Implementation');
+      expect(chip.attributes('title')).toBe('Move from Implementation to another lane');
+    });
+
+    it('does not render lane chip for child sessions', () => {
+      mockKanbanStoreData.getCardBySessionId.mockReturnValue({ id: 'card-1', laneId: 'lane-1' });
+      mockKanbanStoreData.getLaneById.mockReturnValue({ id: 'lane-1', name: 'Implementation' });
+
+      const wrapper = mountComponent({
+        isChild: true,
+        session: { ...baseSession, projectId: 'proj-1' },
+      });
+
+      expect(wrapper.find('.lane-chip').exists()).toBe(false);
+    });
+
+    it('opens move modal when lane chip is clicked', async () => {
+      mockKanbanStoreData.getCardBySessionId.mockReturnValue({ id: 'card-1', laneId: 'lane-1' });
+      mockKanbanStoreData.getLaneById.mockReturnValue({ id: 'lane-1', name: 'Implementation' });
+
+      const wrapper = mountComponent({
+        session: { ...baseSession, projectId: 'proj-1' },
+      });
+
+      await wrapper.find('.lane-chip').trigger('click');
+
+      const modal = wrapper.findComponent({ name: 'MoveCardModal' });
+      expect(modal.exists()).toBe(true);
+      expect(modal.props('isOpen')).toBe(true);
+      expect(modal.props('projectId')).toBe('proj-1');
+      expect(modal.props('cardId')).toBe('card-1');
+      expect(modal.props('currentLaneId')).toBe('lane-1');
+      expect(modal.props('sessionName')).toBe('Test Session');
     });
   });
 
@@ -1421,6 +1492,8 @@ describe('SessionCard', () => {
       const { useKanbanStore } = await import('../stores/kanban.js');
       vi.mocked(useKanbanStore).mockReturnValue({
         isSessionOnBoard: vi.fn(() => true),
+        getCardBySessionId: vi.fn(() => null),
+        getLaneById: vi.fn(() => null),
       });
 
       const wrapper = mountComponent({

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -115,6 +115,49 @@
               v-html="getStatusIcon(indicator.status)"
             />
             <!-- eslint-enable vue/no-v-html -->
+
+            <!-- Kanban lane chip -->
+            <button
+              v-if="sessionLane && !isChild"
+              type="button"
+              class="lane-chip lane-chip-clickable"
+              :title="`Move from ${sessionLane.name} to another lane`"
+              @click.stop.prevent="showMoveCardModal = true"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect
+                  x="3"
+                  y="3"
+                  width="18"
+                  height="18"
+                  rx="2"
+                  ry="2"
+                />
+                <line
+                  x1="9"
+                  y1="3"
+                  x2="9"
+                  y2="21"
+                />
+                <line
+                  x1="15"
+                  y1="3"
+                  x2="15"
+                  y2="21"
+                />
+              </svg>
+              {{ sessionLane.name }}
+            </button>
           </p>
 
           <p
@@ -169,6 +212,18 @@
     :session-id="session.id"
     @close="selectedButtonForModal = null"
   />
+
+  <MoveCardModal
+    v-if="sessionCard && sessionLane"
+    :is-open="showMoveCardModal"
+    :project-id="session.projectId"
+    :card-id="sessionCard.id"
+    :current-lane-id="sessionLane.id"
+    :session-name="session.name"
+    @update:is-open="showMoveCardModal = $event"
+    @close="showMoveCardModal = false"
+    @moved="showMoveCardModal = false"
+  />
 </template>
 
 <script setup>
@@ -179,6 +234,7 @@ import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useKanbanStore } from '../stores/kanban.js';
 import { getStatusIconSvg } from './statusIcons';
 import ButtonStatusModal from './ButtonStatusModal.vue';
+import MoveCardModal from './MoveCardModal.vue';
 import PrIndicators from './PrIndicators.vue';
 import SessionCardSummary from './SessionCardSummary.vue';
 import SessionCardHeaderActions from './SessionCardHeaderActions.vue';
@@ -188,6 +244,7 @@ const sessionsStore = useSessionsStore();
 const commandButtonsStore = useCommandButtonsStore();
 const kanbanStore = useKanbanStore();
 const selectedButtonForModal = ref(null);
+const showMoveCardModal = ref(false);
 
 const props = defineProps({
   session: {
@@ -244,6 +301,11 @@ const emit = defineEmits(['retrySummary', 'archive', 'unarchive', 'addToBoard'])
 
 // Check if session is already on the kanban board
 const isOnBoard = computed(() => kanbanStore.isSessionOnBoard(props.session.id));
+const sessionCard = computed(() => kanbanStore.getCardBySessionId(props.session.id));
+const sessionLane = computed(() => {
+  if (!sessionCard.value) return null;
+  return kanbanStore.getLaneById(sessionCard.value.laneId);
+});
 
 const onAddToBoardClick = () => {
   emit('addToBoard', props.session);
@@ -474,6 +536,32 @@ const onStarClick = () => {
 .button-status-indicator:hover {
   transform: scale(1.15);
   box-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
+}
+
+.lane-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--color-bg-soft, rgba(255, 255, 255, 0.05));
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.lane-chip-clickable {
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.lane-chip-clickable:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.lane-chip svg {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .button-status-running {


### PR DESCRIPTION
## Summary

Three related changes improving API safety, UI cross-linking, and test reliability.

### 1. Model ID validation in REST API (`3dbf`)
- **`model-validation.js`** — new shared module that validates model IDs against registered provider models before accepting create/patch requests
- **`ProviderRepository`** — added `findModelById()` and `findAllModels()` for validation lookups
- Applied validation to session create, session patch, and message-send endpoints
- Unit and integration tests for all new validation paths

### 2. Kanban / Session cross-linking (`2a55`)
- **`SessionCard.vue`** — shows a lane chip (with kanban icon) on session list cards when the session is on the kanban board; clicking opens the Move Card modal
- **`KanbanBoard.vue`** — renders a PR link indicator on kanban cards that have an associated `prUrl`
- Full test coverage for both components

### 3. E2E test fixes
- Updated model IDs in E2E tests to match valid seeded models (e.g. `claude-opus-4-6` instead of `claude-opus-4-6-20250616`)
- Fixes: `draft-session-model.spec.ts`, `cross-kind-switch.spec.ts`, `summary-tab-live-output.spec.ts`

## Files Changed (19)

| Area | Files |
|------|-------|
| Server API | `model-validation.js`, `projects-session-create.js`, `sessions-patch.js`, `sessions-messages.js` |
| Server DB | `ProviderRepository.js` |
| Web components | `SessionCard.vue`, `KanbanBoard.vue` |
| Tests (unit) | `model-validation.test.js`, `projects.test.js`, `sessions-messages.test.js`, `sessions.test.js`, `ProviderRepository.test.js`, `sessions.pendingModel.test.js`, `sessions-message-model.test.js`, `KanbanBoard.test.js`, `SessionCard.test.js` |
| Tests (E2E) | `draft-session-model.spec.ts`, `cross-kind-switch.spec.ts`, `summary-tab-live-output.spec.ts` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)