### PR TITLE
Normalize stale Claude model ids and flag unknown models in selector

### DIFF
--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -298,4 +298,8 @@ export const allMigrations = validateMigrations([
   // --- Drop dormant per-session/per-template targetLaneId routing flag ---
   k.get('sessions-drop-target_lane_id'),
   k.get('session_templates-drop-target_lane_id'),
+
+  // --- Normalize retired Claude model ids in CONFIG columns only ---
+  // (lanes/templates/defaults. Record columns like sessions.model are preserved.)
+  m.get('normalize-stale-claude-model-ids'),
 ]);

--- a/packages/server/src/db/migrations/miscMigrations.js
+++ b/packages/server/src/db/migrations/miscMigrations.js
@@ -3,13 +3,64 @@
  * app_settings, providers, provider_models, agent_call_logs.
  * Each export is an array of { name, up(db) } migration objects.
  */
-import { addColumnIfMissing } from './migrationUtils.js';
+import { addColumnIfMissing, getColumns, tableExists } from './migrationUtils.js';
 
 /**
  * Prompt strings for the default global session templates.
  * Re-exported from defaultSessionTemplates for backward compatibility.
  */
 export { DEFAULT_SESSION_TEMPLATE_PROMPTS } from '../defaultSessionTemplates.js';
+
+/**
+ * Stale Claude model-id aliases → current ids.
+ *
+ * These are ids that used to identify a built-in Anthropic model but were
+ * retired when the catalog was bumped (e.g. claude-sonnet-4-6 → claude-sonnet-5).
+ * Config that still references a retired id will silently spawn/launch on the
+ * wrong model, so we rewrite them. Only CONFIG columns are normalized — see
+ * CONFIG_MODEL_COLUMNS — never record/audit columns (sessions.model, etc.),
+ * which must reflect what actually ran.
+ */
+export const STALE_CLAUDE_MODEL_IDS = Object.freeze({
+  // Sonnet family → current Sonnet 5
+  'claude-sonnet-4-6': 'claude-sonnet-5',
+  'claude-sonnet-4-5-20250929': 'claude-sonnet-5',
+  'claude-sonnet-4-20250514': 'claude-sonnet-5',
+  'sonnet': 'claude-sonnet-5',
+  // Opus orphan → current default Opus 4.8 (4-6/4-7/4-8 remain valid)
+  'claude-opus-4-5-20251101': 'claude-opus-4-8',
+  'opus 4.8': 'claude-opus-4-8',
+  // Haiku alias → current Haiku
+  'haiku': 'claude-haiku-4-5-20251001',
+});
+
+/**
+ * CONFIG columns that hold forward-looking model intent. Only these are
+ * normalized. Record columns (sessions.model, sessions.pending_model,
+ * conversations.model, conversation_messages.model, agent_call_logs.model)
+ * are deliberately excluded — they are historical/audit data.
+ */
+export const CONFIG_MODEL_COLUMNS = Object.freeze([
+  ['kanban_lanes', 'on_enter_model'],
+  ['session_templates', 'model'],
+  ['project_session_defaults', 'model'],
+]);
+
+/**
+ * Rewrite stale Claude model ids in config columns to their current ids.
+ * Idempotent: each UPDATE's WHERE no longer matches after the first run.
+ * @param {import('better-sqlite3').Database} db
+ */
+export function normalizeStaleClaudeModelIds(db) {
+  for (const [table, col] of CONFIG_MODEL_COLUMNS) {
+    if (!tableExists(db, table)) continue;
+    if (!getColumns(db, table).includes(col)) continue;
+    const update = db.prepare(`UPDATE ${table} SET ${col} = ? WHERE ${col} = ?`);
+    for (const [oldId, newId] of Object.entries(STALE_CLAUDE_MODEL_IDS)) {
+      update.run(newId, oldId);
+    }
+  }
+}
 
 /** @type {Array<{name: string, up: (db: import('better-sqlite3').Database) => void}>} */
 export const miscMigrations = [
@@ -102,5 +153,11 @@ export const miscMigrations = [
         CREATE INDEX IF NOT EXISTS idx_agent_call_logs_model ON agent_call_logs(model);
       `);
     },
+  },
+
+  // --- Model-id normalization (config columns only) ---
+  {
+    name: 'normalize-stale-claude-model-ids',
+    up(db) { normalizeStaleClaudeModelIds(db); },
   },
 ];

--- a/packages/server/src/db/migrations/miscMigrations.test.js
+++ b/packages/server/src/db/migrations/miscMigrations.test.js
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { DEFAULT_SESSION_TEMPLATE_PROMPTS } from './miscMigrations.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  DEFAULT_SESSION_TEMPLATE_PROMPTS,
+  miscMigrations,
+  STALE_CLAUDE_MODEL_IDS,
+  CONFIG_MODEL_COLUMNS,
+} from './miscMigrations.js';
 import { providerMigrations } from './providerMigrations.js';
 import { getDatabase } from '../index.js';
 import { allMigrations } from './index.js';
@@ -202,5 +207,191 @@ describe('providers-backfill-built-in-openai-attribution migration', () => {
     const attributionBackfillIdx = names.indexOf('providers-backfill-built-in-openai-attribution');
 
     expect(attributionBackfillIdx).toBeGreaterThan(openAISeedIdx);
+  });
+});
+
+const normalizeMigration = miscMigrations.find(
+  (m) => m.name === 'normalize-stale-claude-model-ids'
+);
+
+describe('normalize-stale-claude-model-ids migration', () => {
+  const PID = 'test-norm-project';
+  const BOARD = 'test-norm-board';
+  const T_PREFIX = 'test-norm-';
+
+  // Test rows seeded with every stale id, plus current/NULL controls.
+  function seed(db) {
+    const now = Date.now();
+    db.prepare('INSERT INTO projects (id, name, working_directory) VALUES (?, ?, ?)')
+      .run(PID, 'Norm Test', '/tmp/norm-test');
+    db.prepare('INSERT INTO kanban_boards (id, project_id) VALUES (?, ?)').run(BOARD, PID);
+
+    const insertLane = db.prepare(
+      'INSERT INTO kanban_lanes (id, board_id, name, on_enter_model) VALUES (?, ?, ?, ?)'
+    );
+    insertLane.run(`${T_PREFIX}lane-sonnet46`, BOARD, 'L1', 'claude-sonnet-4-6');
+    insertLane.run(`${T_PREFIX}lane-alias`, BOARD, 'L2', 'sonnet');
+    insertLane.run(`${T_PREFIX}lane-null`, BOARD, 'L3', null);
+    insertLane.run(`${T_PREFIX}lane-current`, BOARD, 'L4', 'claude-sonnet-5');
+
+    const insertTpl = db.prepare(
+      'INSERT INTO session_templates (id, name, prompt, model) VALUES (?, ?, ?, ?)'
+    );
+    insertTpl.run(`${T_PREFIX}tpl-opus45`, 'T', 'p', 'claude-opus-4-5-20251101');
+    insertTpl.run(`${T_PREFIX}tpl-current`, 'T', 'p', 'claude-haiku-4-5-20251001');
+
+    db.prepare(
+      'INSERT INTO project_session_defaults (id, project_id, model, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+    ).run(`${T_PREFIX}pd`, PID, 'claude-sonnet-4-5-20250929', now, now);
+
+    // RECORD row — must be preserved (sessions.model is historical/audit data).
+    db.prepare('INSERT INTO sessions (id, project_id, name, model) VALUES (?, ?, ?, ?)')
+      .run(`${T_PREFIX}session`, PID, 'S', 'claude-sonnet-4-6');
+  }
+
+  function cleanup(db) {
+    for (const table of [
+      'kanban_lanes',
+      'kanban_boards',
+      'session_templates',
+      'project_session_defaults',
+      'sessions',
+      'projects',
+    ]) {
+      db.prepare(`DELETE FROM ${table} WHERE id LIKE ?`).run(`${T_PREFIX}%`);
+      if (table === 'kanban_boards') {
+        db.prepare('DELETE FROM kanban_boards WHERE id = ?').run(BOARD);
+      }
+      if (table === 'projects') {
+        db.prepare('DELETE FROM projects WHERE id = ?').run(PID);
+      }
+    }
+  }
+
+  beforeEach(() => {
+    const db = getDatabase();
+    cleanup(db); // defensive: clear any leftovers from a failed prior run
+    seed(db);
+  });
+
+  afterEach(() => {
+    cleanup(getDatabase());
+  });
+
+  it('exists and is registered in allMigrations', () => {
+    expect(normalizeMigration).toBeDefined();
+    expect(typeof normalizeMigration.up).toBe('function');
+    const names = allMigrations.map((m) => m.name);
+    expect(names).toContain('normalize-stale-claude-model-ids');
+  });
+
+  it('rewrites stale Sonnet ids in kanban_lanes.on_enter_model', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const row = db
+      .prepare('SELECT on_enter_model FROM kanban_lanes WHERE id = ?')
+      .get(`${T_PREFIX}lane-sonnet46`);
+    expect(row.on_enter_model).toBe('claude-sonnet-5');
+  });
+
+  it('rewrites bare tier aliases (sonnet) in config columns', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const row = db
+      .prepare('SELECT on_enter_model FROM kanban_lanes WHERE id = ?')
+      .get(`${T_PREFIX}lane-alias`);
+    expect(row.on_enter_model).toBe('claude-sonnet-5');
+  });
+
+  it('rewrites stale Opus id in session_templates.model to the current default', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const row = db
+      .prepare('SELECT model FROM session_templates WHERE id = ?')
+      .get(`${T_PREFIX}tpl-opus45`);
+    expect(row.model).toBe('claude-opus-4-8');
+  });
+
+  it('rewrites stale ids in project_session_defaults.model', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const row = db
+      .prepare('SELECT model FROM project_session_defaults WHERE id = ?')
+      .get(`${T_PREFIX}pd`);
+    expect(row.model).toBe('claude-sonnet-5');
+  });
+
+  it('preserves already-current ids', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const lane = db
+      .prepare('SELECT on_enter_model FROM kanban_lanes WHERE id = ?')
+      .get(`${T_PREFIX}lane-current`);
+    const tpl = db
+      .prepare('SELECT model FROM session_templates WHERE id = ?')
+      .get(`${T_PREFIX}tpl-current`);
+    expect(lane.on_enter_model).toBe('claude-sonnet-5');
+    expect(tpl.model).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('preserves NULL config values', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const row = db
+      .prepare('SELECT on_enter_model FROM kanban_lanes WHERE id = ?')
+      .get(`${T_PREFIX}lane-null`);
+    expect(row.on_enter_model).toBeNull();
+  });
+
+  it('does NOT rewrite sessions.model — records are historical, not config', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const row = db
+      .prepare('SELECT model FROM sessions WHERE id = ?')
+      .get(`${T_PREFIX}session`);
+    // A session that actually ran on Sonnet 4.6 must keep recording Sonnet 4.6.
+    expect(row.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('only touches config columns (never record/audit columns)', () => {
+    const db = getDatabase();
+    // Every column the migration touches must be a known config column.
+    const touched = CONFIG_MODEL_COLUMNS.map(([t, c]) => `${t}.${c}`);
+    expect(touched).toEqual(
+      expect.arrayContaining([
+        'kanban_lanes.on_enter_model',
+        'session_templates.model',
+        'project_session_defaults.model',
+      ])
+    );
+    // Guard against accidentally widening scope to record columns later.
+    expect(touched).not.toContain('sessions.model');
+    expect(touched).not.toContain('conversations.model');
+    expect(touched).not.toContain('conversation_messages.model');
+    expect(touched).not.toContain('agent_call_logs.model');
+    expect(Object.keys(STALE_CLAUDE_MODEL_IDS).length).toBeGreaterThan(0);
+    // Smoke-test: running it shouldn't throw on a freshly-seeded DB.
+    expect(() => normalizeMigration.up(db)).not.toThrow();
+  });
+
+  it('is idempotent — re-running changes nothing', () => {
+    const db = getDatabase();
+    normalizeMigration.up(db);
+    const afterFirst = db
+      .prepare('SELECT on_enter_model FROM kanban_lanes WHERE id = ?')
+      .get(`${T_PREFIX}lane-sonnet46`).on_enter_model;
+    normalizeMigration.up(db);
+    const afterSecond = db
+      .prepare('SELECT on_enter_model FROM kanban_lanes WHERE id = ?')
+      .get(`${T_PREFIX}lane-sonnet46`).on_enter_model;
+    expect(afterFirst).toBe('claude-sonnet-5');
+    expect(afterSecond).toBe('claude-sonnet-5');
+    // No stale id remains in any config column after the run.
+    for (const [table, col] of CONFIG_MODEL_COLUMNS) {
+      const count = db
+        .prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE ${col} IN (${Object.keys(STALE_CLAUDE_MODEL_IDS).map(() => '?').join(',')})`)
+        .get(...Object.keys(STALE_CLAUDE_MODEL_IDS)).n;
+      expect(count).toBe(0);
+    }
   });
 });

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -998,4 +998,82 @@ describe('ModelSelector', () => {
       });
     });
   });
