### PR TITLE
Add GPT-5.6 OpenAI models and retire gpt-5.5 from new selections

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ The CLI path also passes configured reasoning effort and commit attribution to C
 | Thinking | ❌ |
 | Resume | ❌ |
 
-Supported OpenAI models: GPT-5.5 (default), GPT-5.4, GPT-5.4 mini, GPT-5.3-Codex.
+Supported OpenAI models: GPT-5.6 Sol (default), GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.4, GPT-5.4 mini, GPT-5.3-Codex. GPT-5.5 has been retired from the built-in model picker; existing sessions that already store `gpt-5.5` continue to run with it.
 
 ### Gemini Agent Details
 

--- a/packages/server/src/api/model-validation.test.js
+++ b/packages/server/src/api/model-validation.test.js
@@ -4,7 +4,7 @@ import { validateModelId } from './model-validation.js';
 
 describe('validateModelId', () => {
   it('accepts a built-in model id', () => {
-    expect(validateModelId('gpt-5.5')).toEqual({ value: 'gpt-5.5' });
+    expect(validateModelId('gpt-5.6-sol')).toEqual({ value: 'gpt-5.6-sol' });
   });
 
   it('accepts tier aliases case-insensitively', () => {
@@ -27,8 +27,31 @@ describe('validateModelId', () => {
 
     expect(result.error).toContain('Invalid model id "not-a-real-model"');
     expect(result.error).toContain('Valid model ids are:');
-    expect(result.error).toContain('gpt-5.5');
+    expect(result.error).toContain('gpt-5.6-sol');
     expect(result.error).toContain('opus');
+  });
+
+  it('does not list the retired gpt-5.5 id on a fresh database', () => {
+    const result = validateModelId('not-a-real-model');
+    expect(result.error).not.toContain('gpt-5.5');
+  });
+
+  it('accepts a retained legacy gpt-5.5 compatibility row (upgraded DB)', () => {
+    // Fresh DBs no longer seed gpt-5.5, but upgraded installations retain the
+    // historical built-in row so existing gpt-5.5 sessions keep validating.
+    const now = Date.now();
+    modelProviders.db
+      .prepare(
+        `INSERT INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run('openai-gpt-5-5-validation-test', 'openai-default', 'gpt-5.5', 'GPT-5.5', 'Retired', 'custom', now);
+
+    try {
+      expect(validateModelId('gpt-5.5')).toEqual({ value: 'gpt-5.5' });
+    } finally {
+      modelProviders.db.prepare('DELETE FROM provider_models WHERE id = ?').run('openai-gpt-5-5-validation-test');
+    }
   });
 
   it('accepts user-registered custom model ids', () => {

--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -1339,7 +1339,7 @@ describe('Projects API', () => {
       await request(app).post(`/api/projects/${projectId}/session-defaults`).send({
         mode: 'plan',
         thinkingEnabled: true,
-        model: 'gpt-5.5',
+        model: 'gpt-5.6-sol',
         providerId: provider.id,
         effortLevel: 'high',
         startImmediately: false,
@@ -1354,7 +1354,7 @@ describe('Projects API', () => {
       const session = sessions.getById(res.body.id);
       expect(session.mode).toBe('plan');
       expect(session.thinkingEnabled).toBe(true);
-      expect(session.model).toBe('gpt-5.5');
+      expect(session.model).toBe('gpt-5.6-sol');
       expect(session.providerId).toBe(provider.id);
       expect(session.effortLevel).toBe('high');
       expect(session.status).toBe('waiting');
@@ -1619,7 +1619,7 @@ describe('Projects API', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('Invalid model id "not-a-real-model"');
       expect(res.body.error).toContain('Valid model ids are:');
-      expect(res.body.error).toContain('gpt-5.5');
+      expect(res.body.error).toContain('gpt-5.6-sol');
     });
 
     it('session model is null when no project default and no param', async () => {

--- a/packages/server/src/api/sessions-messages.test.js
+++ b/packages/server/src/api/sessions-messages.test.js
@@ -137,7 +137,7 @@ describe('Sessions Messages API — POST /:id/message cross-kind guard (Phase 7)
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Invalid model id "not-a-real-model"');
     expect(res.body.error).toContain('Valid model ids are:');
-    expect(res.body.error).toContain('gpt-5.5');
+    expect(res.body.error).toContain('gpt-5.6-sol');
     expect(continueSession).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/api/sessions.test.js
+++ b/packages/server/src/api/sessions.test.js
@@ -160,7 +160,7 @@ describe('Sessions API - PATCH effortLevel', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Invalid model id "not-a-real-model"');
     expect(res.body.error).toContain('Valid model ids are:');
-    expect(res.body.error).toContain('gpt-5.5');
+    expect(res.body.error).toContain('gpt-5.6-sol');
   });
 
   it('updates model to a valid model id', async () => {

--- a/packages/server/src/db/ProviderRepository.test.js
+++ b/packages/server/src/db/ProviderRepository.test.js
@@ -933,12 +933,6 @@ describe('ProviderRepository', () => {
       );
     });
 
-    it('getProviderByModelId resolves gpt-5.6-sol to the built-in OpenAI provider', () => {
-      const result = repo.getProviderByModelId('gpt-5.6-sol');
-      expect(result).not.toBeNull();
-      expect(result.id).toBe('openai-default');
-    });
-
     it('getProviderByModelId prefers a custom provider over built-in OpenAI for duplicate model IDs', () => {
       const provider = repo.create({
         name: 'Custom OpenAI',

--- a/packages/server/src/db/ProviderRepository.test.js
+++ b/packages/server/src/db/ProviderRepository.test.js
@@ -740,7 +740,7 @@ describe('ProviderRepository', () => {
 
         expect(ids).toEqual([...ids].sort());
         expect(ids).toContain('zz-enumerated-model');
-        expect(ids).toContain('gpt-5.5');
+        expect(ids).toContain('gpt-5.6-sol');
         for (const alias of MODEL_TIER_ALIASES) {
           expect(ids).toContain(alias);
           expect(repo.getProviderByModelId(alias)).toBeNull();
@@ -923,7 +923,7 @@ describe('ProviderRepository', () => {
     });
 
     it('getProviderByModelId returns built-in OpenAI for official seeded models', () => {
-      const result = repo.getProviderByModelId('gpt-5.5');
+      const result = repo.getProviderByModelId('gpt-5.6-sol');
       expect(result).not.toBeNull();
       expect(result.id).toBe('openai-default');
       expect(result.kind).toBe('openai');
@@ -931,6 +931,12 @@ describe('ProviderRepository', () => {
       expect(result.models.map((model) => model.modelId).sort()).toEqual(
         OPENAI_MODELS.map((model) => model.id).sort()
       );
+    });
+
+    it('getProviderByModelId resolves gpt-5.6-sol to the built-in OpenAI provider', () => {
+      const result = repo.getProviderByModelId('gpt-5.6-sol');
+      expect(result).not.toBeNull();
+      expect(result.id).toBe('openai-default');
     });
 
     it('getProviderByModelId prefers a custom provider over built-in OpenAI for duplicate model IDs', () => {
@@ -941,17 +947,38 @@ describe('ProviderRepository', () => {
         authToken: 'custom-token',
       });
       repo.addModel(provider.id, {
-        modelId: 'gpt-5.5',
-        displayName: 'Custom GPT-5.5',
+        modelId: 'gpt-5.6-sol',
+        displayName: 'Custom GPT-5.6 Sol',
         tier: 'custom',
       });
 
-      const result = repo.getProviderByModelId('gpt-5.5');
+      const result = repo.getProviderByModelId('gpt-5.6-sol');
       expect(result.id).toBe(provider.id);
       expect(result.baseUrl).toBe('https://proxy.example.com/v1');
       expect(result.authToken).toBe('custom-token');
 
       repo.delete(provider.id);
+    });
+
+    it('getProviderByModelId still resolves a retained legacy gpt-5.5 compatibility row (upgraded DB)', () => {
+      // Fresh DBs no longer seed gpt-5.5, but upgraded installations retain
+      // the historical built-in row so existing sessions keep working.
+      // Simulate that retained row directly.
+      const now = Date.now();
+      repo.db
+        .prepare(
+          `INSERT INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('openai-gpt-5-5', 'openai-default', 'gpt-5.5', 'GPT-5.5', 'Retired', 'custom', now);
+
+      try {
+        const result = repo.getProviderByModelId('gpt-5.5');
+        expect(result).not.toBeNull();
+        expect(result.id).toBe('openai-default');
+      } finally {
+        repo.db.prepare('DELETE FROM provider_models WHERE id = ?').run('openai-gpt-5-5');
+      }
     });
 
     it('getAgentTypeForProvider returns codex for built-in OpenAI', () => {

--- a/packages/server/src/db/migrations/miscMigrations.test.js
+++ b/packages/server/src/db/migrations/miscMigrations.test.js
@@ -169,6 +169,105 @@ describe('providers-seed-built-in-openai migration', () => {
     expect(openAISeedIdx).toBeGreaterThan(kindIdx);
     expect(openAISeedIdx).toBeGreaterThan(historicalSeedIdx);
   });
+
+  it('does not seed a built-in gpt-5.5 row on a fresh DB', () => {
+    const db = getDatabase();
+    const row = db
+      .prepare('SELECT * FROM provider_models WHERE provider_id = ? AND model_id = ?')
+      .get('openai-default', 'gpt-5.5');
+
+    expect(row).toBeUndefined();
+  });
+
+  describe('upgraded database with a pre-GPT-5.6 built-in OpenAI catalog', () => {
+    // Simulate an existing installation whose `provider_models` rows were
+    // seeded before the GPT-5.6 family existed: it still has the retired
+    // `gpt-5.5` row and lacks the new GPT-5.6 rows. Every migration re-runs
+    // on every startup (see DatabaseManager#runMigrations), so re-running
+    // `providers-seed-built-in-openai` with the *current* `OPENAI_MODELS`
+    // list is what backfills the new rows for upgraded databases.
+    function simulateLegacyCatalog(db) {
+      db.prepare('DELETE FROM provider_models WHERE provider_id = ?').run('openai-default');
+      const now = Date.now();
+      const legacyModels = [
+        { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', description: 'Flagship coding and professional work' },
+        { id: 'openai-gpt-5-4', modelId: 'gpt-5.4', displayName: 'GPT-5.4', description: 'High capability professional work' },
+      ];
+      const insert = db.prepare(
+        `INSERT INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
+         VALUES (?, ?, ?, ?, ?, 'custom', ?)`
+      );
+      for (const model of legacyModels) {
+        insert.run(model.id, 'openai-default', model.modelId, model.displayName, model.description, now);
+      }
+    }
+
+    it('backfills missing GPT-5.6 rows without touching the retained gpt-5.5 row', () => {
+      const db = getDatabase();
+      simulateLegacyCatalog(db);
+
+      seedOpenAIMigration.up(db);
+
+      const rows = db
+        .prepare('SELECT * FROM provider_models WHERE provider_id = ? ORDER BY model_id')
+        .all('openai-default');
+      const modelIds = rows.map((row) => row.model_id);
+
+      expect(modelIds).toContain('gpt-5.6-sol');
+      expect(modelIds).toContain('gpt-5.6-terra');
+      expect(modelIds).toContain('gpt-5.6-luna');
+
+      // The retired row is preserved untouched (not deleted, not modified).
+      const legacyRow = rows.find((row) => row.model_id === 'gpt-5.5');
+      expect(legacyRow).toMatchObject({
+        id: 'openai-gpt-5-5',
+        display_name: 'GPT-5.5',
+        description: 'Flagship coding and professional work',
+      });
+    });
+
+    it('is idempotent: re-running does not duplicate rows or touch the legacy row', () => {
+      const db = getDatabase();
+      simulateLegacyCatalog(db);
+
+      seedOpenAIMigration.up(db);
+      seedOpenAIMigration.up(db);
+
+      const rows = db
+        .prepare('SELECT * FROM provider_models WHERE provider_id = ?')
+        .all('openai-default');
+      const modelIds = rows.map((row) => row.model_id);
+
+      expect(new Set(modelIds).size).toBe(modelIds.length);
+      expect(rows.filter((row) => row.model_id === 'gpt-5.5')).toHaveLength(1);
+    });
+
+    it('does not modify custom-provider rows that also use gpt-5.5', () => {
+      const db = getDatabase();
+      simulateLegacyCatalog(db);
+
+      const now = Date.now();
+      db.prepare(
+        `INSERT INTO providers (id, name, kind, is_built_in, created_at, updated_at)
+         VALUES (?, ?, 'openai', 0, ?, ?)`
+      ).run('custom-openai-legacy-test', 'Custom OpenAI', now, now);
+      db.prepare(
+        `INSERT INTO provider_models (id, provider_id, model_id, display_name, description, tier, created_at)
+         VALUES (?, ?, ?, ?, ?, 'custom', ?)`
+      ).run('custom-openai-legacy-test-gpt-5-5', 'custom-openai-legacy-test', 'gpt-5.5', 'Custom GPT-5.5', null, now);
+
+      seedOpenAIMigration.up(db);
+
+      const customRow = db
+        .prepare('SELECT * FROM provider_models WHERE id = ?')
+        .get('custom-openai-legacy-test-gpt-5-5');
+      expect(customRow).toMatchObject({
+        provider_id: 'custom-openai-legacy-test',
+        model_id: 'gpt-5.5',
+        display_name: 'Custom GPT-5.5',
+      });
+    });
+  });
 });
 
 describe('providers-backfill-built-in-openai-attribution migration', () => {

--- a/packages/server/src/db/migrations/providerMigrationHelpers.js
+++ b/packages/server/src/db/migrations/providerMigrationHelpers.js
@@ -46,6 +46,23 @@ export function seedBuiltInAnthropicProvider(db) {
   }
 }
 
+/**
+ * Seed (and backfill) the built-in OpenAI provider and its model rows.
+ *
+ * This runs as the `providers-seed-built-in-openai` migration, and migrations
+ * re-run unconditionally on every startup (see DatabaseManager#runMigrations).
+ * That re-run is the upgrade/backfill path: because the model inserts use
+ * `INSERT OR IGNORE` and iterate the *current* `OPENAI_MODELS` list, existing
+ * databases automatically gain newly added built-in models (e.g. the GPT-5.6
+ * family) on next startup without a dedicated migration. Models removed from
+ * `OPENAI_MODELS` (e.g. the retired `gpt-5.5`) are intentionally NOT deleted
+ * here — existing rows are left in place for runtime compatibility and hidden
+ * from new-selection UI instead.
+ *
+ * NOTE: this backfill relies on migrations running every startup. If that ever
+ * changes to run-once/versioned migrations, add an explicit backfill migration
+ * for newly added built-in models.
+ */
 export function seedBuiltInOpenAIProvider(db) {
   const now = Date.now();
 

--- a/packages/shared/src/types.js
+++ b/packages/shared/src/types.js
@@ -118,10 +118,22 @@ export const DEFAULT_MODEL = 'claude-opus-4-8';
 
 export const OPENAI_MODELS = [
   {
-    id: 'gpt-5.5',
-    name: 'GPT-5.5',
-    description: 'Flagship coding and professional work',
-    seedId: 'openai-gpt-5-5',
+    id: 'gpt-5.6-sol',
+    name: 'GPT-5.6 Sol',
+    description: 'Frontier model for complex professional work',
+    seedId: 'openai-gpt-5-6-sol',
+  },
+  {
+    id: 'gpt-5.6-terra',
+    name: 'GPT-5.6 Terra',
+    description: 'Capable lower-cost GPT-5.6 model',
+    seedId: 'openai-gpt-5-6-terra',
+  },
+  {
+    id: 'gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    description: 'Fastest and most cost-efficient GPT-5.6 model',
+    seedId: 'openai-gpt-5-6-luna',
   },
   {
     id: 'gpt-5.4',
@@ -142,7 +154,32 @@ export const OPENAI_MODELS = [
     seedId: 'openai-gpt-5-3-codex',
   },
 ];
-export const DEFAULT_OPENAI_MODEL = 'gpt-5.5';
+export const DEFAULT_OPENAI_MODEL = 'gpt-5.6-sol';
+
+/**
+ * Built-in OpenAI model ids that have been retired from new selection
+ * workflows (model pickers, defaults) but must remain resolvable/executable
+ * for historical sessions, templates, and provider rows that already
+ * reference them. Retired ids are intentionally NOT removed from existing
+ * `provider_models` rows — only hidden from new-choice UI surfaces.
+ */
+export const RETIRED_BUILT_IN_OPENAI_MODEL_IDS = ['gpt-5.5'];
+
+/**
+ * Determine whether a (provider, modelId) pair should be excluded from
+ * built-in OpenAI new-selection surfaces (e.g. the model picker) because the
+ * model id has been retired. Only applies to the built-in OpenAI provider —
+ * custom/user-created providers that happen to expose the same model id
+ * string are never considered retired.
+ *
+ * @param {{ isBuiltIn?: boolean, kind?: string }|null|undefined} provider
+ * @param {string|null|undefined} modelId
+ * @returns {boolean}
+ */
+export function isRetiredBuiltInOpenAIModelSelection(provider, modelId) {
+  if (!provider?.isBuiltIn || provider.kind !== 'openai') return false;
+  return RETIRED_BUILT_IN_OPENAI_MODEL_IDS.includes(modelId);
+}
 
 export const GEMINI_MODELS = [
   { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Most capable reasoning model', seedId: 'google-gemini-2-5-pro' },

--- a/packages/shared/src/types.test.js
+++ b/packages/shared/src/types.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  OPENAI_MODELS,
+  DEFAULT_OPENAI_MODEL,
+  RETIRED_BUILT_IN_OPENAI_MODEL_IDS,
+  isRetiredBuiltInOpenAIModelSelection,
+} from './types.js';
+
+describe('OPENAI_MODELS', () => {
+  it('includes the GPT-5.6 family', () => {
+    const ids = OPENAI_MODELS.map((m) => m.id);
+    expect(ids).toContain('gpt-5.6-sol');
+    expect(ids).toContain('gpt-5.6-terra');
+    expect(ids).toContain('gpt-5.6-luna');
+  });
+
+  it('does not include the retired gpt-5.5 model', () => {
+    const ids = OPENAI_MODELS.map((m) => m.id);
+    expect(ids).not.toContain('gpt-5.5');
+  });
+
+  it('gives each GPT-5.6 model a stable seed id and display name', () => {
+    expect(OPENAI_MODELS.find((m) => m.id === 'gpt-5.6-sol')).toMatchObject({
+      name: 'GPT-5.6 Sol',
+      seedId: 'openai-gpt-5-6-sol',
+    });
+    expect(OPENAI_MODELS.find((m) => m.id === 'gpt-5.6-terra')).toMatchObject({
+      name: 'GPT-5.6 Terra',
+      seedId: 'openai-gpt-5-6-terra',
+    });
+    expect(OPENAI_MODELS.find((m) => m.id === 'gpt-5.6-luna')).toMatchObject({
+      name: 'GPT-5.6 Luna',
+      seedId: 'openai-gpt-5-6-luna',
+    });
+  });
+
+  it('does not expose the gpt-5.6 alias as a separate choice', () => {
+    const ids = OPENAI_MODELS.map((m) => m.id);
+    expect(ids).not.toContain('gpt-5.6');
+  });
+});
+
+describe('DEFAULT_OPENAI_MODEL', () => {
+  it('defaults to gpt-5.6-sol', () => {
+    expect(DEFAULT_OPENAI_MODEL).toBe('gpt-5.6-sol');
+  });
+});
+
+describe('isRetiredBuiltInOpenAIModelSelection', () => {
+  it('treats gpt-5.5 as retired for the built-in OpenAI provider', () => {
+    const provider = { isBuiltIn: true, kind: 'openai' };
+    expect(isRetiredBuiltInOpenAIModelSelection(provider, 'gpt-5.5')).toBe(true);
+  });
+
+  it('does not treat gpt-5.5 as retired for a custom OpenAI provider', () => {
+    const provider = { isBuiltIn: false, kind: 'openai' };
+    expect(isRetiredBuiltInOpenAIModelSelection(provider, 'gpt-5.5')).toBe(false);
+  });
+
+  it('does not treat current models as retired', () => {
+    const provider = { isBuiltIn: true, kind: 'openai' };
+    expect(isRetiredBuiltInOpenAIModelSelection(provider, 'gpt-5.6-sol')).toBe(false);
+  });
+
+  it('returns false for a missing/null provider', () => {
+    expect(isRetiredBuiltInOpenAIModelSelection(null, 'gpt-5.5')).toBe(false);
+    expect(isRetiredBuiltInOpenAIModelSelection(undefined, 'gpt-5.5')).toBe(false);
+  });
+
+  it('exposes the retired id list', () => {
+    expect(RETIRED_BUILT_IN_OPENAI_MODEL_IDS).toEqual(['gpt-5.5']);
+  });
+});

--- a/packages/web/src/components/ModelSelector.test.js
+++ b/packages/web/src/components/ModelSelector.test.js
@@ -816,7 +816,7 @@ describe('ModelSelector', () => {
           isBuiltIn: true,
           kind: 'openai',
           models: [
-            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
           ],
         },
         {
@@ -825,19 +825,19 @@ describe('ModelSelector', () => {
           isBuiltIn: false,
           kind: 'openai',
           models: [
-            { id: 'custom-gpt-5-5', modelId: 'gpt-5.5', displayName: 'Custom GPT-5.5', tier: 'custom' },
+            { id: 'custom-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'Custom GPT-5.6 Sol', tier: 'custom' },
           ],
         },
       ];
 
-      const wrapper = mountComponent({ modelValue: 'gpt-5.5' });
+      const wrapper = mountComponent({ modelValue: 'gpt-5.6-sol' });
       await flushAll(wrapper);
 
       const optgroups = wrapper.findAll('optgroup');
       expect(optgroups).toHaveLength(1);
       expect(optgroups[0].attributes('label')).toBe('Codex · Custom OpenAI');
       expect(wrapper.findAll('option')).toHaveLength(1);
-      expect(wrapper.find('option').element.value).toBe(optionValue('custom-openai', 'gpt-5.5'));
+      expect(wrapper.find('option').element.value).toBe(optionValue('custom-openai', 'gpt-5.6-sol'));
     });
 
     it('falls back to a visible duplicate option when the requested provider is hidden', async () => {
@@ -849,7 +849,7 @@ describe('ModelSelector', () => {
           isBuiltIn: true,
           kind: 'openai',
           models: [
-            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
           ],
         },
         {
@@ -858,20 +858,20 @@ describe('ModelSelector', () => {
           isBuiltIn: false,
           kind: 'openai',
           models: [
-            { id: 'custom-gpt-5-5', modelId: 'gpt-5.5', displayName: 'Custom GPT-5.5', tier: 'custom' },
+            { id: 'custom-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'Custom GPT-5.6 Sol', tier: 'custom' },
           ],
         },
       ];
 
       const wrapper = mountComponent({
-        modelValue: 'gpt-5.5',
+        modelValue: 'gpt-5.6-sol',
         providerId: 'openai-default',
       });
       await flushAll(wrapper);
 
       const select = wrapper.find('select');
-      expect(select.element.value).toBe(optionValue('custom-openai', 'gpt-5.5'));
-      expect(wrapper.attributes('data-model')).toBe('gpt-5.5');
+      expect(select.element.value).toBe(optionValue('custom-openai', 'gpt-5.6-sol'));
+      expect(wrapper.attributes('data-model')).toBe('gpt-5.6-sol');
       expect(wrapper.attributes('data-provider-id')).toBe('custom-openai');
     });
 
@@ -884,7 +884,7 @@ describe('ModelSelector', () => {
           isBuiltIn: true,
           kind: 'openai',
           models: [
-            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
           ],
         },
       ];
@@ -892,7 +892,7 @@ describe('ModelSelector', () => {
       const onUpdateProviderId = vi.fn();
       const wrapper = mountComponent(
         {
-          modelValue: 'gpt-5.5',
+          modelValue: 'gpt-5.6-sol',
           providerId: null,
           allowEmpty: true,
         },
@@ -900,7 +900,7 @@ describe('ModelSelector', () => {
       );
       await flushAll(wrapper);
 
-      expect(wrapper.find('select').element.value).toBe(optionValue('openai-default', 'gpt-5.5'));
+      expect(wrapper.find('select').element.value).toBe(optionValue('openai-default', 'gpt-5.6-sol'));
       expect(onUpdateProviderId).toHaveBeenCalledWith('openai-default');
     });
 
@@ -913,7 +913,7 @@ describe('ModelSelector', () => {
           isBuiltIn: true,
           kind: 'openai',
           models: [
-            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
           ],
         },
         {
@@ -922,13 +922,13 @@ describe('ModelSelector', () => {
           isBuiltIn: false,
           kind: 'openai',
           models: [
-            { id: 'custom-gpt-5-5', modelId: 'gpt-5.5', displayName: 'Custom GPT-5.5', tier: 'custom' },
+            { id: 'custom-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'Custom GPT-5.6 Sol', tier: 'custom' },
           ],
         },
       ];
 
       const wrapper = mountComponent({
-        modelValue: 'gpt-5.5',
+        modelValue: 'gpt-5.6-sol',
         providerId: 'openai-default',
         hideBuiltInDuplicates: false,
       });
@@ -937,16 +937,93 @@ describe('ModelSelector', () => {
       const options = wrapper.findAll('option');
       expect(options).toHaveLength(2);
       expect(options.map((option) => option.element.value)).toEqual([
-        optionValue('openai-default', 'gpt-5.5'),
-        optionValue('custom-openai', 'gpt-5.5'),
+        optionValue('openai-default', 'gpt-5.6-sol'),
+        optionValue('custom-openai', 'gpt-5.6-sol'),
       ]);
       expect(options.map((option) => option.text())).toEqual([
-        'GPT-5.5 (OpenAI (Official))',
-        'gpt-5.5 (Custom OpenAI)',
+        'GPT-5.6 Sol (OpenAI (Official))',
+        'gpt-5.6-sol (Custom OpenAI)',
       ]);
     });
 
     it('selects and emits the requested provider for duplicate model ids', async () => {
+      const localProvidersStore = useProvidersStore();
+      localProvidersStore.providers = [
+        {
+          id: 'openai-default',
+          name: 'OpenAI (Official)',
+          isBuiltIn: true,
+          kind: 'openai',
+          models: [
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
+          ],
+        },
+        {
+          id: 'custom-openai',
+          name: 'Custom OpenAI',
+          isBuiltIn: false,
+          kind: 'openai',
+          models: [
+            { id: 'custom-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'Custom GPT-5.6 Sol', tier: 'custom' },
+          ],
+        },
+      ];
+
+      const onUpdateModelValue = vi.fn();
+      const onUpdateProviderId = vi.fn();
+      const onModelSelected = vi.fn();
+      const wrapper = mountComponent(
+        {
+          modelValue: 'gpt-5.6-sol',
+          providerId: 'openai-default',
+          hideBuiltInDuplicates: false,
+        },
+        { 'onUpdate:modelValue': onUpdateModelValue, 'onUpdate:providerId': onUpdateProviderId, onModelSelected }
+      );
+      await flushAll(wrapper);
+
+      expect(wrapper.find('select').element.value).toBe(optionValue('openai-default', 'gpt-5.6-sol'));
+
+      const select = wrapper.find('select');
+      select.element.value = optionValue('custom-openai', 'gpt-5.6-sol');
+      await select.trigger('change');
+      await flushAll(wrapper);
+
+      expect(onUpdateModelValue).toHaveBeenCalledWith('gpt-5.6-sol');
+      expect(onUpdateProviderId).toHaveBeenCalledWith('custom-openai');
+      expect(onModelSelected).toHaveBeenCalledWith({
+        modelId: 'gpt-5.6-sol',
+        providerId: 'custom-openai',
+        kind: 'openai',
+      });
+    });
+  });
+
+  describe('retired built-in OpenAI model (gpt-5.5)', () => {
+    it('does not render the built-in OpenAI gpt-5.5 option', async () => {
+      const localProvidersStore = useProvidersStore();
+      localProvidersStore.providers = [
+        {
+          id: 'openai-default',
+          name: 'OpenAI (Official)',
+          isBuiltIn: true,
+          kind: 'openai',
+          models: [
+            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
+          ],
+        },
+      ];
+
+      const wrapper = mountComponent({ modelValue: 'gpt-5.6-sol' });
+      await flushAll(wrapper);
+
+      const values = wrapper.findAll('option').map((option) => option.element.value);
+      expect(values).not.toContain(optionValue('openai-default', 'gpt-5.5'));
+      expect(values).toContain(optionValue('openai-default', 'gpt-5.6-sol'));
+    });
+
+    it('keeps a custom provider gpt-5.5 option selectable', async () => {
       const localProvidersStore = useProvidersStore();
       localProvidersStore.providers = [
         {
@@ -969,33 +1046,38 @@ describe('ModelSelector', () => {
         },
       ];
 
-      const onUpdateModelValue = vi.fn();
-      const onUpdateProviderId = vi.fn();
-      const onModelSelected = vi.fn();
-      const wrapper = mountComponent(
+      const wrapper = mountComponent({ modelValue: 'gpt-5.5', providerId: 'custom-openai' });
+      await flushAll(wrapper);
+
+      const values = wrapper.findAll('option').map((option) => option.element.value);
+      expect(values).toContain(optionValue('custom-openai', 'gpt-5.5'));
+      expect(values).not.toContain(optionValue('openai-default', 'gpt-5.5'));
+    });
+
+    it('does not emit a replacement model value for a persisted gpt-5.5 + openai-default pairing', async () => {
+      const localProvidersStore = useProvidersStore();
+      localProvidersStore.providers = [
         {
-          modelValue: 'gpt-5.5',
-          providerId: 'openai-default',
-          hideBuiltInDuplicates: false,
+          id: 'openai-default',
+          name: 'OpenAI (Official)',
+          isBuiltIn: true,
+          kind: 'openai',
+          models: [
+            { id: 'openai-gpt-5-5', modelId: 'gpt-5.5', displayName: 'GPT-5.5', tier: 'custom' },
+            { id: 'openai-gpt-5-6-sol', modelId: 'gpt-5.6-sol', displayName: 'GPT-5.6 Sol', tier: 'custom' },
+          ],
         },
-        { 'onUpdate:modelValue': onUpdateModelValue, 'onUpdate:providerId': onUpdateProviderId, onModelSelected }
+      ];
+
+      const onUpdateModelValue = vi.fn();
+      const wrapper = mountComponent(
+        { modelValue: 'gpt-5.5', providerId: 'openai-default' },
+        { 'onUpdate:modelValue': onUpdateModelValue }
       );
       await flushAll(wrapper);
 
-      expect(wrapper.find('select').element.value).toBe(optionValue('openai-default', 'gpt-5.5'));
-
-      const select = wrapper.find('select');
-      select.element.value = optionValue('custom-openai', 'gpt-5.5');
-      await select.trigger('change');
-      await flushAll(wrapper);
-
-      expect(onUpdateModelValue).toHaveBeenCalledWith('gpt-5.5');
-      expect(onUpdateProviderId).toHaveBeenCalledWith('custom-openai');
-      expect(onModelSelected).toHaveBeenCalledWith({
-        modelId: 'gpt-5.5',
-        providerId: 'custom-openai',
-        kind: 'openai',
-      });
+      expect(onUpdateModelValue).not.toHaveBeenCalled();
+      expect(wrapper.attributes('data-model')).toBe('gpt-5.5');
     });
   });
 

--- a/packages/web/src/components/ModelSelector.vue
+++ b/packages/web/src/components/ModelSelector.vue
@@ -46,6 +46,7 @@
 <script setup>
 import { ref, computed, watch, toRef, onMounted } from 'vue';
 import { useProvidersStore } from '../stores/providers.js';
+import { isRetiredBuiltInOpenAIModelSelection } from '@circuschief/shared';
 
 const props = defineProps({
   modelValue: {
@@ -152,6 +153,7 @@ const visibleProviders = computed(() => {
   }
 
   return sortedProviders.value
+    .map((provider) => withRetiredModelsHidden(provider))
     .map((provider) => {
       if (!props.hideBuiltInDuplicates || !provider.isBuiltIn) return provider;
       return withCustomModelsHidden(provider, customModelIds);
@@ -173,6 +175,20 @@ function withCustomModelsHidden(provider, customModelIds) {
   return {
     ...provider,
     models: (provider.models || []).filter((model) => !customModelIds.has(model.modelId)),
+  };
+}
+
+// Retired built-in OpenAI model ids (e.g. the superseded 'gpt-5.5') remain
+// resolvable/executable for historical sessions but must not appear as a
+// selectable choice for new selections. This only ever filters the built-in
+// OpenAI provider's own model list — a custom provider that happens to expose
+// the same model id string is never affected.
+function withRetiredModelsHidden(provider) {
+  return {
+    ...provider,
+    models: (provider.models || []).filter(
+      (model) => !isRetiredBuiltInOpenAIModelSelection(provider, model.modelId)
+    ),
   };
 }
 

--- a/packages/web/src/composables/useModelInfo.test.js
+++ b/packages/web/src/composables/useModelInfo.test.js
@@ -284,6 +284,17 @@ describe('useModelInfo', () => {
               tier: 'custom',
             })),
             { id: 'o-gpt4o', modelId: 'gpt-4o', displayName: 'GPT-4o' },
+            // Retained compatibility row for an upgraded database: gpt-5.5 is
+            // no longer part of OPENAI_MODELS, but existing installations
+            // keep the built-in provider_models row so historical sessions
+            // resolve. It should NOT be found in OPENAI_MODELS.
+            {
+              id: 'openai-gpt-5-5',
+              modelId: 'gpt-5.5',
+              displayName: 'GPT-5.5 (legacy)',
+              description: 'Retired model retained for compatibility',
+              tier: 'custom',
+            },
           ],
         },
       ];
@@ -301,14 +312,32 @@ describe('useModelInfo', () => {
       // Prime the capability cache synchronously before reading.
       await fetchAgentCapabilities();
 
-      const info = getModelInfo('gpt-5.5');
+      const info = getModelInfo('gpt-5.6-sol');
       expect(info.agentType).toBe('codex');
       expect(info.capabilities.thinking).toBe(false);
       expect(info.capabilities.reasoningEffort).toBe(true);
       expect(info.providerId).toBe('openai-default');
       expect(info.providerName).toBe('OpenAI (Official)');
-      expect(info.name).toBe('GPT-5.5');
-      expect(info.description).toBe('Flagship coding and professional work');
+      expect(info.name).toBe('GPT-5.6 Sol');
+      expect(info.description).toBe('Frontier model for complex professional work');
+    });
+
+    it('does not resolve gpt-5.5 against OPENAI_MODELS (retired from the curated catalog)', () => {
+      expect(OPENAI_MODELS.find((model) => model.id === 'gpt-5.5')).toBeUndefined();
+    });
+
+    it('falls back to the retained provider-row metadata for a legacy gpt-5.5 compatibility row', async () => {
+      const { getModelInfo, fetchAgentCapabilities } = useModelInfo();
+      await fetchAgentCapabilities();
+
+      const info = getModelInfo('gpt-5.5');
+      expect(info.agentType).toBe('codex');
+      expect(info.providerId).toBe('openai-default');
+      expect(info.providerName).toBe('OpenAI (Official)');
+      // Name/description come from the persisted provider_models row, not
+      // from curated OPENAI_MODELS metadata (which no longer has an entry).
+      expect(info.name).toBe('GPT-5.5 (legacy)');
+      expect(info.description).toBe('Retired model retained for compatibility');
     });
 
     it('resolves every OPENAI_MODELS entry to curated metadata for OpenAI providers', async () => {


### PR DESCRIPTION
## Summary

- **Add GPT-5.6 OpenAI models**: Introduces `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` as first-class built-in OpenAI model choices, and makes `gpt-5.6-sol` the new `DEFAULT_OPENAI_MODEL`.
- **Retire `gpt-5.5` from new selections**: `gpt-5.5` is removed from the shared `OPENAI_MODELS` catalog and filtered out of the built-in OpenAI provider in `ModelSelector`, so it is no longer offered as a new choice. It is intentionally **not** deleted from existing databases — historical sessions/templates that already store `gpt-5.5` continue to resolve and run with it, and custom providers that expose `gpt-5.5` are unaffected.
- **Fresh vs. upgraded databases**: Fresh databases seed only the current catalog (the three GPT-5.6 rows, no built-in `gpt-5.5`). Upgraded databases automatically backfill the new GPT-5.6 rows via the existing `providers-seed-built-in-openai` migration, which re-runs every startup and `INSERT OR IGNORE`s the current `OPENAI_MODELS` list; the retained `gpt-5.5` row is left untouched.
- **Docs**: `docs/development.md` updated to list the GPT-5.6 family and note that `gpt-5.5` is retired from the picker but still supported for existing sessions.

## Test plan
- [x] Shared: `OPENAI_MODELS`/`DEFAULT_OPENAI_MODEL` and the new `isRetiredBuiltInOpenAIModelSelection` helper (`types.test.js`)
- [x] Server: backfill + idempotency + custom-provider isolation for the seed migration (`miscMigrations.test.js`); provider resolution and retained-`gpt-5.5` compatibility (`ProviderRepository.test.js`); model validation (`model-validation.test.js`); session/project default tests
- [x] Web: retired built-in `gpt-5.5` hidden while custom `gpt-5.5` stays selectable, no replacement emitted for persisted `gpt-5.5` (`ModelSelector.test.js`); curated GPT-5.6 metadata and legacy provider-row fallback (`useModelInfo.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)