### PR TITLE
Implement smart retry routing for automatic rescheduling

### DIFF
--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -282,6 +282,9 @@ export const allMigrations = validateMigrations([
   //     stable relative to the providers-widen-kind-check-google table swap) ---
   pr.get('providers-add-enabled'),
 
+  // --- Pending conversation ID for existing-message retry on reschedule ---
+  s.get('sessions-add-pending_conversation_id'),
+
   // --- Repair sessions with ISO text in scheduled_at (should be epoch ms integers) ---
   s.get('sessions-repair-scheduled_at-iso-text'),
 ]);

--- a/packages/server/src/db/migrations/sessionTableRecreate.js
+++ b/packages/server/src/db/migrations/sessionTableRecreate.js
@@ -56,6 +56,7 @@ export const SESSIONS_ALL_CURRENT_COLUMNS = `
     agent_type TEXT DEFAULT 'claude-code',
     target_lane_id TEXT REFERENCES kanban_lanes(id) ON DELETE SET NULL,
     lane_trigger_depth INTEGER NOT NULL DEFAULT 0,
+    pending_conversation_id TEXT REFERENCES conversations(id) ON DELETE SET NULL,
     created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
     updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 `;
@@ -72,7 +73,7 @@ export const SESSIONS_ALL_CURRENT_COLUMN_NAMES = [
   'max_reschedule_count', 'max_total_tokens', 'reschedule_count',
   'reschedule_at_token_count', 'pending_prompt', 'slash_commands',
   'pending_model', 'auto_send_pending_prompt', 'agent_type', 'target_lane_id',
-  'lane_trigger_depth', 'created_at', 'updated_at',
+  'lane_trigger_depth', 'pending_conversation_id', 'created_at', 'updated_at',
 ];
 
 /**

--- a/packages/server/src/db/migrations/sessionsMigrations.js
+++ b/packages/server/src/db/migrations/sessionsMigrations.js
@@ -297,6 +297,17 @@ export const sessionsMigrations = [
     up(db) { migrateSessionsDefaultModeAndThinking(db); },
   },
 
+  // --- Pending conversation ID for existing-message retry on reschedule ---
+  {
+    name: 'sessions-add-pending_conversation_id',
+    up(db) {
+      addColumnIfMissing(
+        db, TABLE_SESSIONS, 'pending_conversation_id',
+        'TEXT REFERENCES conversations(id) ON DELETE SET NULL'
+      );
+    },
+  },
+
   // --- Repair scheduled_at ISO text values to epoch milliseconds ---
   {
     name: 'sessions-repair-scheduled_at-iso-text',

--- a/packages/server/src/db/schemaBaseline.test.js
+++ b/packages/server/src/db/schemaBaseline.test.js
@@ -72,7 +72,7 @@ describe('schema baseline', () => {
         'max_reschedule_count', 'max_total_tokens', 'reschedule_count',
         'reschedule_at_token_count', 'pending_prompt', 'slash_commands',
         'pending_model', 'auto_send_pending_prompt', 'agent_type', 'target_lane_id',
-        'lane_trigger_depth', 'created_at', 'updated_at',
+        'lane_trigger_depth', 'created_at', 'updated_at', 'pending_conversation_id',
       ]);
     });
   });

--- a/packages/server/src/db/session-helpers.js
+++ b/packages/server/src/db/session-helpers.js
@@ -75,6 +75,7 @@ export function mapScheduling(row) {
     maxTotalTokens: row.max_total_tokens,
     rescheduleCount: row.reschedule_count || 0,
     rescheduleAtTokenCount: row.reschedule_at_token_count,
+    pendingConversationId: row.pending_conversation_id || null,
   };
 }
 
@@ -140,6 +141,7 @@ export const DIRECT_FIELD_MAP = {
   rescheduleAtTokenCount: 'reschedule_at_token_count',
   pendingPrompt: 'pending_prompt',
   pendingModel: 'pending_model',
+  pendingConversationId: 'pending_conversation_id',
   effortLevel: 'effort_level',
   targetLaneId: 'target_lane_id',
   laneTriggerDepth: 'lane_trigger_depth',

--- a/packages/server/src/services/schedulerService.js
+++ b/packages/server/src/services/schedulerService.js
@@ -212,6 +212,28 @@ class SchedulerService {
     const { prompt, effectivePrompt, effectiveSystemPrompt, sessionAttachments } =
       await this.resolveScheduledPrompt(session, workingDirectory, project.systemPrompt);
 
+    // Check for existing-message retry first (takes precedence over fresh/continuation branches)
+    if (session.pendingConversationId) {
+      const pendingConversationId = session.pendingConversationId;
+
+      // Clear scheduler state and transition to starting
+      sessions.update(session.id, {
+        status: 'starting',
+        scheduledAt: null,
+        pendingPrompt: null,
+        pendingConversationId: null,
+      });
+      broadcastToSession(session.id, WS_MESSAGE_TYPES.SESSION_STATUS, { sessionId: session.id, status: 'starting' });
+
+      await this.sessionManager.continueSessionWithExistingMessage(
+        session.id,
+        pendingConversationId,
+        workingDirectory,
+        { systemPrompt: effectiveSystemPrompt, model: session.pendingModel }
+      );
+      return;
+    }
+
     // Get the session messages to determine if this is initial or continuation
     const sessionMessages = messages.getBySessionId(session.id);
     const hasAssistantResponses = sessionMessages.some((msg) => msg.role === 'assistant');
@@ -242,9 +264,12 @@ class SchedulerService {
    * Reschedule a session with a delay
    * @param {string} sessionId - Session ID to reschedule
    * @param {string} reason - Reason for rescheduling
+   * @param {{ retryExistingMessage?: boolean, conversationId?: string|null }} [options]
+   *   - retryExistingMessage: if true, retry the existing user message instead of sending "Continue"
+   *   - conversationId: the active conversation to retry (required when retryExistingMessage is true)
    * @returns {boolean} True if rescheduled, false if limits reached
    */