+
+  describe('orphaned (unknown) model id', () => {
+    const ORPHAN = 'claude-sonnet-4-6';
+
+    beforeEach(() => {
+      // Catalog contains claude-sonnet-5 but NOT the retired claude-sonnet-4-6.
+      providersStore.providers = [
+        {
+          id: 'anthropic-default',
+          name: 'Anthropic (Official)',
+          isBuiltIn: true,
+          kind: 'anthropic',
+          models: [
+            { id: 'anthropic-haiku', modelId: 'claude-haiku-4-5-20251001', displayName: 'Haiku 4.5', tier: 'haiku' },
+            { id: 'anthropic-sonnet', modelId: 'claude-sonnet-5', displayName: 'Sonnet 5', tier: 'sonnet' },
+            { id: 'anthropic-opus', modelId: 'claude-opus-4-8', displayName: 'Opus 4.8', tier: 'opus' },
+          ],
+        },
+      ];
+    });
+
+    it('renders the unknown-model badge when modelValue is not in the catalog', async () => {
+      const wrapper = mountComponent({ modelValue: ORPHAN });
+      await flushAll(wrapper);
+      expect(wrapper.find('.unknown-model-badge').exists()).toBe(true);
+    });
+
+    it('does not render the badge for a valid modelValue', async () => {
+      const wrapper = mountComponent({ modelValue: 'claude-sonnet-5' });
+      await flushAll(wrapper);
+      expect(wrapper.find('.unknown-model-badge').exists()).toBe(false);
+    });
+
+    it('does not render the badge for a null modelValue', async () => {
+      const wrapper = mountComponent({ modelValue: null });
+      await flushAll(wrapper);
+      expect(wrapper.find('.unknown-model-badge').exists()).toBe(false);
+    });
+
+    it('does not silently emit a substitution for the orphaned value on mount', async () => {
+      const onUpdateModelValue = vi.fn();
+      mountComponent(
+        { modelValue: ORPHAN },
+        { 'onUpdate:modelValue': onUpdateModelValue }
+      );
+      await flushAll();
+      // The parent's stored orphaned id must NOT be silently overwritten with
+      // the default; the user must choose a replacement explicitly.
+      expect(onUpdateModelValue).not.toHaveBeenCalled();
+    });
+
+    it('still falls back to the default model for display only', async () => {
+      const wrapper = mountComponent({ modelValue: ORPHAN });
+      await flushAll(wrapper);
+      const select = wrapper.find('select');
+      // Default (sonnet) is shown purely so the dropdown isn't empty; the badge
+      // flags that the stored value is actually an orphan.
+      expect(select.element.value).toBe(optionValue('anthropic-default', 'claude-sonnet-5'));
+    });
+
+    it('lets the user pick a replacement, which clears the badge once the parent accepts it', async () => {
+      const onUpdateModelValue = vi.fn();
+      const wrapper = mountComponent(
+        { modelValue: ORPHAN },
+        { 'onUpdate:modelValue': onUpdateModelValue }
+      );
+      await flushAll(wrapper);
+      expect(wrapper.find('.unknown-model-badge').exists()).toBe(true);
+
+      await wrapper.find('select').setValue(optionValue('anthropic-default', 'claude-opus-4-8'));
+      // Simulate the parent accepting the emitted value (v-model round-trip).
+      await wrapper.setProps({ modelValue: 'claude-opus-4-8' });
+      await flushAll(wrapper);
+
+      expect(onUpdateModelValue).toHaveBeenCalledWith('claude-opus-4-8');
+      expect(wrapper.find('.unknown-model-badge').exists()).toBe(false);
+    });
+  });
 });

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -35,6 +35,11 @@
         </option>
       </optgroup>
     </select>
