### PR TITLE
fix: skip kanban completion move when turn ends due to usage limit or outage

### DIFF
--- a/packages/server/src/services/sessionErrors.js
+++ b/packages/server/src/services/sessionErrors.js
@@ -132,67 +132,113 @@ export function shouldRescheduleOnError(session, error, sessionId = null) {
 }
 
 /**
- * Terminal-sounding phrases that indicate a provider genuinely ended a turn due to
- * a usage/token limit or an outage. Used to gate the broad, single-word matchers
- * (`matchesTokenLimitError` / `matchesServiceError`) on the completion path only,
- * so that ordinary successful-work prose (e.g. "increased the pagination limit to
- * 100", "implemented a token bucket rate limiter") doesn't get misclassified.
+ * Normalize candidate text before matching against the completion-path terminal
+ * patterns: lowercase, collapse `_`/`-` runs to a single space (so
+ * "overloaded_error" and "service-unavailable" normalize the same as their
+ * space-separated forms), collapse other punctuation-adjacent separators like a
+ * stray colon (e.g. "Error 529: overloaded_error") the same way, then collapse
+ * whitespace and trim.
+ * @param {string} text
+ * @returns {string}
+ */
+function normalizeTerminalText(text) {
+  return text
+    .toLowerCase()
+    .replace(/[_:-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Terminal-sounding regex patterns that indicate a provider genuinely ended a turn
+ * due to a usage/token limit or an outage. Used to gate the broad, single-word
+ * matchers (`matchesTokenLimitError` / `matchesServiceError`) on the completion
+ * path only, so that ordinary successful-work prose (e.g. "increased the
+ * pagination limit to 100", "implemented a token bucket rate limiter", "Fixed the
+ * HTTP 503 error handling in the proxy") doesn't get misclassified. Each pattern
+ * describes a terminal provider condition, not ordinary prose that happens to
+ * contain a bare word like "token", "limit", "503", "529", "overload", or
+ * "unavailable".
  *
  * Intentionally NOT exported: this is a completion-path-only conservative filter.
  * The error / auto-reschedule path continues to use the broad matchers directly
  * via `checkRescheduleTrigger`, unchanged.
  */
-const TERMINAL_LIMIT_OR_OUTAGE_PHRASES = [
-  'reached your usage limit',
-  'reached my usage limit',
-  'usage limit reached',
-  'hit your token limit',
-  'hit my token limit',
-  'token limit reached',
-  'quota exceeded',
-  'quota reached',
-  'rate limit reached',
-  'rate limited',
-  'too many requests',
-  'context length exceeded',
-  'context window exceeded',
-  'service unavailable',
-  'temporarily unavailable',
-  'currently unavailable',
-  'overloaded',
-  '503',
-  '529',
+const TERMINAL_LIMIT_OR_OUTAGE_PATTERNS = [
+  /\b(?:you(?:'ve| have)|i(?:'ve| have)) reached (?:your|my|the)?\s*usage limit\b/,
+  /\busage limit (?:reached|exceeded)\b/,
+  /\b(?:you(?:'ve| have)|i(?:'ve| have)) hit (?:your|my|the)?\s*(?:token|usage) limit\b/,
+  /\b(?:token|context) (?:limit|window|length) (?:reached|exceeded)\b/,
+  /\b(?:quota|usage cap) (?:reached|exceeded|exhausted)\b/,
+  /\brate limit(?:ed| reached| exceeded)?\b/,
+  /\btoo many requests\b/,
+  /\b(?:service|server|api|provider) (?:is )?(?:temporarily |currently )?unavailable\b/,
+  /\b(?:service|server|api|provider) (?:is )?overloaded\b/,
+  /\boverloaded error\b/,
+  /\b(?:http |error |status )?503 service unavailable\b/,
+  /\b(?:http |error |status )?529 (?:overloaded error|too many requests)\b/,
+  /\b429 too many requests\b/,
 ];
 
 /**
  * Conservative pre-filter for the completion-path limit/outage check. Returns true
- * only when the text contains a terminal, provider-style phrase — never on bare
- * substrings like "token", "limit", "cap", "exceeded", or "unavailable" alone,
- * which appear naturally in ordinary descriptions of completed work.
- * @param {string} message - Already-lowercased text to check
+ * only when the (already-normalized) text matches one of the framed terminal
+ * patterns above — never on bare substrings like "token", "limit", "cap",
+ * "exceeded", "503", "529", "overloaded", or "unavailable" alone, which appear
+ * naturally in ordinary descriptions of completed work.
+ * @param {string} message - Already-normalized (lowercased, `_`/`-`/`:` folded to space) text
  * @returns {boolean}
  */
 function messageLooksLikeTerminalLimitOrOutage(message) {
   if (typeof message !== 'string') return false;
   const text = message.trim();
   if (text === '') return false;
-  return TERMINAL_LIMIT_OR_OUTAGE_PHRASES.some(phrase => text.includes(phrase));
+  return TERMINAL_LIMIT_OR_OUTAGE_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
+ * Shape guard applied only to the last-assistant-message fallback (never to a
+ * captured `result` event — see `isLimitOrOutageText`). Ordinary completion
+ * summaries can legitimately contain terminal-sounding substrings in passing
+ * (e.g. "Fixed HTTP 503 Service Unavailable handling in the proxy", "The service
+ * is unavailable branch is now covered by a test"), so this guard rejects
+ * anything that reads like normal implementation prose rather than a short,
+ * terminal provider failure message: text over 500 characters, or text
+ * containing common completion-summary verbs/nouns.
+ * @param {string} message - Already-normalized text
+ * @returns {boolean}
+ */
+function looksLikeTerminalAssistantMessage(message) {
+  const text = normalizeTerminalText(message);
+  if (text.length > 500) return false;
+  if (/\b(implemented|added|fixed|refactored|updated|covered|tested|handling|handler|constructor)\b/.test(text)) {
+    return false;
+  }
+  return true;
 }
 
 /**
  * Determine whether a single piece of candidate text (result text or an assistant
  * message) indicates a usage-limit/outage termination. Gates the existing, broader
  * `matchesTokenLimitError` / `matchesServiceError` matchers behind the conservative
- * terminal-phrase filter above, per FR-4: the source of truth for what counts as a
+ * terminal-pattern filter above, per FR-4: the source of truth for what counts as a
  * limit/outage pattern still lives solely in those two functions.
+ *
+ * The `result` event is the provider/CLI's authoritative end-of-turn signal, so
+ * only text sourced from the last assistant message (`source: 'assistant'`) is
+ * additionally required to look like a short, terminal failure message via
+ * `looksLikeTerminalAssistantMessage` — captured `result` text is not subjected to
+ * that shape guard.
+ *
  * @param {string|undefined|null} text
+ * @param {{ source?: 'result' | 'assistant' }} [options]
  * @returns {boolean}
  */
-function isLimitOrOutageText(text) {
+function isLimitOrOutageText(text, { source = 'result' } = {}) {
   if (typeof text !== 'string') return false;
-  const trimmed = text.trim();
-  if (trimmed === '') return false;
-  const haystack = trimmed.toLowerCase();
+  const haystack = normalizeTerminalText(text);
+  if (haystack === '') return false;
+  if (source === 'assistant' && !looksLikeTerminalAssistantMessage(haystack)) return false;
   if (!messageLooksLikeTerminalLimitOrOutage(haystack)) return false;
   return matchesTokenLimitError(haystack) || matchesServiceError(haystack);
 }
@@ -202,24 +248,25 @@ function isLimitOrOutageText(text) {
  * so the caller can skip advancing a kanban card on the completion path.
  *
  * Detection is unconditional (ignores reschedule flags) and purely pattern-based,
- * reusing the existing matchers behind a conservative terminal-phrase filter (see
+ * reusing the existing matchers behind a conservative terminal-pattern filter (see
  * `messageLooksLikeTerminalLimitOrOutage`) so ordinary successful-work prose isn't
  * misclassified. Priority order: the captured `result` event's `resultText` (the
  * CLI's authoritative end-of-turn text) is checked first; the last assistant
- * message is checked as a fallback when the result text is empty or absent.
- * Never throws — returns false when there's no signal to check.
+ * message is checked as a fallback — subject to the additional
+ * `looksLikeTerminalAssistantMessage` shape guard — when the result text is empty
+ * or absent. Never throws — returns false when there's no signal to check.
  *
  * @param {string} sessionId - Session ID
  * @param {{ resultText?: string } | null} [resultEvent] - Captured result event record (see streamEventHandler.getResultEvent)
  * @returns {boolean} True if the turn ended due to a usage limit or service outage
  */
 export function turnEndedDueToLimitOrOutage(sessionId, resultEvent = null) {
-  if (isLimitOrOutageText(resultEvent?.resultText)) {
+  if (isLimitOrOutageText(resultEvent?.resultText, { source: 'result' })) {
     return true;
   }
 
   const lastAssistantMessage = getLastAssistantMessage(sessionId);
-  if (isLimitOrOutageText(lastAssistantMessage?.content)) {
+  if (isLimitOrOutageText(lastAssistantMessage?.content, { source: 'assistant' })) {
     return true;
   }
 

--- a/packages/server/src/services/sessionErrors.js
+++ b/packages/server/src/services/sessionErrors.js
@@ -132,6 +132,40 @@ export function shouldRescheduleOnError(session, error, sessionId = null) {
 }
 
 /**
+ * Determine whether a turn ended due to a usage/token limit or provider outage,
+ * so the caller can skip advancing a kanban card on the completion path.
+ *
+ * Detection is unconditional (ignores reschedule flags) and purely pattern-based,
+ * reusing the existing matchers. Priority order: the captured `result` event's
+ * `resultText` (the CLI's authoritative end-of-turn text) is checked first; the
+ * last assistant message is checked as a fallback when the result text is empty
+ * or absent. Never throws — returns false when there's no signal to check.
+ *
+ * @param {string} sessionId - Session ID
+ * @param {{ resultText?: string } | null} [resultEvent] - Captured result event record (see streamEventHandler.getResultEvent)
+ * @returns {boolean} True if the turn ended due to a usage limit or service outage
+ */
+export function turnEndedDueToLimitOrOutage(sessionId, resultEvent = null) {
+  const resultText = resultEvent?.resultText;
+  if (typeof resultText === 'string' && resultText.trim() !== '') {
+    const haystack = resultText.toLowerCase();
+    if (matchesTokenLimitError(haystack) || matchesServiceError(haystack)) {
+      return true;
+    }
+  }
+
+  const lastAssistantMessage = getLastAssistantMessage(sessionId);
+  if (lastAssistantMessage?.content) {
+    const haystack = lastAssistantMessage.content.toLowerCase();
+    if (matchesTokenLimitError(haystack) || matchesServiceError(haystack)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Check if session should be proactively rescheduled based on token count
  * Called after processing each message to check token thresholds
  * @param {string} sessionId - Session ID

--- a/packages/server/src/services/sessionErrors.js
+++ b/packages/server/src/services/sessionErrors.js
@@ -170,7 +170,10 @@ const TERMINAL_LIMIT_OR_OUTAGE_PATTERNS = [
   /\b(?:you(?:'ve| have)|i(?:'ve| have)) hit (?:your|my|the)?\s*(?:token|usage) limit\b/,
   /\b(?:token|context) (?:limit|window|length) (?:reached|exceeded)\b/,
   /\b(?:quota|usage cap) (?:reached|exceeded|exhausted)\b/,
-  /\brate limit(?:ed| reached| exceeded)?\b/,
+  // Terminal suffix is required (non-optional) so the bare noun phrase "a rate
+  // limit" — common in legitimate work summaries like "configured the rate
+  // limit at 100 rps" — does not match on its own (Issue 2).
+  /\brate ?limit(?:ed| reached| exceeded| error)\b/,
   /\btoo many requests\b/,
   /\b(?:service|server|api|provider) (?:is )?(?:temporarily |currently )?unavailable\b/,
   /\b(?:service|server|api|provider) (?:is )?overloaded\b/,
@@ -182,38 +185,47 @@ const TERMINAL_LIMIT_OR_OUTAGE_PATTERNS = [
 
 /**
  * Conservative pre-filter for the completion-path limit/outage check. Returns true
- * only when the (already-normalized) text matches one of the framed terminal
- * patterns above — never on bare substrings like "token", "limit", "cap",
- * "exceeded", "503", "529", "overloaded", or "unavailable" alone, which appear
- * naturally in ordinary descriptions of completed work.
- * @param {string} message - Already-normalized (lowercased, `_`/`-`/`:` folded to space) text
+ * only when the text matches one of the framed terminal patterns above — never on
+ * bare substrings like "token", "limit", "cap", "exceeded", "503", "529",
+ * "overloaded", or "unavailable" alone, which appear naturally in ordinary
+ * descriptions of completed work.
+ *
+ * Single normalization boundary (Issue 5): this helper receives text that has
+ * already been normalized and validated (non-empty string) by the sole caller,
+ * `isLimitOrOutageText` — it does not re-normalize or re-trim.
+ * @param {string} text - Already-normalized (lowercased, `_`/`-`/`:` folded to space, trimmed) text
  * @returns {boolean}
  */
-function messageLooksLikeTerminalLimitOrOutage(message) {
-  if (typeof message !== 'string') return false;
-  const text = message.trim();
-  if (text === '') return false;
+function messageLooksLikeTerminalLimitOrOutage(text) {
   return TERMINAL_LIMIT_OR_OUTAGE_PATTERNS.some(pattern => pattern.test(text));
 }
 
 /**
- * Shape guard applied only to the last-assistant-message fallback (never to a
- * captured `result` event — see `isLimitOrOutageText`). Ordinary completion
- * summaries can legitimately contain terminal-sounding substrings in passing
- * (e.g. "Fixed HTTP 503 Service Unavailable handling in the proxy", "The service
- * is unavailable branch is now covered by a test"), so this guard rejects
- * anything that reads like normal implementation prose rather than a short,
- * terminal provider failure message: text over 500 characters, or text
- * containing common completion-summary verbs/nouns.
- * @param {string} message - Already-normalized text
+ * Word-stem alternation for common completion-summary verbs/nouns, matched as
+ * prefixes (not whole words) so inflections are covered without listing every
+ * form — e.g. `handl` catches "handle", "handled", "handling", "handler";
+ * `add` catches "add", "added", "adding". Used by `looksLikeTerminalAssistantMessage`
+ * to reject ordinary implementation prose (Issue 2).
+ */
+const COMPLETION_VERB_STEM_PATTERN =
+  /\b(?:implement|add|fix|refactor|updat|cover|test|handl|configur|creat|increas|reduc|remov|chang|introduc|adjust|wrote|set up|wired|bumped|construct|return)/;
+
+/**
+ * Shape guard applied to both candidate sources (a captured `result` event's text
+ * and the last-assistant-message fallback — see `isLimitOrOutageText`). For Claude
+ * Code, the SDK `result` event's text IS the final assistant message, so it can
+ * just as easily be an ordinary completion summary that happens to mention a
+ * terminal-sounding phrase in passing (e.g. "Fixed HTTP 503 Service Unavailable
+ * handling in the proxy", "The service is unavailable branch is now covered by a
+ * test"). This guard rejects anything that reads like normal implementation prose
+ * rather than a short, terminal provider failure message: text over 500
+ * characters, or text containing common completion-summary verb/noun stems.
+ * @param {string} text - Already-normalized text
  * @returns {boolean}
  */
-function looksLikeTerminalAssistantMessage(message) {
-  const text = normalizeTerminalText(message);
+function looksLikeTerminalAssistantMessage(text) {
   if (text.length > 500) return false;
-  if (/\b(implemented|added|fixed|refactored|updated|covered|tested|handling|handler|constructor)\b/.test(text)) {
-    return false;
-  }
+  if (COMPLETION_VERB_STEM_PATTERN.test(text)) return false;
   return true;
 }
 
@@ -222,23 +234,25 @@ function looksLikeTerminalAssistantMessage(message) {
  * message) indicates a usage-limit/outage termination. Gates the existing, broader
  * `matchesTokenLimitError` / `matchesServiceError` matchers behind the conservative
  * terminal-pattern filter above, per FR-4: the source of truth for what counts as a
- * limit/outage pattern still lives solely in those two functions.
+ * limit/outage pattern still lives solely in those two functions — the framed
+ * patterns and the shape guard here are only a completion-path *shape gate* (see
+ * the "framed patterns ⊆ shared matchers" invariant test in sessionErrors.test.js).
  *
- * The `result` event is the provider/CLI's authoritative end-of-turn signal, so
- * only text sourced from the last assistant message (`source: 'assistant'`) is
- * additionally required to look like a short, terminal failure message via
- * `looksLikeTerminalAssistantMessage` — captured `result` text is not subjected to
- * that shape guard.
+ * Both candidate sources are treated as assistant-authored prose and therefore
+ * shape-guarded identically: for Claude Code the `result` event's text IS the
+ * final assistant message, so it must not bypass `looksLikeTerminalAssistantMessage`
+ * (Issue 1) — a genuine graceful limit/outage message is short and free of
+ * completion verbs, so the shape guard preserves true positives while rejecting
+ * long work-summary prose that merely mentions a limit phrase.
  *
  * @param {string|undefined|null} text
- * @param {{ source?: 'result' | 'assistant' }} [options]
  * @returns {boolean}
  */
-function isLimitOrOutageText(text, { source = 'result' } = {}) {
+function isLimitOrOutageText(text) {
   if (typeof text !== 'string') return false;
   const haystack = normalizeTerminalText(text);
   if (haystack === '') return false;
-  if (source === 'assistant' && !looksLikeTerminalAssistantMessage(haystack)) return false;
+  if (!looksLikeTerminalAssistantMessage(haystack)) return false;
   if (!messageLooksLikeTerminalLimitOrOutage(haystack)) return false;
   return matchesTokenLimitError(haystack) || matchesServiceError(haystack);
 }
@@ -251,22 +265,23 @@ function isLimitOrOutageText(text, { source = 'result' } = {}) {
  * reusing the existing matchers behind a conservative terminal-pattern filter (see
  * `messageLooksLikeTerminalLimitOrOutage`) so ordinary successful-work prose isn't
  * misclassified. Priority order: the captured `result` event's `resultText` (the
- * CLI's authoritative end-of-turn text) is checked first; the last assistant
- * message is checked as a fallback — subject to the additional
- * `looksLikeTerminalAssistantMessage` shape guard — when the result text is empty
- * or absent. Never throws — returns false when there's no signal to check.
+ * CLI's authoritative end-of-turn text, but still assistant-authored prose for
+ * Claude Code) is checked first; the last assistant message is checked as a
+ * fallback when the result text is empty or absent. Both are subject to the same
+ * `looksLikeTerminalAssistantMessage` shape guard. Never throws — returns false
+ * when there's no signal to check.
  *
  * @param {string} sessionId - Session ID
  * @param {{ resultText?: string } | null} [resultEvent] - Captured result event record (see streamEventHandler.getResultEvent)
  * @returns {boolean} True if the turn ended due to a usage limit or service outage
  */
 export function turnEndedDueToLimitOrOutage(sessionId, resultEvent = null) {
-  if (isLimitOrOutageText(resultEvent?.resultText, { source: 'result' })) {
+  if (isLimitOrOutageText(resultEvent?.resultText)) {
     return true;
   }
 
   const lastAssistantMessage = getLastAssistantMessage(sessionId);
-  if (isLimitOrOutageText(lastAssistantMessage?.content, { source: 'assistant' })) {
+  if (isLimitOrOutageText(lastAssistantMessage?.content)) {
     return true;
   }
 

--- a/packages/server/src/services/sessionErrors.js
+++ b/packages/server/src/services/sessionErrors.js
@@ -132,34 +132,95 @@ export function shouldRescheduleOnError(session, error, sessionId = null) {
 }
 
 /**
+ * Terminal-sounding phrases that indicate a provider genuinely ended a turn due to
+ * a usage/token limit or an outage. Used to gate the broad, single-word matchers
+ * (`matchesTokenLimitError` / `matchesServiceError`) on the completion path only,
+ * so that ordinary successful-work prose (e.g. "increased the pagination limit to
+ * 100", "implemented a token bucket rate limiter") doesn't get misclassified.
+ *
+ * Intentionally NOT exported: this is a completion-path-only conservative filter.
+ * The error / auto-reschedule path continues to use the broad matchers directly
+ * via `checkRescheduleTrigger`, unchanged.
+ */
+const TERMINAL_LIMIT_OR_OUTAGE_PHRASES = [
+  'reached your usage limit',
+  'reached my usage limit',
+  'usage limit reached',
+  'hit your token limit',
+  'hit my token limit',
+  'token limit reached',
+  'quota exceeded',
+  'quota reached',
+  'rate limit reached',
+  'rate limited',
+  'too many requests',
+  'context length exceeded',
+  'context window exceeded',
+  'service unavailable',
+  'temporarily unavailable',
+  'currently unavailable',
+  'overloaded',
+  '503',
+  '529',
+];
+
+/**
+ * Conservative pre-filter for the completion-path limit/outage check. Returns true
+ * only when the text contains a terminal, provider-style phrase — never on bare
+ * substrings like "token", "limit", "cap", "exceeded", or "unavailable" alone,
+ * which appear naturally in ordinary descriptions of completed work.
+ * @param {string} message - Already-lowercased text to check
+ * @returns {boolean}
+ */
+function messageLooksLikeTerminalLimitOrOutage(message) {
+  if (typeof message !== 'string') return false;
+  const text = message.trim();
+  if (text === '') return false;
+  return TERMINAL_LIMIT_OR_OUTAGE_PHRASES.some(phrase => text.includes(phrase));
+}
+
+/**
+ * Determine whether a single piece of candidate text (result text or an assistant
+ * message) indicates a usage-limit/outage termination. Gates the existing, broader
+ * `matchesTokenLimitError` / `matchesServiceError` matchers behind the conservative
+ * terminal-phrase filter above, per FR-4: the source of truth for what counts as a
+ * limit/outage pattern still lives solely in those two functions.
+ * @param {string|undefined|null} text
+ * @returns {boolean}
+ */
+function isLimitOrOutageText(text) {
+  if (typeof text !== 'string') return false;
+  const trimmed = text.trim();
+  if (trimmed === '') return false;
+  const haystack = trimmed.toLowerCase();
+  if (!messageLooksLikeTerminalLimitOrOutage(haystack)) return false;
+  return matchesTokenLimitError(haystack) || matchesServiceError(haystack);
+}
+
+/**
  * Determine whether a turn ended due to a usage/token limit or provider outage,
  * so the caller can skip advancing a kanban card on the completion path.
  *
  * Detection is unconditional (ignores reschedule flags) and purely pattern-based,
- * reusing the existing matchers. Priority order: the captured `result` event's
- * `resultText` (the CLI's authoritative end-of-turn text) is checked first; the
- * last assistant message is checked as a fallback when the result text is empty
- * or absent. Never throws — returns false when there's no signal to check.
+ * reusing the existing matchers behind a conservative terminal-phrase filter (see
+ * `messageLooksLikeTerminalLimitOrOutage`) so ordinary successful-work prose isn't
+ * misclassified. Priority order: the captured `result` event's `resultText` (the
+ * CLI's authoritative end-of-turn text) is checked first; the last assistant
+ * message is checked as a fallback when the result text is empty or absent.
+ * Never throws — returns false when there's no signal to check.
  *
  * @param {string} sessionId - Session ID
  * @param {{ resultText?: string } | null} [resultEvent] - Captured result event record (see streamEventHandler.getResultEvent)
  * @returns {boolean} True if the turn ended due to a usage limit or service outage
  */
 export function turnEndedDueToLimitOrOutage(sessionId, resultEvent = null) {
-  const resultText = resultEvent?.resultText;
-  if (typeof resultText === 'string' && resultText.trim() !== '') {
-    const haystack = resultText.toLowerCase();
-    if (matchesTokenLimitError(haystack) || matchesServiceError(haystack)) {
-      return true;
-    }
+  if (isLimitOrOutageText(resultEvent?.resultText)) {
+    return true;
   }
 
   const lastAssistantMessage = getLastAssistantMessage(sessionId);
-  if (lastAssistantMessage?.content) {
-    const haystack = lastAssistantMessage.content.toLowerCase();
-    if (matchesTokenLimitError(haystack) || matchesServiceError(haystack)) {
-      return true;
-    }
+  if (isLimitOrOutageText(lastAssistantMessage?.content)) {
+    return true;
   }
 
   return false;

--- a/packages/server/src/services/sessionErrors.test.js
+++ b/packages/server/src/services/sessionErrors.test.js
@@ -358,14 +358,30 @@ describe('sessionErrors', () => {
       expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 529' })).toBe(false);
     });
 
-    it('does not require the assistant-message shape guard for captured result text', () => {
-      // The `result` event is the CLI's authoritative end-of-turn signal, so unlike
-      // the assistant-message fallback it is never subjected to the terminal-shape
-      // guard (length / implementation-verb check) — only the pattern prefilter applies.
+    it('applies the terminal-shape guard to captured result text too (Claude Code result text is assistant prose)', () => {
+      // For Claude Code, the SDK `result` event's text IS the final assistant message,
+      // so it must be subjected to the same terminal-shape guard (length /
+      // implementation-verb check) as the assistant-message fallback — otherwise a
+      // genuine completion summary that merely mentions a limit/outage phrase in
+      // passing is misclassified as a usage-limit/outage hold.
       messages.getBySessionId.mockReturnValue([]);
       expect(
+        turnEndedDueToLimitOrOutage('sess-1', { resultText: 'Added a rate limit to the endpoint' })
+      ).toBe(false);
+      expect(
         turnEndedDueToLimitOrOutage('sess-1', { resultText: 'Fixed HTTP 503 Service Unavailable handling in the proxy' })
-      ).toBe(true);
+      ).toBe(false);
+      expect(
+        turnEndedDueToLimitOrOutage('sess-1', { resultText: 'The API now returns 429 Too Many Requests when throttled' })
+      ).toBe(false);
+      expect(
+        turnEndedDueToLimitOrOutage('sess-1', { resultText: 'Added a test for too many requests handling' })
+      ).toBe(false);
+
+      // True-positive guards: short terminal messages must still pass the shape guard.
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: "You've reached your usage limit" })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'usage limit reached' })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'The server is overloaded' })).toBe(true);
     });
 
     it('detects token-limit / service-error text in the last assistant message when result text is empty', () => {
@@ -442,6 +458,34 @@ describe('sessionErrors', () => {
       });
     });
 
+    // Issue 4 / FR-4 invariant: the framed terminal patterns are a completion-path
+    // *shape gate*, not an independent classifier. Every canonical example that
+    // satisfies a framed pattern must ALSO satisfy the shared, broader matchers
+    // (`matchesTokenLimitError` / `matchesServiceError`), which remain the
+    // classifier of record. This locks the "framed set ⊆ broad matchers"
+    // relationship so future edits to either side can't silently drift apart.
+    describe('framed patterns are a subset of the shared matchers (FR-4 invariant)', () => {
+      const canonicalExamples = [
+        "you've reached your usage limit",
+        "you've hit your token limit",
+        'usage limit reached',
+        'token limit reached',
+        'quota exceeded',
+        'rate limited',
+        'too many requests',
+        'service unavailable',
+        'server overloaded',
+        'overloaded error',
+        '503 service unavailable',
+        '529 overloaded error',
+        '429 too many requests',
+      ];
+
+      it.each(canonicalExamples)('"%s" is also matched by the shared matchers', (text) => {
+        expect(matchesTokenLimitError(text) || matchesServiceError(text)).toBe(true);
+      });
+    });
+
     it('normalizes underscores when matching "overloaded_error"', () => {
       messages.getBySessionId.mockReturnValue([]);
       expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'overloaded_error' })).toBe(true);
@@ -474,6 +518,11 @@ describe('sessionErrors', () => {
         'The service is unavailable branch is now covered by a test',
         'Fixed service unavailable handling in the API client',
         'Added service-unavailable handling in the API client',
+        'Configured the rate limit at 100 rps',
+        'Created a rate limit middleware',
+        'Increased the rate limit to 100 rps',
+        'Set up rate limit handling for the API',
+        'Handled the service is unavailable case in the client',
       ];
 
       it.each(cleanCompletions)('does not flag: %s', (text) => {

--- a/packages/server/src/services/sessionErrors.test.js
+++ b/packages/server/src/services/sessionErrors.test.js
@@ -360,7 +360,7 @@ describe('sessionErrors', () => {
     it('detects from the last assistant message when no result event is provided', () => {
       messages.getBySessionId.mockReturnValue([
         { role: 'user', content: 'do something' },
-        { role: 'assistant', content: 'The service is unavailable right now' },
+        { role: 'assistant', content: 'Service temporarily unavailable — please try again shortly.' },
       ]);
       expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(true);
     });
@@ -382,6 +382,51 @@ describe('sessionErrors', () => {
         { role: 'assistant', content: 'Here is the finished implementation.' },
       ]);
       expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'usage limit reached' })).toBe(true);
+    });
+
+    it('falls back to the last assistant message when the result event has empty resultText', () => {
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: 'Quota exceeded for this billing period.' },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: '' })).toBe(true);
+    });
+
+    it('falls back to the last assistant message when the result event is missing', () => {
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: 'Too many requests — please slow down.' },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', undefined)).toBe(true);
+    });
+
+    it('returns false when there is no result event and no assistant message', () => {
+      messages.getBySessionId.mockReturnValue([]);
+      expect(turnEndedDueToLimitOrOutage('sess-1')).toBe(false);
+    });
+
+    // Regression corpus: ordinary successful-work prose that incidentally contains
+    // bare words also matched by matchesTokenLimitError / matchesServiceError
+    // ("token", "limit", "cap", "exceeded", "unavailable") must NOT be classified
+    // as a usage-limit/outage termination. Guards against over-broad false holds.
+    describe('regression corpus (natural completion text, must return false)', () => {
+      const cleanCompletions = [
+        'implemented a token bucket rate limiter',
+        'escaped the special characters',
+        'increased the pagination limit to 100',
+        'added capacity checks',
+        'handled the case where the service is unavailable',
+      ];
+
+      it.each(cleanCompletions)('does not flag: %s', (text) => {
+        messages.getBySessionId.mockReturnValue([]);
+        expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: text })).toBe(false);
+      });
+
+      it.each(cleanCompletions)('does not flag in the assistant-message fallback: %s', (text) => {
+        messages.getBySessionId.mockReturnValue([
+          { role: 'assistant', content: text },
+        ]);
+        expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(false);
+      });
     });
   });
 });

--- a/packages/server/src/services/sessionErrors.test.js
+++ b/packages/server/src/services/sessionErrors.test.js
@@ -23,6 +23,7 @@ import {
   matchesServiceError,
   shouldRescheduleOnError,
   _checkProactiveReschedule,
+  turnEndedDueToLimitOrOutage,
 } from './sessionErrors.js';
 
 describe('sessionErrors', () => {
@@ -328,6 +329,59 @@ describe('sessionErrors', () => {
 
       const result = await _checkProactiveReschedule('sess-1');
       expect(result).toBe(true);
+    });
+  });
+
+  // ── turnEndedDueToLimitOrOutage ───────────────────────────────────────
+
+  describe('turnEndedDueToLimitOrOutage', () => {
+    it('detects token-limit text in the result event', () => {
+      messages.getBySessionId.mockReturnValue([]);
+      const resultEvent = { resultText: "You've reached your usage limit" };
+      expect(turnEndedDueToLimitOrOutage('sess-1', resultEvent)).toBe(true);
+    });
+
+    it('detects service-error text (overloaded / 503 / 529 / unavailable) in the result event', () => {
+      messages.getBySessionId.mockReturnValue([]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'The server is overloaded' })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 503' })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 529' })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'service unavailable' })).toBe(true);
+    });
+
+    it('detects token-limit / service-error text in the last assistant message when result text is empty', () => {
+      messages.getBySessionId.mockReturnValue([
+        { role: 'user', content: 'do something' },
+        { role: 'assistant', content: "You've hit your token limit" },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: '' })).toBe(true);
+    });
+
+    it('detects from the last assistant message when no result event is provided', () => {
+      messages.getBySessionId.mockReturnValue([
+        { role: 'user', content: 'do something' },
+        { role: 'assistant', content: 'The service is unavailable right now' },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(true);
+    });
+
+    it('returns false for clean result text and clean assistant message', () => {
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: 'Here is the finished implementation.' },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'Done, all tests pass.' })).toBe(false);
+    });
+
+    it('returns false with no throw when there is no result event and no assistant message', () => {
+      messages.getBySessionId.mockReturnValue([]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(false);
+    });
+
+    it('prefers the result event text over the assistant message', () => {
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: 'Here is the finished implementation.' },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'usage limit reached' })).toBe(true);
     });
   });
 });

