### PR TITLE
Persist Kanban lane collapse state per project

### DIFF
--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -660,6 +660,99 @@ describe('KanbanBoard.vue', () => {
         expect(wrapper.find('.kanban-lanes-container').classes()).toContain('layout-horizontal');
       });
     });
+
+    describe('8. Lane collapse persistence', () => {
+      it('collapsing a lane in vertical mode writes the project-scoped key to localStorage', async () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        const wrapper = mountBoard({ projectId: 'proj-1' });
+        await wrapper.vm.$nextTick();
+
+        const laneHeaders = wrapper.findAll('.lane-header');
+        await laneHeaders[0].trigger('click');
+        await wrapper.vm.$nextTick();
+
+        const stored = localStorage.getItem('kanbanExpandedLanes:proj-1');
+        expect(stored).not.toBeNull();
+        const parsed = JSON.parse(stored);
+        expect(parsed['lane-1']).toBe(false);
+      });
+
+      it('fresh mount with a saved collapsed state renders that lane collapsed', async () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        localStorage.setItem(
+          'kanbanExpandedLanes:proj-1',
+          JSON.stringify({ 'lane-1': false, 'lane-2': true })
+        );
+        const wrapper = mountBoard({ projectId: 'proj-1' });
+        await wrapper.vm.$nextTick();
+
+        // lane-1 cards container should be hidden
+        const laneCards = wrapper.findAll('.lane-cards');
+        expect(laneCards[0].element.style.display).toBe('none');
+        // lane-2 should be visible
+        expect(laneCards[1].element.style.display).not.toBe('none');
+      });
+
+      it('fresh mount defaults lanes not present in saved state to expanded', async () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        // Only save state for lane-2; lane-1 has no saved state
+        localStorage.setItem(
+          'kanbanExpandedLanes:proj-1',
+          JSON.stringify({ 'lane-2': false })
+        );
+        const wrapper = mountBoard({ projectId: 'proj-1' });
+        await wrapper.vm.$nextTick();
+
+        const laneCards = wrapper.findAll('.lane-cards');
+        // lane-1 has no saved state → defaults to expanded
+        expect(laneCards[0].element.style.display).not.toBe('none');
+        // lane-2 has saved collapsed state
+        expect(laneCards[1].element.style.display).toBe('none');
+      });
+
+      it('two mounts with different projectId values do not share collapse state', async () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        // Collapse lane-1 for proj-1
+        localStorage.setItem(
+          'kanbanExpandedLanes:proj-1',
+          JSON.stringify({ 'lane-1': false, 'lane-2': true })
+        );
+        // proj-2 has no saved state
+        const wrapper = mountBoard({ projectId: 'proj-2' });
+        await wrapper.vm.$nextTick();
+
+        const laneCards = wrapper.findAll('.lane-cards');
+        // proj-2 has no saved state, so all lanes default to expanded
+        expect(laneCards[0].element.style.display).not.toBe('none');
+        expect(laneCards[1].element.style.display).not.toBe('none');
+      });
+
+      it('invalid JSON in localStorage falls back safely (all lanes expanded)', async () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        localStorage.setItem('kanbanExpandedLanes:proj-1', 'not-valid-json{{{');
+        const wrapper = mountBoard({ projectId: 'proj-1' });
+        await wrapper.vm.$nextTick();
+
+        const laneCards = wrapper.findAll('.lane-cards');
+        expect(laneCards[0].element.style.display).not.toBe('none');
+        expect(laneCards[1].element.style.display).not.toBe('none');
+      });
+
+      it('non-boolean values in stored JSON fall back to expanded', async () => {
+        localStorage.setItem('kanbanLayoutMode', 'vertical');
+        // Values like "0", null, 1 are not booleans and must be ignored
+        localStorage.setItem(
+          'kanbanExpandedLanes:proj-1',
+          JSON.stringify({ 'lane-1': 0, 'lane-2': null })
+        );
+        const wrapper = mountBoard({ projectId: 'proj-1' });
+        await wrapper.vm.$nextTick();
+
+        const laneCards = wrapper.findAll('.lane-cards');
+        expect(laneCards[0].element.style.display).not.toBe('none');
+        expect(laneCards[1].element.style.display).not.toBe('none');
+      });
+    });
   });
 
   describe('Command button status indicators', () => {

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -431,14 +431,45 @@ const effectiveLayout = computed(() => {
 // All lanes start expanded by default.
 const expandedLanes = reactive({});
 
+// ==================== Lane collapse persistence ====================
+
+const EXPANDED_LANES_KEY = 'kanbanExpandedLanes';
+
+function readExpandedLanes(projectId) {
+  try {
+    const raw = localStorage.getItem(`${EXPANDED_LANES_KEY}:${projectId}`);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    const result = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === 'boolean') {
+        result[k] = v;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function writeExpandedLanes(projectId, expandedMap) {
+  try {
+    localStorage.setItem(`${EXPANDED_LANES_KEY}:${projectId}`, JSON.stringify(expandedMap));
+  } catch {
+    // ignore (e.g. private browsing with storage blocked)
+  }
+}
+
 watch(
-  () => kanbanStore.board?.lanes,
-  (lanes) => {
+  [() => props.projectId, () => kanbanStore.board?.lanes],
+  ([projectId, lanes]) => {
     if (lanes) {
+      // Clear old-project state to avoid leaking across project switches.
+      for (const k in expandedLanes) delete expandedLanes[k];
+      const saved = readExpandedLanes(projectId);
       for (const lane of lanes) {
-        if (!(lane.id in expandedLanes)) {
-          expandedLanes[lane.id] = true;
-        }
+        expandedLanes[lane.id] = typeof saved[lane.id] === 'boolean' ? saved[lane.id] : true;
       }
     }
   },
@@ -447,6 +478,7 @@ watch(
 
 const toggleLane = (laneId) => {
   expandedLanes[laneId] = !expandedLanes[laneId];
+  writeExpandedLanes(props.projectId, { ...expandedLanes });
 };
 
 // Called when the lane header is clicked; only toggles in vertical mode.

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -550,25 +550,11 @@ const fetchBoard = async () => {
   }
 };
 
-const getStatusIndicator = (status) => {
-  switch (status) {
-    case 'running':
-    case 'starting':
-      return '●';
-    case 'waiting':
-      return '◐';
-    case 'completed':
-      return '✓';
-    case 'error':
-      return '✕';
-    case 'stopped':
-      return '■';
-    case 'scheduled':
-      return '⏰';
-    default:
-      return '○';
-  }
+const STATUS_INDICATORS = {
+  running: '●', starting: '●', waiting: '◐', completed: '✓',
+  error: '✕', stopped: '■', scheduled: '⏰',
 };
+const getStatusIndicator = (status) => STATUS_INDICATORS[status] || '○';
 
 const isCardEffectivelyRunning = (session) => {
   if (!session?.id) return false;


### PR DESCRIPTION
## Summary
- Persist Kanban lane collapsed/expanded state in localStorage per project
- Restore saved lane collapse state when the Kanban board loads
- Add component coverage for per-project lane collapse persistence

## Tests
- Playwright tests Circus command: 1141 passed, 18 skipped
