### PR TITLE
fix: stream circus command output live instead of buffering it

### DIFF
--- a/packages/server/src/api/commandButtons.js
+++ b/packages/server/src/api/commandButtons.js
@@ -4,7 +4,7 @@ import { CreateCommandButtonRequest, UpdateCommandButtonRequest } from '@circusc
 import { commandRunner } from '../services/commandRunner.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import { databaseManager } from '../db/DatabaseManager.js';
-import { broadcastCommandEvent } from './commandEventBroadcast.js';
+import { broadcastCommandEvent, broadcastCommandOutput } from './commandEventBroadcast.js';
 
 // Error message constants
 const ERR_SESSION_NOT_FOUND = 'Session not found';
@@ -22,13 +22,16 @@ const router = Router({ mergeParams: true });
  */
 function createCommandRunCallbacks(sessionId, projectId, runId, buttonId) {
   return {
-    onOutput: (text) => {
-      broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId, buttonId, output: text });
+    onStarted: () => {
+      broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_STARTED, { runId, buttonId, status: 'running' });
     },
-    onComplete: (exitCode, output) => {
+    onOutputChunk: (chunk) => {
+      broadcastCommandOutput(runId, chunk);
+    },
+    onComplete: (exitCode) => {
       const status = exitCode === 0 ? 'success' : 'error';
       console.log(`[CommandButtons] Command completed: runId=${runId}, buttonId=${buttonId}, exitCode=${exitCode}, status=${status}`);
-      broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, { runId, buttonId, status, exitCode, output });
+      broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, { runId, buttonId, status, exitCode });
     },
     onError: (message) => {
       broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_ERROR, { runId, buttonId, error: message });