+    <span
+      v-if="isUnknownModel"
+      class="unknown-model-badge"
+      :title="`Stored model '${model}' is no longer available. Choose a replacement to update it.`"
+    >unknown model</span>
   </div>
 </template>
 
@@ -236,6 +241,16 @@ function resolveModelId(modelValue) {
 const selectedModel = ref(resolveModelId(props.modelValue));
 const selectedProviderId = ref(props.providerId);
 
+// True when the parent supplied a non-empty model id that no longer matches any
+// option in the catalog (e.g. a model retired since the value was stored). We
+// surface this as a visible badge instead of silently substituting the default,
+// so stale config is obvious. Null/empty (unset) is NOT "unknown".
+const isUnknownModel = computed(() => {
+  if (!providersHaveModels.value) return false;
+  if (!props.modelValue) return false;
+  return !isValidModelId(resolveModelId(props.modelValue));
+});
+
 // Computed that ALWAYS returns a valid model ID for the select element
 // This ensures the select never shows empty, even before providers load
 const effectiveSelectedModel = computed(() => {
@@ -299,6 +314,16 @@ function syncSelectionFromProviders() {
   // Check if resolved model is valid (exists as an option)
   if (resolvedModel && isValidModelId(resolvedModel)) {
     applyResolvedModel(resolvedModel);
+    return;
+  }
+
+  // Non-empty value that doesn't resolve to any current option — e.g. a model
+  // id retired from the catalog. Don't silently overwrite the parent's stored
+  // value with the default; surface the orphan via the isUnknownModel badge so
+  // the staleness is visible. Display still falls back to the default through
+  // the effectiveSelectedModel/effectiveSelectedKey computeds.
+  if (props.modelValue) {
+    selectedModel.value = resolveModelId(props.modelValue);
     return;
   }
 
@@ -407,6 +432,21 @@ function optionLabel(provider, model) {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.unknown-model-badge {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-warning, #fbbf24);
+  background-color: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.375rem;
+  cursor: help;
+  white-space: nowrap;
+  line-height: 1.4;
 }
 
 .model-select {


### PR DESCRIPTION
## Summary
- Add a migration that rewrites retired Claude model ids (e.g. `claude-sonnet-4-6`, `sonnet`, `opus 4.8`) to their current equivalents in config columns only (kanban lane `on_enter_model`, session template `model`, project session default `model`) — record/audit columns like `sessions.model` are left untouched.
- `ModelSelector.vue` now surfaces a visible "unknown model" badge when a stored model value doesn't match any current catalog entry, instead of silently falling back to the default.

## Test plan
- [x] `./scripts/pw.sh test` — full E2E suite passed (1150 passed, 19 skipped)
- [x] New/updated unit tests in `miscMigrations.test.js` and `ModelSelector.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)