--- a/packages/server/src/services/sessionErrors.test.js
+++ b/packages/server/src/services/sessionErrors.test.js
@@ -344,9 +344,28 @@ describe('sessionErrors', () => {
     it('detects service-error text (overloaded / 503 / 529 / unavailable) in the result event', () => {
       messages.getBySessionId.mockReturnValue([]);
       expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'The server is overloaded' })).toBe(true);
-      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 503' })).toBe(true);
-      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 529' })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'HTTP 503 Service Unavailable' })).toBe(true);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'Error 529: overloaded_error' })).toBe(true);
       expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'service unavailable' })).toBe(true);
+    });
+
+    it('does not flag bare "503"/"529" without terminal framing (completion-path prefilter)', () => {
+      // The completion-path prefilter intentionally requires terminal, provider-style
+      // framing (e.g. "503 service unavailable") — a bare status code alone must not
+      // be classified as a usage-limit/outage termination.
+      messages.getBySessionId.mockReturnValue([]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 503' })).toBe(false);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'error code 529' })).toBe(false);
+    });
+
+    it('does not require the assistant-message shape guard for captured result text', () => {
+      // The `result` event is the CLI's authoritative end-of-turn signal, so unlike
+      // the assistant-message fallback it is never subjected to the terminal-shape
+      // guard (length / implementation-verb check) — only the pattern prefilter applies.
+      messages.getBySessionId.mockReturnValue([]);
+      expect(
+        turnEndedDueToLimitOrOutage('sess-1', { resultText: 'Fixed HTTP 503 Service Unavailable handling in the proxy' })
+      ).toBe(true);
     });
 
     it('detects token-limit / service-error text in the last assistant message when result text is empty', () => {
@@ -403,30 +422,98 @@ describe('sessionErrors', () => {
       expect(turnEndedDueToLimitOrOutage('sess-1')).toBe(false);
     });
 
+    describe('framed terminal patterns (result event) — must return true', () => {
+      const terminalTexts = [
+        "You've reached your usage limit",
+        "You've hit your token limit",
+        'usage limit reached',
+        'quota exceeded',
+        'context window exceeded',
+        'HTTP 503 Service Unavailable',
+        'Error 529: overloaded_error',
+        'The API is overloaded, please try again later',
+        '429 Too Many Requests',
+        'Too many requests - please try again later',
+      ];
+
+      it.each(terminalTexts)('detects: %s', (text) => {
+        messages.getBySessionId.mockReturnValue([]);
+        expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: text })).toBe(true);
+      });
+    });
+
+    it('normalizes underscores when matching "overloaded_error"', () => {
+      messages.getBySessionId.mockReturnValue([]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'overloaded_error' })).toBe(true);
+    });
+
+    it('normalizes hyphens when matching "service-unavailable"', () => {
+      messages.getBySessionId.mockReturnValue([]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: 'service-unavailable' })).toBe(true);
+    });
+
     // Regression corpus: ordinary successful-work prose that incidentally contains
     // bare words also matched by matchesTokenLimitError / matchesServiceError
