### PR TITLE
fix: label session-summary aggregate-count metric as Sessions

### DIFF
--- a/packages/web/src/components/SessionOverviewCard.test.js
+++ b/packages/web/src/components/SessionOverviewCard.test.js
@@ -131,4 +131,24 @@ describe('SessionOverviewCard.vue', () => {
     });
   });
 
+  describe('Session count metric', () => {
+    it('renders the session count metric with a "Sessions" label', () => {
+      const wrapper = mountComponent({
+        hasMetrics: true,
+        sessionCount: 3,
+      });
+
+      const metrics = wrapper.findAll('.metric');
+      const sessionMetric = metrics.find(
+        (metric) => metric.find('.metric-label').text() === 'Sessions',
+      );
+
+      expect(sessionMetric).toBeTruthy();
+      expect(sessionMetric.find('.metric-value').text()).toBe('3');
+
+      const labels = metrics.map((metric) => metric.find('.metric-label').text());
+      expect(labels).not.toContain('Workspaces');
+    });
+  });
+
 });

--- a/packages/web/src/components/SessionOverviewCard.vue
+++ b/packages/web/src/components/SessionOverviewCard.vue
@@ -37,7 +37,7 @@
         class="metric"
       >
         <span class="metric-value">{{ sessionCount }}</span>
-        <span class="metric-label">Workspaces</span>
+        <span class="metric-label">Sessions</span>
       </div>
       <div
         v-if="hasNonZeroTokens"

--- a/tests/e2e/session-summaries.spec.ts
+++ b/tests/e2e/session-summaries.spec.ts
@@ -967,8 +967,8 @@ test.describe('Session Summaries', () => {
       const metricsRow = page.locator('.overview-metrics');
       await expect(metricsRow).toBeVisible();
 
-      // The Workspaces metric should show "3" (1 parent + 2 children)
-      const sessionsLabel = page.locator('.overview-metrics .metric-label').filter({ hasText: 'Workspaces' });
+      // The Sessions metric should show "3" (1 parent + 2 children)
+      const sessionsLabel = page.locator('.overview-metrics .metric-label').filter({ hasText: 'Sessions' });
       await expect(sessionsLabel).toBeVisible();
 
       const sessionsMetric = sessionsLabel.locator('..');


### PR DESCRIPTION
## Summary\n\n- Fixes the session count metric label in `SessionOverviewCard` to display **"Sessions"** (consistent with Circus Chief's session model)\n- Adds a unit test to `SessionOverviewCard.test.js` verifying the session count metric renders with a "Sessions" label\n\n## Test plan\n\n- [x] Unit test passes: `yarn workspace @circuschief/web test src/components/SessionOverviewCard.test.js`\n- [x] E2E test passes: `tests/e2e/session-summaries.spec.ts` — _Category 10: Summary Tab — Overview Metrics › shows session count > 1 for workflow with children_\n- [x] Full Playwright suite: 1150 passed, 19 skipped, 0 failed\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)