### PR TITLE
fix: hide horizontal overflow on settings view container

### DIFF
--- a/packages/web/src/views/SettingsView.vue
+++ b/packages/web/src/views/SettingsView.vue
@@ -85,6 +85,10 @@ function navigateToTab(tabId) {
 </script>
 
 <style scoped>
+.container {
+  overflow-x: hidden;
+}
+
 h1 {
   margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- Adds `overflow-x: hidden` to the `.container` style in `SettingsView.vue`
- Fixes a horizontal scrollbar that appeared in the Settings layout, which caused the session logs view to appear misaligned or cut off

## Test plan
- [x] Playwright E2E tests passed (1142 passed, 1 flaky/retried, 19 skipped)
- [ ] Navigate to Settings → Logs tab and verify no horizontal scrollbar appears
- [ ] Verify the session logs table renders correctly without layout issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)