-    // ("token", "limit", "cap", "exceeded", "unavailable") must NOT be classified
-    // as a usage-limit/outage termination. Guards against over-broad false holds.
-    describe('regression corpus (natural completion text, must return false)', () => {
+    // ("token", "limit", "cap", "exceeded", "503", "529", "overload", "unavailable")
+    // — or even a fully-framed terminal phrase embedded inside an implementation
+    // summary — must NOT be classified as a usage-limit/outage termination when it
+    // arrives via the last-assistant-message fallback, where the
+    // `looksLikeTerminalAssistantMessage` shape guard applies. Guards against
+    // over-broad false holds.
+    describe('regression corpus (natural completion text via assistant fallback, must return false)', () => {
       const cleanCompletions = [
         'implemented a token bucket rate limiter',
-        'escaped the special characters',
         'increased the pagination limit to 100',
         'added capacity checks',
-        'handled the case where the service is unavailable',
+        'Added an overloaded constructor for the Point class',
+        'Refactored method overloading in the parser',
+        'Fixed the HTTP 503 error handling in the proxy',
+        'Fixed HTTP 503 Service Unavailable handling in the proxy',
+        'Implemented retry on 503 responses',
+        'Bumped max buffer to 529 bytes',
+        'The service is unavailable branch is now covered by a test',
+        'Fixed service unavailable handling in the API client',
+        'Added service-unavailable handling in the API client',
       ];
 
       it.each(cleanCompletions)('does not flag: %s', (text) => {
-        messages.getBySessionId.mockReturnValue([]);
-        expect(turnEndedDueToLimitOrOutage('sess-1', { resultText: text })).toBe(false);
-      });
-
-      it.each(cleanCompletions)('does not flag in the assistant-message fallback: %s', (text) => {
         messages.getBySessionId.mockReturnValue([
           { role: 'assistant', content: text },
         ]);
         expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(false);
       });
+    });
+
+    it('rejects a multi-paragraph completion summary that mentions "usage limit reached" as a string literal', () => {
+      const longSummary = [
+        'Implemented the retry handler for the billing service.',
+        'This change adds a new RetryPolicy class that inspects the error string',
+        'returned by the provider. For example, when the provider responds with',
+        'the literal text "usage limit reached", the handler now schedules a retry',
+        'instead of failing the request immediately.',
+        'Added unit tests covering the new branch and updated the documentation to',
+        'describe the retry behavior in detail so future maintainers understand',
+        'why the string is checked, and covered the edge case where the response',
+        'body is empty.',
+      ].join(' ');
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: longSummary },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(false);
+    });
+
+    it('rejects a completion summary with bullets that includes "429 Too Many Requests" in test-fixture text', () => {
+      const bulletSummary = [
+        'Implemented rate limiting for the public API:',
+        '- Added a token bucket limiter in front of the router',
+        '- Added a regression test asserting the client receives "429 Too Many Requests"',
+        '  when the bucket is empty',
+        '- Updated the changelog',
+      ].join('\n');
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: bulletSummary },
+      ]);
+      expect(turnEndedDueToLimitOrOutage('sess-1', null)).toBe(false);
     });
   });
 });

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -78,14 +78,26 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
   // The waiting write above would otherwise overwrite the scheduled state.
   const wasScheduledMidTurn = await handleScheduledContinuationIfNeeded(sessionId);
 
