### PR TITLE
Fix scheduled draft cancellation and manual start

### DIFF
--- a/packages/server/src/api/sessions.pendingModel.test.js
+++ b/packages/server/src/api/sessions.pendingModel.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { projects, sessions, modelProviders } from '../database.js';
+import { projects, sessions, messages, modelProviders } from '../database.js';
 
 // Mock websocket
 vi.mock('../websocket.js', () => ({
@@ -372,6 +372,41 @@ describe('Sessions API - pendingModel Field', () => {
 
       const updated = sessions.getById(session.id);
       expect(updated.pendingModel).toBeNull();
+    });
+
+    it('starts a scheduled draft directly and clears one-time schedule state', async () => {
+      const scheduledAt = Date.now() + 3600000;
+      const scheduledDraft = sessions.create(project.id, 'Scheduled Draft', null, 'standard', true, null, null, 'scheduled');
+      sessions.update(scheduledDraft.id, {
+        scheduledAt,
+        pendingPrompt: 'Run the scheduled draft now',
+        pendingModel: 'opus',
+      });
+
+      const response = await request(app)
+        .post(`/api/sessions/${scheduledDraft.id}/start`)
+        .send({})
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.session.status).toBe('starting');
+      expect(response.body.session.scheduledAt).toBeNull();
+      expect(response.body.session.pendingPrompt).toBeNull();
+      expect(response.body.session.pendingModel).toBeNull();
+
+      const stored = sessions.getById(scheduledDraft.id);
+      expect(stored.scheduledAt).toBeNull();
+      expect(stored.pendingPrompt).toBeNull();
+      expect(stored.pendingModel).toBeNull();
+
+      const createdUserMessage = messages
+        .getBySessionId(scheduledDraft.id)
+        .find(msg => msg.role === 'user');
+      expect(createdUserMessage?.content).toBe('Run the scheduled draft now');
+
+      expect(vi.mocked(runSession)).toHaveBeenCalledOnce();
+      const optionsArg = vi.mocked(runSession).mock.calls[0][3];
+      expect(optionsArg.model).toBe('opus');
     });
 
     it('renders Liquid in the draft start prompt when renderLiquid is true', async () => {

--- a/packages/server/src/services/draftSessionService.js
+++ b/packages/server/src/services/draftSessionService.js
@@ -6,13 +6,13 @@ import { resolveAgentTypeFromModel } from './sessionProvider.js';
 import { validateModelId } from '../api/model-validation.js';
 
 /**
- * Validates that a session is a draft (waiting status with no assistant messages).
+ * Validates that a session is a draft (waiting/scheduled status with no assistant messages).
  * @param {object} session - The session object
  * @returns {{ valid: boolean, error?: string }}
  */
 export function validateDraftSession(session) {
-  if (session.status !== 'waiting') {
-    return { valid: false, error: 'Session must be in waiting status to start' };
+  if (session.status !== 'waiting' && session.status !== 'scheduled') {
+    return { valid: false, error: 'Session must be in waiting or scheduled status to start' };
   }
 
   const allMessages = messages.getBySessionId(session.id);
@@ -148,6 +148,7 @@ export async function startDraft(session, options = {}) {
   // resolved model + agentType BEFORE runSession() reads them from storage.
   sessions.update(session.id, {
     status: 'starting',
+    scheduledAt: null,
     pendingModel: null,
     ...(model ? { model, agentType } : {}),
     ...(options.providerId !== undefined ? { providerId: options.providerId } : {}),

--- a/packages/server/src/services/draftSessionService.test.js
+++ b/packages/server/src/services/draftSessionService.test.js
@@ -83,13 +83,25 @@ describe('draftSessionService', () => {
       expect(result.error).toBeUndefined();
     });
 
-    it('returns invalid when session is not in waiting status', () => {
+    it('returns invalid when session is not in waiting or scheduled status', () => {
       const session = { id: 's1', status: 'running' };
 
       const result = validateDraftSession(session);
 
       expect(result.valid).toBe(false);
-      expect(result.error).toBe('Session must be in waiting status to start');
+      expect(result.error).toBe('Session must be in waiting or scheduled status to start');
+    });
+
+    it('returns valid for a scheduled session with no assistant messages', () => {
+      const session = { id: 's1', status: 'scheduled' };
+      messages.getBySessionId.mockReturnValue([
+        { id: 'm1', role: 'user', content: 'Hello' },
+      ]);
+
+      const result = validateDraftSession(session);
+
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
     it('returns invalid when session has assistant messages', () => {
@@ -221,6 +233,7 @@ describe('draftSessionService', () => {
       expect(messages.create).not.toHaveBeenCalled();
       expect(sessions.update).toHaveBeenCalledWith('s1', {
         status: 'starting',
+        scheduledAt: null,
         pendingModel: null,
       });
     });
@@ -326,6 +339,7 @@ describe('draftSessionService', () => {
 
       expect(sessions.update).toHaveBeenCalledWith('s1', {
         status: 'starting',
+        scheduledAt: null,
         pendingModel: null,
         model: 'gpt-5.4',
         agentType: 'codex',
@@ -344,6 +358,7 @@ describe('draftSessionService', () => {
 
       expect(sessions.update).toHaveBeenCalledWith('s1', {
         status: 'starting',
+        scheduledAt: null,
         pendingModel: null,
         model: 'claude-sonnet-test',
         agentType: 'claude-code',
@@ -362,6 +377,7 @@ describe('draftSessionService', () => {
 
       expect(sessions.update).toHaveBeenCalledWith('s1', {
         status: 'starting',
+        scheduledAt: null,
         pendingModel: null,
         model: 'gpt-4o-test',
         agentType: 'codex',
@@ -388,6 +404,7 @@ describe('draftSessionService', () => {
       expect(resolveAgentTypeFromModel).toHaveBeenCalledWith('claude-sonnet');
       expect(sessions.update).toHaveBeenCalledWith('s1', {
         status: 'starting',
+        scheduledAt: null,
         pendingModel: null,
         model: 'claude-sonnet',
         agentType: 'claude-code',
@@ -401,6 +418,7 @@ describe('draftSessionService', () => {
 
       expect(sessions.update).toHaveBeenCalledWith('s1', {
         status: 'starting',
+        scheduledAt: null,
         pendingModel: null,
       });
     });

--- a/packages/web/src/components/ConversationTab.test.js
+++ b/packages/web/src/components/ConversationTab.test.js
@@ -3873,6 +3873,55 @@ describe('ConversationTab - Watcher workspace-scoping guards', () => {
     expect(mockSessionsStore.fetchWorkLogs).toHaveBeenCalledWith('parent-1');
   });
 
+  it('restores pendingPrompt when a scheduled session is canceled while the tab stays mounted', async () => {
+    mockSessionsStore.currentSession = {
+      id: 'parent-1',
+      status: 'scheduled',
+      thinkingEnabled: false,
+      mode: 'standard',
+      scheduledAt: Date.now() + 3600000,
+      pendingPrompt: 'Draft from schedule',
+    };
+
+    const wrapper = mountComponent({ sessionId: 'parent-1' });
+    await flushAll(wrapper);
+
+    const textarea = wrapper.find('textarea');
+    await textarea.setValue('');
+    await flushAll(wrapper);
+    expect(textarea.element.value).toBe('');
+
+    mockSessionsStore.currentSession.status = 'stopped';
+    mockSessionsStore.currentSession.scheduledAt = null;
+    await flushAll(wrapper);
+
+    expect(textarea.element.value).toBe('Draft from schedule');
+  });
+
+  it('does not overwrite user-entered text when scheduled cancellation arrives', async () => {
+    mockSessionsStore.currentSession = {
+      id: 'parent-1',
+      status: 'scheduled',
+      thinkingEnabled: false,
+      mode: 'standard',
+      scheduledAt: Date.now() + 3600000,
+      pendingPrompt: 'Draft from schedule',
+    };
+
+    const wrapper = mountComponent({ sessionId: 'parent-1' });
+    await flushAll(wrapper);
+
+    const textarea = wrapper.find('textarea');
+    await textarea.setValue('User typed a different prompt');
+    await flushAll(wrapper);
+
+    mockSessionsStore.currentSession.status = 'stopped';
+    mockSessionsStore.currentSession.scheduledAt = null;
+    await flushAll(wrapper);
+
+    expect(textarea.element.value).toBe('User typed a different prompt');
+  });
+
   it('status watcher DOES refetch on running -> completed when workspace matches', async () => {
     mockSessionsStore.currentSession = {
       id: 'parent-1', status: 'running', thinkingEnabled: false, mode: 'standard',

--- a/packages/web/src/components/ConversationTab.vue
+++ b/packages/web/src/components/ConversationTab.vue
@@ -182,6 +182,7 @@ const conversationMessagesRef = ref(null);
 const attachedFiles = ref([]);
 const selectedModel = ref(null);
 const selectedProviderId = ref(null);
+const lastRestoredDraftValue = ref('');
 let suppressNextModelPersist = false;
 
 // Draft saving composable
@@ -310,16 +311,21 @@ function restoreInitialInput() {
 
   const pending = session?.pendingPrompt;
   const statusAllowsRestore = Boolean(session) && (isDraft.value || RESTORE_ALLOWED_STATUSES.has(session?.status));
+  const canReplaceInput = !input.value || input.value === lastRestoredDraftValue.value;
 
-  if (pending && statusAllowsRestore) {
+  if (pending && statusAllowsRestore && canReplaceInput) {
     // No imperative DOM write — ResizableTextarea's watch(modelValue)
     // syncs the DOM when `input.value` changes.
     input.value = pending;
+    lastRestoredDraftValue.value = pending;
     return;
   }
   if (isDraft.value && sessionsStore.messages.length > 0) {
     const userMessage = sessionsStore.messages.find(msg => msg.role === 'user');
-    if (userMessage) input.value = userMessage.content;
+    if (userMessage && canReplaceInput) {
+      input.value = userMessage.content;
+      lastRestoredDraftValue.value = userMessage.content;
+    }
   }
 }
 
@@ -434,6 +440,25 @@ watch(
   }
 );
 
+// Restore a pending draft into an already-open overlay when schedule state
+// changes in place, such as canceling a future schedule.
+watch(
+  () => {
+    const session = sessionsStore.currentSession;
+    return {
+      id: session?.id,
+      status: session?.status,
+      scheduledAt: session?.scheduledAt,
+      pendingPrompt: session?.pendingPrompt,
+    };
+  },
+  (newSessionState) => {
+    if (newSessionState.id !== props.sessionId) return;
+    if (!newSessionState.pendingPrompt) return;
+    restoreInitialInput();
+  }
+);
+
 // Watch for messages loading on draft sessions and populate textarea.
 // Uses `input.value` (the reactive source of truth) rather than peeking at
 // the DOM via the textareaRef — the `input` ref is the canonical value.
@@ -448,6 +473,7 @@ watch(
     const userMessage = newMessages.find(msg => msg.role === 'user');
     if (userMessage && userMessage.content) {
       input.value = userMessage.content;
+      lastRestoredDraftValue.value = userMessage.content;
     }
   },
   { deep: true, immediate: true }


### PR DESCRIPTION
## Summary
- Allow `startDraft` to work on sessions with `scheduled` status (not just `waiting`), so users can manually start a scheduled session before its fire time
- Clear `scheduledAt` when starting a draft so the session no longer appears as scheduled after manual start
- Fix `ConversationTab` to avoid overwriting user-typed input when session state changes (e.g., canceling a schedule) by tracking the last restored value and only restoring when the field is empty or unchanged

## Test plan
- [ ] Manually start a scheduled session — should transition to `starting` without errors
- [ ] Cancel a scheduled session's schedule — the pending prompt should restore in the conversation input without overwriting any text the user has typed
- [ ] Verify existing draft start behavior still works for `waiting` sessions
- [ ] Unit tests in `draftSessionService.test.js`, `sessions.pendingModel.test.js`, and `ConversationTab.test.js` cover the new branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)