### PR TITLE
Add Kanban vertical (accordion) layout with persistence

### DIFF
--- a/packages/web/src/components/KanbanBoard.css
+++ b/packages/web/src/components/KanbanBoard.css
@@ -55,23 +55,144 @@
   text-decoration: underline;
 }
 
+/* ==================== Board header bar (layout toggle) ==================== */
+
+.board-header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.5rem 1rem 0;
+  flex-shrink: 0;
+}
+
+.layout-toggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.layout-toggle-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-soft);
+  cursor: pointer;
+  padding: 0.375rem 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.layout-toggle-btn:not(:last-child) {
+  border-right: 1px solid var(--color-border);
+}
+
+.layout-toggle-btn:hover {
+  background: var(--color-bg-soft);
+  color: var(--color-text);
+}
+
+.layout-toggle-btn.active {
+  background: var(--color-bg-soft);
+  color: var(--color-primary);
+}
+
+/* ==================== Lanes container (shared) ==================== */
+
 .kanban-lanes-container {
   display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ==================== Layout: horizontal (column view) ==================== */
+
+.kanban-lanes-container.layout-horizontal {
   gap: 1rem;
   padding: 1rem;
   overflow-x: auto;
-  flex: 1;
   align-items: flex-start;
 }
 
-.kanban-lane {
+.layout-horizontal .kanban-lane {
   flex-shrink: 0;
   width: 280px;
+  max-height: calc(100vh - 200px);
+}
+
+.layout-horizontal .lane-cards {
+  overflow-y: auto;
+}
+
+/* ==================== Layout: vertical (accordion / list view) ==================== */
+
+.kanban-lanes-container.layout-vertical {
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  overflow-x: visible;
+  overflow-y: auto;
+}
+
+.layout-vertical .kanban-lane {
+  width: 100%;
+  max-height: none;
+}
+
+.layout-vertical .lane-header-accordion {
+  cursor: pointer;
+  min-height: 44px;
+  user-select: none;
+}
+
+.layout-vertical .lane-cards {
+  overflow: visible;
+  max-height: none;
+}
+
+/* Always-visible card controls in vertical mode (touch-friendly) */
+.layout-vertical .card-move-btn,
+.layout-vertical .card-remove-btn,
+.layout-vertical .card-reorder-arrows {
+  opacity: 1;
+}
+
+/* Larger hit targets for touch in vertical mode */
+.layout-vertical .card-move-btn,
+.layout-vertical .card-remove-btn {
+  padding: 0.5rem;
+  min-width: 32px;
+  min-height: 32px;
+}
+
+.layout-vertical .card-reorder-btn {
+  padding: 0.375rem;
+  min-width: 28px;
+  min-height: 28px;
+}
+
+/* ==================== Lane chevron (accordion indicator) ==================== */
+
+.lane-chevron {
+  flex-shrink: 0;
+  color: var(--color-text-soft);
+  transition: transform 0.2s ease;
+  transform: rotate(0deg);
+}
+
+.lane-chevron.lane-chevron-expanded {
+  transform: rotate(90deg);
+}
+
+/* ==================== Shared lane styles ==================== */
+
+.kanban-lane {
   background: var(--color-bg-soft, rgba(255, 255, 255, 0.05));
   border-radius: 8px;
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 200px);
 }
 
 .lane-header {
@@ -145,7 +266,6 @@
 
 .lane-cards {
   flex: 1;
-  overflow-y: auto;
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
@@ -353,6 +473,11 @@
 .add-lane-container {
   flex-shrink: 0;
   min-width: 200px;
+}
+
+.layout-vertical .add-lane-container {
+  min-width: unset;
+  width: 100%;
 }
 
 .add-lane-btn {

--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -102,6 +102,20 @@ vi.mock('./PrIndicators.vue', () => ({
   }),
 }));
 
+// Helper that builds a matchMedia stub returning the given matches value.
+function makeMatchMedia(matches = false) {
+  return vi.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
 describe('KanbanBoard.vue', () => {
   let pinia;
   let mockKanbanStore;
@@ -113,6 +127,9 @@ describe('KanbanBoard.vue', () => {
     setActivePinia(pinia);
     vi.useRealTimers();
     vi.clearAllMocks();
+    // Reset to wide screen and clear localStorage between tests.
+    window.matchMedia = makeMatchMedia(false);
+    localStorage.clear();
 
     mockKanbanStoreData.board = createMockBoard();
     mockKanbanStoreData.loading = false;
@@ -479,6 +496,169 @@ describe('KanbanBoard.vue', () => {
       // Component state not exposed - skip assertion
       // Covered by E2E tests
       expect(addButton.exists()).toBe(true);
+    });
+  });
+
+  describe('Layout toggle and accordion behavior', () => {
+    // Tests 1–7 from the plan
+
+    it('1. renders horizontal layout class by default on wide screens', () => {
+      // matchMedia returns matches: false (wide) — set in beforeEach
+      const wrapper = mountBoard();
+      const container = wrapper.find('.kanban-lanes-container');
+      expect(container.classes()).toContain('layout-horizontal');
+      expect(container.classes()).not.toContain('layout-vertical');
+    });
+
+    it('2. matchMedia narrow → renders vertical layout class when layoutMode is auto', () => {
+      // Simulate narrow screen
+      window.matchMedia = makeMatchMedia(true);
+      const wrapper = mountBoard();
+      const container = wrapper.find('.kanban-lanes-container');
+      expect(container.classes()).toContain('layout-vertical');
+      expect(container.classes()).not.toContain('layout-horizontal');
+    });
+
+    it('3. manual toggle to horizontal overrides narrow breakpoint', async () => {
+      // Start narrow so auto → vertical
+      window.matchMedia = makeMatchMedia(true);
+      const wrapper = mountBoard();
+      expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-vertical');
+
+      // Click the columns (horizontal) toggle button (first button)
+      const toggleBtns = wrapper.findAll('.layout-toggle-btn');
+      await toggleBtns[0].trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-horizontal');
+      expect(wrapper.find('.kanban-lanes-container').classes()).not.toContain('layout-vertical');
+    });
+
+    it('3. manual toggle to vertical overrides wide breakpoint', async () => {
+      // Wide screen so auto → horizontal
+      const wrapper = mountBoard();
+      expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-horizontal');
+
+      // Click the list (vertical) toggle button (second button)
+      const toggleBtns = wrapper.findAll('.layout-toggle-btn');
+      await toggleBtns[1].trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-vertical');
+    });
+
+    it('4. clicking a lane header in vertical mode collapses its cards', async () => {
+      localStorage.setItem('kanbanLayoutMode', 'vertical');
+      const wrapper = mountBoard();
+      await wrapper.vm.$nextTick();
+
+      const firstLane = wrapper.findAll('.kanban-lane')[0];
+      const laneCards = firstLane.find('.lane-cards');
+
+      // Initially all lanes are expanded (no display: none)
+      // Note: isVisible() requires attachment to document.body; use style check instead.
+      expect(laneCards.element.style.display).not.toBe('none');
+
+      // Collapse by clicking the header
+      const header = firstLane.find('.lane-header');
+      await header.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(laneCards.element.style.display).toBe('none');
+    });
+
+    it('4. clicking the same lane header again re-expands it', async () => {
+      localStorage.setItem('kanbanLayoutMode', 'vertical');
+      const wrapper = mountBoard();
+      await wrapper.vm.$nextTick();
+
+      const firstLane = wrapper.findAll('.kanban-lane')[0];
+      const laneCards = firstLane.find('.lane-cards');
+      const header = firstLane.find('.lane-header');
+
+      // Collapse
+      await header.trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(laneCards.element.style.display).toBe('none');
+
+      // Re-expand
+      await header.trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(laneCards.element.style.display).not.toBe('none');
+    });
+
+    it('5. settings gear click does not toggle accordion (click.stop)', async () => {
+      localStorage.setItem('kanbanLayoutMode', 'vertical');
+      const wrapper = mountBoard();
+      await wrapper.vm.$nextTick();
+
+      const firstLane = wrapper.findAll('.kanban-lane')[0];
+      const laneCards = firstLane.find('.lane-cards');
+
+      // Clicking the settings button should NOT collapse the lane (click.stop prevents propagation)
+      const settingsBtn = firstLane.find('.lane-settings-btn');
+      await settingsBtn.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(laneCards.element.style.display).not.toBe('none');
+    });
+
+    it('6. move-to-lane button and reorder arrows are present in vertical mode', () => {
+      localStorage.setItem('kanbanLayoutMode', 'vertical');
+      const wrapper = mountBoard();
+
+      // The layout class is applied so the CSS override (opacity: 1) activates.
+      expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-vertical');
+
+      // The buttons exist in the DOM (rendered, not removed by v-if).
+      expect(wrapper.find('.card-move-btn').exists()).toBe(true);
+      expect(wrapper.find('.card-reorder-arrows').exists()).toBe(true);
+      expect(wrapper.find('.card-reorder-btn').exists()).toBe(true);
+    });
+
+    describe('7. Persistence', () => {
+      it('toggling to vertical writes "vertical" to localStorage', async () => {
+        const wrapper = mountBoard();
+        const toggleBtns = wrapper.findAll('.layout-toggle-btn');
+        // Second button is the list/vertical toggle
+        await toggleBtns[1].trigger('click');
+        expect(localStorage.getItem('kanbanLayoutMode')).toBe('vertical');
+      });
+
+      it('toggling to horizontal writes "horizontal" to localStorage', async () => {
+        // Start in vertical so horizontal is a real change
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        const wrapper = mountBoard();
+        const toggleBtns = wrapper.findAll('.layout-toggle-btn');
+        await toggleBtns[0].trigger('click');
+        expect(localStorage.getItem('kanbanLayoutMode')).toBe('horizontal');
+      });
+
+      it('fresh mount with "vertical" in localStorage renders vertical on first render', () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        const wrapper = mountBoard();
+        // No $nextTick needed — synchronous read during setup.
+        expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-vertical');
+      });
+
+      it('fresh mount with "horizontal" in localStorage renders horizontal on first render', () => {
+        localStorage.setItem('kanbanLayoutMode', 'horizontal');
+        const wrapper = mountBoard();
+        expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-horizontal');
+      });
+
+      it('fresh mount with invalid localStorage value falls back to auto (horizontal on wide)', () => {
+        localStorage.setItem('kanbanLayoutMode', 'invalid-layout-value');
+        const wrapper = mountBoard();
+        // Falls back to 'auto' → wide screen → horizontal
+        expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-horizontal');
+      });
+
+      it('fresh mount with missing localStorage value falls back to auto (horizontal on wide)', () => {
+        // localStorage is clear (cleared in beforeEach)
+        const wrapper = mountBoard();
+        expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-horizontal');
+      });
     });
   });
 

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -10,9 +10,7 @@
           title="Column layout"
           @click="layoutMode = 'horizontal'"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-            <rect x="2" y="3" width="6" height="18" rx="1"/><rect x="10" y="3" width="6" height="18" rx="1"/><rect x="18" y="3" width="4" height="18" rx="1"/>
-          </svg>
+          <KanbanBoardIcon name="columns" />
         </button>
         <!-- List (vertical/accordion) toggle -->
         <button
@@ -21,9 +19,7 @@
           title="List layout"
           @click="layoutMode = 'vertical'"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
-          </svg>
+          <KanbanBoardIcon name="list" />
         </button>
       </div>
     </div>
@@ -76,13 +72,12 @@
         >
           <div class="lane-title-row">
             <!-- Chevron: only shown in vertical/accordion mode -->
-            <svg
+            <KanbanBoardIcon
               v-if="effectiveLayout === 'vertical'"
+              name="chevron"
               class="lane-chevron"
               :class="{ 'lane-chevron-expanded': expandedLanes[lane.id] }"
-              xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
-              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            ><polyline points="9 18 15 12 9 6" /></svg>
+            />
             <h3 class="lane-title">
               {{ lane.name }}
             </h3>
@@ -91,9 +86,7 @@
               class="lane-automation-indicator"
               title="Automation enabled"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
+              <KanbanBoardIcon name="automation" />
             </span>
           </div>
           <div class="lane-header-actions">
@@ -103,10 +96,7 @@
               title="Lane settings"
               @click.stop="openLaneSettings(lane)"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-              </svg>
+              <KanbanBoardIcon name="settings" />
             </button>
           </div>
         </div>
@@ -171,9 +161,10 @@
                   class="card-scheduled-info"
                 >
                   <span class="status-badge status-scheduled">
-                    <svg class="schedule-icon-inline" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
-                    </svg>
+                    <KanbanBoardIcon
+                      name="schedule"
+                      class="schedule-icon-inline"
+                    />
                     scheduled
                   </span>
                   <span
@@ -199,9 +190,7 @@
                   title="Move card up"
                   @click.prevent="moveCardInLane(lane.id, cardIndex, cardIndex - 1)"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="18 15 12 9 6 15" />
-                  </svg>
+                  <KanbanBoardIcon name="reorder-up" />
                 </button>
                 <button
                   v-if="cardIndex < lane.cards.length - 1"
@@ -209,9 +198,7 @@
                   title="Move card down"
                   @click.prevent="moveCardInLane(lane.id, cardIndex, cardIndex + 1)"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="6 9 12 15 18 9" />
-                  </svg>
+                  <KanbanBoardIcon name="reorder-down" />
                 </button>
               </div>
               <button
@@ -219,12 +206,7 @@
                 title="Move to lane"
                 @click.prevent="openMoveCardModal(card, lane.id)"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polyline points="15 4 19 4 19 8" />
-                  <line x1="14" y1="10" x2="19" y2="4" />
-                  <polyline points="9 20 5 20 5 16" />
-                  <line x1="10" y1="14" x2="5" y2="20" />
-                </svg>
+                <KanbanBoardIcon name="move" />
               </button>
               <button
                 class="card-remove-btn"
@@ -366,6 +348,7 @@ import LaneSettingsModal from './LaneSettingsModal.vue';
 import MoveCardModal from './MoveCardModal.vue';
 import PrIndicators from './PrIndicators.vue';
 import SessionRunningSpinner from './SessionRunningSpinner.vue';
+import KanbanBoardIcon from './KanbanBoardIcon.vue';
 import { mapRunsToButtonStatuses } from '../utils/commandButtonStatuses.js';
 import './KanbanBoard.css';
 

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -1,5 +1,33 @@
 <template>
   <div class="kanban-board">
+    <!-- Board header bar: always rendered (outside the loading/error/empty chain) -->
+    <div class="board-header-bar">
+      <div class="layout-toggle">
+        <!-- Columns (horizontal) toggle -->
+        <button
+          class="layout-toggle-btn"
+          :class="{ active: effectiveLayout === 'horizontal' }"
+          title="Column layout"
+          @click="layoutMode = 'horizontal'"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <rect x="2" y="3" width="6" height="18" rx="1"/><rect x="10" y="3" width="6" height="18" rx="1"/><rect x="18" y="3" width="4" height="18" rx="1"/>
+          </svg>
+        </button>
+        <!-- List (vertical/accordion) toggle -->
+        <button
+          class="layout-toggle-btn"
+          :class="{ active: effectiveLayout === 'vertical' }"
+          title="List layout"
+          @click="layoutMode = 'vertical'"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+
     <div
       v-if="loading"
       class="kanban-loading"
@@ -32,16 +60,29 @@
     <div
       v-else
       class="kanban-lanes-container"
+      :class="effectiveLayout === 'vertical' ? 'layout-vertical' : 'layout-horizontal'"
     >
       <div
         v-for="lane in board.lanes"
         :key="lane.id"
         class="kanban-lane"
-        @dragover.prevent="handleCardDragOver($event, lane.id, lane.cards?.length || 0)"
-        @drop="handleDrop($event, lane.id)"
+        @dragover.prevent="effectiveLayout === 'horizontal' ? handleCardDragOver($event, lane.id, lane.cards?.length || 0) : null"
+        @drop="effectiveLayout === 'horizontal' ? handleDrop($event, lane.id) : null"
       >
-        <div class="lane-header">
+        <div
+          class="lane-header"
+          :class="{ 'lane-header-accordion': effectiveLayout === 'vertical' }"
+          @click="handleLaneHeaderClick(lane.id)"
+        >
           <div class="lane-title-row">
+            <!-- Chevron: only shown in vertical/accordion mode -->
+            <svg
+              v-if="effectiveLayout === 'vertical'"
+              class="lane-chevron"
+              :class="{ 'lane-chevron-expanded': expandedLanes[lane.id] }"
+              xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            ><polyline points="9 18 15 12 9 6" /></svg>
             <h3 class="lane-title">
               {{ lane.name }}
             </h3>
@@ -50,13 +91,7 @@
               class="lane-automation-indicator"
               title="Automation enabled"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
+              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
             </span>
@@ -66,31 +101,21 @@
             <button
               class="lane-settings-btn"
               title="Lane settings"
-              @click="openLaneSettings(lane)"
+              @click.stop="openLaneSettings(lane)"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="3"
-                />
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="3" />
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
               </svg>
             </button>
           </div>
         </div>
 
-        <div class="lane-cards">
+        <!-- Cards: always shown in horizontal; shown when expanded in vertical -->
+        <div
+          v-show="effectiveLayout === 'horizontal' || expandedLanes[lane.id]"
+          class="lane-cards"
+        >
           <template
             v-for="(card, cardIndex) in lane.cards"
             :key="card.id"
@@ -104,10 +129,10 @@
             <div
               class="kanban-card"
               :class="{ 'dragging': dragType === 'card' && draggedCard?.id === card.id }"
-              draggable="true"
-              @dragstart.stop="handleCardDragStart($event, card, lane.id, cardIndex)"
-              @dragover.prevent.stop="handleCardDragOver($event, lane.id, cardIndex)"
-              @dragend="handleDragEnd"
+              :draggable="effectiveLayout === 'horizontal'"
+              @dragstart.stop="effectiveLayout === 'horizontal' ? handleCardDragStart($event, card, lane.id, cardIndex) : null"
+              @dragover.prevent.stop="effectiveLayout === 'horizontal' ? handleCardDragOver($event, lane.id, cardIndex) : null"
+              @dragend="effectiveLayout === 'horizontal' ? handleDragEnd() : null"
             >
               <router-link
                 v-if="card.sessions?.[0]"
@@ -146,24 +171,8 @@
                   class="card-scheduled-info"
                 >
                   <span class="status-badge status-scheduled">
-                    <svg
-                      class="schedule-icon-inline"
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="12"
-                      height="12"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <circle
-                        cx="12"
-                        cy="12"
-                        r="10"
-                      />
-                      <polyline points="12 6 12 12 16 14" />
+                    <svg class="schedule-icon-inline" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
                     </svg>
                     scheduled
                   </span>
@@ -190,17 +199,7 @@
                   title="Move card up"
                   @click.prevent="moveCardInLane(lane.id, cardIndex, cardIndex - 1)"
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="10"
-                    height="10"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                     <polyline points="18 15 12 9 6 15" />
                   </svg>
                 </button>
@@ -210,17 +209,7 @@
                   title="Move card down"
                   @click.prevent="moveCardInLane(lane.id, cardIndex, cardIndex + 1)"
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="10"
-                    height="10"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                     <polyline points="6 9 12 15 18 9" />
                   </svg>
                 </button>
@@ -230,31 +219,11 @@
                 title="Move to lane"
                 @click.prevent="openMoveCardModal(card, lane.id)"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <polyline points="15 4 19 4 19 8" />
-                  <line
-                    x1="14"
-                    y1="10"
-                    x2="19"
-                    y2="4"
-                  />
+                  <line x1="14" y1="10" x2="19" y2="4" />
                   <polyline points="9 20 5 20 5 16" />
-                  <line
-                    x1="10"
-                    y1="14"
-                    x2="5"
-                    y2="20"
-                  />
+                  <line x1="10" y1="14" x2="5" y2="20" />
                 </svg>
               </button>
               <button
@@ -282,8 +251,11 @@
           </div>
         </div>
 
-        <!-- Lane footer with automation info and add session button -->
-        <div class="lane-footer">
+        <!-- Lane footer: always shown in horizontal; shown when expanded in vertical -->
+        <div
+          v-show="effectiveLayout === 'horizontal' || expandedLanes[lane.id]"
+          class="lane-footer"
+        >
           <span
             v-if="lane.onEnterTemplateId"
             class="lane-automation"
@@ -381,7 +353,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch, toRef } from 'vue';
+import { ref, reactive, computed, onMounted, onUnmounted, watch, toRef } from 'vue';
 import { formatDistanceToNow, format } from 'date-fns';
 import { useKanbanStore } from '../stores/kanban.js';
 import { useSessionsStore } from '../stores/sessions.js';
@@ -408,7 +380,101 @@ const kanbanStore = useKanbanStore();
 const sessionsStore = useSessionsStore();
 const commandButtonsStore = useCommandButtonsStore();
 
-// Local state
+// ==================== Layout state ====================
+
+const LAYOUT_MODE_KEY = 'kanbanLayoutMode';
+const VALID_LAYOUT_MODES = ['auto', 'horizontal', 'vertical'];
+
+function readLayoutMode() {
+  try {
+    const stored = localStorage.getItem(LAYOUT_MODE_KEY);
+    return VALID_LAYOUT_MODES.includes(stored) ? stored : 'auto';
+  } catch {
+    return 'auto';
+  }
+}
+
+function writeLayoutMode(value) {
+  try {
+    localStorage.setItem(LAYOUT_MODE_KEY, value);
+  } catch {
+    // ignore (e.g. private browsing with storage blocked)
+  }
+}
+
+// layoutMode: 'auto' | 'horizontal' | 'vertical'
+// Read synchronously from localStorage so first render uses the restored value.
+const layoutMode = ref(readLayoutMode());
+
+watch(layoutMode, (value) => {
+  writeLayoutMode(value);
+});
+
+// isNarrow: true when the viewport is <= 640px.
+// Initialized synchronously to avoid a flash on first render.
+const isNarrow = ref(
+  typeof window !== 'undefined' && window.matchMedia
+    ? window.matchMedia('(max-width: 640px)').matches
+    : false
+);
+
+let _mql = null;
+const onMqlChange = (e) => { isNarrow.value = e.matches; };
+
+onMounted(() => {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    _mql = window.matchMedia('(max-width: 640px)');
+    isNarrow.value = _mql.matches;
+    _mql.addEventListener('change', onMqlChange);
+  }
+});
+
+onUnmounted(() => {
+  if (_mql) {
+    _mql.removeEventListener('change', onMqlChange);
+    _mql = null;
+  }
+});
+
+// effectiveLayout: the layout actually used for rendering.
+const effectiveLayout = computed(() => {
+  if (layoutMode.value === 'auto') {
+    return isNarrow.value ? 'vertical' : 'horizontal';
+  }
+  return layoutMode.value;
+});
+
+// expandedLanes: record of laneId → boolean (true = expanded).
+// All lanes start expanded by default.
+const expandedLanes = reactive({});
+
+watch(
+  () => kanbanStore.board?.lanes,
+  (lanes) => {
+    if (lanes) {
+      for (const lane of lanes) {
+        if (!(lane.id in expandedLanes)) {
+          expandedLanes[lane.id] = true;
+        }
+      }
+    }
+  },
+  { immediate: true }
+);
+
+const toggleLane = (laneId) => {
+  expandedLanes[laneId] = !expandedLanes[laneId];
+};
+
+// Called when the lane header is clicked; only toggles in vertical mode.
+const handleLaneHeaderClick = (laneId) => {
+  if (effectiveLayout.value === 'vertical') {
+    toggleLane(laneId);
+  }
+};
+
+// ==================== Local state ====================
+
 const showAddLane = ref(false);
 const newLaneName = ref('');
 
@@ -526,6 +592,7 @@ const cardButtonStatuses = computed(() => {
 
   return result;
 });
+
 const handleRemoveCard = async (cardId) => {
   if (!confirm('Remove this session from the board?')) return;
 

--- a/packages/web/src/components/KanbanBoardIcon.vue
+++ b/packages/web/src/components/KanbanBoardIcon.vue
@@ -1,0 +1,182 @@
+<template>
+  <!-- eslint-disable vue/no-multiple-template-root -- conditional single-root svg per icon -->
+  <svg
+    v-if="name === 'columns'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+  >
+    <rect
+      x="2"
+      y="3"
+      width="6"
+      height="18"
+      rx="1"
+    />
+    <rect
+      x="10"
+      y="3"
+      width="6"
+      height="18"
+      rx="1"
+    />
+    <rect
+      x="18"
+      y="3"
+      width="4"
+      height="18"
+      rx="1"
+    />
+  </svg>
+  <svg
+    v-else-if="name === 'list'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <line
+      x1="3"
+      y1="6"
+      x2="21"
+      y2="6"
+    />
+    <line
+      x1="3"
+      y1="12"
+      x2="21"
+      y2="12"
+    />
+    <line
+      x1="3"
+      y1="18"
+      x2="21"
+      y2="18"
+    />
+  </svg>
+  <svg
+    v-else-if="name === 'chevron'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  ><polyline points="9 18 15 12 9 6" /></svg>
+  <svg
+    v-else-if="name === 'automation'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+  ><path d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>
+  <svg
+    v-else-if="name === 'settings'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="3"
+    />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+  <svg
+    v-else-if="name === 'schedule'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+    />
+    <polyline points="12 6 12 12 16 14" />
+  </svg>
+  <svg
+    v-else-if="name === 'reorder-up'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="10"
+    height="10"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  ><polyline points="18 15 12 9 6 15" /></svg>
+  <svg
+    v-else-if="name === 'reorder-down'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="10"
+    height="10"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  ><polyline points="6 9 12 15 18 9" /></svg>
+  <svg
+    v-else-if="name === 'move'"
+    xmlns="http://www.w3.org/2000/svg"
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <polyline points="15 4 19 4 19 8" />
+    <line
+      x1="14"
+      y1="10"
+      x2="19"
+      y2="4"
+    />
+    <polyline points="9 20 5 20 5 16" />
+    <line
+      x1="10"
+      y1="14"
+      x2="5"
+      y2="20"
+    />
+  </svg>
+</template>
+
+<script setup>
+defineProps({
+  name: {
+    type: String,
+    required: true,
+  },
+});
+</script>

--- a/packages/web/vitest.setup.js
+++ b/packages/web/vitest.setup.js
@@ -6,20 +6,23 @@ import { setActivePinia, createPinia } from 'pinia';
 // Default: wide screen (matches = false for max-width: 640px).
 // Individual tests can override:
 //   window.matchMedia = vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  configurable: true,
-  value: vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+// Guard for test files that opt into `@vitest-environment node` (no global `window`).
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 // Mock DOMPurify for tests that use markdown rendering
 // This mock provides a simple sanitization function that removes script tags

--- a/packages/web/vitest.setup.js
+++ b/packages/web/vitest.setup.js
@@ -2,6 +2,25 @@
 import { beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
+// Stub window.matchMedia (jsdom does not implement it).
+// Default: wide screen (matches = false for max-width: 640px).
+// Individual tests can override:
+//   window.matchMedia = vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 // Mock DOMPurify for tests that use markdown rendering
 // This mock provides a simple sanitization function that removes script tags
 vi.mock('dompurify', () => ({


### PR DESCRIPTION
## Summary

Adds an alternate **vertical, accordion-style** layout for the Kanban board (mobile-friendly) alongside the existing horizontal column layout, and fixes the circus-command failures that surfaced after merging `main`.

### Feature — vertical accordion layout (336d79c6)
Per the plan on the root session canvas:
- **Layout modes:** `auto` (follows the 640px breakpoint), `horizontal`, `vertical`, switchable via a manual segmented toggle in a new always-rendered board header.
- **Persistence (hard requirement):** the selected layout survives page refresh — `layoutMode` is read synchronously from `localStorage` (`kanbanLayoutMode`) during setup (no flash) and written on every change.
- **Accordion:** in vertical mode, lane headers expand/collapse their cards; a chevron rotates; the settings gear uses `@click.stop` so it doesn't toggle the accordion.
- **Touch-friendly:** card move/remove/reorder controls are always visible (`opacity:1`) in vertical mode; drag-and-drop is gated to horizontal mode (reorder arrows + move modal cover vertical).
- **Tests:** 7 layout/accordion/persistence cases in `KanbanBoard.test.js`; a `window.matchMedia` stub added to `vitest.setup.js`.

### Circus-command fixes (d830a6b6)
After merging `main`, three commands were failing. Fixed without changing the plan's behavior:
- **Coverage (`yarn test:coverage`):** the new `window.matchMedia` stub ran unconditionally at load, crashing the three `@vitest-environment node` suites (`modalZIndex`, `toastZIndex`, `touchActionCss`) with `ReferenceError: window is not defined`. Guarded with `typeof window !== 'undefined'`.
- **Lint (`yarn lint`):** inline single-line SVG attributes produced 101 `vue/max-attributes-per-line` warnings, and `KanbanBoard.vue` sat at 597/600 `max-lines` (couldn't reformat in place). Extracted inline SVGs into `KanbanBoardIcon.vue` — 0 warnings, file down to 580/600 effective lines. Behavior unchanged (Vue class/attr fallthrough preserves the chevron rotation, schedule icon, etc.).
- **Playwright:** no regressions; all 48 Kanban specs and the full suite pass.

## Test plan
- [x] `yarn lint` — 0 errors, 0 warnings
- [x] `yarn test:coverage` — green, thresholds met
- [x] Kanban E2E subset — 48 passed
- [x] Full E2E `./scripts/pw.sh test` (playwright circus command) — 1141 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)