+  // Determine once, up front, whether this turn ended gracefully because the
+  // provider hit a usage/token limit or was unavailable — not because the work
+  // actually finished. This MUST be computed before the proactive-reschedule
+  // branch below: otherwise a held turn that also crosses the proactive
+  // token-reschedule threshold would return early and skip the FRD-required
+  // side effects (PR extraction, summary activity, changes broadcast, auto-send,
+  // template trigger) that must still run for held turns.
+  const shouldHoldKanbanCompletion = turnEndedDueToLimitOrOutage(sessionId, getResultEvent(sessionId));
+
   // Check if session should be proactively rescheduled based on token threshold.
   // Explicit mid-turn continuations win over automatic token-management reschedules.
   const { checkProactiveReschedule } = callbacks;
+  let wasProactivelyRescheduled = false;
   if (!wasScheduledMidTurn && checkProactiveReschedule) {
-    const wasRescheduled = await checkProactiveReschedule(sessionId);
-    if (wasRescheduled) {
+    wasProactivelyRescheduled = await checkProactiveReschedule(sessionId);
+    if (wasProactivelyRescheduled && !shouldHoldKanbanCompletion) {
       return true; // Session was rescheduled, don't continue with normal completion
     }
+    // A held turn falls through even when proactively rescheduled, so the
+    // FRD-required side effects below still run for it.
   }
 
   // Extract PR URL immediately (lightweight, no API call)
@@ -107,7 +119,7 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
   // so the card must stay put. Skip only the completion move — all other side
   // effects on this path (waiting status, summaries, auto-send, template trigger)
   // still run as usual.
-  if (turnEndedDueToLimitOrOutage(sessionId, getResultEvent(sessionId))) {
+  if (shouldHoldKanbanCompletion) {
     console.log(`[kanban] Session ${sessionId}: usage-limit/outage — completion move skipped`);
   } else {
     await kanbanService.handleCompletionMove(sessionId);
@@ -126,7 +138,7 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
     await handleTemplateTriggerIfNeeded(sessionId);
   }
 
-  return false;
+  return wasProactivelyRescheduled;
 }
 
 /**

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -78,26 +78,21 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
   // The waiting write above would otherwise overwrite the scheduled state.
   const wasScheduledMidTurn = await handleScheduledContinuationIfNeeded(sessionId);
 
-  // Determine once, up front, whether this turn ended gracefully because the
-  // provider hit a usage/token limit or was unavailable — not because the work
-  // actually finished. This MUST be computed before the proactive-reschedule
-  // branch below: otherwise a held turn that also crosses the proactive
-  // token-reschedule threshold would return early and skip the FRD-required
-  // side effects (PR extraction, summary activity, changes broadcast, auto-send,
-  // template trigger) that must still run for held turns.
-  const shouldHoldKanbanCompletion = turnEndedDueToLimitOrOutage(sessionId, getResultEvent(sessionId));
-
   // Check if session should be proactively rescheduled based on token threshold.
   // Explicit mid-turn continuations win over automatic token-management reschedules.
+  // A proactively-rescheduled turn — held or not — never advances the card and
+  // must not run any other normal-completion side effect either: the session is
+  // about to be re-run automatically, so PR extraction, summary activity, changes
+  // broadcast, auto-send, and the next-template trigger belong to the *continued*
+  // turn, not this one. Running them here would let the next-template trigger
+  // double-drive a session that's simultaneously scheduled to retry (Issue 3).
   const { checkProactiveReschedule } = callbacks;
   let wasProactivelyRescheduled = false;
   if (!wasScheduledMidTurn && checkProactiveReschedule) {
     wasProactivelyRescheduled = await checkProactiveReschedule(sessionId);
-    if (wasProactivelyRescheduled && !shouldHoldKanbanCompletion) {
+    if (wasProactivelyRescheduled) {
       return true; // Session was rescheduled, don't continue with normal completion
     }
-    // A held turn falls through even when proactively rescheduled, so the
-    // FRD-required side effects below still run for it.
   }
 
   // Extract PR URL immediately (lightweight, no API call)
@@ -118,7 +113,10 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
   // hit a usage/token limit or was unavailable did NOT actually complete any work,
   // so the card must stay put. Skip only the completion move — all other side
   // effects on this path (waiting status, summaries, auto-send, template trigger)
-  // still run as usual.
+  // still run as usual. Only reached for turns that were NOT proactively
+  // rescheduled, so getResultEvent() is only consumed here, not on the
+  // held+rescheduled early-return path above.
+  const shouldHoldKanbanCompletion = turnEndedDueToLimitOrOutage(sessionId, getResultEvent(sessionId));
   if (shouldHoldKanbanCompletion) {
     console.log(`[kanban] Session ${sessionId}: usage-limit/outage — completion move skipped`);
   } else {

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -4,6 +4,7 @@ import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as summaryService from './summaryService.js';
 import * as kanbanService from './kanbanService.js';
 import { createVisibleFinalErrorMessage } from './visibleFinalErrorMessage.js';
+import { turnEndedDueToLimitOrOutage } from './sessionErrors.js';
 import {
   lastMessageIds,
   activeSessions,
@@ -12,6 +13,7 @@ import {
   associateAndBroadcastWorkLogs,
   broadcastSessionStatus,
   broadcastChangesUpdate,
+  getResultEvent,
 } from './streamEventHandler.js';
 
 /**
@@ -100,7 +102,16 @@ async function handleActiveSessionCompletion(sessionId, workingDirectory, callba
   // Advance the card to its current lane's completion target now that the
   // session has finished a turn successfully. This is the only correct
   // trigger: work was actually done while parked in this lane.
-  await kanbanService.handleCompletionMove(sessionId);
+  // Exception: a turn that ended gracefully (success result) because the provider
+  // hit a usage/token limit or was unavailable did NOT actually complete any work,
+  // so the card must stay put. Skip only the completion move — all other side
+  // effects on this path (waiting status, summaries, auto-send, template trigger)
+  // still run as usual.
+  if (turnEndedDueToLimitOrOutage(sessionId, getResultEvent(sessionId))) {
+    console.log(`[kanban] Session ${sessionId}: usage-limit/outage — completion move skipped`);
+  } else {
+    await kanbanService.handleCompletionMove(sessionId);
+  }
 
   // Auto-send queued prompt if enabled (runs BEFORE template trigger)
   const { handleAutoSendIfNeeded, handleTemplateTriggerIfNeeded } = callbacks;

--- a/packages/server/src/services/streamEventHandler.js
+++ b/packages/server/src/services/streamEventHandler.js
@@ -54,8 +54,13 @@ export const finalResultEvents = new Map();
  * (delete from the map) on read. This guarantees a later turn's completion check
  * can never accidentally observe a previous turn's stale result-event payload —
  * each captured result event is readable exactly once, by whichever completion
- * check reads it first. `cleanupSessionState`'s deletion remains a final
- * safeguard for paths that never call this getter (e.g. thrown-error turns).
+ * check reads it first.
+ *
+ * Note (Issue 6): `cleanupSessionState`'s deletion in the `_executeSession`
+ * `finally` block is the primary mechanism that guarantees no stale payload
+ * survives across turns; this consume-on-read behavior is redundant
+ * defense-in-depth for the (normally unreachable) case of a path that reads this
+ * getter without going through that cleanup.
  * @param {string} sessionId
  * @returns {{ subtype: string, isError: boolean, resultText: string } | null}
  */

--- a/packages/server/src/services/streamEventHandler.js
+++ b/packages/server/src/services/streamEventHandler.js
@@ -42,6 +42,22 @@ export const loggedToolUseIds = new Map();
 /** @type {Set<string>} Track sessions that received a final result.error event */
 export const finalErrorSessionIds = new Set();
 
+/**
+ * @type {Map<string, { subtype: string, isError: boolean, resultText: string }>}
+ * Captures the CLI's authoritative turn-termination payload (the `result` event) per session,
+ * so the completion path can consult it to detect a graceful usage-limit/outage termination.
+ */
+export const finalResultEvents = new Map();
+
+/**
+ * Get the captured `result` event record for a session, if any.
+ * @param {string} sessionId
+ * @returns {{ subtype: string, isError: boolean, resultText: string } | null}
+ */
+export function getResultEvent(sessionId) {
+  return finalResultEvents.get(sessionId) || null;
+}
+
 // ── Helper functions ───────────────────────────────────────────────────────
 
 /**
@@ -401,6 +417,14 @@ function handleContentBlockStop(sessionId, _event) {
  * @param {Object} event
  */
 function handleResultEvent(sessionId, event) {
+  // Capture the authoritative turn-termination text regardless of subtype, so the
+  // completion path can later detect a graceful usage-limit/outage termination.
+  finalResultEvents.set(sessionId, {
+    subtype: event.subtype,
+    isError: Boolean(event.is_error),
+    resultText: typeof event.result === 'string' ? event.result : '',
+  });
+
   if (event.subtype === 'error') {
     handleResultError(sessionId, event);
   } else {
@@ -498,6 +522,7 @@ export function cleanupSessionState(sessionId, includeConversationId = false) {
   currentModels.delete(sessionId);
   loggedToolUseIds.delete(sessionId);
   finalErrorSessionIds.delete(sessionId);
+  finalResultEvents.delete(sessionId);
   activeSessions.delete(sessionId);
   if (includeConversationId) {
     activeConversationIds.delete(sessionId);

--- a/packages/server/src/services/streamEventHandler.js
+++ b/packages/server/src/services/streamEventHandler.js
@@ -50,12 +50,20 @@ export const finalErrorSessionIds = new Set();
 export const finalResultEvents = new Map();
 
 /**
- * Get the captured `result` event record for a session, if any.
+ * Get the captured `result` event record for a session, if any, and consume it
+ * (delete from the map) on read. This guarantees a later turn's completion check
+ * can never accidentally observe a previous turn's stale result-event payload —
+ * each captured result event is readable exactly once, by whichever completion
+ * check reads it first. `cleanupSessionState`'s deletion remains a final
+ * safeguard for paths that never call this getter (e.g. thrown-error turns).
  * @param {string} sessionId
  * @returns {{ subtype: string, isError: boolean, resultText: string } | null}
  */
 export function getResultEvent(sessionId) {
-  return finalResultEvents.get(sessionId) || null;
+  const entry = finalResultEvents.get(sessionId);
+  if (entry === undefined) return null;
+  finalResultEvents.delete(sessionId);
+  return entry;
 }
 
 // ── Helper functions ───────────────────────────────────────────────────────

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -609,6 +609,61 @@ describe('streamEventHandler', () => {
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
     });
 
+    it('held turns with proactive token-threshold rescheduling still preserve FRD-required side effects and do not advance the card', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: "You've reached your usage limit" });
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(true);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+      const mockAutoSend = vi.fn().mockResolvedValue(false);
+
+      const result = await handleTurnCompletion('sess-1', '/workspace', {
+        handleTemplateTriggerIfNeeded: mockHandleTemplate,
+        checkProactiveReschedule: mockCheckReschedule,
+        handleAutoSendIfNeeded: mockAutoSend,
+      });
+
+      // Proactive reschedule still ran and fired.
+      expect(mockCheckReschedule).toHaveBeenCalledWith('sess-1');
+      expect(result).toBe(true);
+      // But the card must not advance...
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
+      // ...and every other FRD-required completion side effect must still run.
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
+      expect(summaryService.extractPrUrlIfNeeded).toHaveBeenCalledWith('sess-1');
+      expect(summaryService.onSessionActivity).toHaveBeenCalledWith('sess-1');
+      expect(diffService.getChanges).toHaveBeenCalledWith('/workspace');
+      expect(mockAutoSend).toHaveBeenCalledWith('sess-1');
+      expect(mockHandleTemplate).toHaveBeenCalledWith('sess-1');
+    });
+
+    it('non-held turns with proactive token-threshold rescheduling keep existing reschedule behavior (early return, no side effects)', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      messages.getBySessionId.mockReturnValue([]);
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(true);
+      const mockHandleTemplate = vi.fn();
+      const mockAutoSend = vi.fn();
+
+      const result = await handleTurnCompletion('sess-1', '/workspace', {
+        handleTemplateTriggerIfNeeded: mockHandleTemplate,
+        checkProactiveReschedule: mockCheckReschedule,
+        handleAutoSendIfNeeded: mockAutoSend,
+      });
+
+      expect(result).toBe(true);
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
+      // Unchanged legacy behavior: reschedule short-circuits before other side effects.
+      expect(summaryService.extractPrUrlIfNeeded).not.toHaveBeenCalled();
+      expect(summaryService.onSessionActivity).not.toHaveBeenCalled();
+      expect(mockAutoSend).not.toHaveBeenCalled();
+      expect(mockHandleTemplate).not.toHaveBeenCalled();
+    });
+
     it('does not reuse a stale held result event on a later natural completion (consume-on-read)', async () => {
       activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
       workLogs.associatePendingLogs.mockReturnValue(0);

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -90,6 +90,7 @@ import {
   loggedToolUseIds,
   finalErrorSessionIds,
   finalResultEvents,
+  getResultEvent,
 } from './streamEventHandler.js';
 
 describe('streamEventHandler', () => {
@@ -303,6 +304,38 @@ describe('streamEventHandler', () => {
 
       expect(diffService.getChanges).not.toHaveBeenCalled();
       expect(broadcastToSession).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── getResultEvent ────────────────────────────────────────────────────
+
+  describe('getResultEvent', () => {
+    it('returns null when no result event was captured', () => {
+      expect(getResultEvent('sess-1')).toBeNull();
+    });
+
+    it('returns the captured result event record', () => {
+      const record = { subtype: 'success', isError: false, resultText: 'Done.' };
+      finalResultEvents.set('sess-1', record);
+      expect(getResultEvent('sess-1')).toEqual(record);
+    });
+
+    it('consumes the entry on read — a second read returns null', () => {
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: 'Done.' });
+
+      expect(getResultEvent('sess-1')).not.toBeNull();
+      expect(getResultEvent('sess-1')).toBeNull();
+      expect(finalResultEvents.has('sess-1')).toBe(false);
+    });
+
+    it('does not affect other sessions when consuming one', () => {
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: 'A' });
+      finalResultEvents.set('sess-2', { subtype: 'success', isError: false, resultText: 'B' });
+
+      getResultEvent('sess-1');
+
+      expect(finalResultEvents.has('sess-1')).toBe(false);
+      expect(finalResultEvents.has('sess-2')).toBe(true);
     });
   });
 
@@ -574,6 +607,38 @@ describe('streamEventHandler', () => {
 
       expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
+    });
+
+    it('does not reuse a stale held result event on a later natural completion (consume-on-read)', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      messages.getBySessionId.mockReturnValue([]);
+
+      // First turn: a genuine usage-limit result event holds the completion move.
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: "You've reached your usage limit" });
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
+      // The held event must have been consumed (deleted) on read.
+      expect(finalResultEvents.has('sess-1')).toBe(false);
+
+      // Second turn: no new result event was captured for this turn (e.g. the
+      // handler ran before a fresh `result` event arrived). The stale held
+      // payload from the first turn must NOT be reused — completion should
+      // proceed normally since there's no signal for this turn.
+      vi.clearAllMocks();
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      messages.getBySessionId.mockReturnValue([]);
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+      expect(kanbanService.handleCompletionMove).toHaveBeenCalledWith('sess-1');
     });
 
     it('skips template trigger when auto-send fires', async () => {

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -575,6 +575,26 @@ describe('streamEventHandler', () => {
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
     });
 
+    it('advances the card when a genuine completion summary merely mentions a limit/outage phrase in passing', async () => {
+      // Regression guard for Issue 1: the Claude Code `result` event's text IS the
+      // final assistant message, so a work summary that happens to contain a framed
+      // terminal phrase (e.g. "Fixed HTTP 503 Service Unavailable handling...") must
+      // still advance the card, not be misclassified as a graceful usage-limit/outage hold.
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: 'Fixed HTTP 503 Service Unavailable handling in the proxy' });
+      messages.getBySessionId.mockReturnValue([]);
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+
+      expect(kanbanService.handleCompletionMove).toHaveBeenCalledWith('sess-1');
+    });
+
     it('does not call kanban completion hooks when the result event carries usage-limit text, but still sets waiting', async () => {
       activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
       workLogs.associatePendingLogs.mockReturnValue(0);
@@ -609,7 +629,13 @@ describe('streamEventHandler', () => {
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
     });
 
-    it('held turns with proactive token-threshold rescheduling still preserve FRD-required side effects and do not advance the card', async () => {
+    it('held + proactively-rescheduled turns early-return before any normal-completion side effect runs (Issue 3)', async () => {
+      // A proactively-rescheduled turn never advances the card, held or not — the
+      // session is about to be re-run automatically, so completion side effects
+      // (PR extraction, summary, changes broadcast, auto-send, template trigger)
+      // belong to the *continued* turn, not this one. Running them here would let
+      // handleTemplateTriggerIfNeeded double-drive the session while it's
+      // simultaneously scheduled to retry.
       activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
       workLogs.associatePendingLogs.mockReturnValue(0);
       sessions.getById.mockReturnValue({ projectId: 'proj-1' });
@@ -629,15 +655,17 @@ describe('streamEventHandler', () => {
       // Proactive reschedule still ran and fired.
       expect(mockCheckReschedule).toHaveBeenCalledWith('sess-1');
       expect(result).toBe(true);
-      // But the card must not advance...
+      // The card must not advance...
       expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
-      // ...and every other FRD-required completion side effect must still run.
+      // ...and the next-template trigger must not fire (the session was rescheduled)...
+      expect(mockHandleTemplate).not.toHaveBeenCalled();
+      // ...nor any other normal-completion side effect, deferred to the continued turn.
+      expect(summaryService.extractPrUrlIfNeeded).not.toHaveBeenCalled();
+      expect(summaryService.onSessionActivity).not.toHaveBeenCalled();
+      expect(diffService.getChanges).not.toHaveBeenCalled();
+      expect(mockAutoSend).not.toHaveBeenCalled();
+      // The waiting-status transition (before the reschedule check) still occurs.
       expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
-      expect(summaryService.extractPrUrlIfNeeded).toHaveBeenCalledWith('sess-1');
-      expect(summaryService.onSessionActivity).toHaveBeenCalledWith('sess-1');
-      expect(diffService.getChanges).toHaveBeenCalledWith('/workspace');
-      expect(mockAutoSend).toHaveBeenCalledWith('sess-1');
-      expect(mockHandleTemplate).toHaveBeenCalledWith('sess-1');
     });
 
     it('non-held turns with proactive token-threshold rescheduling keep existing reschedule behavior (early return, no side effects)', async () => {

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -89,6 +89,7 @@ import {
   currentModels,
   loggedToolUseIds,
   finalErrorSessionIds,
+  finalResultEvents,
 } from './streamEventHandler.js';
 
 describe('streamEventHandler', () => {
@@ -104,7 +105,9 @@ describe('streamEventHandler', () => {
     currentModels.clear();
     loggedToolUseIds.clear();
     finalErrorSessionIds.clear();
+    finalResultEvents.clear();
     messages.getByConversationId.mockReturnValue([]);
+    messages.getBySessionId.mockReturnValue([]);
     messages.create.mockImplementation((sessionId, role, content, options = {}) => ({
       id: `msg-${role}`,
       sessionId,
@@ -518,6 +521,59 @@ describe('streamEventHandler', () => {
       await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
 
       expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
+    });
+
+    it('calls kanban completion hooks on natural completion (no usage-limit/outage signal)', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: 'Done, all tests pass.' });
+      messages.getBySessionId.mockReturnValue([
+        { role: 'assistant', content: 'Here is the finished implementation.' },
+      ]);
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+
+      expect(kanbanService.handleCompletionMove).toHaveBeenCalledWith('sess-1');
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
+    });
+
+    it('does not call kanban completion hooks when the result event carries usage-limit text, but still sets waiting', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: "You've reached your usage limit" });
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
+      expect(summaryService.onSessionActivity).toHaveBeenCalledWith('sess-1');
+      expect(mockHandleTemplate).toHaveBeenCalledWith('sess-1');
+    });
+
+    it('does not call kanban completion hooks when the result event carries service-error text, but still sets waiting', async () => {
+      activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
+      workLogs.associatePendingLogs.mockReturnValue(0);
+      sessions.getById.mockReturnValue({ projectId: 'proj-1' });
+      diffService.getChanges.mockResolvedValue({ staged: null, unstaged: null, untracked: null });
+      finalResultEvents.set('sess-1', { subtype: 'success', isError: false, resultText: 'The server is overloaded' });
+
+      const mockCheckReschedule = vi.fn().mockResolvedValue(false);
+      const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
+
+      await handleTurnCompletion('sess-1', '/workspace', { handleTemplateTriggerIfNeeded: mockHandleTemplate, checkProactiveReschedule: mockCheckReschedule });
+
+      expect(kanbanService.handleCompletionMove).not.toHaveBeenCalled();
+      expect(sessions.update).toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });
     });
 
     it('skips template trigger when auto-send fires', async () => {


### PR DESCRIPTION
## Summary

- Adds `turnEndedDueToLimitOrOutage()` to `sessionErrors.js` to detect when a turn ended gracefully due to token/usage limits or provider outages (reusing existing pattern matchers)
- Captures the CLI's authoritative `result` event per session in a new `finalResultEvents` map in `streamEventHandler.js`, exposing it via `getResultEvent()`
- Updates `streamEventCallbacks.js` to skip `kanbanService.handleCompletionMove()` when the turn ended due to a limit/outage — since no real work was completed, the card should stay in its current lane
- Hardens the guard: gates the broad `matchesTokenLimitError` / `matchesServiceError` patterns behind a conservative terminal-phrase check so ordinary successful-work prose (e.g. "increased the pagination limit to 100") is never misclassified as a usage-limit/outage completion. Also makes `getResultEvent()` consume-on-read so a later turn can never reuse a stale held result-event payload.

## Problem

Previously, when a Claude Code session hit a token limit or experienced a provider outage and terminated gracefully with a success result, the kanban card would still advance to the next lane as if work had been completed. This caused workspaces to move forward on the board even when no actual progress was made.

## Test plan

- [x] Unit tests added for `turnEndedDueToLimitOrOutage()` in `sessionErrors.test.js`
- [x] Unit tests added for `getResultEvent()` and `finalResultEvents` cleanup in `streamEventHandler.test.js`
- [x] Playwright E2E tests pass (1150 passed, 19 skipped, 0 failed)
- [ ] Verify kanban card does NOT advance when session ends due to token limit
- [ ] Verify kanban card DOES advance normally on genuine completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)