### PR TITLE
Rename session creation button to workspace

### DIFF
--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -3131,7 +3131,7 @@ describe('Add Session button responsive labels', () => {
     const desktopBtn = wrapper.find('.tabs-desktop .btn-primary');
     expect(desktopBtn.exists()).toBe(true);
     expect(desktopBtn.find('.add-session-label-full').exists()).toBe(true);
-    expect(desktopBtn.find('.add-session-label-full').text()).toBe('+ Session');
+    expect(desktopBtn.find('.add-session-label-full').text()).toBe('+ Workspace');
     expect(desktopBtn.find('.add-session-label-short').exists()).toBe(true);
     expect(desktopBtn.find('.add-session-label-short').text()).toBe('+');
   });
@@ -3142,16 +3142,16 @@ describe('Add Session button responsive labels', () => {
 
     const desktopBtn = wrapper.find('.tabs-desktop .btn-primary');
     expect(desktopBtn.exists()).toBe(true);
-    expect(desktopBtn.attributes('aria-label')).toBe('New Session');
+    expect(desktopBtn.attributes('aria-label')).toBe('New Workspace');
   });
 
-  it('renders mobile button with "+ Session" text', async () => {
+  it('renders mobile button with "+ Workspace" text', async () => {
     const wrapper = mount(SessionListView);
     await flushAll(wrapper);
 
     const mobileBtn = wrapper.find('.mobile-only.btn-primary');
     expect(mobileBtn.exists()).toBe(true);
-    expect(mobileBtn.text()).toContain('+ Session');
+    expect(mobileBtn.text()).toContain('+ Workspace');
   });
 
   it('does not affect empty-state button text', async () => {
@@ -3164,7 +3164,7 @@ describe('Add Session button responsive labels', () => {
 
     const emptyStateBtn = wrapper.find('.empty-state .btn-primary');
     expect(emptyStateBtn.exists()).toBe(true);
-    expect(emptyStateBtn.text()).toBe('New Session');
+    expect(emptyStateBtn.text()).toBe('New Workspace');
   });
 });
 

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -49,7 +49,7 @@
         :to="`/projects/${route.params.id}/sessions/new`"
         class="btn btn-primary mobile-only"
       >
-        + Session
+        + Workspace
       </router-link>
     </div>
 
@@ -105,9 +105,9 @@
           v-if="activeTab === 'sessions'"
           :to="`/projects/${route.params.id}/sessions/new`"
           class="btn btn-primary desktop-only"
-          aria-label="New Session"
+          aria-label="New Workspace"
         >
-          <span class="add-session-label-full">+ Session</span><span class="add-session-label-short">+</span>
+          <span class="add-session-label-full">+ Workspace</span><span class="add-session-label-short">+</span>
         </router-link>
       </div>
 
@@ -190,7 +190,7 @@
           :to="`/projects/${route.params.id}/sessions/new`"
           class="btn btn-primary"
         >
-          New Session
+          New Workspace
         </router-link>
       </div>
 


### PR DESCRIPTION
## Summary
- Rename the SessionListView creation button from "+ Session" to "+ Workspace"

## Tests
- Playwright Circus command passed: 1159 Playwright tests passed, 6 skipped
- Full command completed successfully with exitCode 0