### PR TITLE
Rename 'Scheduled Workspaces' header to 'Scheduled Sessions'

### DIFF
--- a/packages/web/src/components/SessionOverviewCard.test.js
+++ b/packages/web/src/components/SessionOverviewCard.test.js
@@ -32,19 +32,19 @@ describe('SessionOverviewCard.vue', () => {
     });
   }
 
-  describe('Scheduled Workspaces', () => {
-    it('renders no scheduled workspaces section when array is empty', () => {
+  describe('Scheduled Sessions', () => {
+    it('renders no scheduled sessions section when array is empty', () => {
       const wrapper = mountComponent({ scheduledSessions: [] });
       // The card should not render at all when there's no content
       expect(wrapper.find('.overview-scheduled-sessions').exists()).toBe(false);
     });
 
-    it('renders no scheduled workspaces section when prop is omitted', () => {
+    it('renders no scheduled sessions section when prop is omitted', () => {
       const wrapper = mountComponent();
       expect(wrapper.find('.overview-scheduled-sessions').exists()).toBe(false);
     });
 
-    it('renders scheduled workspaces section when array has items', () => {
+    it('renders scheduled sessions section when array has items', () => {
       const scheduledSessions = [
         { id: 'c1', name: 'Child 1', status: 'scheduled', scheduledAt: Date.now() + 3600000 },
       ];
@@ -54,7 +54,7 @@ describe('SessionOverviewCard.vue', () => {
       });
 
       expect(wrapper.find('.overview-scheduled-sessions').exists()).toBe(true);
-      expect(wrapper.find('.scheduled-sessions-heading').text()).toBe('Scheduled Workspaces (1)');
+      expect(wrapper.find('.scheduled-sessions-heading').text()).toBe('Scheduled Sessions (1)');
     });
 
     it('renders multiple ScheduledChildCard stubs', () => {
@@ -69,7 +69,7 @@ describe('SessionOverviewCard.vue', () => {
       });
 
       expect(wrapper.find('.overview-scheduled-sessions').exists()).toBe(true);
-      expect(wrapper.find('.scheduled-sessions-heading').text()).toBe('Scheduled Workspaces (3)');
+      expect(wrapper.find('.scheduled-sessions-heading').text()).toBe('Scheduled Sessions (3)');
       const stubs = wrapper.findAll('.scheduled-child-card-stub');
       expect(stubs.length).toBe(3);
       expect(stubs[0].text()).toBe('Child 1');
@@ -93,7 +93,7 @@ describe('SessionOverviewCard.vue', () => {
       expect(cards[1].props('projectId')).toBe('proj-1');
     });
 
-    it('shows overview card when only scheduled workspaces exist (no summary, PR, metrics)', () => {
+    it('shows overview card when only scheduled sessions exist (no summary, PR, metrics)', () => {
       const scheduledSessions = [
         { id: 'c1', name: 'Child 1', status: 'scheduled', scheduledAt: Date.now() + 3600000 },
       ];
@@ -106,7 +106,7 @@ describe('SessionOverviewCard.vue', () => {
       expect(wrapper.find('.overview-scheduled-sessions').exists()).toBe(true);
     });
 
-    it('does not show "Workspace Overview" header when only scheduled workspaces exist', () => {
+    it('does not show "Workspace Overview" header when only scheduled sessions exist', () => {
       const scheduledSessions = [
         { id: 'c1', name: 'Child 1', status: 'scheduled', scheduledAt: Date.now() + 3600000 },
       ];

--- a/packages/web/src/components/SessionOverviewCard.vue
+++ b/packages/web/src/components/SessionOverviewCard.vue
@@ -132,7 +132,7 @@
       class="overview-scheduled-sessions"
     >
       <h4 class="scheduled-sessions-heading">
-        Scheduled Workspaces ({{ scheduledSessions.length }})
+        Scheduled Sessions ({{ scheduledSessions.length }})
       </h4>
       <div class="scheduled-sessions-list">
         <ScheduledChildCard

--- a/packages/web/src/components/SummaryTab.test.js
+++ b/packages/web/src/components/SummaryTab.test.js
@@ -1229,7 +1229,7 @@ describe('SummaryTab', () => {
     });
   });
 
-  describe('Scheduled Workspaces', () => {
+  describe('Scheduled Sessions', () => {
     it('passes parent + scheduled children to SessionOverviewCard when parent is scheduled', async () => {
       sessionsStore.currentSession = {
         id: 'sess-123',

--- a/tests/e2e/scheduling-ui.spec.ts
+++ b/tests/e2e/scheduling-ui.spec.ts
@@ -208,7 +208,7 @@ test.describe('Scheduling UI', () => {
       // Verify scheduling info is visible in the overview card
       const schedulingSection = page.locator('.overview-scheduled-sessions');
       await expect(schedulingSection).toBeVisible({ timeout: 5000 });
-      await expect(schedulingSection).toContainText('Scheduled Workspaces');
+      await expect(schedulingSection).toContainText('Scheduled Sessions');
       await expect(schedulingSection).toContainText('Edit');
     });
 


### PR DESCRIPTION
## Summary
- Renames the "Scheduled Workspaces" section heading in `SessionOverviewCard.vue` to "Scheduled Sessions" for more accurate terminology
- Updates all corresponding unit test assertions and E2E test expectations to match the new label

## Test plan
- [x] All 1149 Playwright E2E tests pass (19 skipped)
- [x] Unit tests updated to reflect new heading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)