### PR TITLE
Fix Kanban completion for lane-triggered child sessions

### DIFF
--- a/packages/server/src/services/kanbanService.js
+++ b/packages/server/src/services/kanbanService.js
@@ -214,7 +214,30 @@ export async function handleTurnCompletion(sessionId) {
 }
 
 /**
+ * Walk up the ancestor chain to find the nearest session that has a kanban card.
+ * Returns null if no ancestor has a card.
+ *
+ * @param {Object} session - The starting session (not checked itself)
+ * @returns {{ session: Object, card: Object }|null}
+ */
+function findCardInAncestors(session) {
+  let current = session;
+  while (current.parentSessionId) {
+    const parent = sessions.getById(current.parentSessionId);
+    if (!parent) break;
+    const card = kanbanCards.getBySessionId(parent.id);
+    if (card) return { session: parent, card };
+    current = parent;
+  }
+  return null;
+}
+
+/**
  * Move an existing card based on the current lane's completion target.
+ *
+ * When the completing session has no card (e.g. it was spawned by a lane's
+ * on-enter prompt), the full ancestor chain is walked to find the session
+ * that owns the card so that the parent's card is still advanced.
  *
  * @param {string} sessionId - The session that just completed its turn
  */
@@ -224,9 +247,15 @@ export async function handleCompletionMove(sessionId) {
     return;
   }
 
-  const card = kanbanCards.getBySessionId(sessionId);
+  // Find the card — either directly on this session or on a card-owning ancestor.
+  let cardSession = session;
+  let card = kanbanCards.getBySessionId(sessionId);
+
   if (!card) {
-    return;
+    const ancestor = findCardInAncestors(session);
+    if (!ancestor) return;
+    cardSession = ancestor.session;
+    card = ancestor.card;
   }
 
   const currentLane = kanbanLanes.getById(card.laneId);
@@ -244,7 +273,7 @@ export async function handleCompletionMove(sessionId) {
     return;
   }
 
-  await moveExistingSessionCard(session, card, targetLaneId);
+  await moveExistingSessionCard(cardSession, card, targetLaneId);
 }
 
 /**

--- a/packages/server/src/services/kanbanService.test.js
+++ b/packages/server/src/services/kanbanService.test.js
@@ -353,12 +353,64 @@ describe('kanbanService', () => {
       );
     });
 
-    it('does nothing when the session has no card', async () => {
+    it('does nothing when the session has no card and no ancestors with a card', async () => {
       const session = createSession();
 
       await handleCompletionMove(session.id);
 
       expect(kanbanCards.getBySessionId(session.id)).toBeNull();
+      expect(broadcastToProject).not.toHaveBeenCalled();
+    });
+
+    it('moves the parent card when a lane-triggered child session completes', async () => {
+      // Parent has the card; child (spawned by on-enter prompt) has no card
+      const parent = createSession('Parent');
+      kanbanCards.create(lanes[0].id, parent.id);
+      kanbanLanes.update(lanes[0].id, { completionTargetLaneId: lanes[1].id });
+
+      const child = sessions.create(projectId, 'Child', 'Prompt');
+      sessions.update(child.id, { parentSessionId: parent.id, laneTriggerDepth: 1 });
+
+      await handleCompletionMove(child.id);
+
+      const card = kanbanCards.getBySessionId(parent.id);
+      expect(card.laneId).toBe(lanes[1].id);
+      expect(broadcastToProject).toHaveBeenCalledWith(
+        projectId,
+        WS_MESSAGE_TYPES.KANBAN_CARD_MOVED,
+        expect.objectContaining({
+          fromLaneId: lanes[0].id,
+          toLaneId: lanes[1].id,
+        })
+      );
+    });
+
+    it('walks the full ancestor chain when a grandchild session completes', async () => {
+      // Root has the card; child and grandchild have none (nested lane triggers)
+      const root = createSession('Root');
+      kanbanCards.create(lanes[0].id, root.id);
+      kanbanLanes.update(lanes[0].id, { completionTargetLaneId: lanes[1].id });
+
+      const child = sessions.create(projectId, 'Child', 'Prompt');
+      sessions.update(child.id, { parentSessionId: root.id, laneTriggerDepth: 1 });
+
+      const grandchild = sessions.create(projectId, 'Grandchild', 'Prompt');
+      sessions.update(grandchild.id, { parentSessionId: child.id, laneTriggerDepth: 2 });
+
+      await handleCompletionMove(grandchild.id);
+
+      const card = kanbanCards.getBySessionId(root.id);
+      expect(card.laneId).toBe(lanes[1].id);
+    });
+
+    it('does nothing when child has no card and parent also has no card', async () => {
+      const parent = createSession('Parent');
+      // No card for parent either
+      const child = sessions.create(projectId, 'Child', 'Prompt');
+      sessions.update(child.id, { parentSessionId: parent.id });
+
+      await handleCompletionMove(child.id);
+
       expect(broadcastToProject).not.toHaveBeenCalled();
     });
 
@@ -411,6 +463,53 @@ describe('kanbanService', () => {
 
       const card = kanbanCards.getBySessionId(session.id);
       expect(card.laneId).toBe(lanes[2].id);
+    });
+  });
+
+  // ── on-enter prompt child completing advances the parent's card ───────
+  //
+  // Regression test for the bug where a card placed in a lane with both an
+  // onEnterPrompt AND a completionTargetLaneId would never advance: the
+  // on-enter trigger spawns a cardless child to do the work, and when that
+  // child finished its turn handleCompletionMove found no card and returned
+  // early, leaving the parent's card stuck in the originating lane forever.
+
+  describe('on-enter prompt child completing advances the parent card', () => {
+    it('moves the parent card when the lane-triggered child session completes its turn', async () => {
+      // Configure the lane with both an on-enter prompt and a completion target.
+      kanbanLanes.update(lanes[0].id, {
+        onEnterPrompt: 'Implement the plan',
+        completionTargetLaneId: lanes[1].id,
+      });
+
+      // Place the parent session on the board — this fires the on-enter trigger
+      // and creates a child session (runSession is mocked; the child is created
+      // synchronously by buildChildSessionFromPrompt before runSession is called).
+      const parent = createSession('Parent');
+      await addSessionToBoard(parent.id, lanes[0].id);
+
+      // Find the child that the on-enter trigger created.
+      const allSessions = sessions.getByProjectId(projectId);
+      const child = allSessions.find((s) => s.parentSessionId === parent.id);
+      expect(child).toBeDefined();
+      expect(kanbanCards.getBySessionId(child.id)).toBeNull(); // child has no card
+
+      vi.clearAllMocks();
+
+      // Simulate the child completing its turn.
+      await handleCompletionMove(child.id);
+
+      // The parent's card should have advanced to the completion target lane.
+      const card = kanbanCards.getBySessionId(parent.id);
+      expect(card.laneId).toBe(lanes[1].id);
+      expect(broadcastToProject).toHaveBeenCalledWith(
+        projectId,
+        WS_MESSAGE_TYPES.KANBAN_CARD_MOVED,
+        expect.objectContaining({
+          fromLaneId: lanes[0].id,
+          toLaneId: lanes[1].id,
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Walk up the parent session chain when a completed session has no Kanban card so lane-triggered child sessions can advance the card-owning parent.
- Add regression coverage for lane-triggered child and grandchild completion flows.

## Testing
- Playwright circus command passed: 1159 tests passed.
- Coverage/lint command output in the same successful Circus run also completed successfully.