### PR TITLE
Rename 'New Workspace' button to 'New Session' in chat overlay

### DIFF
--- a/packages/web/src/components/SessionChatContent.vue
+++ b/packages/web/src/components/SessionChatContent.vue
@@ -346,7 +346,7 @@ async function addChildSession() {
 
     const newSession = await api.createSession(currentSession.projectId, {
       prompt: ' ',
-      name: 'New Workspace',
+      name: 'New Session',
       parentSessionId: activeSessionId.value,
       startImmediately: false,
       ...(currentSession.model ? { model: currentSession.model } : {}),

--- a/packages/web/src/components/SessionChatContent.vue
+++ b/packages/web/src/components/SessionChatContent.vue
@@ -146,7 +146,7 @@
               y2="12"
             />
           </svg>
-          {{ isCreatingSession ? 'Creating...' : 'New Workspace' }}
+          {{ isCreatingSession ? 'Creating...' : 'New Session' }}
         </button>
       </div>
     </div>

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -964,13 +964,13 @@ describe('SessionChatOverlay', () => {
     });
   });
 
-  describe('Add Workspace button', () => {
-    it('renders add workspace button in overlay', async () => {
+  describe('Add Session button', () => {
+    it('renders add session button in overlay', async () => {
       const wrapper = mountOverlay();
       await nextTick();
       const btn = document.querySelector('[data-testid="overlay-add-session-btn"]');
       expect(btn).toBeTruthy();
-      expect(btn.textContent.trim()).toContain('New Workspace');
+      expect(btn.textContent.trim()).toContain('New Session');
       wrapper.unmount();
     });
 

--- a/packages/web/src/components/SessionChatOverlay.test.js
+++ b/packages/web/src/components/SessionChatOverlay.test.js
@@ -1035,7 +1035,7 @@ describe('SessionChatOverlay', () => {
       expect(generateWorktreeBranch).not.toHaveBeenCalled();
       expect(api.createSession).toHaveBeenCalledWith('proj-123', {
         prompt: ' ',
-        name: 'New Workspace',
+        name: 'New Session',
         parentSessionId: 'sess-root',
         startImmediately: false,
         gitMode: 'worktree',
@@ -1063,7 +1063,7 @@ describe('SessionChatOverlay', () => {
       // triggering git checkout in directories that may not be git repos
       expect(api.createSession).toHaveBeenCalledWith('proj-123', {
         prompt: ' ',
-        name: 'New Workspace',
+        name: 'New Session',
         parentSessionId: 'sess-root',
         startImmediately: false,
       });
@@ -1086,7 +1086,7 @@ describe('SessionChatOverlay', () => {
 
       expect(api.createSession).toHaveBeenCalledWith('proj-123', {
         prompt: ' ',
-        name: 'New Workspace',
+        name: 'New Session',
         parentSessionId: 'sess-root',
         startImmediately: false,
       });
@@ -1219,7 +1219,7 @@ describe('SessionChatOverlay', () => {
       expect(generateWorktreeBranch).not.toHaveBeenCalled();
       expect(api.createSession).toHaveBeenCalledWith('proj-123', {
         prompt: ' ',
-        name: 'New Workspace',
+        name: 'New Session',
         parentSessionId: 'sess-root',
         startImmediately: false,
       });
@@ -1242,7 +1242,7 @@ describe('SessionChatOverlay', () => {
 
       expect(api.createSession).toHaveBeenCalledWith('proj-123', {
         prompt: ' ',
-        name: 'New Workspace',
+        name: 'New Session',
         parentSessionId: 'sess-root',
         startImmediately: false,
         model: 'gpt-5.4',
@@ -1268,7 +1268,7 @@ describe('SessionChatOverlay', () => {
 
       expect(api.createSession).toHaveBeenCalledWith('proj-123', {
         prompt: ' ',
-        name: 'New Workspace',
+        name: 'New Session',
         parentSessionId: 'sess-root',
         startImmediately: false,
       });

--- a/tests/e2e/child-session-send.spec.ts
+++ b/tests/e2e/child-session-send.spec.ts
@@ -57,11 +57,11 @@ test.describe('Child Session Start from Overlay', () => {
 
     // 4. Wait for overlay to switch to the new draft child session
     const dropdownName = overlay.locator('.dropdown-name');
-    await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+    await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
     // 5. Find the child session via API (need its ID for status checks)
     const allSessions = await getProjectSessions(project.id);
-    const childSession = allSessions.find((s: any) => s.name === 'New Workspace');
+    const childSession = allSessions.find((s: any) => s.name === 'New Session');
     expect(childSession).toBeDefined();
 
     // 6. Type prompt in the draft textarea

--- a/tests/e2e/debug-new-session-button.spec.ts
+++ b/tests/e2e/debug-new-session-button.spec.ts
@@ -141,13 +141,13 @@ test.describe('Debug: New Session Button', () => {
       console.log('Overlay not visible after click (may have closed)');
     }
 
-    // Check that the session detail page switched to "New Workspace"
+    // Check that the session detail page switched to "New Session"
     const pageTitle = page.locator('[data-testid="session-name"]');
     try {
-      await expect(pageTitle).toHaveText('New Workspace', { timeout: 5000 });
-      console.log('Page successfully switched to New Workspace');
+      await expect(pageTitle).toHaveText('New Session', { timeout: 5000 });
+      console.log('Page successfully switched to New Session');
     } catch (e) {
-      console.log('Failed to confirm page switched to New Workspace');
+      console.log('Failed to confirm page switched to New Session');
     }
 
     // Report resource and console errors

--- a/tests/e2e/session-chat-overlay.spec.ts
+++ b/tests/e2e/session-chat-overlay.spec.ts
@@ -881,7 +881,7 @@ test.describe('Session Chat Overlay', () => {
 
       const addBtn = overlay.locator('[data-testid="overlay-add-session-btn"]');
       await expect(addBtn).toBeVisible({ timeout: 5000 });
-      await expect(addBtn).toContainText('New Workspace');
+      await expect(addBtn).toContainText('New Session');
     });
 
     test('add session button is visible on standalone session (no children)', async ({ page }) => {
@@ -906,12 +906,12 @@ test.describe('Session Chat Overlay', () => {
 
       // The dropdown should switch to show the new child session
       const dropdownName = overlay.locator('.dropdown-name');
-      await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+      await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
       // Verify session was created in backend (child of any session in the tree)
       const allSessions = await getProjectSessions(project.id);
       const newChildren = allSessions.filter(
-        (s: any) => s.name === 'New Workspace'
+        (s: any) => s.name === 'New Session'
       );
       expect(newChildren.length).toBeGreaterThanOrEqual(1);
     });
@@ -924,7 +924,7 @@ test.describe('Session Chat Overlay', () => {
 
       // Wait for overlay to switch to the new session (visible in dropdown)
       const dropdownName = overlay.locator('.dropdown-name');
-      await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+      await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
       // Verify the conversation input area is visible (the session is a draft and accepts prompt input)
       await expect(overlay.locator('.overlay-content')).toBeVisible();
@@ -938,7 +938,7 @@ test.describe('Session Chat Overlay', () => {
 
       // Wait for overlay to switch to the new session (visible in dropdown)
       const dropdownName = overlay.locator('.dropdown-name');
-      await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+      await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
       // Open picker and verify both parent and new session are listed
       const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
@@ -946,7 +946,7 @@ test.describe('Session Chat Overlay', () => {
       const picker = page.locator('[data-testid="session-chat-picker"]');
       await expect(picker).toBeVisible({ timeout: 5000 });
       await expect(picker).toContainText('Parent Session');
-      await expect(picker).toContainText('New Workspace');
+      await expect(picker).toContainText('New Session');
     });
 
     test('can create multiple child sessions in sequence', async ({ page }) => {
@@ -957,7 +957,7 @@ test.describe('Session Chat Overlay', () => {
       await addBtn.click();
 
       const dropdownName = overlay.locator('.dropdown-name');
-      await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+      await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
       // Navigate back to parent via session picker
       const dropdown = overlay.locator('[data-testid="session-tree-dropdown"]');
@@ -979,12 +979,12 @@ test.describe('Session Chat Overlay', () => {
 
       // Create second child
       await addBtn.click();
-      await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+      await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
       // Verify via API that two new child sessions were created in the tree
       const allSessions = await getProjectSessions(project.id);
       const newChildren = allSessions.filter(
-        (s: any) => s.name === 'New Workspace'
+        (s: any) => s.name === 'New Session'
       );
       expect(newChildren.length).toBeGreaterThanOrEqual(2);
     });
@@ -998,10 +998,10 @@ test.describe('Session Chat Overlay', () => {
       // The button may briefly show "Creating..." - we verify the final state
       // After creation completes, the dropdown should show the new session
       const dropdownName = overlay.locator('.dropdown-name');
-      await expect(dropdownName).toContainText('New Workspace', { timeout: 10000 });
+      await expect(dropdownName).toContainText('New Session', { timeout: 10000 });
 
       // Button text should be back to "New Session" after creation
-      await expect(addBtn).toContainText('New Workspace', { timeout: 5000 });
+      await expect(addBtn).toContainText('New Session', { timeout: 5000 });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Renames the default child session name from `'New Workspace'` to `'New Session'` in `SessionChatContent.vue` so the label accurately describes the concept (a new session, not a workspace)
- Updates unit tests in `SessionChatOverlay.test.js` to expect the new name
- Updates E2E test assertions in `session-chat-overlay.spec.ts`, `child-session-send.spec.ts`, and `debug-new-session-button.spec.ts` to match

## Test plan
- [x] All 1148 Playwright E2E tests pass (19 skipped, 0 failures)
- [x] Unit tests updated to reflect new session name

🤖 Generated with [Claude Code](https://claude.com/claude-code)