### PR TITLE
feat: default autoRescheduleEnabled to true in new session form

### DIFF
--- a/packages/web/src/composables/useNewSessionForm.js
+++ b/packages/web/src/composables/useNewSessionForm.js
@@ -23,7 +23,7 @@ export function useNewSessionForm(storageKey) {
   const parentSessionId = ref(null);
   const schedulingData = ref({
     scheduledAt: null,
-    autoRescheduleEnabled: false,
+    autoRescheduleEnabled: true,
     rescheduleDelayMinutes: DEFAULT_RESCHEDULE_DELAY_MINUTES,
     rescheduleOnTokenLimit: true,
     rescheduleOnServiceError: true,
@@ -101,7 +101,7 @@ export function useNewSessionForm(storageKey) {
   function resetSchedulingData() {
     schedulingData.value = {
       scheduledAt: null,
-      autoRescheduleEnabled: false,
+      autoRescheduleEnabled: true,
       rescheduleDelayMinutes: DEFAULT_RESCHEDULE_DELAY_MINUTES,
       rescheduleOnTokenLimit: true,
       rescheduleOnServiceError: true,

--- a/packages/web/src/composables/useNewSessionForm.test.js
+++ b/packages/web/src/composables/useNewSessionForm.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useNewSessionForm, buildSessionPayload } from './useNewSessionForm.js';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, value) => { store[key] = String(value); },
+    removeItem: (key) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+// Mock the shared package
+vi.mock('@circuschief/shared', () => ({
+  generateWorktreeBranch: vi.fn((prefix, prompt) => `branch-${prompt.slice(0, 10)}`),
+  DEFAULT_RESCHEDULE_DELAY_MINUTES: 15,
+}));
+
+describe('useNewSessionForm', () => {
+  const storageKey = { value: 'test-draft-key' };
+
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  describe('initial state', () => {
+    it('initializes schedulingData.autoRescheduleEnabled to true', () => {
+      const form = useNewSessionForm(storageKey);
+      expect(form.schedulingData.value.autoRescheduleEnabled).toBe(true);
+    });
+
+    it('initializes other scheduling fields with expected defaults', () => {
+      const form = useNewSessionForm(storageKey);
+      expect(form.schedulingData.value.scheduledAt).toBeNull();
+      expect(form.schedulingData.value.rescheduleDelayMinutes).toBe(15);
+      expect(form.schedulingData.value.rescheduleOnTokenLimit).toBe(true);
+      expect(form.schedulingData.value.rescheduleOnServiceError).toBe(true);
+      expect(form.schedulingData.value.maxRescheduleCount).toBeNull();
+      expect(form.schedulingData.value.maxTotalTokens).toBeNull();
+      expect(form.schedulingData.value.rescheduleAtTokenCount).toBeNull();
+    });
+  });
+
+  describe('resetSchedulingData', () => {
+    it('restores autoRescheduleEnabled to true after being set to false', () => {
+      const form = useNewSessionForm(storageKey);
+
+      // Simulate user turning off auto-reschedule
+      form.schedulingData.value.autoRescheduleEnabled = false;
+      expect(form.schedulingData.value.autoRescheduleEnabled).toBe(false);
+
+      form.resetSchedulingData();
+      expect(form.schedulingData.value.autoRescheduleEnabled).toBe(true);
+    });
+
+    it('resets all scheduling fields to defaults', () => {
+      const form = useNewSessionForm(storageKey);
+
+      // Mutate scheduling data
+      form.schedulingData.value = {
+        scheduledAt: Date.now() + 3600000,
+        autoRescheduleEnabled: false,
+        rescheduleDelayMinutes: 60,
+        rescheduleOnTokenLimit: false,
+        rescheduleOnServiceError: false,
+        maxRescheduleCount: 5,
+        maxTotalTokens: 100000,
+        rescheduleAtTokenCount: 50000,
+      };
+
+      form.resetSchedulingData();
+
+      expect(form.schedulingData.value.scheduledAt).toBeNull();
+      expect(form.schedulingData.value.autoRescheduleEnabled).toBe(true);
+      expect(form.schedulingData.value.rescheduleDelayMinutes).toBe(15);
+      expect(form.schedulingData.value.rescheduleOnTokenLimit).toBe(true);
+      expect(form.schedulingData.value.rescheduleOnServiceError).toBe(true);
+      expect(form.schedulingData.value.maxRescheduleCount).toBeNull();
+      expect(form.schedulingData.value.maxTotalTokens).toBeNull();
+      expect(form.schedulingData.value.rescheduleAtTokenCount).toBeNull();
+    });
+  });
+});
+
+describe('buildSessionPayload', () => {
+  const storageKey = { value: 'test-key' };
+
+  it('includes autoRescheduleEnabled: true by default in payload', () => {
+    const form = useNewSessionForm(storageKey);
+    const payload = buildSessionPayload(form, { currentPrompt: 'test prompt' });
+    expect(payload.autoRescheduleEnabled).toBe(true);
+  });
+
+  it('preserves explicit false when user has turned off auto-reschedule', () => {
+    const form = useNewSessionForm(storageKey);
+    form.schedulingData.value.autoRescheduleEnabled = false;
+
+    const payload = buildSessionPayload(form, { currentPrompt: 'test prompt' });
+    expect(payload.autoRescheduleEnabled).toBe(false);
+  });
+
+  it('includes all scheduling fields in the payload', () => {
+    const form = useNewSessionForm(storageKey);
+    form.schedulingData.value.rescheduleDelayMinutes = 30;
+    form.schedulingData.value.maxRescheduleCount = 5;
+
+    const payload = buildSessionPayload(form, { currentPrompt: 'test prompt' });
+
+    expect(payload).toHaveProperty('autoRescheduleEnabled', true);
+    expect(payload).toHaveProperty('rescheduleDelayMinutes', 30);
+    expect(payload).toHaveProperty('rescheduleOnTokenLimit', true);
+    expect(payload).toHaveProperty('rescheduleOnServiceError', true);
+    expect(payload).toHaveProperty('maxRescheduleCount', 5);
+    expect(payload).toHaveProperty('maxTotalTokens', null);
+    expect(payload).toHaveProperty('rescheduleAtTokenCount', null);
+  });
+});

--- a/tests/e2e/new-session-auto-reschedule-default.spec.ts
+++ b/tests/e2e/new-session-auto-reschedule-default.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  cleanupCreatedResources,
+  getSession,
+  getProjectSessions,
+  BASE_URL,
+} from './helpers';
+
+test.describe('New workspace form: auto-reschedule default', () => {
+  // Keep tests serial — they share project state and git worktree operations
+  // should not race.
+  test.describe.configure({ mode: 'serial', timeout: 60000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+    // Use process.cwd() (a real git repo/worktree) so the form's git panel
+    // loads and the submit button is enabled — mirrors git-session-creation.spec.ts.
+    project = await seedProject('AutoReschedule Default Test', process.cwd());
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('auto-reschedule toggle defaults ON when Start Immediately is turned off', async ({ page }) => {
+    // Navigate to the new session form
+    await page.goto(`${BASE_URL}/projects/${project.id}/sessions/new`);
+
+    // Wait for the git options panel — confirms the form has fully loaded
+    await page.waitForSelector(
+      '[data-testid="git-status-panel"], .git-status, .git-mode-select, select[name="gitMode"], [class*="git"]',
+      { timeout: 15000, state: 'visible' },
+    ).catch(() => {
+      // If no explicit git panel, the form may still be usable
+    });
+
+    // Turn OFF Start Immediately by clicking the toggle label inside .field-with-badge
+    const startImmediatelyToggle = page
+      .locator('.field-with-badge')
+      .filter({ hasText: 'Start Immediately' })
+      .locator('label.toggle-switch');
+    await startImmediatelyToggle.click();
+
+    // Assert the Start Immediately input is now unchecked
+    const startImmediatelyInput = page
+      .locator('.field-with-badge')
+      .filter({ hasText: 'Start Immediately' })
+      .locator('input[type="checkbox"]');
+    await expect(startImmediatelyInput).not.toBeChecked();
+
+    // The scheduling section should now be visible
+    await expect(page.locator('.scheduling-options')).toBeVisible();
+
+    // Locate the auto-reschedule checkbox via its label text
+    const autoRescheduleCheckbox = page.locator(
+      'label.toggle-switch:has-text("Auto-reschedule on errors") input[type="checkbox"]',
+    );
+
+    // Assert auto-reschedule is checked by default (the core assertion)
+    await expect(autoRescheduleCheckbox).toBeChecked();
+
+    // Assert the dependent reschedule-settings block is visible — confirms
+    // the default-on state cascades properly to the UI.
+    await expect(
+      page.locator('.scheduling-options .reschedule-settings'),
+    ).toBeVisible();
+  });
+
+  test('auto-reschedule default ON persists into the created workspace', async ({ page }) => {
+    // Navigate to the new session form
+    await page.goto(`${BASE_URL}/projects/${project.id}/sessions/new`);
+
+    // Wait for the git panel to confirm the form is fully loaded
+    await page.waitForSelector(
+      '[data-testid="git-status-panel"], .git-status, .git-mode-select, select[name="gitMode"], [class*="git"]',
+      { timeout: 15000, state: 'visible' },
+    ).catch(() => {});
+
+    // Turn off Start Immediately
+    const startImmediatelyToggle = page
+      .locator('.field-with-badge')
+      .filter({ hasText: 'Start Immediately' })
+      .locator('label.toggle-switch');
+    await startImmediatelyToggle.click();
+
+    // Wait for the scheduling options to appear
+    await expect(page.locator('.scheduling-options')).toBeVisible();
+
+    // Set a scheduled time at least 1 hour in the future so the workspace
+    // stays dormant and does not attempt to spawn an agent.
+    const futureTime = new Date(Date.now() + 3600000);
+    const timeString = futureTime.toISOString().slice(0, 16); // YYYY-MM-DDTHH:mm
+    const scheduledInput = page.locator('.scheduling-options input[type="datetime-local"]');
+    await scheduledInput.fill(timeString);
+
+    // Fill the prompt textarea (submit requires non-empty content)
+    await page.fill('textarea[id="prompt"]', 'Auto-reschedule default test prompt');
+
+    // Submit the form
+    await page.click('button:has-text("Create Workspace")');
+
+    // Wait for navigation to the created session URL
+    await expect(page).toHaveURL(
+      /\/sessions\/(?!new(?:$|[/?#]))[0-9a-f-]+/,
+      { timeout: 30000 },
+    );
+
+    // Extract the session ID from the URL
+    const url = page.url();
+    const sessionIdMatch = url.match(/\/sessions\/([0-9a-f-]+)/);
+    expect(sessionIdMatch).toBeTruthy();
+    const sessionId = sessionIdMatch![1];
+
+    // Give the server a moment to persist the session
+    await page.waitForTimeout(500);
+
+    // Fetch the created session and assert autoRescheduleEnabled is true
+    const session = await getSession(sessionId);
+    expect(session).toBeTruthy();
+    expect(session.autoRescheduleEnabled).toBe(true);
+  });
+
+  test('explicit opt-out of auto-reschedule flows through to created workspace', async ({ page }) => {
+    // Navigate to the new session form
+    await page.goto(`${BASE_URL}/projects/${project.id}/sessions/new`);
+
+    // Wait for the git panel
+    await page.waitForSelector(
+      '[data-testid="git-status-panel"], .git-status, .git-mode-select, select[name="gitMode"], [class*="git"]',
+      { timeout: 15000, state: 'visible' },
+    ).catch(() => {});
+
+    // Turn off Start Immediately
+    const startImmediatelyToggle = page
+      .locator('.field-with-badge')
+      .filter({ hasText: 'Start Immediately' })
+      .locator('label.toggle-switch');
+    await startImmediatelyToggle.click();
+
+    // Wait for the scheduling options to appear
+    await expect(page.locator('.scheduling-options')).toBeVisible();
+
+    // Set a future scheduled time so the workspace stays dormant
+    const futureTime = new Date(Date.now() + 3600000);
+    const timeString = futureTime.toISOString().slice(0, 16);
+    const scheduledInput = page.locator('.scheduling-options input[type="datetime-local"]');
+    await scheduledInput.fill(timeString);
+
+    // The auto-reschedule toggle should be ON by default — turn it OFF
+    const autoRescheduleLabel = page.locator(
+      'label.toggle-switch:has-text("Auto-reschedule on errors")',
+    );
+    await autoRescheduleLabel.click();
+
+    // Assert it is now unchecked
+    const autoRescheduleCheckbox = page.locator(
+      'label.toggle-switch:has-text("Auto-reschedule on errors") input[type="checkbox"]',
+    );
+    await expect(autoRescheduleCheckbox).not.toBeChecked();
+
+    // Assert the reschedule-settings block is now hidden (v-if="autoRescheduleEnabled")
+    await expect(
+      page.locator('.scheduling-options .reschedule-settings'),
+    ).not.toBeVisible();
+
+    // Fill the prompt and submit
+    await page.fill('textarea[id="prompt"]', 'Auto-reschedule opt-out test prompt');
+    await page.click('button:has-text("Create Workspace")');
+
+    // Wait for navigation to the created session URL
+    await expect(page).toHaveURL(
+      /\/sessions\/(?!new(?:$|[/?#]))[0-9a-f-]+/,
+      { timeout: 30000 },
+    );
+
+    // Extract the session ID
+    const url = page.url();
+    const sessionIdMatch = url.match(/\/sessions\/([0-9a-f-]+)/);
+    expect(sessionIdMatch).toBeTruthy();
+    const sessionId = sessionIdMatch![1];
+
+    await page.waitForTimeout(500);
+
+    // Fetch the created session and assert autoRescheduleEnabled is false
+    const session = await getSession(sessionId);
+    expect(session).toBeTruthy();
+    expect(session.autoRescheduleEnabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Changes `autoRescheduleEnabled` default from `false` to `true` in `useNewSessionForm.js` so new sessions automatically opt into rescheduling
- Updates `resetSchedulingData()` to also restore `autoRescheduleEnabled` to `true`
- Adds comprehensive unit tests for `useNewSessionForm` covering initial state, reset behavior, and payload building

## Test plan
- [x] All 1146 Playwright E2E tests pass
- [x] Unit tests cover `autoRescheduleEnabled` default=true in initial state
- [x] Unit tests cover `resetSchedulingData` restores autoRescheduleEnabled to true
- [x] Unit tests cover `buildSessionPayload` includes correct autoRescheduleEnabled value

🤖 Generated with [Claude Code](https://claude.com/claude-code)