-  async rescheduleSession(sessionId, reason) {
+  async rescheduleSession(sessionId, reason, { retryExistingMessage = false, conversationId = null } = {}) {
     const session = sessions.getById(sessionId);
     if (!session) {
       console.error(`[SchedulerService] Session not found: ${sessionId}`);
@@ -262,20 +287,6 @@ class SchedulerService {
       return false;
     }
 
-    // Get the last user message to use as pendingPrompt for restart
-    const sessionMessages = messages.getBySessionId(sessionId);
-    const lastUserMessage = [...sessionMessages].reverse().find(msg => msg.role === 'user');
-
-    if (!lastUserMessage) {
-      console.error(`[SchedulerService] No user message found for session ${sessionId}`);
-      sessions.update(sessionId, {
-        status: 'error',
-        error: `Cannot reschedule: No user message found. ${reason}`,
-      });
-      broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_STATUS, { sessionId, status: 'error' });
-      return false;
-    }
-
     // Calculate new scheduled time
     const newScheduledAt = Date.now() + session.rescheduleDelayMinutes * 60 * 1000;
     const delayMinutes = session.rescheduleDelayMinutes;
@@ -285,12 +296,39 @@ class SchedulerService {
       `[SchedulerService] Rescheduling session ${sessionId} for ${delayMinutes} minutes from now (attempt ${newRescheduleCount})`
     );
 
+    let pendingPrompt;
+    let pendingConversationId = null;
+
+    if (retryExistingMessage && conversationId) {
+      // Existing-message retry: use the last user message from the active conversation
+      // and store pendingConversationId so startScheduledSession can route correctly.
+      const convMessages = messages.getByConversationId(conversationId);
+      const lastUserMessage = [...convMessages].reverse().find(msg => msg.role === 'user');
+
+      if (!lastUserMessage) {
+        // Fall back to Continue path if no user message found in conversation
+        console.warn(`[SchedulerService] No user message found in conversation ${conversationId}, falling back to Continue`);
+        pendingPrompt = 'Continue';
+        pendingConversationId = null;
+      } else {
+        pendingPrompt = lastUserMessage.content;
+        pendingConversationId = conversationId;
+        console.log(`[SchedulerService] Existing-message retry for session ${sessionId}, conversation ${conversationId}`);
+      }
+    } else {
+      // Continue path: next attempt sends "Continue" as a new user message
+      pendingPrompt = 'Continue';
+      pendingConversationId = null;
+      console.log(`[SchedulerService] Continue retry for session ${sessionId}`);
+    }
+
     // Update session to scheduled status with new time and pendingPrompt
     const updated = sessions.update(sessionId, {
       status: 'scheduled',
-      scheduledAt: newScheduledAt,           // Fixed: camelCase
-      rescheduleCount: newRescheduleCount,   // Fixed: camelCase
-      pendingPrompt: lastUserMessage.content, // Set prompt for scheduler
+      scheduledAt: newScheduledAt,
+      rescheduleCount: newRescheduleCount,
+      pendingPrompt,
+      pendingConversationId,
       error: `Rescheduled (${newRescheduleCount}x): ${reason}`,
     });
 

--- a/packages/server/src/services/schedulerService.js
+++ b/packages/server/src/services/schedulerService.js
@@ -296,31 +296,7 @@ class SchedulerService {
       `[SchedulerService] Rescheduling session ${sessionId} for ${delayMinutes} minutes from now (attempt ${newRescheduleCount})`
     );
 
-    let pendingPrompt;
-    let pendingConversationId = null;
-
-    if (retryExistingMessage && conversationId) {
-      // Existing-message retry: use the last user message from the active conversation
-      // and store pendingConversationId so startScheduledSession can route correctly.
-      const convMessages = messages.getByConversationId(conversationId);
-      const lastUserMessage = [...convMessages].reverse().find(msg => msg.role === 'user');
-
-      if (!lastUserMessage) {
-        // Fall back to Continue path if no user message found in conversation
-        console.warn(`[SchedulerService] No user message found in conversation ${conversationId}, falling back to Continue`);
-        pendingPrompt = 'Continue';
-        pendingConversationId = null;
-      } else {
-        pendingPrompt = lastUserMessage.content;
-        pendingConversationId = conversationId;
-        console.log(`[SchedulerService] Existing-message retry for session ${sessionId}, conversation ${conversationId}`);
-      }
-    } else {
-      // Continue path: next attempt sends "Continue" as a new user message
-      pendingPrompt = 'Continue';
-      pendingConversationId = null;
-      console.log(`[SchedulerService] Continue retry for session ${sessionId}`);
-    }
+    const { pendingPrompt, pendingConversationId } = this._resolvePendingPrompt(sessionId, retryExistingMessage, conversationId);
 
     // Update session to scheduled status with new time and pendingPrompt
     const updated = sessions.update(sessionId, {
@@ -335,6 +311,31 @@ class SchedulerService {
     broadcastRescheduledSession(sessionId, updated);
 
     return true;
+  }
+
+  /**
+   * Resolve the pending prompt and conversation ID for a reschedule attempt.
+   * @param {string} sessionId - Session ID (used for logging)
+   * @param {boolean} retryExistingMessage - Whether to retry the existing user message
+   * @param {string|null} conversationId - Active conversation to retry
+   * @returns {{ pendingPrompt: string, pendingConversationId: string|null }}
+   */
+  _resolvePendingPrompt(sessionId, retryExistingMessage, conversationId) {
+    if (retryExistingMessage && conversationId) {
+      const convMessages = messages.getByConversationId(conversationId);
+      const lastUserMessage = [...convMessages].reverse().find(msg => msg.role === 'user');
+
+      if (!lastUserMessage) {
+        console.warn(`[SchedulerService] No user message found in conversation ${conversationId}, falling back to Continue`);
+        return { pendingPrompt: 'Continue', pendingConversationId: null };
+      }
+
+      console.log(`[SchedulerService] Existing-message retry for session ${sessionId}, conversation ${conversationId}`);
+      return { pendingPrompt: lastUserMessage.content, pendingConversationId: conversationId };
+    }
+
+    console.log(`[SchedulerService] Continue retry for session ${sessionId}`);
+    return { pendingPrompt: 'Continue', pendingConversationId: null };
   }
 
   /**

--- a/packages/server/src/services/schedulerService.test.js
+++ b/packages/server/src/services/schedulerService.test.js
@@ -11,6 +11,7 @@ vi.mock('../database.js', () => ({
   },
   messages: {
     getBySessionId: vi.fn(),
+    getByConversationId: vi.fn(),
     create: vi.fn(),
   },
   conversations: {
@@ -40,6 +41,8 @@ describe('SchedulerService', () => {
     scheduler = new SchedulerService();
     mockSessionManager = {
       runSession: vi.fn().mockResolvedValue(undefined),
+      continueSession: vi.fn().mockResolvedValue(undefined),
+      continueSessionWithExistingMessage: vi.fn().mockResolvedValue(undefined),
     };
     vi.clearAllMocks();
 
@@ -314,7 +317,7 @@ describe('SchedulerService', () => {
     it('continues session when there are existing assistant messages', async () => {
       scheduler.initialize(mockSessionManager);
       mockSessionManager.continueSession = vi.fn().mockResolvedValue(undefined);
-      const session = { id: 'session-1', name: 'Test Session', projectId: 'project-1', pendingPrompt: 'Follow-up message', pendingModel: 'claude-opus-4-5' };
+      const session = { id: 'session-1', name: 'Test Session', projectId: 'project-1', pendingPrompt: 'Follow-up message', pendingConversationId: null, pendingModel: 'claude-opus-4-5' };
 
       projects.getById.mockReturnValue({ id: 'project-1', workingDirectory: '/tmp' });
       messages.getBySessionId.mockReturnValue([
@@ -328,10 +331,86 @@ describe('SchedulerService', () => {
       expect(mockSessionManager.continueSession).toHaveBeenCalledWith('session-1', 'Follow-up message', '/tmp', { systemPrompt: undefined, fileAttachments: [], model: 'claude-opus-4-5' });
       expect(mockSessionManager.runSession).not.toHaveBeenCalled();
     });
+
+    it('uses continueSessionWithExistingMessage when pendingConversationId is set', async () => {
+      scheduler.initialize(mockSessionManager);
+      mockSessionManager.continueSessionWithExistingMessage = vi.fn().mockResolvedValue(undefined);
+      const session = {
+        id: 'session-1',
+        name: 'Test Session',
+        projectId: 'project-1',
+        pendingPrompt: 'Initial prompt',
+        pendingConversationId: 'conv-99',
+        pendingModel: 'claude-sonnet-4-5',
+      };
+
+      projects.getById.mockReturnValue({ id: 'project-1', workingDirectory: '/tmp', systemPrompt: 'Be helpful' });
+      attachments.getBySessionId.mockReturnValue([]);
+
+      await scheduler.startScheduledSession(session);
+
+      // Should call continueSessionWithExistingMessage, not runSession or continueSession
+      expect(mockSessionManager.continueSessionWithExistingMessage).toHaveBeenCalledWith(
+        'session-1',
+        'conv-99',
+        '/tmp',
+        { systemPrompt: 'Be helpful', model: 'claude-sonnet-4-5' }
+      );
+      expect(mockSessionManager.runSession).not.toHaveBeenCalled();
+      expect(mockSessionManager.continueSession).not.toHaveBeenCalled();
+    });
+
+    it('clears pendingConversationId and pendingPrompt when using existing-message retry', async () => {
+      scheduler.initialize(mockSessionManager);
+      mockSessionManager.continueSessionWithExistingMessage = vi.fn().mockResolvedValue(undefined);
+      const session = {
+        id: 'session-1',
+        name: 'Test Session',
+        projectId: 'project-1',
+        pendingPrompt: 'Initial prompt',
+        pendingConversationId: 'conv-99',
+        pendingModel: null,
+      };
+
+      projects.getById.mockReturnValue({ id: 'project-1', workingDirectory: '/tmp' });
+      attachments.getBySessionId.mockReturnValue([]);
+
+      await scheduler.startScheduledSession(session);
+
+      expect(sessions.update).toHaveBeenCalledWith('session-1', {
+        status: 'starting',
+        scheduledAt: null,
+        pendingPrompt: null,
+        pendingConversationId: null,
+      });
+    });
+
+    it('pendingConversationId takes precedence over hasAssistantResponses check', async () => {
+      scheduler.initialize(mockSessionManager);
+      mockSessionManager.continueSessionWithExistingMessage = vi.fn().mockResolvedValue(undefined);
+      const session = {
+        id: 'session-1',
+        name: 'Test Session',
+        projectId: 'project-1',
+        pendingPrompt: 'Initial prompt',
+        pendingConversationId: 'conv-initial',
+        pendingModel: null,
+      };
+
+      projects.getById.mockReturnValue({ id: 'project-1', workingDirectory: '/tmp' });
+      // Even if session-wide messages shows no assistant (fresh session), pendingConversationId wins
+      messages.getBySessionId.mockReturnValue([]);
+      attachments.getBySessionId.mockReturnValue([]);
+
+      await scheduler.startScheduledSession(session);
+
+      expect(mockSessionManager.continueSessionWithExistingMessage).toHaveBeenCalled();
+      expect(mockSessionManager.runSession).not.toHaveBeenCalled();
+    });
   });
 
   describe('rescheduleSession', () => {
-    it('reschedules session with delay', async () => {
+    it('reschedules session with delay using Continue by default', async () => {
       scheduler.initialize(mockSessionManager);
       const now = Date.now();
       vi.setSystemTime(now);
@@ -349,15 +428,13 @@ describe('SchedulerService', () => {
         status: 'scheduled',
         scheduledAt: now + 15 * 60 * 1000,
         rescheduleCount: 1,
-        pendingPrompt: 'First message',
+        pendingPrompt: 'Continue',
+        pendingConversationId: null,
         error: 'Rescheduled (1x): Token limit reached',
       };
 
       sessions.getById.mockReturnValue(session);
       sessions.update.mockReturnValue(updatedSession);
-      messages.getBySessionId.mockReturnValue([
-        { role: 'user', content: 'First message' },
-      ]);
 
       const result = await scheduler.rescheduleSession('session-1', 'Token limit reached');
 
@@ -366,7 +443,8 @@ describe('SchedulerService', () => {
         status: 'scheduled',
         scheduledAt: now + 15 * 60 * 1000,
         rescheduleCount: 1,
-        pendingPrompt: 'First message',
+        pendingPrompt: 'Continue',
+        pendingConversationId: null,
         error: expect.stringContaining('Rescheduled (1x)'),
       });
       expect(broadcastToSession).toHaveBeenCalledWith('session-1', WS_MESSAGE_TYPES.SESSION_STATUS, {
@@ -382,6 +460,94 @@ describe('SchedulerService', () => {
         sessionId: 'session-1',
         session: updatedSession,
       });
+    });
+
+    it('with retryExistingMessage=true sets pendingPrompt to existing message and stores pendingConversationId', async () => {
+      scheduler.initialize(mockSessionManager);
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      const session = {
+        id: 'session-1',
+        projectId: 'project-1',
+        rescheduleDelayMinutes: 15,
+        rescheduleCount: 0,
+        maxRescheduleCount: null,
+        maxTotalTokens: null,
+      };
+
+      sessions.getById.mockReturnValue(session);
+      sessions.update.mockReturnValue({ ...session, status: 'scheduled' });
+      messages.getByConversationId.mockReturnValue([
+        { role: 'user', content: 'Do the thing' },
+      ]);
+
+      const result = await scheduler.rescheduleSession(
+        'session-1',
+        'Token limit reached',
+        { retryExistingMessage: true, conversationId: 'conv-1' }
+      );
+
+      expect(result).toBe(true);
+      expect(sessions.update).toHaveBeenCalledWith('session-1', expect.objectContaining({
+        pendingPrompt: 'Do the thing',
+        pendingConversationId: 'conv-1',
+      }));
+    });
+
+    it('with retryExistingMessage=true falls back to Continue when no user message in conversation', async () => {
+      scheduler.initialize(mockSessionManager);
+      const session = {
+        id: 'session-1',
+        projectId: 'project-1',
+        rescheduleDelayMinutes: 15,
+        rescheduleCount: 0,
+        maxRescheduleCount: null,
+        maxTotalTokens: null,
+      };
+
+      sessions.getById.mockReturnValue(session);
+      sessions.update.mockReturnValue({ ...session, status: 'scheduled' });
+      messages.getByConversationId.mockReturnValue([]);
+
+      const result = await scheduler.rescheduleSession(
+        'session-1',
+        'Token limit reached',
+        { retryExistingMessage: true, conversationId: 'conv-1' }
+      );
+
+      expect(result).toBe(true);
+      expect(sessions.update).toHaveBeenCalledWith('session-1', expect.objectContaining({
+        pendingPrompt: 'Continue',
+        pendingConversationId: null,
+      }));
+    });
+
+    it('explicit retryExistingMessage=false sets Continue and no conversationId', async () => {
+      scheduler.initialize(mockSessionManager);
+      const session = {
+        id: 'session-1',
+        projectId: 'project-1',
+        rescheduleDelayMinutes: 15,
+        rescheduleCount: 0,
+        maxRescheduleCount: null,
+        maxTotalTokens: null,
+      };
+
+      sessions.getById.mockReturnValue(session);
+      sessions.update.mockReturnValue({ ...session, status: 'scheduled' });
+
+      const result = await scheduler.rescheduleSession(
+        'session-1',
+        'Token threshold',
+        { retryExistingMessage: false }
+      );
+
+      expect(result).toBe(true);
+      expect(sessions.update).toHaveBeenCalledWith('session-1', expect.objectContaining({
+        pendingPrompt: 'Continue',
+        pendingConversationId: null,
+      }));
     });
 
     it('respects max reschedule count', async () => {
@@ -425,9 +591,6 @@ describe('SchedulerService', () => {
       };
 
       sessions.getById.mockReturnValue(session);
-      messages.getBySessionId.mockReturnValue([
-        { role: 'user', content: 'Test message' },
-      ]);
 
       await scheduler.rescheduleSession('session-1', 'Reason');
 

--- a/packages/server/src/services/sessionErrors.js
+++ b/packages/server/src/services/sessionErrors.js
@@ -161,10 +161,12 @@ export async function _checkProactiveReschedule(sessionId) {
       return false;
     }
 
-    // Gracefully reschedule
+    // Gracefully reschedule — proactive rescheduling always continues
+    // (turn completed, so "Continue" is the correct next prompt)
     await schedulerService.rescheduleSession(
       sessionId,
-      `Token threshold reached (${totalTokens.toLocaleString()} tokens)`
+      `Token threshold reached (${totalTokens.toLocaleString()} tokens)`,
+      { retryExistingMessage: false }
     );
     return true;
   }

--- a/packages/server/src/services/sessionErrors.test.js
+++ b/packages/server/src/services/sessionErrors.test.js
@@ -297,7 +297,8 @@ describe('sessionErrors', () => {
       expect(result).toBe(true);
       expect(schedulerService.rescheduleSession).toHaveBeenCalledWith(
         'sess-1',
-        expect.stringContaining('Token threshold reached')
+        expect.stringContaining('Token threshold reached'),
+        { retryExistingMessage: false }
       );
     });
 

--- a/packages/server/src/services/sessionManager.proactiveReschedule.test.js
+++ b/packages/server/src/services/sessionManager.proactiveReschedule.test.js
@@ -126,7 +126,8 @@ describe('sessionManager - Proactive Rescheduling', () => {
 
       expect(mockSchedulerService.rescheduleSession).toHaveBeenCalledWith(
         session.id,
-        expect.stringContaining('Token threshold reached')
+        expect.stringContaining('Token threshold reached'),
+        { retryExistingMessage: false }
       );
     });
 
@@ -170,7 +171,8 @@ describe('sessionManager - Proactive Rescheduling', () => {
       expect(mockSchedulerService.hasReachedLimits).toHaveBeenCalled();
       expect(mockSchedulerService.rescheduleSession).toHaveBeenCalledWith(
         session.id,
-        expect.stringContaining('Token threshold reached')
+        expect.stringContaining('Token threshold reached'),
+        { retryExistingMessage: false }
       );
     });
 
@@ -205,7 +207,8 @@ describe('sessionManager - Proactive Rescheduling', () => {
 
       expect(mockSchedulerService.rescheduleSession).toHaveBeenCalledWith(
         session.id,
-        expect.stringContaining('Token threshold reached')
+        expect.stringContaining('Token threshold reached'),
+        { retryExistingMessage: false }
       );
     });
 
@@ -222,7 +225,8 @@ describe('sessionManager - Proactive Rescheduling', () => {
 
       expect(mockSchedulerService.rescheduleSession).toHaveBeenCalledWith(
         session.id,
-        expect.stringContaining('Token threshold reached')
+        expect.stringContaining('Token threshold reached'),
+        { retryExistingMessage: false }
       );
     });
 
@@ -319,7 +323,8 @@ describe('sessionManager - Proactive Rescheduling', () => {
 
       expect(mockSchedulerService.rescheduleSession).toHaveBeenCalledWith(
         session.id,
-        expect.any(String)
+        expect.any(String),
+        { retryExistingMessage: false }
       );
     });
 
@@ -399,7 +404,8 @@ describe('sessionManager - Proactive Rescheduling', () => {
 
       expect(mockSchedulerService.rescheduleSession).toHaveBeenCalledWith(
         session.id,
-        expect.stringContaining('Token threshold reached')
+        expect.stringContaining('Token threshold reached'),
+        { retryExistingMessage: false }
       );
     });
 

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -1,4 +1,4 @@
-import { sessions, conversations } from '../database.js';
+import { sessions, conversations, messages } from '../database.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as summaryService from './summaryService.js';
@@ -107,6 +107,51 @@ export async function handleTurnCompletion(sessionId, workingDirectory, callback
 }
 
 /**
+ * Determine retry mode for a session error reschedule.
+ * Returns { retryExistingMessage, conversationId }.
+ *
+ * If the active conversation has a last user message and no assistant message
+ * after it, we retry the existing user message (no duplicate). Otherwise we
+ * schedule a "Continue" prompt.
+ *
+ * @param {string} sessionId
+ * @returns {{ retryExistingMessage: boolean, conversationId: string|null }}
+ */
+function computeRetryMode(sessionId) {
+  const activeConversationId = activeConversationIds.get(sessionId);
+  if (!activeConversationId) {
+    return { retryExistingMessage: false, conversationId: null };
+  }
+
+  const convMessages = messages.getByConversationId(activeConversationId);
+  // Find the last user message index and whether an assistant message follows it
+  let lastUserIndex = -1;
+  for (let i = convMessages.length - 1; i >= 0; i--) {
+    if (convMessages[i].role === 'user') {
+      lastUserIndex = i;
+      break;
+    }
+  }
+
+  if (lastUserIndex === -1) {
+    // No user message found — can't retry existing message
+    return { retryExistingMessage: false, conversationId: null };
+  }
+
+  const hasAssistantAfterLastUser = convMessages
+    .slice(lastUserIndex + 1)
+    .some(m => m.role === 'assistant');
+
+  if (!hasAssistantAfterLastUser) {
+    // The turn hasn't started yet: retry the existing user message
+    return { retryExistingMessage: true, conversationId: activeConversationId };
+  }
+
+  // Partial turn already has assistant content: next attempt should Continue
+  return { retryExistingMessage: false, conversationId: null };
+}
+
+/**
  * Try to reschedule the session due to an error.
  * Returns true if rescheduled, false otherwise.
  * @param {string} sessionId
@@ -120,9 +165,17 @@ async function tryRescheduleOnError(sessionId, error, shouldRescheduleOnError, s
   if (!session || !shouldRescheduleOnError(session, error, sessionId)) {
     return false;
   }
-  const rescheduled = await schedulerService.rescheduleSession(sessionId, error.message);
+
+  // Determine retry mode: re-use existing user message or send "Continue"
+  const { retryExistingMessage, conversationId } = computeRetryMode(sessionId);
+
+  const rescheduled = await schedulerService.rescheduleSession(
+    sessionId,
+    error.message,
+    { retryExistingMessage, conversationId }
+  );
   if (rescheduled) {
-    console.log(`[SessionManager] Session ${sessionId} rescheduled due to error`);
+    console.log(`[SessionManager] Session ${sessionId} rescheduled due to error (retryExistingMessage=${retryExistingMessage})`);
     return true;
   }
   return false;

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -666,7 +666,11 @@ describe('streamEventHandler', () => {
 
       expect(result).toBe(true);
       expect(mockShouldReschedule).toHaveBeenCalledWith(mockSession, error, 'sess-1');
-      expect(mockScheduler.rescheduleSession).toHaveBeenCalledWith('sess-1', error.message);
+      expect(mockScheduler.rescheduleSession).toHaveBeenCalledWith(
+        'sess-1',
+        error.message,
+        expect.objectContaining({ retryExistingMessage: expect.any(Boolean) })
+      );
     });
 
     it('falls through to error handling when reschedule fails', async () => {


### PR DESCRIPTION
## Summary
- add `pending_conversation_id` tracking for scheduled retry routing
- retry the existing user message when an error happens before assistant output is produced
- use a fresh `Continue` prompt for partial assistant output and proactive token-threshold reschedules
- update scheduler/session error tests and schema expectations

## Validation
- Playwright Circus command passed: 1159 passed, exit code 0
- Full command output also reported unit/coverage run success: 4680 passed, 103 skipped, exit code 0
