### PR TITLE
Bump shell-quote from 1.8.3 to 1.8.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4045,9 +4045,9 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.8.1:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

Bumps the `shell-quote` dependency from **1.8.3 → 1.8.4** in `yarn.lock`, merging the Dependabot security update into this branch.

## Changes

- `yarn.lock`: `shell-quote` resolved version `1.8.3` → `1.8.4`

No application source changes — `shell-quote` is a transitive dependency.

## Verification

- [ ] `yarn install` resolves cleanly
- [ ] `yarn test` passes
- [ ] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)