### PR TITLE
Fix scheduled session PATCH scheduling

### DIFF
--- a/packages/server/src/api/sessions-patch.js
+++ b/packages/server/src/api/sessions-patch.js
@@ -83,6 +83,27 @@ function validateProviderId(value) {
 }
 
 /**
+ * Validate and normalize scheduledAt field.
+ * Accepts null (clear), numeric epoch milliseconds, or an ISO 8601 string.
+ * Rejects anything that cannot be unambiguously converted to a finite integer.
+ * @param {*} value
+ * @returns {{ error?: string, value: * }}
+ */
+function validateScheduledAt(value) {
+  if (value === null) return { value: null };
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return { error: 'Invalid scheduledAt' };
+    return { value: Math.trunc(value) };
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) return { error: 'Invalid scheduledAt' };
+    return { value: parsed };
+  }
+  return { error: 'Invalid scheduledAt' };
+}
+
+/**
  * Validate prUrl field
  * @param {*} value
  * @returns {{ error?: string, value: * }}
@@ -121,7 +142,7 @@ const FIELD_DEFINITIONS = [
   // Git fields
   { field: 'gitWorktree' },
   // Scheduling fields
-  { field: 'scheduledAt' },
+  { field: 'scheduledAt', validate: validateScheduledAt },
   { field: 'autoRescheduleEnabled', transform: Boolean },
   { field: 'rescheduleDelayMinutes', transform: (v) => parseInt(v, 10) },
   { field: 'rescheduleOnTokenLimit', transform: Boolean },

--- a/packages/server/src/api/sessions.scheduling.test.js
+++ b/packages/server/src/api/sessions.scheduling.test.js
@@ -112,5 +112,42 @@ describe('Sessions API - Scheduling PATCH behavior', () => {
       expect(response.body.status).toBe('starting');
       expect(response.body.scheduledAt).toBe(scheduledAt);
     });
+
+    it('normalizes ISO scheduledAt strings to epoch milliseconds', async () => {
+      const futureMs = Date.now() + 3600000;
+      const isoString = new Date(futureMs).toISOString();
+
+      const response = await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ scheduledAt: isoString })
+        .expect(200);
+
+      expect(typeof response.body.scheduledAt).toBe('number');
+      expect(response.body.scheduledAt).toBe(futureMs);
+
+      const stored = sessions.getById(session.id);
+      expect(typeof stored.scheduledAt).toBe('number');
+      expect(stored.scheduledAt).toBe(futureMs);
+    });
+
+    it('rejects invalid scheduledAt strings with 400', async () => {
+      const response = await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ scheduledAt: 'not-a-date' })
+        .expect(400);
+
+      expect(response.body.error).toBeTruthy();
+    });
+
+    it('rejects non-finite and non-date values with 400', async () => {
+      for (const bad of ['NaN', 'Infinity', [], {}]) {
+        const response = await request(app)
+          .patch(`/api/sessions/${session.id}`)
+          .send({ scheduledAt: bad })
+          .expect(400);
+
+        expect(response.body.error).toBeTruthy();
+      }
+    });
   });
 });

--- a/packages/server/src/db/SessionRepository.test.js
+++ b/packages/server/src/db/SessionRepository.test.js
@@ -1476,6 +1476,34 @@ describe('SessionRepository', () => {
     });
   });
 
+  describe('getScheduledSessionsDue', () => {
+    it('returns due sessions after ISO text scheduled_at is repaired by migration', () => {
+      // 1. Create a scheduled session with a valid integer timestamp in the past
+      const session = repo.create(projectId, 'Stuck Session', 'Prompt', 'standard', false, null, null, 'scheduled');
+      repo.update(session.id, { scheduledAt: Date.now() - 1000 });
+
+      // 2. Overwrite stored value with an ISO text string (the bug)
+      repo.db.prepare('UPDATE sessions SET scheduled_at = ? WHERE id = ?').run('2020-01-01T00:00:00Z', session.id);
+
+      // 3. Confirm getScheduledSessionsDue does NOT return the session (reproduces the bug)
+      const beforeRepair = repo.getScheduledSessionsDue(Date.now());
+      expect(beforeRepair.find(s => s.id === session.id)).toBeUndefined();
+
+      // 4. Run the repair SQL (same as the migration)
+      repo.db.prepare(`
+        UPDATE sessions
+        SET scheduled_at = CAST(strftime('%s', scheduled_at) AS INTEGER) * 1000
+        WHERE scheduled_at IS NOT NULL
+          AND typeof(scheduled_at) = 'text'
+          AND scheduled_at GLOB '????-??-??T??:??:??*'
+      `).run();
+
+      // 5. Confirm the session is now returned
+      const afterRepair = repo.getScheduledSessionsDue(Date.now());
+      expect(afterRepair.find(s => s.id === session.id)).toBeDefined();
+    });
+  });
+
   describe('lastActivityAt', () => {
     it('populates lastActivityAt on session objects returned by getById', () => {
       const session = repo.create(projectId, 'Test', 'Prompt');

--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -281,4 +281,7 @@ export const allMigrations = validateMigrations([
   // --- Providers enable/disable flag (appended last to keep column order
   //     stable relative to the providers-widen-kind-check-google table swap) ---
   pr.get('providers-add-enabled'),
+
+  // --- Repair sessions with ISO text in scheduled_at (should be epoch ms integers) ---
+  s.get('sessions-repair-scheduled_at-iso-text'),
 ]);

--- a/packages/server/src/db/migrations/sessionsMigrations.js
+++ b/packages/server/src/db/migrations/sessionsMigrations.js
@@ -297,4 +297,18 @@ export const sessionsMigrations = [
     up(db) { migrateSessionsDefaultModeAndThinking(db); },
   },
 
+  // --- Repair scheduled_at ISO text values to epoch milliseconds ---
+  {
+    name: 'sessions-repair-scheduled_at-iso-text',
+    up(db) {
+      db.prepare(`
+        UPDATE sessions
+        SET scheduled_at = CAST(strftime('%s', scheduled_at) AS INTEGER) * 1000
+        WHERE scheduled_at IS NOT NULL
+          AND typeof(scheduled_at) = 'text'
+          AND scheduled_at GLOB '????-??-??T??:??:??*'
+      `).run();
+    },
+  },
+
 ];

--- a/packages/server/test/sessions-scheduling.test.js
+++ b/packages/server/test/sessions-scheduling.test.js
@@ -400,6 +400,25 @@ describe('Sessions API - Scheduling Endpoints', () => {
     });
   });
 
+  describe('PATCH /api/sessions/:id - ISO scheduledAt normalization', () => {
+    it('PATCH with ISO string stores numeric scheduledAt and promotes to scheduled status', async () => {
+      // Put the session into waiting so auto-promotion to scheduled can fire
+      sessions.update(session.id, { status: 'waiting' });
+
+      const futureMs = Date.now() + 3600000;
+      const isoString = new Date(futureMs).toISOString();
+
+      const res = await request(app)
+        .patch(`/api/sessions/${session.id}`)
+        .send({ scheduledAt: isoString })
+        .expect(200);
+
+      expect(typeof res.body.scheduledAt).toBe('number');
+      expect(res.body.scheduledAt).toBe(futureMs);
+      expect(res.body.status).toBe('scheduled');
+    });
+  });
+
   describe('scheduling with rescheduling', () => {
     it('creates a complete reschedule scenario', async () => {
       const res = await request(app)


### PR DESCRIPTION
## Summary
- Normalize PATCH `scheduledAt` values from ISO strings so scheduled sessions do not remain stuck.

## Validation
- Playwright Circus command: passed (1159 Playwright tests, exitCode 0)
- Lint Circus command: passed
- Coverage/unit run in Circus command output: passed