### PR TITLE
feat: always show orchestration panel for future scheduled sessions

### DIFF
--- a/packages/web/src/components/InputForm.test.js
+++ b/packages/web/src/components/InputForm.test.js
@@ -375,9 +375,9 @@ describe('InputForm', () => {
       expect(wrapper.findComponent({ name: 'OrchestrationPanel' }).exists()).toBe(true);
     });
 
-    it('should hide OrchestrationPanel when scheduled for future', () => {
-      const wrapper = mountComponent({ isScheduledForFuture: true });
-      expect(wrapper.findComponent({ name: 'OrchestrationPanel' }).exists()).toBe(false);
+    it('should show OrchestrationPanel when scheduled for future', () => {
+      const wrapper = mountComponent({ sessionStatus: 'scheduled', canSendMessage: true, isScheduledForFuture: true });
+      expect(wrapper.findComponent({ name: 'OrchestrationPanel' }).exists()).toBe(true);
     });
 
     it('should show OrchestrationPanel when running', () => {

--- a/packages/web/src/components/InputForm.vue
+++ b/packages/web/src/components/InputForm.vue
@@ -130,7 +130,7 @@
 
     <!-- Orchestration Panel - shows after input controls -->
     <OrchestrationPanel
-      v-if="(canSendMessage || isDraft || isRunning) && !isScheduledForFuture"
+      v-if="canSendMessage || isDraft || isRunning"
       :session-id="sessionId"
       :project-id="projectId"
       :current-template-id="currentTemplateId"

--- a/packages/web/vitest.config.js
+++ b/packages/web/vitest.config.js
@@ -7,6 +7,15 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.js'],
+    // Increase default timeout from 5s to 10s. Under coverage instrumentation
+    // the full suite runs much slower (jsdom environment setup dominates), and
+    // normally-fast component mount/interaction tests can exceed the 5s default.
+    testTimeout: 10000,
+    // Automatically retry tests once to smooth over truly transient flakes
+    // (e.g. a mount that briefly exceeds the timeout under CPU/disk load during
+    // coverage runs). Real failures still surface because they fail on both the
+    // initial run and the retry. Mirrors the server package configuration.
+    retry: 1,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -2016,9 +2016,11 @@ export async function seedScheduledSession(
     prompt: data.prompt,
     startImmediately: false,
     scheduledAt: new Date(data.scheduledAt ?? Date.now() + 3600000).toISOString(), // default 1 hour from now
+    // Default autoRescheduleEnabled to false so tests get deterministic panel behavior
+    // (the REST API now defaults it to true for agent convenience). Mirrors seedSession.
+    autoRescheduleEnabled: data.autoRescheduleEnabled ?? false,
   };
   if (data.name) body.name = data.name;
-  if (data.autoRescheduleEnabled !== undefined) body.autoRescheduleEnabled = data.autoRescheduleEnabled;
   if (data.rescheduleDelayMinutes !== undefined) body.rescheduleDelayMinutes = data.rescheduleDelayMinutes;
   if (data.rescheduleOnTokenLimit !== undefined) body.rescheduleOnTokenLimit = data.rescheduleOnTokenLimit;
   if (data.rescheduleOnServiceError !== undefined) body.rescheduleOnServiceError = data.rescheduleOnServiceError;

--- a/tests/e2e/orchestration-panel.spec.ts
+++ b/tests/e2e/orchestration-panel.spec.ts
@@ -3,6 +3,7 @@ import {
   seedProject,
   seedSession,
   seedProjectTemplate,
+  seedScheduledSession,
   setNextTemplate,
   updateSessionScheduling,
   getSession,
@@ -808,5 +809,102 @@ test.describe('Orchestration Panel - Integration', () => {
 
     const statusBadge = page.locator('.status-badge');
     await expect(statusBadge).toContainText('Enabled');
+  });
+});
+
+// ============================================================
+// Category 6: Future Scheduled Session — Panel Always Visible (3 tests)
+// ============================================================
+
+test.describe('Orchestration Panel - Future Scheduled Session', () => {
+  test.describe.configure({ timeout: 15000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupAll();
+    await cleanupTemplates();
+    project = await seedProject('OrchPanel ScheduledFuture', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupTemplates();
+    await cleanupAll();
+  });
+
+  test('orchestration panel is visible for a future scheduled session', async ({ page }) => {
+    const session = await seedScheduledSession(project.id, {
+      prompt: 'Scheduled future prompt',
+      name: 'Future Scheduled Session',
+    });
+
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
+
+    const panel = page.locator('.orchestration-panel');
+    await expect(panel).toBeVisible();
+
+    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    await expect(panelHeader).toBeVisible();
+    await expect(panelHeader).toContainText('Orchestration');
+  });
+
+  test('template selection and auto-reschedule controls are reachable for future scheduled session', async ({ page }) => {
+    const template = await seedProjectTemplate(project.id, {
+      name: 'Future Scheduled Template',
+      prompt: 'Do scheduled task',
+    });
+
+    const session = await seedScheduledSession(project.id, {
+      prompt: 'Scheduled future prompt',
+      name: 'Future Scheduled Controls Test',
+    });
+
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
+
+    // Expand the panel
+    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    await panelHeader.click();
+
+    const content = page.locator('.orchestration-content');
+    await expect(content).toBeVisible();
+
+    // Template selector should be visible and usable
+    const templateSelector = page.locator('.template-selector');
+    await expect(templateSelector).toBeVisible();
+
+    const dropdown = page.locator('.template-selector select.form-input');
+    await expect(dropdown).toBeVisible();
+    await dropdown.selectOption(template.id);
+
+    const preview = page.locator('.template-preview');
+    await expect(preview).toBeVisible({ timeout: 5000 });
+
+    // Auto-reschedule configure button should be visible
+    const configureBtn = page.locator('.btn-configure');
+    await expect(configureBtn).toBeVisible();
+  });
+
+  test('schedule button is disabled for already scheduled session', async ({ page }) => {
+    const session = await seedScheduledSession(project.id, {
+      prompt: 'Scheduled future prompt',
+      name: 'Future Scheduled Disabled Button Test',
+    });
+
+    await navigateAndWait(page, `/sessions/${session.id}/summary`);
+    await openSessionOverlay(page);
+
+    // Expand the panel
+    const panelHeader = page.locator('.orchestration-panel .panel-header');
+    await panelHeader.click();
+
+    const content = page.locator('.orchestration-content');
+    await expect(content).toBeVisible();
+
+    // Schedule button should be disabled because session is already scheduled
+    const scheduleBtn = page.locator('.btn-schedule');
+    await expect(scheduleBtn).toBeVisible();
+    await expect(scheduleBtn).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

- Always show the orchestration panel when a session has a future `scheduledAt` date, even if `autoRescheduleEnabled` is false
- Added E2E tests covering orchestration panel display logic for scheduled sessions
- Stabilized web coverage vitest run with timeout and retry configuration
- Fixed `seedScheduledSession` test helper to default `autoRescheduleEnabled` to `false` for deterministic E2E test behavior (mirrors the REST API's new default of `true`)

## Test plan

- [x] Playwright E2E tests pass (1145 passed, 1 flaky on retry, 19 skipped)
- [x] New `tests/e2e/orchestration-panel.spec.ts` validates orchestration panel visibility
- [x] `seedScheduledSession` helper defaults `autoRescheduleEnabled: false` so scheduled-session tests don't inherit the API's agent-convenience default

🤖 Generated with [Claude Code](https://claude.com/claude-code)