### PR TITLE
fix: orchestration panel no longer auto-expands due to autoRescheduleEnabled

### DIFF
--- a/packages/web/src/components/OrchestrationPanel.test.js
+++ b/packages/web/src/components/OrchestrationPanel.test.js
@@ -48,11 +48,9 @@ describe('OrchestrationPanel', () => {
       expect(wrapper.find('.orchestration-content').exists()).toBe(true);
     });
 
-    it('starts expanded when autoRescheduleEnabled is true', () => {
-      const wrapper = mountComponent({
-        autoRescheduleEnabled: true,
-      });
-      expect(wrapper.find('.orchestration-content').exists()).toBe(true);
+    it('starts collapsed when autoRescheduleEnabled is true (retry settings do not expand panel)', () => {
+      const wrapper = mountComponent({ autoRescheduleEnabled: true, currentTemplateId: null });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(false);
     });
 
     it('starts expanded when both currentTemplateId and autoRescheduleEnabled are set', () => {
@@ -316,6 +314,33 @@ describe('OrchestrationPanel', () => {
 
       // Change props - should maintain expanded state
       await wrapper.setProps({ sessionStatus: 'running' });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(true);
+    });
+  });
+
+  describe('reactive watcher for currentTemplateId', () => {
+    it('expands when currentTemplateId prop changes from null to a value after mount', async () => {
+      const wrapper = mountComponent({ currentTemplateId: null });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(false);
+
+      await wrapper.setProps({ currentTemplateId: 'template-1' });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(true);
+    });
+
+    it('does not expand when autoRescheduleEnabled changes from false to true after mount', async () => {
+      const wrapper = mountComponent({ autoRescheduleEnabled: false, currentTemplateId: null });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(false);
+
+      await wrapper.setProps({ autoRescheduleEnabled: true });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(false);
+    });
+
+    it('does not collapse when currentTemplateId is removed after user had expanded', async () => {
+      const wrapper = mountComponent({ currentTemplateId: 'template-1' });
+      expect(wrapper.find('.orchestration-content').exists()).toBe(true);
+
+      // Watcher only opens, never closes
+      await wrapper.setProps({ currentTemplateId: null });
       expect(wrapper.find('.orchestration-content').exists()).toBe(true);
     });
   });

--- a/packages/web/src/components/OrchestrationPanel.vue
+++ b/packages/web/src/components/OrchestrationPanel.vue
@@ -99,7 +99,7 @@
 </template>
 
 <script setup>
-import { ref, defineOptions } from 'vue';
+import { ref, watch, defineOptions } from 'vue';
 import TemplateSelector from './TemplateSelector.vue';
 
 defineOptions({
@@ -119,7 +119,14 @@ const props = defineProps({
 
 const emit = defineEmits(['openSchedule', 'update:templateId', 'openAutoReschedule']);
 
-const isExpanded = ref(props.autoRescheduleEnabled || Boolean(props.currentTemplateId));
+const isExpanded = ref(Boolean(props.currentTemplateId));
+
+watch(
+  () => Boolean(props.currentTemplateId),
+  (hasTemplate) => {
+    if (hasTemplate) isExpanded.value = true;
+  }
+);
 
 function toggle() {
   isExpanded.value = !isExpanded.value;

--- a/tests/e2e/orchestration-panel.spec.ts
+++ b/tests/e2e/orchestration-panel.spec.ts
@@ -74,25 +74,25 @@ test.describe('Orchestration Panel - Panel Visibility & Expand/Collapse', () => 
     await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
   });
 
-  test('panel starts expanded when auto-reschedule is enabled', async ({ page }) => {
+  test('panel starts collapsed when only auto-reschedule is enabled (no template)', async ({ page }) => {
     const session = await seedSession(project.id, {
       prompt: 'Test',
       name: 'AutoExpand Reschedule Test',
       startImmediately: false,
     });
 
-    // Enable auto-reschedule via API
+    // Enable auto-reschedule via API (but no next template)
     await updateSessionScheduling(session.id, { autoRescheduleEnabled: true });
 
     await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await openSessionOverlay(page);
 
-    // Content should be visible without clicking (auto-expanded)
+    // Panel content should NOT be visible (retry settings alone do not auto-expand)
     const content = page.locator('.orchestration-content');
-    await expect(content).toBeVisible();
+    await expect(content).not.toBeVisible();
 
     const toggleButton = page.locator('.orchestration-panel .toggle-button');
-    await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
   });
 
   test('panel starts expanded when next template is set', async ({ page }) => {
@@ -395,8 +395,11 @@ test.describe('Orchestration Panel - Auto-Reschedule Modal', () => {
     await navigateAndWait(page, `/sessions/${session.id}/summary`);
     await openSessionOverlay(page);
 
-    // Panel should be expanded (auto-expanded because autoRescheduleEnabled)
+    // Panel is collapsed by default — manually expand it to access the status button
     const content = page.locator('.orchestration-content');
+    await expect(content).not.toBeVisible();
+    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    await panelHeader.click();
     await expect(content).toBeVisible();
 
     // Click status button to open modal


### PR DESCRIPTION
## Summary

- `OrchestrationPanel` was initializing `isExpanded` from `props.autoRescheduleEnabled || Boolean(props.currentTemplateId)`. Because `autoRescheduleEnabled` defaults to `true` for virtually all sessions (the server sets it unless explicitly opted out), the panel was expanded for every session by default.
- Fixed `isExpanded` to only auto-expand when `currentTemplateId` is set (a deliberate next-template chaining action by the user). Retry settings alone are not a signal to expand.
- Added a reactive `watch` on `currentTemplateId` so the panel opens if a next-template is assigned after mount (e.g. via a WebSocket `SESSION_UPDATED` event), while never forcing the panel closed — preserving user-initiated collapse.
- Updated unit tests (`OrchestrationPanel.test.js`) and E2E tests (`orchestration-panel.spec.ts`) to assert the new behavior.

## Test plan

- [x] Unit tests: existing `autoRescheduleEnabled` test updated to expect collapsed; 3 new tests for watcher behavior added — all passing
- [x] E2E tests: two orchestration-panel specs updated to match new collapsed-by-default behavior — 1141 E2E tests passing
- [x] Coverage passing (168/169 test files pass)
- [x] Lint passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)