@@ -142,7 +145,7 @@ router.post('/run/:buttonId', (req, res) => {
   const workingDirectory = session.gitWorktree || session.project?.workingDirectory || process.cwd();
   const runId = databaseManager.generateId();
 
-  res.json({ runId, buttonId, status: 'running', output: '' });
+  res.json({ runId, buttonId, status: 'running' });
 
   const callbacks = createCommandRunCallbacks(sessionId, session.projectId, runId, buttonId);
 
@@ -185,7 +188,8 @@ router.get('/runs', (req, res) => {
       runId: run.id,
       buttonId: run.buttonId,
       status: run.status,
-      output: run.output,
+      hasOutput: run.hasOutput,
+      outputHighWater: run.outputHighWater,
       exitCode: run.exitCode,
       startedAt: run.startedAt,
       completedAt: run.completedAt,
@@ -228,11 +232,22 @@ router.get('/runs/:runId', (req, res) => {
     runId: run.id,
     buttonId: run.buttonId,
     status: run.status,
-    output: run.output,
+      hasOutput: run.hasOutput,
+      outputHighWater: run.outputHighWater,
     exitCode: run.exitCode,
     startedAt: run.startedAt,
     completedAt: run.completedAt,
   });
+});
+
+// GET bounded persisted output. Cursor is the last fully applied sequence.
+router.get('/runs/:runId/output', (req, res) => {
+  const { sessionId, runId } = req.params;
+  const session = sessions.getById(sessionId);
+  const run = commandRuns.getById(runId);
+  if (!session || !run || run.sessionId !== sessionId) return res.status(404).json({ error: 'Run not found' });
+  const page = commandRuns.readAfter(runId, req.query.after, req.query.limitBytes);
+  res.json({ ...page, after: Number(req.query.after) || 0 });
 });
 
 // DELETE /api/sessions/:sessionId/circus-commands/runs/:runId - Delete a command run record

--- a/packages/server/src/api/commandButtons.test.js
+++ b/packages/server/src/api/commandButtons.test.js
@@ -15,6 +15,7 @@ vi.mock('../websocket.js', () => ({
   broadcastToSession: vi.fn(),
   broadcastToProject: vi.fn(),
   broadcastToSessionAndProject: vi.fn(),
+  broadcastCommandRunOutput: vi.fn(),
 }));
 
 // Mock sessionManager
@@ -41,7 +42,7 @@ vi.mock('../services/commandRunner.js', () => ({
 // Import after mocks are set up
 import commandButtonsRouter from './commandButtons.js';
 import sessionsRouter from './sessions.js';
-import { broadcastToSession, broadcastToProject, broadcastToSessionAndProject } from '../websocket.js';
+import { broadcastToSession, broadcastToProject, broadcastToSessionAndProject, broadcastCommandRunOutput } from '../websocket.js';
 import { commandRunner } from '../services/commandRunner.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 
@@ -351,7 +352,7 @@ describe('Command Buttons API', () => {
       expect(res.body.runId).toBeDefined();
       expect(res.body.buttonId).toBe(buttonId);
       expect(res.body.status).toBe('running');
-      expect(res.body.output).toBe('');
+      expect(res.body).not.toHaveProperty('output');
     });
 
     it('returns 404 for non-existent session', async () => {
@@ -385,21 +386,21 @@ describe('Command Buttons API', () => {
       // Verify commandRunner.run was called
       expect(commandRunner.run).toHaveBeenCalled();
 
-      // New signature: run({ runId, command, workingDirectory }, { onOutput, onComplete, onError }, metadata)
+      // New signature keeps lifecycle metadata separate from persisted output chunks.
       const runCall = commandRunner.run.mock.calls[0];
       expect(runCall[0].runId).toBe(res.body.runId); // params.runId
       expect(runCall[0].command).toBe('echo test'); // params.command
       expect(typeof runCall[0].workingDirectory).toBe('string'); // params.workingDirectory
-      expect(typeof runCall[1].onOutput).toBe('function'); // callbacks.onOutput
+      expect(typeof runCall[1].onStarted).toBe('function');
+      expect(typeof runCall[1].onOutputChunk).toBe('function');
       expect(typeof runCall[1].onComplete).toBe('function'); // callbacks.onComplete
       expect(typeof runCall[1].onError).toBe('function'); // callbacks.onError
     });
 
-    it('broadcasts command output via a single union broadcast to session and project', async () => {
+    it('broadcasts persisted command output chunks by run subscription', async () => {
       commandRunner.run.mockImplementation(async (_params, callbacks, _metadata) => {
-        // Simulate command output (new signature uses callbacks object)
-        callbacks.onOutput('Hello ');
-        callbacks.onOutput('World\n');
+        callbacks.onOutputChunk({ sequence: 1, content: 'Hello ' });
+        callbacks.onOutputChunk({ sequence: 2, content: 'World\n' });
       });
 
       await request(app).post(
@@ -414,24 +415,13 @@ describe('Command Buttons API', () => {
       expect(broadcastToSession).not.toHaveBeenCalled();
       expect(broadcastToProject).not.toHaveBeenCalled();
 
-      const outputBroadcasts = broadcastToSessionAndProject.mock.calls.filter(
-        (call) => call[2] === WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT && call[3].output === 'Hello '
-      );
-
-      expect(outputBroadcasts.length).toBe(1);
-      const [calledSessionId, calledProjectId, , payload] = outputBroadcasts[0];
-      expect(calledSessionId).toBe(sessionId);
-      expect(calledProjectId).toBe(projects.getById(projectId).id);
-      expect(payload).toEqual({
-        runId: expect.any(String),
-        buttonId,
-        output: 'Hello ',
-      });
+      expect(broadcastCommandRunOutput).toHaveBeenNthCalledWith(1, expect.any(String), { sequence: 1, content: 'Hello ' });
+      expect(broadcastCommandRunOutput).toHaveBeenNthCalledWith(2, expect.any(String), { sequence: 2, content: 'World\n' });
     });
 
     it('broadcasts completion when command exits successfully', async () => {
       commandRunner.run.mockImplementation(async (_params, callbacks, _metadata) => {
-        callbacks.onComplete(0, 'output');
+        callbacks.onComplete(0);
       });
 
       await request(app).post(`/api/sessions/${sessionId}/circus-commands/${buttonId}/run`);
@@ -453,13 +443,12 @@ describe('Command Buttons API', () => {
         buttonId,
         status: 'success',
         exitCode: 0,
-        output: 'output',
       });
     });
 
     it('broadcasts error when command exits with non-zero code', async () => {
       commandRunner.run.mockImplementation(async (_params, callbacks, _metadata) => {
-        callbacks.onComplete(1, 'error output');
+        callbacks.onComplete(1);
       });
 
       await request(app).post(`/api/sessions/${sessionId}/circus-commands/${buttonId}/run`);
@@ -525,8 +514,9 @@ describe('Command Buttons API', () => {
       // Wait a bit for async execution to start
       await new Promise((resolve) => setTimeout(resolve, 50));
 
+      commandRunner.run.mock.calls[0][1].onStarted();
       const initialBroadcasts = broadcastToSessionAndProject.mock.calls.filter(
-        (call) => call[2] === WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT && call[3].output === ''
+        (call) => call[2] === WS_MESSAGE_TYPES.COMMAND_RUN_STARTED
       );
 
       expect(initialBroadcasts.length).toBe(1);
@@ -536,7 +526,7 @@ describe('Command Buttons API', () => {
       expect(payload).toEqual({
         runId: expect.any(String),
         buttonId,
-        output: '',
+        status: 'running',
       });
     });
   });

--- a/packages/server/src/api/commandEventBroadcast.js
+++ b/packages/server/src/api/commandEventBroadcast.js
@@ -1,4 +1,4 @@
-import { broadcastToSessionAndProject } from '../websocket.js';
+import { broadcastToSessionAndProject, broadcastCommandRunOutput } from '../websocket.js';
 
 /**
  * Broadcast a command-run lifecycle event (output/complete/error/deleted) to the
@@ -15,4 +15,8 @@ import { broadcastToSessionAndProject } from '../websocket.js';
  */
 export function broadcastCommandEvent(sessionId, projectId, type, payload) {
   broadcastToSessionAndProject(sessionId, projectId, type, payload);
+}
+
+export function broadcastCommandOutput(runId, chunk) {
+  broadcastCommandRunOutput(runId, chunk);
 }

--- a/packages/server/src/api/projects-helpers.js
+++ b/packages/server/src/api/projects-helpers.js
@@ -56,6 +56,7 @@ export function buildRunsBySession(dbRuns, runningRuns) {
     runsBySession[run.sessionId][run.buttonId] = {
       buttonId: run.buttonId, status: run.status, exitCode: run.exitCode,
       runId: run.id, startedAt: run.startedAt, completedAt: run.completedAt,
+      hasOutput: run.hasOutput, outputHighWater: run.outputHighWater,
     };
   }
   for (const run of runningRuns) {

--- a/packages/server/src/api/sessions-commands.js
+++ b/packages/server/src/api/sessions-commands.js
@@ -4,7 +4,7 @@ import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import { requireRootSessionAndProject } from '../middleware/sessionLookup.js';
 import { commandRunner } from '../services/commandRunner.js';
 import { databaseManager } from '../db/DatabaseManager.js';
-import { broadcastCommandEvent } from './commandEventBroadcast.js';
+import { broadcastCommandEvent, broadcastCommandOutput } from './commandEventBroadcast.js';
 
 // Error message constants
 const ERR_BUTTON_NOT_FOUND = 'Circus Command not found';
@@ -16,11 +16,6 @@ const router = Router();
  * @param {{ sessionId: string, projectId: string, runId: string, buttonId: string }} ctx - Context
  * @param {string} output - Output text
  */
-function broadcastCommandOutput(ctx, output) {
-  const { sessionId, projectId, runId, buttonId } = ctx;
-  broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId, buttonId, output });
-}
-
 /**
  * Broadcast command completion to session and project subscribers.
  * @param {{ sessionId: string, projectId: string, runId: string, buttonId: string }} ctx - Context
@@ -28,10 +23,10 @@ function broadcastCommandOutput(ctx, output) {
  */
 function broadcastCommandComplete(ctx, result) {
   const { sessionId, projectId, runId, buttonId } = ctx;
-  const { exitCode, output } = result;
+  const { exitCode } = result;
   const status = exitCode === 0 ? 'success' : 'error';
   console.log(`[RUN] Command completed for runId: ${runId}, exitCode: ${exitCode}, status: ${status}`);
-  broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, { runId, buttonId, status, exitCode, output });
+  broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE, { runId, buttonId, status, exitCode });
 }
 
 /**
@@ -71,15 +66,12 @@ router.post('/:id/circus-commands/:buttonId/run', requireRootSessionAndProject, 
   console.log(`[RUN] Generated runId: ${runId} for command: ${button.command}`);
 
   // Return immediately with runId
-  res.json({ runId, buttonId, status: 'running', output: '' });
+  res.json({ runId, buttonId, status: 'running' });
 
   // Capture middleware values for use in async callbacks
   const projectId = req.rootSession_.projectId;
   const workingDirectory = req.rootWorkingDirectory;
   const ctx = { sessionId, projectId, runId, buttonId };
-
-  // Broadcast initial "running" status immediately so session list can show the running indicator
-  broadcastCommandOutput(ctx, '');
 
   // Execute command asynchronously
   (async () => {
@@ -88,11 +80,11 @@ router.post('/:id/circus-commands/:buttonId/run', requireRootSessionAndProject, 
       await commandRunner.run(
         { runId, command: button.command, workingDirectory },
         {
-          onOutput: (text) => {
-            console.log(`[RUN] Output received for runId: ${runId}`);
-            broadcastCommandOutput(ctx, text);
+          onStarted: () => broadcastCommandEvent(sessionId, projectId, WS_MESSAGE_TYPES.COMMAND_RUN_STARTED, { runId, buttonId, status: 'running' }),
+          onOutputChunk: (chunk) => {
+            broadcastCommandOutput(runId, chunk);
           },
-          onComplete: (exitCode, output) => broadcastCommandComplete(ctx, { exitCode, output }),
+          onComplete: (exitCode) => broadcastCommandComplete(ctx, { exitCode }),
           onError: (message) => broadcastCommandError(ctx, message),
         },
         { sessionId, buttonId }
@@ -136,11 +128,20 @@ router.get('/:id/circus-commands/runs/:runId', requireRootSessionAndProject, (re
     runId: run.id,
     buttonId: run.buttonId,
     status: run.status,
-    output: run.output,
+    hasOutput: run.hasOutput,
+    outputHighWater: run.outputHighWater,
     exitCode: run.exitCode,
     startedAt: run.startedAt,
     completedAt: run.completedAt,
   });
+});
+
+router.get('/:id/circus-commands/runs/:runId/output', requireRootSessionAndProject, (req, res) => {
+  const { runId } = req.params;
+  const run = commandRuns.getById(runId);
+  if (!run || run.sessionId !== req.rootSessionId) return res.status(404).json({ error: 'Run not found' });
+  const page = commandRuns.readAfter(runId, req.query.after, req.query.limitBytes);
+  res.json({ ...page, after: Number(req.query.after) || 0 });
 });
 
 // DELETE /api/sessions/:id/circus-commands/runs/:runId - Delete a command run record

--- a/packages/server/src/api/sessions-commands.test.js
+++ b/packages/server/src/api/sessions-commands.test.js
@@ -11,6 +11,7 @@ vi.mock('../websocket.js', () => ({
   broadcastToSession: vi.fn(),
   broadcastToProject: vi.fn(),
   broadcastToSessionAndProject: vi.fn(),
+  broadcastCommandRunOutput: vi.fn(),
 }));
 
 // Mock sessionManager
@@ -79,6 +80,7 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
         .get(`/api/sessions/${child.id}/circus-commands`);
 
       expect(res.status).toBe(200);
+
       expect(res.body).toHaveLength(1);
       expect(res.body[0].id).toBe(button.id);
     });
@@ -113,13 +115,15 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
 
       expect(res.status).toBe(200);
 
+      commandRunner.run.mock.calls[0][1].onStarted();
+
       expect(broadcastToSession).not.toHaveBeenCalled();
       expect(broadcastToProject).not.toHaveBeenCalled();
       expect(broadcastToSessionAndProject).toHaveBeenCalledWith(
         session.id,
         project.id,
-        WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT,
-        { runId: res.body.runId, buttonId: button.id, output: '' }
+        WS_MESSAGE_TYPES.COMMAND_RUN_STARTED,
+        { runId: res.body.runId, buttonId: button.id, status: 'running' }
       );
     });
 
@@ -226,14 +230,17 @@ describe('Sessions API - Command Routes (sessions-commands.js)', () => {
       const child = createChildSession();
       const button = commandButtons.create({ projectId: project.id, label: 'Done Button', command: 'echo done' });
       commandRuns.create({ id: 'root-complete', sessionId: session.id, buttonId: button.id });
-      commandRuns.complete('root-complete', 0, 'done');
+      commandRuns.appendOutput('root-complete', 'done');
+      commandRuns.complete('root-complete', 0);
 
       const res = await request(app)
         .get(`/api/sessions/${child.id}/circus-commands/runs/root-complete`);
 
       expect(res.status).toBe(200);
       expect(res.body.runId).toBe('root-complete');
-      expect(res.body.output).toBe('done');
+      expect(res.body.hasOutput).toBe(true);
+      expect(res.body.outputHighWater).toBe(1);
+      expect(res.body).not.toHaveProperty('output');
     });
 
     it('does not return child-owned persisted runs through a child session', async () => {

--- a/packages/server/src/api/sessions.js
+++ b/packages/server/src/api/sessions.js
@@ -149,6 +149,8 @@ router.get('/:id', requireSession, (req, res) => {
       startedAt: run.startedAt,
       completedAt: run.completedAt,
       output: run.output || null,
+      hasOutput: run.hasOutput,
+      outputHighWater: run.outputHighWater,
     };
   }
 

--- a/packages/server/src/api/sessions.test.js
+++ b/packages/server/src/api/sessions.test.js
@@ -227,7 +227,8 @@ describe('Sessions API - workflow-root command metadata', () => {
     });
     const button = commandButtons.create({ projectId: project.id, label: 'Build', command: 'echo build' });
     commandRuns.create({ id: 'root-run', sessionId: root.id, buttonId: button.id });
-    commandRuns.complete('root-run', 0, 'done');
+    commandRuns.appendOutput('root-run', 'done');
+    commandRuns.complete('root-run', 0);
 
     const res = await request(app).get(`/api/sessions/${child.id}`);
 
@@ -238,9 +239,11 @@ describe('Sessions API - workflow-root command metadata', () => {
       expect.objectContaining({
         buttonId: button.id,
         runId: 'root-run',
-        output: 'done',
+        status: 'success',
+        exitCode: 0,
       }),
     ]);
+    expect(res.body.latestCommandRuns[0].output).toBeNull();
   });
 });
 

--- a/packages/server/src/db/CommandRunRepository.js
+++ b/packages/server/src/db/CommandRunRepository.js
@@ -14,7 +14,10 @@ export class CommandRunRepository extends BaseRepository {
       sessionId: row.session_id,
       buttonId: row.button_id,
       status: row.status,
+      // Kept for legacy rows only. New runs write append-only chunks.
       output: row.output || '',
+      hasOutput: Boolean(row.has_output) || Boolean(row.output),
+      outputHighWater: row.output_high_water || 0,
       exitCode: row.exit_code,
       startedAt: row.started_at,
       completedAt: row.completed_at,
@@ -36,35 +39,83 @@ export class CommandRunRepository extends BaseRepository {
    * Append text to run output (buffered for performance)
    */
   appendOutput(runId, text) {
-    if (!text) return;
-    this.db
-      .prepare(`UPDATE command_runs SET output = output || ? WHERE id = ?`)
-      .run(text, runId);
+    return this.appendBatch(runId, text ? [text] : []);
+  }
+
+  /** Persist bounded, append-only chunks and return their assigned cursors. */
+  appendBatch(runId, chunks) {
+    const items = chunks.filter(Boolean);
+    if (!items.length) return [];
+    const write = this.db.transaction(() => {
+      const next = this.db.prepare(
+        'SELECT COALESCE(MAX(sequence), 0) + 1 AS sequence FROM command_run_output_chunks WHERE run_id = ?'
+      ).get(runId).sequence;
+      const insert = this.db.prepare(
+        `INSERT INTO command_run_output_chunks (run_id, sequence, content, byte_length, created_at)
+         VALUES (?, ?, ?, ?, ?)`
+      );
+      return items.map((content, index) => {
+        const sequence = next + index;
+        insert.run(runId, sequence, content, Buffer.byteLength(content), Date.now());
+        return { sequence, content };
+      });
+    });
+    return write();
+  }
+
+  getHighWater(runId) {
+    return this.db.prepare(
+      'SELECT COALESCE(MAX(sequence), 0) AS sequence FROM command_run_output_chunks WHERE run_id = ?'
+    ).get(runId).sequence;
+  }
+
+  /** Read an ordered, bounded page without materializing the full transcript. */
+  readAfter(runId, after = 0, limitBytes = 65536) {
+    const limit = Math.max(1, Math.min(Number(limitBytes) || 65536, 1024 * 1024));
+    const rows = this.db.prepare(
+      `SELECT sequence, content, byte_length FROM command_run_output_chunks
+       WHERE run_id = ? AND sequence > ? ORDER BY sequence ASC`
+    ).all(runId, Number(after) || 0);
+    const chunks = [];
+    let bytes = 0;
+    for (const row of rows) {
+      if (chunks.length && bytes + row.byte_length > limit) break;
+      chunks.push({ sequence: row.sequence, content: row.content });
+      bytes += row.byte_length;
+      if (bytes >= limit) break;
+    }
+    // Legacy rows predate chunks and remain readable as one bounded chunk.
+    if (!chunks.length && !after) {
+      const legacy = this.db.prepare('SELECT output FROM command_runs WHERE id = ?').get(runId)?.output;
+      if (legacy) return { chunks: [{ sequence: 1, content: legacy.slice(0, limit) }], highWater: 1, hasMore: Buffer.byteLength(legacy) > limit };
+    }
+    const highWater = this.getHighWater(runId);
+    return { chunks, highWater, hasMore: chunks.length ? chunks[chunks.length - 1].sequence < highWater : false };
   }
 
   /**
    * Mark run as completed with exit code and final output
    */
-  complete(runId, exitCode, finalOutput) {
+  complete(runId, exitCode) {
     const status = exitCode === 0 ? 'success' : 'error';
     const now = Date.now();
     this.db
       .prepare(
-        `UPDATE command_runs SET status = ?, output = ?, exit_code = ?, completed_at = ? WHERE id = ?`
+        `UPDATE command_runs SET status = ?, exit_code = ?, completed_at = ? WHERE id = ?`
       )
-      .run(status, finalOutput, exitCode, now, runId);
+      .run(status, exitCode, now, runId);
   }
 
   /**
    * Mark run as killed
    */
-  markKilled(runId, finalOutput) {
+  markKilled(runId) {
     const now = Date.now();
     this.db
       .prepare(
-        `UPDATE command_runs SET status = 'killed', output = ?, completed_at = ? WHERE id = ?`
+        `UPDATE command_runs SET status = 'killed', completed_at = ? WHERE id = ?`
       )
-      .run(finalOutput, now, runId);
+      .run(now, runId);
   }
 
   /**
@@ -72,7 +123,9 @@ export class CommandRunRepository extends BaseRepository {
    */
   getBySessionId(sessionId) {
     const rows = this.db
-      .prepare('SELECT * FROM command_runs WHERE session_id = ? ORDER BY started_at DESC')
+      .prepare(`SELECT cr.*, EXISTS(SELECT 1 FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS has_output,
+        (SELECT COALESCE(MAX(sequence), 0) FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS output_high_water
+        FROM command_runs cr WHERE session_id = ? ORDER BY started_at DESC`)
       .all(sessionId);
     return this.mapAll(rows);
   }
@@ -83,7 +136,9 @@ export class CommandRunRepository extends BaseRepository {
    */
   getRecentBySessionId(sessionId, windowMs = 3600000, includeRunning = true) {
     const cutoffTime = Date.now() - windowMs;
-    let query = `SELECT * FROM command_runs WHERE session_id = ?`;
+    let query = `SELECT cr.*, EXISTS(SELECT 1 FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS has_output,
+      (SELECT COALESCE(MAX(sequence), 0) FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS output_high_water
+      FROM command_runs cr WHERE session_id = ?`;
 
     if (includeRunning) {
       query += ` AND (started_at > ? OR status = 'running')`;
@@ -101,7 +156,9 @@ export class CommandRunRepository extends BaseRepository {
    * Get a single run by ID
    */
   getById(id) {
-    const row = this.db.prepare('SELECT * FROM command_runs WHERE id = ?').get(id);
+    const row = this.db.prepare(`SELECT cr.*, EXISTS(SELECT 1 FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS has_output,
+      (SELECT COALESCE(MAX(sequence), 0) FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS output_high_water
+      FROM command_runs cr WHERE id = ?`).get(id);
     return this.map(row);
   }
 
@@ -110,7 +167,9 @@ export class CommandRunRepository extends BaseRepository {
    */
   getLastRunForButton(buttonId) {
     const row = this.db
-      .prepare('SELECT * FROM command_runs WHERE button_id = ? ORDER BY started_at DESC LIMIT 1')
+      .prepare(`SELECT cr.*, EXISTS(SELECT 1 FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS has_output,
+        (SELECT COALESCE(MAX(sequence), 0) FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS output_high_water
+        FROM command_runs cr WHERE button_id = ? ORDER BY started_at DESC LIMIT 1`)
       .get(buttonId);
     return this.map(row);
   }
@@ -183,6 +242,8 @@ export class CommandRunRepository extends BaseRepository {
         `SELECT *
          FROM (
            SELECT cr.id, cr.session_id, cr.button_id, cr.status, cr.exit_code, cr.started_at, cr.completed_at,
+             EXISTS(SELECT 1 FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS has_output,
+             (SELECT COALESCE(MAX(sequence), 0) FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS output_high_water,
              ROW_NUMBER() OVER (PARTITION BY cr.session_id, cr.button_id ORDER BY COALESCE(cr.completed_at, cr.started_at) DESC, cr.id DESC) as rn
            FROM command_runs cr
            INNER JOIN sessions s ON cr.session_id = s.id
@@ -206,6 +267,8 @@ export class CommandRunRepository extends BaseRepository {
         `SELECT *
          FROM (
            SELECT cr.id, cr.session_id, cr.button_id, cr.status, cr.exit_code, cr.output, cr.started_at, cr.completed_at,
+             EXISTS(SELECT 1 FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS has_output,
+             (SELECT COALESCE(MAX(sequence), 0) FROM command_run_output_chunks c WHERE c.run_id = cr.id) AS output_high_water,
              ROW_NUMBER() OVER (PARTITION BY cr.button_id ORDER BY COALESCE(cr.completed_at, cr.started_at) DESC, cr.id DESC) as rn
            FROM command_runs cr
            WHERE cr.session_id = ?

--- a/packages/server/src/db/CommandRunRepository.test.js
+++ b/packages/server/src/db/CommandRunRepository.test.js
@@ -54,17 +54,20 @@ describe('CommandRunRepository', () => {
   });
 
   describe('appendOutput', () => {
-    it('appends text to run output', () => {
+    it('appends text as ordered output chunks', () => {
       const run = repository.create({ id: 'run-1', sessionId: testSessionId, buttonId: testButtonId });
       expect(run.output).toBe('');
 
       repository.appendOutput('run-1', 'line 1\n');
-      let updated = repository.getById('run-1');
-      expect(updated.output).toBe('line 1\n');
+      let page = repository.readAfter('run-1');
+      expect(page.chunks).toEqual([{ sequence: 1, content: 'line 1\n' }]);
 
       repository.appendOutput('run-1', 'line 2\n');
-      updated = repository.getById('run-1');
-      expect(updated.output).toBe('line 1\nline 2\n');
+      page = repository.readAfter('run-1');
+      expect(page.chunks).toEqual([
+        { sequence: 1, content: 'line 1\n' },
+        { sequence: 2, content: 'line 2\n' },
+      ]);
     });
 
     it('handles empty text gracefully', () => {
@@ -85,36 +88,36 @@ describe('CommandRunRepository', () => {
       repository.create({ id: 'run-1', sessionId: testSessionId, buttonId: testButtonId });
       repository.appendOutput('run-1', 'some output');
 
-      repository.complete('run-1', 0, 'final output');
+      repository.complete('run-1', 0);
 
       const run = repository.getById('run-1');
       expect(run.status).toBe('success');
       expect(run.exitCode).toBe(0);
-      expect(run.output).toBe('final output');
+      expect(run.hasOutput).toBe(true);
       expect(run.completedAt).toBeDefined();
     });
 
     it('marks run as error with non-zero exit code', () => {
       repository.create({ id: 'run-1', sessionId: testSessionId, buttonId: testButtonId });
 
-      repository.complete('run-1', 1, 'error output');
+      repository.complete('run-1', 1);
 
       const run = repository.getById('run-1');
       expect(run.status).toBe('error');
       expect(run.exitCode).toBe(1);
-      expect(run.output).toBe('error output');
+      expect(run.output).toBe('');
     });
   });
 
   describe('markKilled', () => {
-    it('marks run as killed with provided output', () => {
+    it('marks run as killed without materializing output', () => {
       repository.create({ id: 'run-1', sessionId: testSessionId, buttonId: testButtonId });
 
-      repository.markKilled('run-1', 'killed output');
+      repository.markKilled('run-1');
 
       const run = repository.getById('run-1');
       expect(run.status).toBe('killed');
-      expect(run.output).toBe('killed output');
+      expect(run.output).toBe('');
       expect(run.completedAt).toBeDefined();
     });
   });
@@ -458,14 +461,16 @@ describe('CommandRunRepository', () => {
   });
 
   describe('output exclusion in lightweight queries', () => {
-    it('getLatestRunsForSession includes output (needed for status modal)', () => {
+    it('getLatestRunsForSession returns output metadata without content', () => {
       repository.create({ id: 'run-1', sessionId: testSessionId, buttonId: testButtonId });
-      repository.complete('run-1', 0, 'full output content');
+      repository.appendOutput('run-1', 'full output content');
+      repository.complete('run-1', 0);
 
       const latestRuns = repository.getLatestRunsForSession(testSessionId);
       expect(latestRuns.length).toBe(1);
       expect(latestRuns[0].id).toBe('run-1');
-      expect(latestRuns[0].output).toBe('full output content');
+      expect(latestRuns[0].output).toBe('');
+      expect(latestRuns[0].hasOutput).toBe(true);
     });
 
     it('getLatestRunsForProject returns empty output (excludes output column)', () => {
@@ -480,12 +485,14 @@ describe('CommandRunRepository', () => {
       expect(latestRuns[0].output).toBe('');
     });
 
-    it('getById still returns full output', () => {
+    it('getById returns output metadata without full output', () => {
       repository.create({ id: 'run-1', sessionId: testSessionId, buttonId: testButtonId });
-      repository.complete('run-1', 0, 'full output content');
+      repository.appendOutput('run-1', 'full output content');
+      repository.complete('run-1', 0);
 
       const run = repository.getById('run-1');
-      expect(run.output).toBe('full output content');
+      expect(run.output).toBe('');
+      expect(run.hasOutput).toBe(true);
     });
   });
 

--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -178,6 +178,7 @@ export const allMigrations = validateMigrations([
 
   // --- Command buttons ---
   m.get('command_buttons-add-show_on_list'),
+  m.get('command_runs-create-output-chunks'),
 
   // --- Session todos ---
   c.get('session_todos-add-conversation_id'),

--- a/packages/server/src/db/migrations/miscMigrations.js
+++ b/packages/server/src/db/migrations/miscMigrations.js
@@ -71,6 +71,23 @@ export const miscMigrations = [
       addColumnIfMissing(db, 'command_buttons', 'show_on_list', 'INTEGER NOT NULL DEFAULT 0');
     },
   },
+  {
+    name: 'command_runs-create-output-chunks',
+    up(db) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS command_run_output_chunks (
+          run_id TEXT NOT NULL REFERENCES command_runs(id) ON DELETE CASCADE,
+          sequence INTEGER NOT NULL,
+          content TEXT NOT NULL,
+          byte_length INTEGER NOT NULL,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          PRIMARY KEY (run_id, sequence)
+        );
+        CREATE INDEX IF NOT EXISTS idx_command_run_output_chunks_run_sequence
+          ON command_run_output_chunks(run_id, sequence);
+      `);
+    },
+  },
 
   // --- Session templates ---
   {

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -3,8 +3,8 @@ import { execSync } from 'child_process';
 import { mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { createApp } from './app.js';
-import { initDatabase } from './database.js';
-import { initWebSocket, webSocketManager } from './websocket.js';
+import { initDatabase, commandRuns, sessions } from './database.js';
+import { initWebSocket, webSocketManager, setCommandRunOutputAuthorizer } from './websocket.js';
 import { parseCliOptions } from './cli.js';
 import { settings } from './db/index.js';
 import * as prStatusService from './services/prStatusService.js';
@@ -54,6 +54,11 @@ mkdirSync(dirname(dbPath), { recursive: true });
 
 // Initialize database
 initDatabase(dbPath);
+setCommandRunOutputAuthorizer((runId, requestedSessionId) => {
+  const run = commandRuns.getById(runId);
+  const rootSessionId = sessions.getRootSessionId(requestedSessionId);
+  return { allowed: Boolean(run && rootSessionId && run.sessionId === rootSessionId), highWater: run ? commandRuns.getHighWater(runId) : 0 };
+});
 console.log(`Database initialized: ${dbPath}`);
 console.log(`VCR_MODE: ${process.env.VCR_MODE || '(unset)'}`);
 

--- a/packages/server/src/schema.sql
+++ b/packages/server/src/schema.sql
@@ -274,6 +274,19 @@ CREATE TABLE IF NOT EXISTS command_runs (
   completed_at INTEGER
 );
 
+-- Command output is deliberately kept out of command_runs.  Updating a large
+-- TEXT field for every flush copies the entire transcript in SQLite.
+CREATE TABLE IF NOT EXISTS command_run_output_chunks (
+  run_id TEXT NOT NULL REFERENCES command_runs(id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  byte_length INTEGER NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  PRIMARY KEY (run_id, sequence)
+);
+CREATE INDEX IF NOT EXISTS idx_command_run_output_chunks_run_sequence
+  ON command_run_output_chunks(run_id, sequence);
+
 CREATE TABLE IF NOT EXISTS project_session_defaults (
   id TEXT PRIMARY KEY,
   project_id TEXT NOT NULL UNIQUE,

--- a/packages/server/src/services/commandOutputMetrics.js
+++ b/packages/server/src/services/commandOutputMetrics.js
@@ -1,0 +1,41 @@
+/**
+ * Lightweight, in-memory diagnostics for command-output transport. Values are
+ * deliberately numeric only: command output must never become telemetry.
+ */
+export const COMMAND_OUTPUT_METRICS = Object.freeze({
+  PRODUCED_BYTES: 'producedBytes',
+  PERSISTED_BYTES: 'persistedBytes',
+  FLUSH_COUNT: 'flushCount',
+  FLUSH_FAILURES: 'flushFailures',
+  FLUSH_DURATION_MS: 'flushDurationMs',
+  OUTPUT_BYTES_SENT: 'outputBytesSent',
+  OUTPUT_RESYNCS: 'outputResyncs',
+  BACKPRESSURE_EVENTS: 'backpressureEvents',
+  OUTPUT_EVENTS: 'outputEvents',
+  LIFECYCLE_EVENTS: 'lifecycleEvents',
+  OUTPUT_SUBSCRIBERS: 'outputSubscribers',
+});
+
+class CommandOutputMetrics {
+  #counters = new Map();
+  #gauges = new Map();
+
+  increment(name, amount = 1) {
+    this.#counters.set(name, (this.#counters.get(name) || 0) + amount);
+  }
+
+  setGauge(name, value) {
+    this.#gauges.set(name, value);
+  }
+
+  snapshot() {
+    return { counters: Object.fromEntries(this.#counters), gauges: Object.fromEntries(this.#gauges) };
+  }
+
+  reset() {
+    this.#counters.clear();
+    this.#gauges.clear();
+  }
+}
+
+export const commandOutputMetrics = new CommandOutputMetrics();

--- a/packages/server/src/services/commandOutputMetrics.test.js
+++ b/packages/server/src/services/commandOutputMetrics.test.js
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { commandOutputMetrics, COMMAND_OUTPUT_METRICS } from './commandOutputMetrics.js';
+
+describe('command output metrics', () => {
+  beforeEach(() => commandOutputMetrics.reset());
+
+  it('exposes numeric counters and gauges without retaining output content', () => {
+    commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.PRODUCED_BYTES, 12);
+    commandOutputMetrics.setGauge(`${COMMAND_OUTPUT_METRICS.OUTPUT_SUBSCRIBERS}:run-1`, 2);
+
+    expect(commandOutputMetrics.snapshot()).toEqual({
+      counters: { producedBytes: 12 },
+      gauges: { 'outputSubscribers:run-1': 2 },
+    });
+    expect(JSON.stringify(commandOutputMetrics.snapshot())).not.toContain('secret command output');
+  });
+});

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -3,6 +3,7 @@ import * as osModule from 'os';
 import { commandRuns } from '../database.js';
 import { createRobustEnv } from './nodeSpawnHelper.js';
 import { TerminalOutputProcessor } from './terminalOutput.js';
+import { commandOutputMetrics, COMMAND_OUTPUT_METRICS } from './commandOutputMetrics.js';
 
 // Re-export for backward compatibility
 export { stripAnsiCodes, TerminalOutputProcessor } from './terminalOutput.js';
@@ -76,17 +77,27 @@ export class CommandRunner {
     entry.onOutput?.(chunks.join(''));
     if (!entry.sessionId || !entry.buttonId) return;
     if (!commandRuns || typeof commandRuns.appendBatch !== 'function') return;
+    const startedAt = performance.now();
+    commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.FLUSH_COUNT);
     try {
       const persisted = commandRuns.appendBatch(runId, chunks);
+      commandOutputMetrics.increment(
+        COMMAND_OUTPUT_METRICS.PERSISTED_BYTES,
+        chunks.reduce((bytes, chunk) => bytes + Buffer.byteLength(chunk), 0),
+      );
       for (const chunk of persisted) entry.onOutputChunk?.(chunk);
       Object.assign(entry, { lastDbWrite: Date.now() });
     } catch (err) {
+      commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.FLUSH_FAILURES);
       console.warn(`[commandRunner.run] Warning: Error flushing output to database for runId: ${runId}`, err.message);
+    } finally {
+      commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.FLUSH_DURATION_MS, performance.now() - startedAt);
     }
   }
 
   #appendOutput(entry, text) {
     if (!text) return;
+    commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.PRODUCED_BYTES, Buffer.byteLength(text));
     Object.assign(entry, {
       outputChunks: [...entry.outputChunks, text],
       outputBytes: entry.outputBytes + Buffer.byteLength(text),

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -35,6 +35,7 @@ export class CommandRunner {
    * Create database record for a command run.
    */
   #createDatabaseRecord(runId, sessionId, buttonId) {
+    if (!sessionId || !buttonId) return;
     if (!commandRuns || typeof commandRuns.create !== 'function') return;
     try {
       commandRuns.create({ id: runId, sessionId, buttonId });
@@ -68,15 +69,16 @@ export class CommandRunner {
    */
   #flushOutputBuffer(entryInput, runId) {
     const entry = entryInput;
-    if (!entry.outputChunks.length || !entry.sessionId || !entry.buttonId) return;
-    if (!commandRuns || typeof commandRuns.appendBatch !== 'function') return;
+    if (!entry.outputChunks.length) return;
     const chunks = entry.outputChunks;
     entry.outputChunks = [];
     entry.outputBytes = 0;
+    entry.onOutput?.(chunks.join(''));
+    if (!entry.sessionId || !entry.buttonId) return;
+    if (!commandRuns || typeof commandRuns.appendBatch !== 'function') return;
     try {
       const persisted = commandRuns.appendBatch(runId, chunks);
       for (const chunk of persisted) entry.onOutputChunk?.(chunk);
-      entry.onOutput?.(chunks.join(''));
       Object.assign(entry, { lastDbWrite: Date.now() });
     } catch (err) {
       console.warn(`[commandRunner.run] Warning: Error flushing output to database for runId: ${runId}`, err.message);
@@ -160,7 +162,6 @@ export class CommandRunner {
     return new Promise((resolve) => {
       try {
         this.#createDatabaseRecord(runId, sessionId, buttonId);
-        onStarted?.();
         const wrappedCommand = wrapCommandForPlatform(command);
 
         const child = spawn('sh', ['-c', wrappedCommand], {
@@ -178,6 +179,10 @@ export class CommandRunner {
           try { callbacks.onOutputChunk?.(chunk); } catch (err) { console.warn('[commandRunner.run] Output callback failed:', err.message); }
         };
         this.processes.set(runId, entry);
+        // Do not announce the run until status lookups can observe it. Clients
+        // refresh active runs in response to this event and would otherwise
+        // race the process-map registration, clearing the running indicator.
+        onStarted?.();
 
         entry.bufferFlushTimer = setInterval(() => this.#flushOutputBuffer(entry, runId), this.outputBufferFlushInterval);
 

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -24,10 +24,11 @@ export function wrapCommandForPlatform(command, currentPlatform = osModule.platf
  * Service for running commands and managing their execution
  */
 export class CommandRunner {
-  constructor({ outputBroadcastInterval = 250, outputDbFlushInterval = 500 } = {}) {
+  constructor({ outputBroadcastInterval = 250, outputDbFlushInterval = 500, outputBufferMaxBytes = 64 * 1024 } = {}) {
     this.processes = new Map();
     this.outputBroadcastInterval = outputBroadcastInterval;
     this.outputBufferFlushInterval = outputDbFlushInterval;
+    this.outputBufferMaxBytes = outputBufferMaxBytes;
   }
 
   /**
@@ -52,9 +53,8 @@ export class CommandRunner {
       startTime: Date.now(),
       sessionId,
       buttonId,
-      output: '',
-      dbOutputBuffer: '',
-      broadcastOutputBuffer: '',
+      outputChunks: [],
+      outputBytes: 0,
       lastDbWrite: Date.now(),
       bufferFlushTimer: null,
       broadcastFlushTimer: null,
@@ -68,32 +68,26 @@ export class CommandRunner {
    */
   #flushOutputBuffer(entryInput, runId) {
     const entry = entryInput;
-    if (!entry.dbOutputBuffer || !entry.sessionId || !entry.buttonId) return;
-    if (!commandRuns || typeof commandRuns.appendOutput !== 'function') return;
+    if (!entry.outputChunks.length || !entry.sessionId || !entry.buttonId) return;
+    if (!commandRuns || typeof commandRuns.appendBatch !== 'function') return;
+    const chunks = entry.outputChunks;
+    entry.outputChunks = [];
+    entry.outputBytes = 0;
     try {
-      commandRuns.appendOutput(runId, entry.dbOutputBuffer);
+      const persisted = commandRuns.appendBatch(runId, chunks);
+      for (const chunk of persisted) entry.onOutputChunk?.(chunk);
+      entry.onOutput?.(chunks.join(''));
       Object.assign(entry, { lastDbWrite: Date.now() });
     } catch (err) {
       console.warn(`[commandRunner.run] Warning: Error flushing output to database for runId: ${runId}`, err.message);
-    }
-    Object.assign(entry, { dbOutputBuffer: '' });
-  }
-
-  #flushBroadcastOutput(entry, onOutput) {
-    if (!entry.broadcastOutputBuffer) return;
-    const output = entry.broadcastOutputBuffer;
-    Object.assign(entry, { broadcastOutputBuffer: '' });
-    try { onOutput?.(output); } catch (err) {
-      console.warn('[commandRunner.run] Output callback failed:', err.message);
     }
   }
 
   #appendOutput(entry, text) {
     if (!text) return;
     Object.assign(entry, {
-      output: entry.output + text,
-      dbOutputBuffer: entry.dbOutputBuffer + text,
-      broadcastOutputBuffer: entry.broadcastOutputBuffer + text,
+      outputChunks: [...entry.outputChunks, text],
+      outputBytes: entry.outputBytes + Buffer.byteLength(text),
     });
   }
 
@@ -108,23 +102,22 @@ export class CommandRunner {
    * @param {{ entry: object, runId: string, exitCode: number|null, signal: string|null }} ctx
    * @param {function|undefined} onComplete - Completion callback
    */
-  #handleProcessClose(ctx, onComplete, onOutput) {
+  #handleProcessClose(ctx, onComplete) {
     const { entry, runId, exitCode, signal } = ctx;
     if (entry.finalized) return exitCode ?? 1;
     entry.finalized = true;
     this.#clearFlushTimers(entry);
     const remainingText = entry.outputProcessor.flush();
     this.#appendOutput(entry, remainingText);
-    this.#flushBroadcastOutput(entry, onOutput);
     this.#flushOutputBuffer(entry, runId);
     console.log(`[commandRunner.run] Process closed for runId: ${runId}, exitCode: ${exitCode}, signal: ${signal}`);
 
     if (commandRuns && typeof commandRuns.complete === 'function' && typeof commandRuns.markKilled === 'function') {
       try {
         if (signal) {
-          commandRuns.markKilled(runId, entry.output);
+          commandRuns.markKilled(runId);
         } else {
-          commandRuns.complete(runId, exitCode || 0, entry.output);
+          commandRuns.complete(runId, exitCode || 0);
         }
         console.log(`[commandRunner.run] Marked run as complete in database for runId: ${runId}`);
       } catch (dbErr) {
@@ -133,29 +126,26 @@ export class CommandRunner {
     }
 
     this.processes.delete(runId);
-    if (onComplete) onComplete(exitCode, entry.output);
+    if (onComplete) onComplete(exitCode);
     // Normalize to 1 on signal termination (signal info already logged above)
     return exitCode ?? 1;
   }
 
   /** Handle a run failure (process error or setup exception). Flushes output, marks failed, resolves. */
-  #handleRunFailure({ entry: entryParam, runId, err, onError, onOutput, resolve }) {
+  #handleRunFailure({ entry: entryParam, runId, err, onError, resolve }) {
     const entry = entryParam;
-    let errorOutput = `[Error] Failed to execute command: ${err.message}`;
     if (entry) {
       if (entry.finalized) return;
       entry.finalized = true;
       this.#clearFlushTimers(entry);
       this.#appendOutput(entry, entry.outputProcessor.flush());
-      this.#flushBroadcastOutput(entry, onOutput);
       this.#flushOutputBuffer(entry, runId);
-      errorOutput = entry.output;
     }
     const msg = entry ? `Failed to execute command: ${err.message}` : `Error running command: ${err.message}`;
     console.error(`[commandRunner.run] Error for runId: ${runId}`, err);
     if (onError) onError(msg);
     if (commandRuns && typeof commandRuns.complete === 'function') {
-      try { commandRuns.complete(runId, 1, errorOutput); } catch (dbErr) { console.warn(`[commandRunner.run] DB error for runId: ${runId}`, dbErr.message); }
+      try { commandRuns.complete(runId, 1); } catch (dbErr) { console.warn(`[commandRunner.run] DB error for runId: ${runId}`, dbErr.message); }
     }
     this.processes.delete(runId);
     resolve(1);
@@ -164,12 +154,13 @@ export class CommandRunner {
   /** Run a command and stream output via callback. Returns exit code. */
   async run(params, callbacks = {}, metadata = {}) {
     const { runId, command, workingDirectory } = params;
-    const { onOutput, onComplete, onError } = callbacks;
+    const { onOutput, onComplete, onError, onStarted } = callbacks;
     const { sessionId, buttonId } = metadata;
 
     return new Promise((resolve) => {
       try {
         this.#createDatabaseRecord(runId, sessionId, buttonId);
+        onStarted?.();
         const wrappedCommand = wrapCommandForPlatform(command);
 
         const child = spawn('sh', ['-c', wrappedCommand], {
@@ -180,18 +171,21 @@ export class CommandRunner {
         });
 
         const entry = this.#createProcessEntry(child, sessionId, buttonId);
+        entry.onOutput = (text) => {
+          try { onOutput?.(text); } catch (err) { console.warn('[commandRunner.run] Output callback failed:', err.message); }
+        };
+        entry.onOutputChunk = (chunk) => {
+          try { callbacks.onOutputChunk?.(chunk); } catch (err) { console.warn('[commandRunner.run] Output callback failed:', err.message); }
+        };
         this.processes.set(runId, entry);
 
         entry.bufferFlushTimer = setInterval(() => this.#flushOutputBuffer(entry, runId), this.outputBufferFlushInterval);
-        entry.broadcastFlushTimer = setInterval(
-          () => this.#flushBroadcastOutput(entry, onOutput),
-          this.outputBroadcastInterval,
-        );
 
         const handleData = (data) => {
           const text = entry.outputProcessor.process(data.toString());
           if (text) {
             this.#appendOutput(entry, text);
+            if (entry.outputBytes >= this.outputBufferMaxBytes) this.#flushOutputBuffer(entry, runId);
           }
         };
 
@@ -199,14 +193,14 @@ export class CommandRunner {
         child.stderr.on('data', handleData);
 
         child.on('error', (err) => {
-          this.#handleRunFailure({ entry, runId, err, onError, onOutput, resolve });
+          this.#handleRunFailure({ entry, runId, err, onError, resolve });
         });
 
         child.on('close', (exitCode, signal) => {
-          resolve(this.#handleProcessClose({ entry, runId, exitCode, signal }, onComplete, onOutput));
+          resolve(this.#handleProcessClose({ entry, runId, exitCode, signal }, onComplete));
         });
       } catch (err) {
-        this.#handleRunFailure({ entry: null, runId, err, onError, onOutput, resolve });
+        this.#handleRunFailure({ entry: null, runId, err, onError, resolve });
       }
     });
   }
@@ -286,7 +280,7 @@ export class CommandRunner {
           buttonId: entry.buttonId,
           sessionId: entry.sessionId,
           status: 'running',
-          output: entry.output,
+          output: '',
           exitCode: null,
           startedAt: entry.startTime,
         });
@@ -302,7 +296,7 @@ export class CommandRunner {
     );
     if (typeof commandRuns.complete === 'function') {
       try {
-        commandRuns.complete(dbRun.id, -1, dbRun.output || '');
+        commandRuns.complete(dbRun.id, -1);
       } catch (updateErr) {
         console.warn(
           `[commandRunner.getRunsBySession] Failed to update orphaned run: ${updateErr.message}`
@@ -328,7 +322,7 @@ export class CommandRunner {
       runId: dbRun.id,
       buttonId: dbRun.buttonId,
       status,
-      output: dbRun.output,
+      output: '',
       exitCode,
       startedAt: dbRun.startedAt,
     };
@@ -344,7 +338,7 @@ export class CommandRunner {
           runId,
           buttonId: entry.buttonId,
           status: 'running',
-          output: entry.output,
+          output: '',
           exitCode: undefined,
           startedAt: entry.startTime,
         });

--- a/packages/server/src/services/commandRunner.js
+++ b/packages/server/src/services/commandRunner.js
@@ -1,25 +1,12 @@
 import { spawn } from 'child_process';
-import * as osModule from 'os';
 import { commandRuns } from '../database.js';
-import { createRobustEnv } from './nodeSpawnHelper.js';
 import { TerminalOutputProcessor } from './terminalOutput.js';
 import { commandOutputMetrics, COMMAND_OUTPUT_METRICS } from './commandOutputMetrics.js';
+import { createCommandRunnerEnv, wrapCommandForPlatform } from './commandRunnerPlatform.js';
 
 // Re-export for backward compatibility
 export { stripAnsiCodes, TerminalOutputProcessor } from './terminalOutput.js';
-
-export function createCommandRunnerEnv(baseEnv = process.env) {
-  const env = createRobustEnv(baseEnv);
-  delete env.CIRCUSCHIEF_COMMIT_ATTRIBUTION;
-  return env;
-}
-
-export function wrapCommandForPlatform(command, currentPlatform = osModule.platform()) {
-  const cmd = JSON.stringify(command);
-  return currentPlatform === 'linux'
-    ? `script -q -e -c ${cmd} /dev/null`
-    : `script -q /dev/null sh -c ${cmd} < /dev/null`;
-}
+export { createCommandRunnerEnv, wrapCommandForPlatform } from './commandRunnerPlatform.js';
 
 /**
  * Service for running commands and managing their execution

--- a/packages/server/src/services/commandRunner.test.js
+++ b/packages/server/src/services/commandRunner.test.js
@@ -19,19 +19,16 @@ describe('CommandRunner', () => {
     it('coalesces rapid output and flushes the final buffer before completion', async () => {
       const throttledRunner = new CommandRunner({ outputBroadcastInterval: 1000, outputDbFlushInterval: 1000 });
       const output = [];
-      let completedOutput = '';
 
       const exitCode = await throttledRunner.run(
         { runId: 'coalesced-output', command: 'printf first; printf second', workingDirectory: process.cwd() },
-        { onOutput: text => output.push(text), onComplete: (_code, text) => { completedOutput = text; } },
+        { onOutput: text => output.push(text) },
       );
 
       expect(exitCode).toBe(0);
       expect(output).toHaveLength(1);
       expect(output[0]).toContain('first');
       expect(output[0]).toContain('second');
-      expect(completedOutput).toContain('first');
-      expect(completedOutput).toContain('second');
     });
 
     it('contains an output callback failure while still completing the run', async () => {
@@ -44,7 +41,7 @@ describe('CommandRunner', () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(onComplete).toHaveBeenCalledWith(0, expect.stringContaining('retained'));
+      expect(onComplete).toHaveBeenCalledWith(0);
     });
 
     it('strips commit attribution from command-button environments', () => {
@@ -223,16 +220,14 @@ describe('CommandRunner', () => {
       it('calls onComplete callback with correct parameters', async () => {
         let callbackCalled = false;
         let callbackExitCode = null;
-        let callbackOutput = null;
 
         const exitCode = await runner.run(
           { runId: 'test-options-4', command: 'echo "complete test"', workingDirectory: process.cwd() },
           {
             onOutput: () => {},
-            onComplete: (code, output) => {
+            onComplete: (code) => {
               callbackCalled = true;
               callbackExitCode = code;
-              callbackOutput = output;
             },
           }
         );
@@ -240,7 +235,6 @@ describe('CommandRunner', () => {
         expect(exitCode).toBe(0);
         expect(callbackCalled).toBe(true);
         expect(callbackExitCode).toBe(0);
-        expect(callbackOutput).toContain('complete test');
       });
 
       it('calls onError callback when command fails', async () => {
@@ -515,17 +509,14 @@ describe('CommandRunner', () => {
       }
     });
 
-    it('buffers output in the process entry', async () => {
+    it('delivers buffered output through onOutput', async () => {
       const runId = 'test-buffer-1';
       let capturedOutput = '';
 
       await runner.run(
         { runId, command: 'echo "buffered output"', workingDirectory: process.cwd() },
         {
-          onOutput: () => {},
-          onComplete: (exitCode, output) => {
-            capturedOutput = output;
-          },
+          onOutput: (output) => { capturedOutput += output; },
           onError: () => {},
         },
         { sessionId: 'session-1', buttonId: 'button-1' }
@@ -534,13 +525,14 @@ describe('CommandRunner', () => {
       expect(capturedOutput).toContain('buffered output');
     });
 
-    it('passes buffered output to onComplete callback', async () => {
+    it('does not attach the transcript to the completion callback', async () => {
       let completeOutput = null;
+      let streamedOutput = '';
 
       await runner.run(
         { runId: 'test-complete-output', command: 'echo "line1"; echo "line2"', workingDirectory: process.cwd() },
         {
-          onOutput: () => {},
+          onOutput: (output) => { streamedOutput += output; },
           onComplete: (exitCode, output) => {
             completeOutput = output;
           },
@@ -549,8 +541,9 @@ describe('CommandRunner', () => {
         { sessionId: 's1', buttonId: 'b1' }
       );
 
-      expect(completeOutput).toContain('line1');
-      expect(completeOutput).toContain('line2');
+      expect(completeOutput).toBeUndefined();
+      expect(streamedOutput).toContain('line1');
+      expect(streamedOutput).toContain('line2');
     });
 
     it('works without metadata', async () => {
@@ -607,7 +600,7 @@ describe('CommandRunner', () => {
       expect(runs).toEqual([]);
     });
 
-    it('includes buffered output in returned runs', async () => {
+    it('does not materialize buffered output in returned run metadata', async () => {
       const runId = 'test-output-in-runs';
       let runsWithOutput = [];
 
@@ -624,7 +617,7 @@ describe('CommandRunner', () => {
       await runPromise;
 
       expect(runsWithOutput.length).toBe(1);
-      expect(runsWithOutput[0].output).toContain('captured');
+      expect(runsWithOutput[0].output).toBe('');
     });
   });
 
@@ -789,24 +782,23 @@ describe('CommandRunner', () => {
       expect(collectedOutput).toContain('line3');
     });
 
-    it('passes output buffer to onComplete callback', async () => {
-      let completeOutput = '';
+    it('delivers output separately from the completion callback', async () => {
+      let streamedOutput = '';
+      const onComplete = vi.fn();
 
       await runner.run(
         { runId: 'test-complete-buffer', command: 'echo "output1"; echo "output2"', workingDirectory: process.cwd() },
         {
-          onOutput: () => {},
-          onComplete: (exitCode, output) => {
-            completeOutput = output;
-          },
+          onOutput: (output) => { streamedOutput += output; },
+          onComplete,
           onError: () => {},
         },
         { sessionId: 'complete-session', buttonId: 'btn-1' }
       );
 
-      expect(completeOutput.length).toBeGreaterThan(0);
-      expect(completeOutput).toContain('output1');
-      expect(completeOutput).toContain('output2');
+      expect(onComplete).toHaveBeenCalledWith(0);
+      expect(streamedOutput).toContain('output1');
+      expect(streamedOutput).toContain('output2');
     });
 
     it('handles large output streams without losing data', async () => {
@@ -821,9 +813,7 @@ describe('CommandRunner', () => {
           onOutput: (text) => {
             totalOutputLength += text.length;
           },
-          onComplete: (exitCode, output) => {
-            totalOutputLength = output.length;
-          },
+          onComplete: () => {},
           onError: () => {},
         },
         { sessionId: 'large-session', buttonId: 'btn-1' }

--- a/packages/server/src/services/commandRunnerPlatform.js
+++ b/packages/server/src/services/commandRunnerPlatform.js
@@ -1,0 +1,15 @@
+import * as osModule from 'os';
+import { createRobustEnv } from './nodeSpawnHelper.js';
+
+export function createCommandRunnerEnv(baseEnv = process.env) {
+  const env = createRobustEnv(baseEnv);
+  delete env.CIRCUSCHIEF_COMMIT_ATTRIBUTION;
+  return env;
+}
+
+export function wrapCommandForPlatform(command, currentPlatform = osModule.platform()) {
+  const cmd = JSON.stringify(command);
+  return currentPlatform === 'linux'
+    ? `script -q -e -c ${cmd} /dev/null`
+    : `script -q /dev/null sh -c ${cmd} < /dev/null`;
+}

--- a/packages/server/src/websocket.js
+++ b/packages/server/src/websocket.js
@@ -7,5 +7,7 @@ export {
   broadcastToSession,
   broadcastToProject,
   broadcastToSessionAndProject,
+  broadcastCommandRunOutput,
+  setCommandRunOutputAuthorizer,
   getWebSocketServer,
 } from './ws/index.js';

--- a/packages/server/src/ws/WebSocketManager.js
+++ b/packages/server/src/ws/WebSocketManager.js
@@ -1,5 +1,6 @@
 import { WebSocketServer } from 'ws';
 import { WS_MESSAGE_TYPES, parseMessage, createMessage } from '@circuschief/shared';
+import { commandOutputMetrics, COMMAND_OUTPUT_METRICS } from '../services/commandOutputMetrics.js';
 
 const OUTPUT_SOCKET_HIGH_WATER_BYTES = 256 * 1024;
 
@@ -59,7 +60,10 @@ export class WebSocketManager {
         for (const subscribers of this.#projectSubscriptions.values()) {
           subscribers.delete(ws);
         }
-        for (const subscribers of this.#commandRunOutputSubscriptions.values()) subscribers.delete(ws);
+        for (const [runId, subscribers] of this.#commandRunOutputSubscriptions) {
+          subscribers.delete(ws);
+          commandOutputMetrics.setGauge(`${COMMAND_OUTPUT_METRICS.OUTPUT_SUBSCRIBERS}:${runId}`, subscribers.size);
+        }
       });
 
       ws.on('error', (error) => {
@@ -143,13 +147,17 @@ export class WebSocketManager {
     }
     if (!this.#commandRunOutputSubscriptions.has(runId)) this.#commandRunOutputSubscriptions.set(runId, new Set());
     this.#commandRunOutputSubscriptions.get(runId).add(ws);
+    commandOutputMetrics.setGauge(`${COMMAND_OUTPUT_METRICS.OUTPUT_SUBSCRIBERS}:${runId}`, this.#commandRunOutputSubscriptions.get(runId).size);
     if (ws.readyState === 1) ws.send(createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_SUBSCRIBED, {
       runId, highWater: authorization.highWater,
     }));
   }
 
   #handleUnsubscribeCommandRunOutput(ws, message) {
-    if (message.runId) this.#commandRunOutputSubscriptions.get(message.runId)?.delete(ws);
+    if (!message.runId) return;
+    const subscribers = this.#commandRunOutputSubscriptions.get(message.runId);
+    subscribers?.delete(ws);
+    commandOutputMetrics.setGauge(`${COMMAND_OUTPUT_METRICS.OUTPUT_SUBSCRIBERS}:${message.runId}`, subscribers?.size || 0);
   }
 
   /** Send a persisted output chunk to explicit viewers only. */
@@ -157,19 +165,23 @@ export class WebSocketManager {
     const subscribers = this.#commandRunOutputSubscriptions.get(runId);
     if (!subscribers?.size) return;
     const message = createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId, sequence: chunk.sequence, content: chunk.content });
+    commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.OUTPUT_EVENTS);
     for (const client of subscribers) {
       if (client.readyState !== 1) continue;
       if (client.bufferedAmount >= OUTPUT_SOCKET_HIGH_WATER_BYTES) {
+        commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.BACKPRESSURE_EVENTS);
         const pending = this.#outputResyncRequired.get(client) || new Set();
         if (!pending.has(runId)) {
           pending.add(runId);
           this.#outputResyncRequired.set(client, pending);
+          commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.OUTPUT_RESYNCS);
           client.send(createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_RESYNC_REQUIRED, { runId }));
         }
         continue;
       }
       this.#outputResyncRequired.get(client)?.delete(runId);
       client.send(message);
+      commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.OUTPUT_BYTES_SENT, Buffer.byteLength(message));
     }
   }
 
@@ -179,6 +191,7 @@ export class WebSocketManager {
    * @param {Object} payload - Message payload
    */
   broadcast(type, payload) {
+    this.#recordLifecycleEvent(type);
     const message = createMessage(type, payload);
     for (const client of this.#clients) {
       if (client.readyState === 1) {
@@ -195,6 +208,7 @@ export class WebSocketManager {
    * @param {Object} payload - Message payload
    */
   broadcastToSession(sessionId, type, payload) {
+    this.#recordLifecycleEvent(type);
     const subscribers = this.#sessionSubscriptions.get(sessionId);
 
     // Buffer SESSION_USAGE_UPDATE messages if no subscribers exist
@@ -231,6 +245,7 @@ export class WebSocketManager {
    * @param {Object} payload - Message payload
    */
   broadcastToProject(projectId, type, payload) {
+    this.#recordLifecycleEvent(type);
     const subscribers = this.#projectSubscriptions.get(projectId);
     if (!subscribers || subscribers.size === 0) return;
 
@@ -245,6 +260,7 @@ export class WebSocketManager {
 
   /** Broadcast one serialized frame to the union of session and project subscribers. */
   broadcastToSessionAndProject(sessionId, projectId, type, payload) {
+    this.#recordLifecycleEvent(type);
     const subscribers = new Set([
       ...(this.#sessionSubscriptions.get(sessionId) || []),
       ...(this.#projectSubscriptions.get(projectId) || []),
@@ -265,6 +281,16 @@ export class WebSocketManager {
    */
   getServer() {
     return this.#wss;
+  }
+
+  #recordLifecycleEvent(type) {
+    if ([
+      WS_MESSAGE_TYPES.COMMAND_RUN_STARTED,
+      WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE,
+      WS_MESSAGE_TYPES.COMMAND_RUN_ERROR,
+      WS_MESSAGE_TYPES.COMMAND_RUN_KILLED,
+      WS_MESSAGE_TYPES.COMMAND_RUN_DELETED,
+    ].includes(type)) commandOutputMetrics.increment(COMMAND_OUTPUT_METRICS.LIFECYCLE_EVENTS);
   }
 
   /**

--- a/packages/server/src/ws/WebSocketManager.js
+++ b/packages/server/src/ws/WebSocketManager.js
@@ -1,6 +1,8 @@
 import { WebSocketServer } from 'ws';
 import { WS_MESSAGE_TYPES, parseMessage, createMessage } from '@circuschief/shared';
 
+const OUTPUT_SOCKET_HIGH_WATER_BYTES = 256 * 1024;
+
 /**
  * WebSocket manager class for handling WebSocket connections and messaging
  */
@@ -16,6 +18,15 @@ export class WebSocketManager {
 
   /** @type {Map<string, Set<import('ws').WebSocket>>} */
   #projectSubscriptions = new Map();
+
+  /** @type {Map<string, Set<import('ws').WebSocket>>} */
+  #commandRunOutputSubscriptions = new Map();
+  #outputResyncRequired = new WeakMap();
+  #commandRunOutputAuthorizer = null;
+
+  setCommandRunOutputAuthorizer(authorizer) {
+    this.#commandRunOutputAuthorizer = authorizer;
+  }
 
   /** @type {Map<string, Array<Object>>} */
   #usageUpdateBuffer = new Map();
@@ -48,6 +59,7 @@ export class WebSocketManager {
         for (const subscribers of this.#projectSubscriptions.values()) {
           subscribers.delete(ws);
         }
+        for (const subscribers of this.#commandRunOutputSubscriptions.values()) subscribers.delete(ws);
       });
 
       ws.on('error', (error) => {
@@ -69,6 +81,8 @@ export class WebSocketManager {
       [WS_MESSAGE_TYPES.UNSUBSCRIBE_SESSION]: () => this.#handleUnsubscribeSession(ws, message),
       [WS_MESSAGE_TYPES.SUBSCRIBE_PROJECT]: () => this.#handleSubscribeProject(ws, message),
       [WS_MESSAGE_TYPES.UNSUBSCRIBE_PROJECT]: () => this.#handleUnsubscribeProject(ws, message),
+      [WS_MESSAGE_TYPES.SUBSCRIBE_COMMAND_RUN_OUTPUT]: () => this.#handleSubscribeCommandRunOutput(ws, message),
+      [WS_MESSAGE_TYPES.UNSUBSCRIBE_COMMAND_RUN_OUTPUT]: () => this.#handleUnsubscribeCommandRunOutput(ws, message),
     };
     handlers[message.type]?.();
   }
@@ -117,6 +131,46 @@ export class WebSocketManager {
     const { projectId } = message;
     if (!projectId) return;
     this.#projectSubscriptions.get(projectId)?.delete(ws);
+  }
+
+  #handleSubscribeCommandRunOutput(ws, message) {
+    const { runId, sessionId } = message;
+    const authorization = runId && sessionId && this.#commandRunOutputAuthorizer?.(runId, sessionId);
+    // Deliberately return the same generic response for missing and cross-root runs.
+    if (!authorization?.allowed) {
+      if (ws.readyState === 1) ws.send(createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_RESYNC_REQUIRED, { runId }));
+      return;
+    }
+    if (!this.#commandRunOutputSubscriptions.has(runId)) this.#commandRunOutputSubscriptions.set(runId, new Set());
+    this.#commandRunOutputSubscriptions.get(runId).add(ws);
+    if (ws.readyState === 1) ws.send(createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_SUBSCRIBED, {
+      runId, highWater: authorization.highWater,
+    }));
+  }
+
+  #handleUnsubscribeCommandRunOutput(ws, message) {
+    if (message.runId) this.#commandRunOutputSubscriptions.get(message.runId)?.delete(ws);
+  }
+
+  /** Send a persisted output chunk to explicit viewers only. */
+  broadcastCommandRunOutput(runId, chunk) {
+    const subscribers = this.#commandRunOutputSubscriptions.get(runId);
+    if (!subscribers?.size) return;
+    const message = createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId, sequence: chunk.sequence, content: chunk.content });
+    for (const client of subscribers) {
+      if (client.readyState !== 1) continue;
+      if (client.bufferedAmount >= OUTPUT_SOCKET_HIGH_WATER_BYTES) {
+        const pending = this.#outputResyncRequired.get(client) || new Set();
+        if (!pending.has(runId)) {
+          pending.add(runId);
+          this.#outputResyncRequired.set(client, pending);
+          client.send(createMessage(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_RESYNC_REQUIRED, { runId }));
+        }
+        continue;
+      }
+      this.#outputResyncRequired.get(client)?.delete(runId);
+      client.send(message);
+    }
   }
 
   /**
@@ -253,6 +307,7 @@ export class WebSocketManager {
     this.#clients.clear();
     this.#sessionSubscriptions.clear();
     this.#projectSubscriptions.clear();
+    this.#commandRunOutputSubscriptions.clear();
     this.#usageUpdateBuffer.clear();
   }
 }

--- a/packages/server/src/ws/index.js
+++ b/packages/server/src/ws/index.js
@@ -3,6 +3,10 @@ export { WebSocketManager, webSocketManager } from './WebSocketManager.js';
 // Legacy function exports for backward compatibility
 import { webSocketManager } from './WebSocketManager.js';
 
+export function setCommandRunOutputAuthorizer(authorizer) {
+  webSocketManager.setCommandRunOutputAuthorizer(authorizer);
+}
+
 /**
  * Initialize WebSocket server
  * @param {import('http').Server} server
@@ -43,6 +47,10 @@ export function broadcastToProject(projectId, type, payload) {
 
 export function broadcastToSessionAndProject(sessionId, projectId, type, payload) {
   webSocketManager.broadcastToSessionAndProject(sessionId, projectId, type, payload);
+}
+
+export function broadcastCommandRunOutput(runId, chunk) {
+  return webSocketManager.broadcastCommandRunOutput(runId, chunk);
 }
 
 /**

--- a/packages/shared/src/protocol.js
+++ b/packages/shared/src/protocol.js
@@ -8,6 +8,8 @@ export const WS_MESSAGE_TYPES = {
   UNSUBSCRIBE_SESSION: 'unsubscribe:session',
   SUBSCRIBE_PROJECT: 'subscribe:project',
   UNSUBSCRIBE_PROJECT: 'unsubscribe:project',
+  SUBSCRIBE_COMMAND_RUN_OUTPUT: 'subscribe:command_run_output',
+  UNSUBSCRIBE_COMMAND_RUN_OUTPUT: 'unsubscribe:command_run_output',
 
   // Server -> Client
   SESSION_CREATED: 'session:created',
@@ -38,9 +40,13 @@ export const WS_MESSAGE_TYPES = {
 
   // Command button events
   COMMAND_RUN_OUTPUT: 'command:run:output',
+  COMMAND_RUN_STARTED: 'command:run:started',
   COMMAND_RUN_COMPLETE: 'command:run:complete',
   COMMAND_RUN_ERROR: 'command:run:error',
+  COMMAND_RUN_KILLED: 'command:run:killed',
   COMMAND_RUN_DELETED: 'command:run:deleted',
+  COMMAND_RUN_OUTPUT_SUBSCRIBED: 'command:run:output_subscribed',
+  COMMAND_RUN_OUTPUT_RESYNC_REQUIRED: 'command:run:output_resync_required',
 
   // System metrics events
   SYSTEM_METRICS: 'system:metrics',

--- a/packages/web/src/api/resources/CommandButtonsApi.js
+++ b/packages/web/src/api/resources/CommandButtonsApi.js
@@ -84,6 +84,12 @@ export function CommandButtonsApi(ApiClient) {
       return this._get(`/sessions/${sessionId}/circus-commands/runs/${runId}`);
     },
 
+    /** Read a bounded, cursor-based page of persisted command output. */
+    async getCommandRunOutput(sessionId, runId, { after = 0, limitBytes = 65536 } = {}) {
+      const query = new URLSearchParams({ after: String(after), limitBytes: String(limitBytes) });
+      return this._get(`/sessions/${sessionId}/circus-commands/runs/${runId}/output?${query}`);
+    },
+
     /**
      * Get the latest run for each button per session within a project
      * @param {string} projectId - Project ID

--- a/packages/web/src/components/ButtonStatusModal.vue
+++ b/packages/web/src/components/ButtonStatusModal.vue
@@ -244,6 +244,7 @@ import { computed, ref, onMounted, onBeforeUnmount, watch } from 'vue';
 import { ansiToHtml } from '../utils/ansi.js';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useOutputAutoTail } from '../composables/useOutputAutoTail.js';
+import { subscribeCommandRunOutput } from '../composables/useCommandRunOutputSubscription.js';
 
 const commandButtonsStore = useCommandButtonsStore();
 
@@ -283,6 +284,7 @@ const outputContainerRef = ref(null);
 const DISPLAY_LINE_LIMIT = 200;
 const loadingOutput = ref(false);
 const { handleScroll, resetTail, handleRenderedOutput } = useOutputAutoTail(outputContainerRef);
+let unsubscribeOutput = null;
 
 // Computed property that resolves output from store first, then props
 const resolvedOutput = computed(() => {
@@ -291,7 +293,7 @@ const resolvedOutput = computed(() => {
 });
 
 // Check if we have any output (either from store or props)
-const hasOutput = computed(() => Boolean(resolvedOutput.value) || loadingOutput.value);
+const hasOutput = computed(() => Boolean(resolvedOutput.value) || props.latestRun?.hasOutput || props.latestRun?.status === 'running' || loadingOutput.value);
 
 const updateFormattedOutput = () => {
   const output = resolvedOutput.value;
@@ -485,7 +487,10 @@ watch(
 watch(
   showOutput,
   (isVisible) => {
+    unsubscribeOutput?.();
+    unsubscribeOutput = null;
     if (isVisible) {
+      unsubscribeOutput = subscribeCommandRunOutput(props.sessionId, props.latestRun?.runId);
       resetTail({ scroll: true });
     }
   }
@@ -539,6 +544,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  unsubscribeOutput?.();
   stopTimer();
 });
 </script>

--- a/packages/web/src/components/CommandButtonItem.vue
+++ b/packages/web/src/components/CommandButtonItem.vue
@@ -126,6 +126,7 @@ import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useUiStore } from '../stores/ui.js';
 import { getStatusIconSvg } from './statusIcons';
 import { useOutputAutoTail } from '../composables/useOutputAutoTail.js';
+import { subscribeCommandRunOutput } from '../composables/useCommandRunOutputSubscription.js';
 import ActionMenu from './ActionMenu.vue';
 
 /**
@@ -214,6 +215,7 @@ const menuItems = computed(() => [
 // Template ref for output container (used for auto-tail scrolling)
 const outputContainerRef = ref(null);
 const { handleScroll, resetTail, handleRenderedOutput } = useOutputAutoTail(outputContainerRef);
+let unsubscribeOutput = null;
 
 // NEW: Elapsed time for running commands
 const elapsedTime = ref('0:00');
@@ -361,7 +363,10 @@ watch(
 watch(
   () => showOutput.value,
   (isVisible) => {
+    unsubscribeOutput?.();
+    unsubscribeOutput = null;
     if (isVisible) {
+      unsubscribeOutput = subscribeCommandRunOutput(props.sessionId, props.run?.runId);
       resetTail({ scroll: true });
     }
   },
@@ -506,6 +511,7 @@ onMounted(() => {
  * Clean up the timer to prevent memory leaks.
  */
 onBeforeUnmount(() => {
+  unsubscribeOutput?.();
   stopTimer();
 });
 

--- a/packages/web/src/components/CommandsTab.vue
+++ b/packages/web/src/components/CommandsTab.vue
@@ -189,11 +189,28 @@ const onSendToCanvas = async (buttonLabel, output) => {
  * Setup WebSocket handlers for command events
  */
 const setupWebSocketHandlers = () => {
-  const { subscribe, unsubscribe, onCommandOutput, onCommandComplete, onCommandError, onCommandRunDeleted } =
+  const { subscribe, unsubscribe, onCommandStarted, onCommandOutput, onCommandComplete, onCommandError, onCommandRunDeleted } =
     useSessionSubscription(props.sessionId);
 
   // Subscribe to session updates
   subscribe();
+
+  cleanups.push(
+    onCommandStarted((runId, buttonId) => {
+      if (!commandButtonsStore.runs[runId]) {
+        commandButtonsStore.runs[runId] = {
+          runId,
+          buttonId,
+          sessionId: props.sessionId,
+          status: 'running',
+          output: '',
+          exitCode: null,
+          startedAt: Date.now(),
+          outputTruncated: false,
+        };
+      }
+    })
+  );
 
   // Handle command output updates
   cleanups.push(

--- a/packages/web/src/composables/useCommandRunOutputSubscription.js
+++ b/packages/web/src/composables/useCommandRunOutputSubscription.js
@@ -1,0 +1,72 @@
+import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+import { useWebSocket } from './useWebSocket.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
+
+const subscriptions = new Map();
+let listenersInstalled = false;
+
+function installListeners() {
+  if (listenersInstalled) return;
+  listenersInstalled = true;
+  const { on } = useWebSocket();
+
+  on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, (message) => {
+    const entry = subscriptions.get(message.runId);
+    if (!entry || message.sequence <= entry.highWater) return;
+    // A missed sequence means the socket was backpressured. Re-read the
+    // persisted stream instead of attempting to repair it from live events.
+    if (message.sequence !== entry.highWater + 1) {
+      void entry.sync();
+      return;
+    }
+    entry.store.appendOutput(message.runId, message.content);
+    entry.highWater = message.sequence;
+  });
+
+  on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_SUBSCRIBED, (message) => {
+    const entry = subscriptions.get(message.runId);
+    if (entry) void entry.sync();
+  });
+
+  on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_RESYNC_REQUIRED, (message) => {
+    const entry = subscriptions.get(message.runId);
+    if (entry) void entry.sync();
+  });
+}
+
+/** Subscribe while a command output pane is visible. Multiple viewers share one socket subscription. */
+export function subscribeCommandRunOutput(sessionId, runId) {
+  if (!sessionId || !runId) return () => {};
+  installListeners();
+  const ws = useWebSocket();
+  let entry = subscriptions.get(runId);
+  if (entry) {
+    entry.count += 1;
+  } else {
+    const store = useCommandButtonsStore();
+    entry = {
+      count: 1,
+      store,
+      highWater: store.runs[runId]?.outputHighWater || 0,
+      syncing: null,
+      sync() {
+        if (!this.syncing) {
+          this.syncing = store.syncRunOutput(sessionId, runId, this.highWater)
+            .then((highWater) => { this.highWater = Math.max(this.highWater, highWater); })
+            .finally(() => { this.syncing = null; });
+        }
+        return this.syncing;
+      },
+    };
+    subscriptions.set(runId, entry);
+    ws.send(WS_MESSAGE_TYPES.SUBSCRIBE_COMMAND_RUN_OUTPUT, { sessionId, runId });
+    void entry.sync();
+  }
+
+  return () => {
+    const current = subscriptions.get(runId);
+    if (!current || --current.count > 0) return;
+    subscriptions.delete(runId);
+    ws.send(WS_MESSAGE_TYPES.UNSUBSCRIBE_COMMAND_RUN_OUTPUT, { runId });
+  };
+}

--- a/packages/web/src/composables/useCommandRunOutputSubscription.js
+++ b/packages/web/src/composables/useCommandRunOutputSubscription.js
@@ -12,15 +12,12 @@ function installListeners() {
 
   on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, (message) => {
     const entry = subscriptions.get(message.runId);
-    if (!entry || message.sequence <= entry.highWater) return;
-    // A missed sequence means the socket was backpressured. Re-read the
-    // persisted stream instead of attempting to repair it from live events.
-    if (message.sequence !== entry.highWater + 1) {
-      void entry.sync();
+    if (!entry) return;
+    if (entry.initializing) {
+      entry.pending.set(message.sequence, message);
       return;
     }
-    entry.store.appendOutput(message.runId, message.content);
-    entry.highWater = message.sequence;
+    entry.applyChunk(message);
   });
 
   on(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_SUBSCRIBED, (message) => {
@@ -48,11 +45,43 @@ export function subscribeCommandRunOutput(sessionId, runId) {
       count: 1,
       store,
       highWater: store.runs[runId]?.outputHighWater || 0,
+      initializing: true,
+      pending: new Map(),
       syncing: null,
+      applyChunk(chunk) {
+        if (chunk.sequence <= this.highWater) return true;
+        // A missed sequence means the socket was backpressured. Re-read the
+        // persisted stream instead of attempting to repair it from live events.
+        if (chunk.sequence !== this.highWater + 1) {
+          void this.sync();
+          return false;
+        }
+        this.store.appendOutput(runId, chunk.content);
+        this.highWater = chunk.sequence;
+        return true;
+      },
+      drainPending() {
+        for (const chunk of [...this.pending.values()].sort((a, b) => a.sequence - b.sequence)) {
+          this.pending.delete(chunk.sequence);
+          if (!this.applyChunk(chunk)) break;
+        }
+      },
       sync() {
+        // Lightweight component-store mocks and legacy embedding contexts may
+        // not expose streaming yet; live output remains safely inactive there.
+        if (typeof store.syncRunOutput !== 'function') {
+          this.initializing = false;
+          return Promise.resolve();
+        }
         if (!this.syncing) {
-          this.syncing = store.syncRunOutput(sessionId, runId, this.highWater)
-            .then((highWater) => { this.highWater = Math.max(this.highWater, highWater); })
+          this.syncing = store.syncRunOutput(sessionId, runId, this.highWater, (chunk) => this.applyChunk(chunk))
+            .then(({ hasMore }) => {
+              this.initializing = false;
+              this.drainPending();
+              // Yield to the event loop between capped catch-up batches. This
+              // preserves single-flight sync while a producer is still ahead.
+              if (hasMore) setTimeout(() => void this.sync(), 0);
+            })
             .finally(() => { this.syncing = null; });
         }
         return this.syncing;

--- a/packages/web/src/composables/useProjectSessionSubscription.js
+++ b/packages/web/src/composables/useProjectSessionSubscription.js
@@ -78,6 +78,19 @@ export function useProjectSessionSubscription(projectId, summaryCallbacks, strea
     });
   }
 
+  function handleCommandRunStarted(runId, sessionId, buttonId) {
+    const startedAt = Date.now();
+    if (!commandButtonsStore.runs[runId]) {
+      commandButtonsStore.runs[runId] = {
+        runId, buttonId, sessionId, status: 'running', output: '', exitCode: null,
+        startedAt, outputTruncated: false,
+      };
+    }
+    sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
+      buttonId, status: 'running', runId, startedAt,
+    });
+  }
+
   /**
    * Handle command run complete.
    * Extracted to avoid excessive callback nesting inside the watch handler.
@@ -145,7 +158,7 @@ export function useProjectSessionSubscription(projectId, summaryCallbacks, strea
     const {
       onSessionCreated, onSessionUpdated, onSessionDeleted,
       onSessionSummaryUpdated,
-      onCommandRunOutput, onCommandRunComplete, onCommandRunError, onCommandRunDeleted,
+      onCommandRunStarted, onCommandRunOutput, onCommandRunComplete, onCommandRunError, onCommandRunDeleted,
       onKanbanBoardUpdated, onKanbanCardMoved, onKanbanCardAdded, onKanbanCardRemoved,
     } = subscription;
 
@@ -161,6 +174,7 @@ export function useProjectSessionSubscription(projectId, summaryCallbacks, strea
       callbacks.cleanupSummary(sid);
     }));
     handlers.push(onSessionSummaryUpdated((sid, summary) => { callbacks.updateSummary(sid, summary); }));
+    if (onCommandRunStarted) handlers.push(onCommandRunStarted(handleCommandRunStarted));
     handlers.push(onCommandRunOutput(handleCommandRunOutput));
     handlers.push(onCommandRunComplete(handleCommandRunComplete));
     handlers.push(onCommandRunError(handleCommandRunError));
@@ -251,6 +265,7 @@ export function useProjectSessionSubscription(projectId, summaryCallbacks, strea
         onSessionUpdated,
         onSessionDeleted,
         onSessionSummaryUpdated,
+        onCommandRunStarted,
         onCommandRunOutput,
         onCommandRunComplete,
         onCommandRunError,
@@ -268,6 +283,7 @@ export function useProjectSessionSubscription(projectId, summaryCallbacks, strea
         {
           onSessionCreated, onSessionUpdated, onSessionDeleted,
           onSessionSummaryUpdated,
+          onCommandRunStarted,
           onCommandRunOutput, onCommandRunComplete, onCommandRunError, onCommandRunDeleted,
           onKanbanBoardUpdated, onKanbanCardMoved, onKanbanCardAdded, onKanbanCardRemoved,
         },

--- a/packages/web/src/composables/useProjectSubscription.js
+++ b/packages/web/src/composables/useProjectSubscription.js
@@ -58,6 +58,14 @@ export function useProjectSubscription(projectId) {
   };
 
   // Command run handlers for real-time status icon updates on session lists
+  const onCommandRunStarted = (callback) => {
+    const handler = (msg) => {
+      if (msg.projectId === projectId) callback(msg.runId, msg.sessionId, msg.buttonId);
+    };
+    on(WS_MESSAGE_TYPES.COMMAND_RUN_STARTED, handler);
+    return () => off(WS_MESSAGE_TYPES.COMMAND_RUN_STARTED, handler);
+  };
+
   const onCommandRunOutput = (callback) => {
     const handler = (msg) => {
       if (msg.projectId === projectId) {
@@ -158,6 +166,7 @@ export function useProjectSubscription(projectId) {
     onSessionUpdated,
     onSessionDeleted,
     onSessionSummaryUpdated,
+    onCommandRunStarted,
     onCommandRunOutput,
     onCommandRunComplete,
     onCommandRunError,

--- a/packages/web/src/composables/useSessionInitializer.js
+++ b/packages/web/src/composables/useSessionInitializer.js
@@ -17,8 +17,23 @@ import { api } from './useApi.js';
  */
 function registerCommandHandlers(subscription, sessionId, stores) {
   const { sessionsStore, commandButtonsStore } = stores;
-  const { onCommandOutput, onCommandComplete, onCommandError, onCommandRunDeleted } = subscription;
+  const { onCommandStarted, onCommandOutput, onCommandComplete, onCommandError, onCommandRunDeleted } = subscription;
   const handlers = [];
+
+  if (onCommandStarted) handlers.push(
+    onCommandStarted((runId, buttonId) => {
+      const startedAt = Date.now();
+      if (!commandButtonsStore.runs[runId]) {
+        commandButtonsStore.runs[runId] = {
+          runId, buttonId, sessionId, status: 'running', output: '', exitCode: null,
+          startedAt, outputTruncated: false,
+        };
+      }
+      sessionsStore.updateSessionCommandRun(sessionId, buttonId, {
+        buttonId, status: 'running', runId, startedAt,
+      });
+    })
+  );
 
   handlers.push(
     onCommandOutput((runId, buttonId, output) => {

--- a/packages/web/src/composables/useSessionSubscription.js
+++ b/packages/web/src/composables/useSessionSubscription.js
@@ -75,6 +75,8 @@ function registerEventHandlers(on, off, sessionId) {
       { filter: bySession, args: (msg) => [msg.conversationId, msg.newActiveConversation] }),
     onUsageUpdate: handler(WS_MESSAGE_TYPES.SESSION_USAGE_UPDATE,
       { filter: bySession, args: (msg) => [msg] }, { replaySessionId: sessionId }),
+    onCommandStarted: handler(WS_MESSAGE_TYPES.COMMAND_RUN_STARTED,
+      { filter: bySession, args: (msg) => [msg.runId, msg.buttonId] }),
     onCommandOutput: handler(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT,
       { filter: bySession, args: (msg) => [msg.runId, msg.buttonId, msg.output] }),
     onCommandComplete: handler(WS_MESSAGE_TYPES.COMMAND_RUN_COMPLETE,

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -10,6 +10,9 @@ import {
   buildErrorRunUpdate,
 } from './commandButtonsOutputBuffer.js';
 
+export const MAX_SYNC_PAGES_PER_CALL = 32;
+export const SYNC_PAGE_BYTES = 256 * 1024;
+
 export const useCommandButtonsStore = defineStore('commandButtons', {
   state: () => ({
     buttons: [],
@@ -245,22 +248,25 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
-    async syncRunOutput(sessionId, runId, after = 0) {
+    async syncRunOutput(sessionId, runId, after = 0, applyChunk) {
       const existing = this.runs[runId];
-      if (!existing) return after;
+      if (!existing) return { highWater: after, hasMore: false };
       let cursor = after;
       let hasMore = true;
-      while (hasMore) {
-        const page = await api.getCommandRunOutput(sessionId, runId, { after: cursor, limitBytes: 65536 });
+      let pages = 0;
+      while (hasMore && pages < MAX_SYNC_PAGES_PER_CALL) {
+        const page = await api.getCommandRunOutput(sessionId, runId, { after: cursor, limitBytes: SYNC_PAGE_BYTES });
+        pages += 1;
         for (const chunk of page.chunks) {
-          this.appendOutput(runId, chunk.content);
-          cursor = chunk.sequence;
+          // The subscription owns ordering and can reject an overlapping live
+          // chunk. A regular caller still appends every persisted chunk.
+          if (!applyChunk || applyChunk(chunk)) cursor = Math.max(cursor, chunk.sequence);
         }
         hasMore = page.hasMore && page.chunks.length > 0;
       }
       this.flushPendingOutput(runId);
       if (this.runs[runId]) this.runs[runId].outputHighWater = cursor;
-      return cursor;
+      return { highWater: cursor, hasMore };
     },
 
     setOutputCollapsed(runId, isCollapsed) {

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -225,17 +225,19 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
 
     async fetchRunOutput(sessionId, runId) {
       const existing = this.runs[runId];
-      if (!existing || existing.status === 'running') return; // Don't fetch for running commands (streaming via WS)
+      if (!existing) return;
       if (existing.output && existing.output.length > 0) return; // Already have output, skip
 
       try {
-        const run = await api.getCommandRun(sessionId, runId);
-        if (run.output && this.runs[runId]) {
-          const { output, truncated } = truncateOutput(run.output);
+        const page = await api.getCommandRunOutput(sessionId, runId, { limitBytes: 2 * 1024 * 1024 });
+        const output = page.chunks.map((chunk) => chunk.content).join('');
+        if (this.runs[runId]) {
+          const { output: boundedOutput, truncated } = truncateOutput(output);
           this.runs[runId] = {
             ...this.runs[runId],
-            output,
+            output: boundedOutput,
             outputTruncated: truncated,
+            outputHighWater: page.highWater,
           };
         }
       } catch (err) {

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -245,6 +245,24 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
+    async syncRunOutput(sessionId, runId, after = 0) {
+      const existing = this.runs[runId];
+      if (!existing) return after;
+      let cursor = after;
+      let hasMore = true;
+      while (hasMore) {
+        const page = await api.getCommandRunOutput(sessionId, runId, { after: cursor, limitBytes: 65536 });
+        for (const chunk of page.chunks) {
+          this.appendOutput(runId, chunk.content);
+          cursor = chunk.sequence;
+        }
+        hasMore = page.hasMore && page.chunks.length > 0;
+      }
+      this.flushPendingOutput(runId);
+      if (this.runs[runId]) this.runs[runId].outputHighWater = cursor;
+      return cursor;
+    },
+
     setOutputCollapsed(runId, isCollapsed) {
       this.collapsedStates[runId] = isCollapsed;
     },

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -12,6 +12,7 @@ vi.mock('../composables/useApi.js', () => ({
     getActiveRuns: vi.fn(),
     killCommandRun: vi.fn(),
     getCommandRun: vi.fn(),
+    getCommandRunOutput: vi.fn(),
     deleteCommandRun: vi.fn(),
     deleteAllRunsForButton: vi.fn(),
     getLatestRunsForProject: vi.fn(),
@@ -1119,23 +1120,20 @@ describe('CommandButtons Store', () => {
         },
       };
 
-      api.getCommandRun.mockResolvedValue({
-        runId: 'r1',
-        buttonId: 'b1',
-        status: 'success',
-        output: 'fetched output',
-        exitCode: 0,
-        startedAt: Date.now(),
-        completedAt: Date.now(),
+      api.getCommandRunOutput.mockResolvedValue({
+        chunks: [{ sequence: 1, content: 'fetched ' }, { sequence: 2, content: 'output' }],
+        highWater: 2,
+        hasMore: false,
       });
 
       await store.fetchRunOutput('sess-1', 'r1');
 
       expect(store.runs['r1'].output).toBe('fetched output');
       expect(store.runs['r1'].outputTruncated).toBe(false);
+      expect(store.runs['r1'].outputHighWater).toBe(2);
     });
 
-    it('skips fetch when run is currently running', async () => {
+    it('fetches persisted chunks while a run is currently running', async () => {
       const store = useCommandButtonsStore();
       store.runs = {
         'r1': {
@@ -1151,7 +1149,11 @@ describe('CommandButtons Store', () => {
 
       await store.fetchRunOutput('sess-1', 'r1');
 
-      expect(api.getCommandRun).not.toHaveBeenCalled();
+      expect(api.getCommandRunOutput).toHaveBeenCalledWith(
+        'sess-1',
+        'r1',
+        { limitBytes: 2 * 1024 * 1024 }
+      );
     });
 
     it('skips fetch when output is already loaded', async () => {
@@ -1170,7 +1172,7 @@ describe('CommandButtons Store', () => {
 
       await store.fetchRunOutput('sess-1', 'r1');
 
-      expect(api.getCommandRun).not.toHaveBeenCalled();
+      expect(api.getCommandRunOutput).not.toHaveBeenCalled();
     });
 
     it('handles API error gracefully', async () => {
@@ -1188,7 +1190,7 @@ describe('CommandButtons Store', () => {
       };
 
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      api.getCommandRun.mockRejectedValue(new Error('Network error'));
+      api.getCommandRunOutput.mockRejectedValue(new Error('Network error'));
 
       await store.fetchRunOutput('sess-1', 'r1');
 
@@ -1219,12 +1221,10 @@ describe('CommandButtons Store', () => {
 
       // Create output with more than 2000 lines
       const longOutput = Array.from({ length: 2500 }, (_, i) => `Line ${i + 1}`).join('\n');
-      api.getCommandRun.mockResolvedValue({
-        runId: 'r1',
-        buttonId: 'b1',
-        status: 'success',
-        output: longOutput,
-        exitCode: 0,
+      api.getCommandRunOutput.mockResolvedValue({
+        chunks: [{ sequence: 1, content: longOutput }],
+        highWater: 1,
+        hasMore: false,
       });
 
       await store.fetchRunOutput('sess-1', 'r1');
@@ -1239,7 +1239,7 @@ describe('CommandButtons Store', () => {
 
       await store.fetchRunOutput('sess-1', 'nonexistent-run-id');
 
-      expect(api.getCommandRun).not.toHaveBeenCalled();
+      expect(api.getCommandRunOutput).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { useCommandButtonsStore } from './commandButtons.js';
+import { MAX_SYNC_PAGES_PER_CALL, useCommandButtonsStore } from './commandButtons.js';
 
 // Mock the API module
 vi.mock('../composables/useApi.js', () => ({
@@ -1240,6 +1240,21 @@ describe('CommandButtons Store', () => {
       await store.fetchRunOutput('sess-1', 'nonexistent-run-id');
 
       expect(api.getCommandRunOutput).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncRunOutput', () => {
+    it('bounds each catch-up invocation and preserves its cursor for a later retry', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = { r1: { runId: 'r1', output: '', outputTruncated: false } };
+      api.getCommandRunOutput.mockImplementation(async (_sessionId, _runId, { after }) => ({
+        chunks: [{ sequence: after + 1, content: 'x' }], highWater: after + 1, hasMore: true,
+      }));
+
+      const result = await store.syncRunOutput('sess-1', 'r1');
+
+      expect(api.getCommandRunOutput).toHaveBeenCalledTimes(MAX_SYNC_PAGES_PER_CALL);
+      expect(result).toEqual({ highWater: MAX_SYNC_PAGES_PER_CALL, hasMore: true });
     });
   });
 

--- a/packages/web/src/stores/commandButtonsOutputBuffer.js
+++ b/packages/web/src/stores/commandButtonsOutputBuffer.js
@@ -39,6 +39,8 @@ export function buildRunEntry(run, runId, existing) {
     exitCode: run.exitCode ?? null,
     startedAt: run.startedAt,
     completedAt: run.completedAt,
+    hasOutput: run.hasOutput ?? existing?.hasOutput ?? Boolean(output),
+    outputHighWater: run.outputHighWater ?? existing?.outputHighWater ?? 0,
     outputTruncated: hasExistingOutput ? existing.outputTruncated : truncated,
   };
 }
@@ -162,6 +164,8 @@ export function processRunFromApi(run, sessionId, existing) {
     exitCode: run.exitCode !== undefined ? run.exitCode : null,
     startedAt: run.startedAt,
     completedAt: run.completedAt,
+    hasOutput: run.hasOutput ?? existing?.hasOutput ?? Boolean(resolvedOutput),
+    outputHighWater: run.outputHighWater ?? existing?.outputHighWater ?? 0,
     outputTruncated: resolvedTruncated,
   };
 }

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1089,7 +1089,22 @@ export async function runCommandButtonAndWait(
   timeout = 30000
 ) {
   const { runId } = await runCommandButton(sessionId, buttonId);
-  return waitForCommandRunComplete(sessionId, runId, timeout);
+  const run = await waitForCommandRunComplete(sessionId, runId, timeout);
+  const chunks: Array<{ sequence: number; content: string }> = [];
+  let after = 0;
+  let hasMore = true;
+  while (hasMore) {
+    const response = await fetch(
+      `${API_URL}/api/sessions/${sessionId}/circus-commands/runs/${runId}/output?after=${after}&limitBytes=${1024 * 1024}`
+    );
+    if (!response.ok) throw new Error(`Failed to fetch command output: ${response.status}`);
+    const page = await response.json();
+    chunks.push(...page.chunks);
+    hasMore = page.hasMore;
+    if (page.chunks.length) after = page.chunks[page.chunks.length - 1].sequence;
+    else break;
+  }
+  return { ...run, output: chunks.map(chunk => chunk.content).join('') };
 }
 
 /**

--- a/tests/e2e/websocket.spec.ts
+++ b/tests/e2e/websocket.spec.ts
@@ -610,34 +610,36 @@ test.describe('WebSocket Communication', () => {
   // ===========================================================================
 
   test.describe('Category 6: Command Events', () => {
-    test('26. command:run:output broadcasts to session subscribers', async () => {
+    test('26. command:run:output broadcasts to explicit run-output subscribers', async () => {
       test.setTimeout(30000);
       const project = await seedProject('WS Cmd Output', process.cwd());
       const session = await seedSession(project.id, { prompt: 'test', startImmediately: false });
       const button = await seedCommandButton(project.id, {
         label: 'Echo Test',
-        command: 'echo "hello world"',
+        command: 'sleep 1; echo "hello world"',
       });
 
       const ws = await connect();
       subscribeToSession(ws, session.id);
       await new Promise(r => setTimeout(r, 100));
 
-      // The server first sends an empty-output "running" broadcast, then sends the actual output.
-      // Use a matcher to skip the initial empty broadcast and wait for real output.
+      const { runId } = await runCommandButton(session.id, button.id);
+      const subscribedPromise = waitForWSMessage(ws, 'command:run:output_subscribed', 10000);
+      ws.send(JSON.stringify({ type: 'subscribe:command_run_output', runId, sessionId: session.id }));
+      await subscribedPromise;
+
       const msgPromise = waitForWSMessage(
         ws,
         'command:run:output',
         20000,
-        (m: any) => m.output && m.output.length > 0
+        (m: any) => m.content && m.content.length > 0
       );
-      await runCommandButton(session.id, button.id);
       const msg = await msgPromise;
 
       expect(msg.type).toBe('command:run:output');
-      expect(msg.sessionId).toBe(session.id);
-      expect(msg.buttonId).toBe(button.id);
-      expect(msg.output).toContain('hello world');
+      expect(msg.runId).toBe(runId);
+      expect(msg.sequence).toBeGreaterThan(0);
+      expect(msg.content).toContain('hello world');
     });
 
     test('27. command:run:complete broadcasts to session subscribers', async () => {


### PR DESCRIPTION
## Summary
- Stream circus command output over a WebSocket channel instead of returning the full accumulated buffer on every status poll, bounding memory/response size for long-running commands
- Track `hasOutput`/`outputHighWater` on runs so clients can detect new output without re-fetching the whole buffer
- Fix a race where `onStarted` fired before the run was registered in the process map, which could cause clients that refreshed immediately after starting a run to miss the "running" status

## Test plan
- [x] `./scripts/pw.sh test` — 1158 passed, 3 flaky (passed on retry), 0 failed
- [x] Unit tests updated for the new streaming behavior (`commandRunner.test.js`, `commandButtons.test.js`, `sessions.test.js`, `CommandRunRepository.test.js`, `commandButtons.test.js` store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)