### PR TITLE
feat: rename repository/repositories to project/projects in user-facing UI

### DIFF
--- a/packages/web/src/views/ProjectEditView.vue
+++ b/packages/web/src/views/ProjectEditView.vue
@@ -277,7 +277,7 @@ async function handleSubmit() {
       await defaultsStore.updateDefaults(route.params.id, defaultsData);
     }
 
-    uiStore.success('Repository updated');
+    uiStore.success('Project updated');
     router.push(`/projects/${route.params.id}/sessions`);
   } catch (err) {
     error.value = err.message;
@@ -291,7 +291,7 @@ async function handleDelete() {
 
   try {
     await projectsStore.deleteProject(route.params.id);
-    uiStore.success('Repository removed');
+    uiStore.success('Project removed');
     router.push('/');
   } catch (err) {
     error.value = err.message;

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -51,7 +51,7 @@ describe('ProjectListView', () => {
   });
 
   describe('Page Header', () => {
-    it('displays "Repositories" as page title', async () => {
+    it('displays "Projects" as page title', async () => {
       projectsStore.projects = [];
       projectsStore.loading = false;
       projectsStore.error = null;
@@ -62,10 +62,10 @@ describe('ProjectListView', () => {
 
       await flushAll(wrapper);
 
-      expect(wrapper.find('h1').text()).toBe('Repositories');
+      expect(wrapper.find('h1').text()).toBe('Projects');
     });
 
-    it('shows "Add Repository" button', async () => {
+    it('shows "Add Project" button', async () => {
       projectsStore.projects = [];
       projectsStore.loading = false;
       projectsStore.error = null;
@@ -79,7 +79,7 @@ describe('ProjectListView', () => {
       const link = wrapper.find('.page-header .btn-primary');
       expect(link.exists()).toBe(true);
       // Desktop label should be visible
-      expect(link.find('.add-repo-label-full').text()).toBe('Add Repository');
+      expect(link.find('.add-repo-label-full').text()).toBe('Add Project');
     });
   });
 
@@ -129,7 +129,7 @@ describe('ProjectListView', () => {
 
       const cta = wrapper.find('.cta-button');
       expect(cta.exists()).toBe(true);
-      expect(cta.text()).toBe('Add Your First Repository');
+      expect(cta.text()).toBe('Add Your First Project');
       // router-link renders as <a href="...">; the 'to' prop becomes the href attribute
       expect(cta.attributes('href')).toBe('/projects/new');
     });

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -111,7 +111,7 @@ describe('ProjectListView', () => {
 
       const steps = wrapper.findAll('.step-card');
       expect(steps).toHaveLength(3);
-      expect(steps[0].text()).toContain('Pick a repo folder');
+      expect(steps[0].text()).toContain('Pick a project folder');
       expect(steps[1].text()).toContain('Create coding sessions');
       expect(steps[2].text()).toContain('Track changes');
     });

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -50,7 +50,7 @@
             1
           </div>
           <h3 class="step-title">
-            Pick a repo folder
+            Pick a project folder
           </h3>
           <p class="step-desc">
             Point to any codebase on your machine

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="container">
     <div class="page-header">
-      <h1>Repositories</h1>
+      <h1>Projects</h1>
       <router-link
         to="/projects/new"
         class="btn btn-primary"
       >
-        <span class="add-repo-label-full">Add Repository</span>
+        <span class="add-repo-label-full">Add Project</span>
         <span class="add-repo-label-short">+ Add</span>
       </router-link>
     </div>
@@ -84,7 +84,7 @@
         to="/projects/new"
         class="btn btn-primary cta-button"
       >
-        Add Your First Repository
+        Add Your First Project
       </router-link>
     </div>
 

--- a/packages/web/src/views/ProjectNewView.test.js
+++ b/packages/web/src/views/ProjectNewView.test.js
@@ -77,7 +77,7 @@ describe('ProjectNewView', () => {
   });
 
   describe('Page Title and Labels', () => {
-    it('displays "Add a Repository" as page title', async () => {
+    it('displays "Add a Project" as page title', async () => {
       await router.push('/projects/new');
       await router.isReady();
 
@@ -87,10 +87,10 @@ describe('ProjectNewView', () => {
 
       await flushAll(wrapper);
 
-      expect(wrapper.find('h1').text()).toBe('Add a Repository');
+      expect(wrapper.find('h1').text()).toBe('Add a Project');
     });
 
-    it('shows "Repository Folder" label', async () => {
+    it('shows "Project Folder" label', async () => {
       await router.push('/projects/new');
       await router.isReady();
 
@@ -101,7 +101,7 @@ describe('ProjectNewView', () => {
       await flushAll(wrapper);
 
       const text = wrapper.text();
-      expect(text).toContain('Repository Folder');
+      expect(text).toContain('Project Folder');
     });
 
     it('shows "Display Name" label', async () => {
@@ -118,7 +118,7 @@ describe('ProjectNewView', () => {
       expect(text).toContain('Display Name');
     });
 
-    it('submit button says "Add Repository"', async () => {
+    it('submit button says "Add Project"', async () => {
       await router.push('/projects/new');
       await router.isReady();
 
@@ -129,7 +129,7 @@ describe('ProjectNewView', () => {
       await flushAll(wrapper);
 
       const submitBtn = wrapper.find('button[type="submit"]');
-      expect(submitBtn.text()).toContain('Add Repository');
+      expect(submitBtn.text()).toContain('Add Project');
     });
   });
 
@@ -175,7 +175,7 @@ describe('ProjectNewView', () => {
   });
 
   describe('Form Submission', () => {
-    it('shows success toast "Repository added" on submit', async () => {
+    it('shows success toast "Project added" on submit', async () => {
       await router.push('/projects/new');
       await router.isReady();
 
@@ -195,7 +195,7 @@ describe('ProjectNewView', () => {
       await form.trigger('submit');
       await flushAll(wrapper);
 
-      expect(uiStore.success).toHaveBeenCalledWith('Repository added');
+      expect(uiStore.success).toHaveBeenCalledWith('Project added');
     });
   });
 

--- a/packages/web/src/views/ProjectNewView.vue
+++ b/packages/web/src/views/ProjectNewView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <h1>Add a Repository</h1>
+    <h1>Add a Project</h1>
 
     <form
       class="form card"
@@ -10,7 +10,7 @@
         <label
           class="form-label"
           for="workingDirectory"
-        >Repository Folder</label>
+        >Project Folder</label>
         <PathChooser v-model="workingDirectory" />
         <p class="form-help">
           The root of your codebase — typically a git repository.
@@ -147,7 +147,7 @@
             v-if="loading"
             class="loading-spinner"
           />
-          Add Repository
+          Add Project
         </button>
       </div>
     </form>
@@ -237,7 +237,7 @@ async function handleSubmit() {
       onSessionDeleted: onSessionDeleted.value || undefined,
       worktreePath: worktreePath.value || null,
     });
-    uiStore.success('Repository added');
+    uiStore.success('Project added');
     router.push(`/projects/${project.id}/sessions`);
   } catch (err) {
     error.value = err.message;

--- a/tests/e2e/path-chooser.spec.ts
+++ b/tests/e2e/path-chooser.spec.ts
@@ -216,7 +216,7 @@ test.describe('Path Chooser Selection', () => {
     expect(inputValue).toBe('/tmp');
 
     // Submit form
-    await page.click('button:has-text("Add Repository")');
+    await page.click('button:has-text("Add Project")');
 
     // Should redirect to sessions page
     await expect(page).toHaveURL(/\/projects\/.*\/sessions/);
@@ -232,7 +232,7 @@ test.describe('Path Chooser Selection', () => {
     // the create-project request to 400 and the URL to stay on /projects/new.
     await page.fill('.path-chooser input', '/tmp');
 
-    await page.click('button:has-text("Add Repository")');
+    await page.click('button:has-text("Add Project")');
 
     await expect(page).toHaveURL(/\/projects\/.*\/sessions/);
   });

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -20,12 +20,12 @@ test.describe('Project Management', () => {
     mkdirSync('/tmp/test-project', { recursive: true });
 
     await page.goto('/');
-    await page.click('text=Add Repository');
+    await page.click('text=Add Project');
 
     await expect(page).toHaveURL('/projects/new');
 
     await page.fill('.path-chooser input', '/tmp/test-project');
-    await page.click('button:has-text("Add Repository")');
+    await page.click('button:has-text("Add Project")');
 
     // Should redirect to sessions page with project ID in URL
     await expect(page).toHaveURL(/\/projects\/[\w-]+\/sessions/);
@@ -154,7 +154,7 @@ test.describe('Project Management', () => {
     mkdirSync('/tmp/test-project', { recursive: true });
 
     await page.goto('/');
-    await page.click('text=Add Repository');
+    await page.click('text=Add Project');
 
     await expect(page).toHaveURL('/projects/new');
 
@@ -166,7 +166,7 @@ test.describe('Project Management', () => {
     const customPrompt = 'You are a specialized coding assistant.';
     await page.fill('textarea[id="systemPrompt"]', customPrompt);
 
-    await page.click('button:has-text("Add Repository")');
+    await page.click('button:has-text("Add Project")');
 
     // Should redirect to sessions page with project ID in URL
     await expect(page).toHaveURL(/\/projects\/[\w-]+\/sessions/);


### PR DESCRIPTION
## Summary

- Replace all user-facing references to "repository/repositories" (when referring to the app project entity) with "project/projects" across ProjectListView, ProjectNewView, and ProjectEditView
- Update unit tests (ProjectListView.test.js, ProjectNewView.test.js) and E2E tests (projects.spec.ts, path-chooser.spec.ts) to match the new terminology
- Fix empty-state onboarding copy: rename "repo folder" to "project folder" in ProjectListView
- Git/GitHub-specific references (e.g. "Repository URL", "typically a git repository") are intentionally left unchanged

## Test plan

- [x] Lint passes (yarn lint)
- [x] Coverage passes (yarn test:coverage)
- [x] Playwright E2E tests pass (./scripts/pw.sh test) - 1138 passed, 3 flaky, 18 skipped

Generated with Claude Code