### PR TITLE
Add GET /api/providers to agent system prompt

### DIFF
--- a/docs/agent-system-prompt.md
+++ b/docs/agent-system-prompt.md
@@ -44,6 +44,7 @@ The prompt provides the agent with its own session ID, project ID, and current w
 |--------|----------|-------------|
 | POST | `/api/projects/{projectId}/workspaces` | Create a new workspace. Required body field: `prompt`. See optional fields below. |
 | POST | `/api/workspaces/{workspaceId}/sessions` | Add a session to the current workspace. Required body fields: `prompt`, `parentSessionId`. `parentSessionId` must reference a session in this workspace (the root or a descendant); pass the current session ID to chain, or the workspace ID to attach directly to the root. Unknown or cross-workspace values are rejected — there is no fallback. |
+| GET | `/api/providers` | List configured providers. Each entry has `kind` (`anthropic`/`openai`/`google`) and a `models` array of `{modelId, displayName, tier, enabled, lifecycle}` — the authoritative list of valid `model` values for workspace/session creation. |
 | POST | `/api/sessions/{session_id}/message` | Send a follow-up message. Body: `{"content": "..."}` |
 | GET | `/api/sessions` | List all active sessions |
 | GET | `/api/sessions/{session_id}` | Get session details |

--- a/packages/server/src/services/sessionApiPrompts.js
+++ b/packages/server/src/services/sessionApiPrompts.js
@@ -23,6 +23,12 @@ Optional fields: same as creating a workspace. Add \`scheduledAt\` to schedule t
 
 **Note:** "workspace" here refers to a group of related sessions. This is distinct from the Codex \`workspace-write\` sandbox mode — those are separate concepts.
 
+### List Providers & Available Models
+\`\`\`bash
+curl ${apiUrl}/api/providers
+\`\`\`
+Returns configured providers, each with \`kind\` (\`anthropic\` | \`openai\` | \`google\`) and a \`models\` array of \`{modelId, displayName, tier, enabled, lifecycle}\`. Use a \`models[].modelId\` value as the \`model\` field when creating a workspace/session (see below) — this is the authoritative list of accepted values.
+
 ### Send a Follow-up Message
 \`\`\`bash
 curl -X POST ${apiUrl}/api/sessions/<session_id>/message \\

--- a/packages/web/src/composables/useCommandRunOutputSubscription.js
+++ b/packages/web/src/composables/useCommandRunOutputSubscription.js
@@ -48,6 +48,7 @@ export function subscribeCommandRunOutput(sessionId, runId) {
       initializing: true,
       pending: new Map(),
       syncing: null,
+      resyncQueued: false,
       applyChunk(chunk) {
         if (chunk.sequence <= this.highWater) return true;
         // A missed sequence means the socket was backpressured. Re-read the
@@ -56,7 +57,9 @@ export function subscribeCommandRunOutput(sessionId, runId) {
           void this.sync();
           return false;
         }
-        this.store.appendOutput(runId, chunk.content);
+        // Ordering and de-duplication are owned here (by sequence), so the run
+        // completing mid-catch-up must not discard the remaining output.
+        this.store.appendOutput(runId, chunk.content, { allowAfterCompletion: true });
         this.highWater = chunk.sequence;
         return true;
       },
@@ -73,17 +76,23 @@ export function subscribeCommandRunOutput(sessionId, runId) {
           this.initializing = false;
           return Promise.resolve();
         }
-        if (!this.syncing) {
-          this.syncing = store.syncRunOutput(sessionId, runId, this.highWater, (chunk) => this.applyChunk(chunk))
-            .then(({ hasMore }) => {
-              this.initializing = false;
-              this.drainPending();
-              // Yield to the event loop between capped catch-up batches. This
-              // preserves single-flight sync while a producer is still ahead.
-              if (hasMore) setTimeout(() => void this.sync(), 0);
-            })
-            .finally(() => { this.syncing = null; });
+        if (this.syncing) {
+          // Chunks rejected while a read is already in flight may have been
+          // persisted after that read started, so a follow-up pass is required
+          // once it settles - otherwise their content is lost for good.
+          this.resyncQueued = true;
+          return this.syncing;
         }
+        this.resyncQueued = false;
+        this.syncing = store.syncRunOutput(sessionId, runId, this.highWater, (chunk) => this.applyChunk(chunk))
+          .then(({ hasMore }) => {
+            this.initializing = false;
+            this.drainPending();
+            // Yield to the event loop between capped catch-up batches. This
+            // preserves single-flight sync while a producer is still ahead.
+            if (hasMore || this.resyncQueued) setTimeout(() => void this.sync(), 0);
+          })
+          .finally(() => { this.syncing = null; });
         return this.syncing;
       },
     };

--- a/packages/web/src/composables/useCommandRunOutputSubscription.js
+++ b/packages/web/src/composables/useCommandRunOutputSubscription.js
@@ -50,6 +50,11 @@ export function subscribeCommandRunOutput(sessionId, runId) {
       syncing: null,
       resyncQueued: false,
       applyChunk(chunk) {
+        // The store cursor records what is already rendered. A snapshot fetch
+        // (expanding a collapsed pane) reads the same persisted stream from the
+        // start and can land mid-catch-up, so adopt its progress before
+        // deciding whether this chunk still needs to be appended.
+        this.adoptRenderedCursor();
         if (chunk.sequence <= this.highWater) return true;
         // A missed sequence means the socket was backpressured. Re-read the
         // persisted stream instead of attempting to repair it from live events.
@@ -61,7 +66,15 @@ export function subscribeCommandRunOutput(sessionId, runId) {
         // completing mid-catch-up must not discard the remaining output.
         this.store.appendOutput(runId, chunk.content, { allowAfterCompletion: true });
         this.highWater = chunk.sequence;
+        // Publish the cursor so a snapshot fetch, or a subscription created
+        // later for the same run, resumes here instead of replaying output.
+        this.store.advanceOutputHighWater?.(runId, chunk.sequence);
         return true;
+      },
+      /** Raise the in-memory cursor to the output already rendered by the store. */
+      adoptRenderedCursor() {
+        const rendered = this.store.runs[runId]?.outputHighWater || 0;
+        if (rendered > this.highWater) this.highWater = rendered;
       },
       drainPending() {
         for (const chunk of [...this.pending.values()].sort((a, b) => a.sequence - b.sequence)) {
@@ -84,6 +97,7 @@ export function subscribeCommandRunOutput(sessionId, runId) {
           return this.syncing;
         }
         this.resyncQueued = false;
+        this.adoptRenderedCursor();
         this.syncing = store.syncRunOutput(sessionId, runId, this.highWater, (chunk) => this.applyChunk(chunk))
           .then(({ hasMore }) => {
             this.initializing = false;

--- a/packages/web/src/composables/useCommandRunOutputSubscription.test.js
+++ b/packages/web/src/composables/useCommandRunOutputSubscription.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WS_MESSAGE_TYPES } from '@circuschief/shared';
+
+const SESSION_ID = 'session-1';
+const RUN_ID = 'run-1';
+
+/** Handlers registered through the mocked `useWebSocket().on`. */
+let wsHandlers;
+let sent;
+let store;
+let subscribeCommandRunOutput;
+
+/** Deliver a socket frame to every handler registered for its type. */
+function receive(type, payload) {
+  for (const handler of wsHandlers.get(type) || []) handler(payload);
+}
+
+/** A promise plus its resolver, so a sync can be held open mid-test. */
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+vi.mock('./useWebSocket.js', () => ({
+  useWebSocket: () => ({
+    on: (type, handler) => {
+      if (!wsHandlers.has(type)) wsHandlers.set(type, []);
+      wsHandlers.get(type).push(handler);
+    },
+    send: (type, payload) => sent.push({ type, payload }),
+  }),
+}));
+
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: () => store,
+}));
+
+describe('subscribeCommandRunOutput', () => {
+  beforeEach(async () => {
+    wsHandlers = new Map();
+    sent = [];
+    store = {
+      runs: { [RUN_ID]: { runId: RUN_ID, status: 'running', outputHighWater: 0 } },
+      appendOutput: vi.fn(),
+      syncCalls: [],
+      syncRunOutput: vi.fn(),
+    };
+    // Module-level subscription bookkeeping must not leak between tests.
+    vi.resetModules();
+    ({ subscribeCommandRunOutput } = await import('./useCommandRunOutputSubscription.js'));
+  });
+
+  /** Subscribe and settle the initial catch-up read with no chunks. */
+  async function subscribeAndSettleInitialSync() {
+    store.syncRunOutput.mockResolvedValueOnce({ highWater: 0, hasMore: false });
+    const unsubscribe = subscribeCommandRunOutput(SESSION_ID, RUN_ID);
+    await vi.waitFor(() => expect(store.syncRunOutput).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    await Promise.resolve();
+    return unsubscribe;
+  }
+
+  it('subscribes on the socket and issues an initial catch-up read', async () => {
+    await subscribeAndSettleInitialSync();
+
+    expect(sent).toContainEqual({
+      type: WS_MESSAGE_TYPES.SUBSCRIBE_COMMAND_RUN_OUTPUT,
+      payload: { sessionId: SESSION_ID, runId: RUN_ID },
+    });
+    expect(store.syncRunOutput).toHaveBeenCalledWith(SESSION_ID, RUN_ID, 0, expect.any(Function));
+  });
+
+  it('applies in-order live chunks with completion-tolerant appends', async () => {
+    await subscribeAndSettleInitialSync();
+
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 1, content: 'LINE 1\n' });
+
+    // Ordering and de-duplication live here (by sequence), so the store must
+    // not second-guess a chunk that lands after the run is marked complete.
+    expect(store.appendOutput).toHaveBeenCalledWith(RUN_ID, 'LINE 1\n', { allowAfterCompletion: true });
+  });
+
+  it('ignores chunks already covered by the current high-water mark', async () => {
+    await subscribeAndSettleInitialSync();
+
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 1, content: 'LINE 1\n' });
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 1, content: 'LINE 1\n' });
+
+    expect(store.appendOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads the persisted stream when a live sequence is missing', async () => {
+    await subscribeAndSettleInitialSync();
+    store.syncRunOutput.mockResolvedValueOnce({ highWater: 4, hasMore: false });
+
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 5, content: 'LINE 5\n' });
+
+    expect(store.appendOutput).not.toHaveBeenCalled();
+    expect(store.syncRunOutput).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs a follow-up read for chunks rejected while a read was in flight', async () => {
+    await subscribeAndSettleInitialSync();
+
+    const inFlight = deferred();
+    store.syncRunOutput.mockReturnValueOnce(inFlight.promise);
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 5, content: 'LINE 5\n' });
+    expect(store.syncRunOutput).toHaveBeenCalledTimes(2);
+
+    // This chunk is rejected while the read is open. It may have been persisted
+    // after that read started, so dropping it here would lose it permanently.
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 6, content: 'LINE 6\n' });
+    expect(store.syncRunOutput).toHaveBeenCalledTimes(2);
+
+    store.syncRunOutput.mockResolvedValueOnce({ highWater: 6, hasMore: false });
+    inFlight.resolve({ highWater: 5, hasMore: false });
+
+    await vi.waitFor(() => expect(store.syncRunOutput).toHaveBeenCalledTimes(3));
+  });
+
+  it('shares one socket subscription across viewers and releases it on the last unsubscribe', async () => {
+    const unsubscribeA = await subscribeAndSettleInitialSync();
+    const unsubscribeB = subscribeCommandRunOutput(SESSION_ID, RUN_ID);
+
+    const subscribeFrames = sent.filter((f) => f.type === WS_MESSAGE_TYPES.SUBSCRIBE_COMMAND_RUN_OUTPUT);
+    expect(subscribeFrames).toHaveLength(1);
+
+    unsubscribeA();
+    expect(sent.some((f) => f.type === WS_MESSAGE_TYPES.UNSUBSCRIBE_COMMAND_RUN_OUTPUT)).toBe(false);
+
+    unsubscribeB();
+    expect(sent).toContainEqual({
+      type: WS_MESSAGE_TYPES.UNSUBSCRIBE_COMMAND_RUN_OUTPUT,
+      payload: { runId: RUN_ID },
+    });
+  });
+});

--- a/packages/web/src/composables/useCommandRunOutputSubscription.test.js
+++ b/packages/web/src/composables/useCommandRunOutputSubscription.test.js
@@ -119,6 +119,41 @@ describe('subscribeCommandRunOutput', () => {
     await vi.waitFor(() => expect(store.syncRunOutput).toHaveBeenCalledTimes(3));
   });
 
+  it('publishes the applied cursor so a later viewer does not replay output', async () => {
+    await subscribeAndSettleInitialSync();
+    store.advanceOutputHighWater = vi.fn();
+
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 1, content: 'LINE 1\n' });
+
+    expect(store.advanceOutputHighWater).toHaveBeenCalledWith(RUN_ID, 1);
+  });
+
+  it('skips chunks a snapshot fetch rendered while the catch-up read was open', async () => {
+    await subscribeAndSettleInitialSync();
+
+    // Expanding a collapsed pane reads the same persisted stream from the start.
+    // Whichever loader lands second must not append output twice.
+    store.runs[RUN_ID] = { ...store.runs[RUN_ID], status: 'success', outputHighWater: 2 };
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 1, content: 'LINE 1\n' });
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 2, content: 'LINE 2\n' });
+
+    expect(store.appendOutput).not.toHaveBeenCalled();
+
+    // The stream still continues from where the snapshot left off.
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT, { runId: RUN_ID, sequence: 3, content: 'LINE 3\n' });
+    expect(store.appendOutput).toHaveBeenCalledWith(RUN_ID, 'LINE 3\n', { allowAfterCompletion: true });
+  });
+
+  it('resumes a catch-up read from the output already rendered by the store', async () => {
+    await subscribeAndSettleInitialSync();
+    store.runs[RUN_ID] = { ...store.runs[RUN_ID], outputHighWater: 5 };
+    store.syncRunOutput.mockResolvedValueOnce({ highWater: 5, hasMore: false });
+
+    receive(WS_MESSAGE_TYPES.COMMAND_RUN_OUTPUT_RESYNC_REQUIRED, { runId: RUN_ID });
+
+    expect(store.syncRunOutput).toHaveBeenLastCalledWith(SESSION_ID, RUN_ID, 5, expect.any(Function));
+  });
+
   it('shares one socket subscription across viewers and releases it on the last unsubscribe', async () => {
     const unsubscribeA = await subscribeAndSettleInitialSync();
     const unsubscribeB = subscribeCommandRunOutput(SESSION_ID, RUN_ID);

--- a/packages/web/src/composables/useOutputAutoTail.js
+++ b/packages/web/src/composables/useOutputAutoTail.js
@@ -21,8 +21,9 @@ export const OUTPUT_BOTTOM_TOLERANCE_PX = 16;
  *   has changed (post-render), and only schedules a scroll when already
  *   tailing.
  *
- * Programmatic scrolling performed by this composable never mutates
- * `isTailing` itself - only `handleScroll` (a real user scroll event) does.
+ * Programmatic scrolling performed by this composable never pauses tailing:
+ * `handleScroll` ignores the scroll events its own scroll-to-bottom produces,
+ * so only a real user scroll away from the bottom changes `isTailing`.
  *
  * @param {import('vue').Ref<HTMLElement|null>} containerRef - template ref
  *   for the element that owns vertical scrolling.
@@ -33,6 +34,10 @@ export function useOutputAutoTail(containerRef) {
   let pendingFrame = false;
   let frameId = null;
   let disposed = false;
+  // Offset written by our own scroll-to-bottom, awaiting the scroll event it
+  // will produce. Null whenever no such event is outstanding, so ordinary user
+  // scrolling is always evaluated.
+  let pendingProgrammaticTop = null;
 
   function getDistanceFromBottom(el) {
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
@@ -48,6 +53,13 @@ export function useOutputAutoTail(containerRef) {
   function handleScroll() {
     const el = containerRef.value;
     if (!el) return;
+    // The scroll event for our own scroll-to-bottom is delivered asynchronously,
+    // by which time streaming output may already have grown the container. The
+    // pane then measures far from the bottom even though the user never moved
+    // it, which would strand the tail. Consume that one event by its offset.
+    const programmaticTop = pendingProgrammaticTop;
+    pendingProgrammaticTop = null;
+    if (programmaticTop !== null && el.scrollTop === programmaticTop) return;
     isTailing.value = getDistanceFromBottom(el) <= OUTPUT_BOTTOM_TOLERANCE_PX;
   }
 
@@ -61,7 +73,12 @@ export function useOutputAutoTail(containerRef) {
     if (!isTailing.value) return;
     const el = containerRef.value;
     if (!el) return;
+    const before = el.scrollTop;
     el.scrollTop = el.scrollHeight;
+    // Record the clamped result so the scroll event this produces is not
+    // mistaken for the user scrolling away from the bottom. An unchanged offset
+    // emits no event, so nothing is left armed to swallow a later user scroll.
+    if (el.scrollTop !== before) pendingProgrammaticTop = el.scrollTop;
   }
 
   /**

--- a/packages/web/src/composables/useOutputAutoTail.js
+++ b/packages/web/src/composables/useOutputAutoTail.js
@@ -55,6 +55,10 @@ export function useOutputAutoTail(containerRef) {
     frameId = null;
     pendingFrame = false;
     if (disposed) return;
+    // A frame scheduled while tailing can still be pending when the user
+    // scrolls away. Re-read the state at frame time so a paused pane is never
+    // yanked back to the bottom by work queued before the pause.
+    if (!isTailing.value) return;
     const el = containerRef.value;
     if (!el) return;
     el.scrollTop = el.scrollHeight;

--- a/packages/web/src/composables/useOutputAutoTail.test.js
+++ b/packages/web/src/composables/useOutputAutoTail.test.js
@@ -170,6 +170,27 @@ describe('useOutputAutoTail', () => {
     expect(el.scrollTop).toBe(50000);
   });
 
+  it('a scroll-away before an already-scheduled frame runs keeps the pane paused', async () => {
+    const el = createFakeElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
+    const elRef = ref(el);
+    const { api } = mountComposable(elRef);
+
+    // Output arrives while tailing, so a scroll-to-bottom frame is queued.
+    api().handleRenderedOutput();
+    await nextTick();
+    expect(rafQueue.length).toBe(1);
+
+    // The user scrolls to the top before that frame gets a chance to run.
+    el.scrollTop = 0;
+    api().handleScroll();
+    expect(api().isTailing.value).toBe(false);
+
+    flushFrames();
+
+    expect(el.scrollTop).toBe(0);
+    expect(api().isTailing.value).toBe(false);
+  });
+
   it('repeated notifications before the frame runs coalesce to one frame', async () => {
     const el = createFakeElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
     const elRef = ref(el);

--- a/packages/web/src/composables/useOutputAutoTail.test.js
+++ b/packages/web/src/composables/useOutputAutoTail.test.js
@@ -261,6 +261,40 @@ describe('useOutputAutoTail', () => {
     expect(api().isTailing.value).toBe(true); // only because resetTail set it, not the scroll itself
   });
 
+  it('a scroll event from our own scroll-to-bottom does not pause a growing pane', async () => {
+    const el = createFakeElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
+    const elRef = ref(el);
+    const { api } = mountComposable(elRef);
+
+    api().handleRenderedOutput();
+    await nextTick();
+    flushFrames();
+    expect(el.scrollTop).toBe(1000);
+
+    // More output lands before the browser delivers the scroll event for the
+    // write above, so the pane now measures far from the bottom even though
+    // the user never touched it.
+    el.scrollHeight = 5000;
+    api().handleScroll();
+
+    expect(api().isTailing.value).toBe(true);
+  });
+
+  it('still pauses when the user scrolls up after a programmatic scroll', async () => {
+    const el = createFakeElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
+    const elRef = ref(el);
+    const { api } = mountComposable(elRef);
+
+    api().handleRenderedOutput();
+    await nextTick();
+    flushFrames();
+
+    el.scrollTop = 0;
+    api().handleScroll();
+
+    expect(api().isTailing.value).toBe(false);
+  });
+
   it('disposal cancels pending frame work and a late frame cannot mutate the element', async () => {
     const el = createFakeElement({ scrollHeight: 1000, scrollTop: 0, clientHeight: 300 });
     const elRef = ref(el);

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -13,6 +13,17 @@ import {
 export const MAX_SYNC_PAGES_PER_CALL = 32;
 export const SYNC_PAGE_BYTES = 256 * 1024;
 
+/**
+ * Whether a run's persisted output has already been delivered to this client,
+ * either rendered into `output` or applied by a catch-up read (tracked by the
+ * high-water cursor, since appends can still be sitting in the flush buffer).
+ * @param {Object} run - Run entry from the store
+ * @returns {boolean}
+ */
+function hasRenderedOutput(run) {
+  return Boolean(run.output && run.output.length > 0) || (run.outputHighWater || 0) > 0;
+}
+
 export const useCommandButtonsStore = defineStore('commandButtons', {
   state: () => ({
     buttons: [],
@@ -229,18 +240,24 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
     async fetchRunOutput(sessionId, runId) {
       const existing = this.runs[runId];
       if (!existing) return;
-      if (existing.output && existing.output.length > 0) return; // Already have output, skip
+      // A non-zero cursor means a catch-up read has already applied chunks -
+      // possibly still sitting in the throttled buffer rather than in `output`.
+      if (hasRenderedOutput(existing)) return; // Already have output, skip
 
       try {
         const page = await api.getCommandRunOutput(sessionId, runId, { limitBytes: 2 * 1024 * 1024 });
         const output = page.chunks.map((chunk) => chunk.content).join('');
-        if (this.runs[runId]) {
+        const current = this.runs[runId];
+        // A live catch-up read for the same run may have rendered this output
+        // while the request was in flight; overwriting it would duplicate or
+        // truncate what the viewer is already looking at.
+        if (current && !hasRenderedOutput(current)) {
           const { output: boundedOutput, truncated } = truncateOutput(output);
           this.runs[runId] = {
-            ...this.runs[runId],
+            ...current,
             output: boundedOutput,
             outputTruncated: truncated,
-            outputHighWater: page.highWater,
+            outputHighWater: Math.max(page.highWater || 0, current.outputHighWater || 0),
           };
         }
       } catch (err) {
@@ -248,10 +265,23 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
+    /**
+     * Record how far the rendered output has been applied. The cursor is shared
+     * state: a snapshot fetch and a live catch-up read can both write output,
+     * and whichever runs second must not replay what is already on screen.
+     */
+    advanceOutputHighWater(runId, sequence) {
+      const run = this.runs[runId];
+      if (!run) return;
+      if (sequence > (run.outputHighWater || 0)) run.outputHighWater = sequence;
+    },
+
     async syncRunOutput(sessionId, runId, after = 0, applyChunk) {
       const existing = this.runs[runId];
       if (!existing) return { highWater: after, hasMore: false };
-      let cursor = after;
+      // Never re-read below what is already rendered - `after` is captured by
+      // the caller before awaiting and can be stale by the time we run.
+      let cursor = Math.max(after, existing.outputHighWater || 0);
       let hasMore = true;
       let pages = 0;
       while (hasMore && pages < MAX_SYNC_PAGES_PER_CALL) {
@@ -265,7 +295,7 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
         hasMore = page.hasMore && page.chunks.length > 0;
       }
       this.flushPendingOutput(runId);
-      if (this.runs[runId]) this.runs[runId].outputHighWater = cursor;
+      this.advanceOutputHighWater(runId, cursor);
       return { highWater: cursor, hasMore };
     },
 

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -203,8 +203,8 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
       }
     },
 
-    appendOutput(runId, text) {
-      appendOutputHelper(this, runId, text);
+    appendOutput(runId, text, options) {
+      appendOutputHelper(this, runId, text, options);
     },
 
     flushPendingOutput(runId) {

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -1157,6 +1157,30 @@ describe('CommandButtons Store', () => {
       expect(store.runs['r1'].outputHighWater).toBe(2);
     });
 
+    it('skips the snapshot read when a catch-up read already applied chunks', async () => {
+      const store = useCommandButtonsStore();
+      // Output is still in the throttled flush buffer, so only the cursor shows
+      // that the chunks have been applied. Re-reading here would duplicate them.
+      store.runs = { r1: { runId: 'r1', status: 'success', output: '', outputHighWater: 2, outputTruncated: false } };
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      expect(api.getCommandRunOutput).not.toHaveBeenCalled();
+    });
+
+    it('leaves output alone when a catch-up read renders it mid-request', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = { r1: { runId: 'r1', status: 'success', output: '', outputHighWater: 0, outputTruncated: false } };
+      api.getCommandRunOutput.mockImplementation(async () => {
+        store.runs.r1 = { ...store.runs.r1, output: 'streamed output', outputHighWater: 2 };
+        return { chunks: [{ sequence: 1, content: 'streamed ' }, { sequence: 2, content: 'output' }], highWater: 2, hasMore: false };
+      });
+
+      await store.fetchRunOutput('sess-1', 'r1');
+
+      expect(store.runs.r1.output).toBe('streamed output');
+    });
+
     it('fetches persisted chunks while a run is currently running', async () => {
       const store = useCommandButtonsStore();
       store.runs = {
@@ -1279,6 +1303,48 @@ describe('CommandButtons Store', () => {
 
       expect(api.getCommandRunOutput).toHaveBeenCalledTimes(MAX_SYNC_PAGES_PER_CALL);
       expect(result).toEqual({ highWater: MAX_SYNC_PAGES_PER_CALL, hasMore: true });
+    });
+
+    it('never re-reads below output already rendered by another loader', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = { r1: { runId: 'r1', output: 'already rendered', outputTruncated: false, outputHighWater: 4 } };
+      api.getCommandRunOutput.mockResolvedValue({ chunks: [], highWater: 4, hasMore: false });
+
+      // `after` is captured before awaiting, so a stale caller must not make the
+      // catch-up read replay chunks that are already on screen.
+      const result = await store.syncRunOutput('sess-1', 'r1', 0);
+
+      expect(api.getCommandRunOutput).toHaveBeenCalledWith('sess-1', 'r1', expect.objectContaining({ after: 4 }));
+      expect(result.highWater).toBe(4);
+    });
+
+    it('does not lower the rendered cursor when a read returns nothing', async () => {
+      const store = useCommandButtonsStore();
+      store.runs = { r1: { runId: 'r1', output: 'rendered', outputTruncated: false, outputHighWater: 7 } };
+      api.getCommandRunOutput.mockResolvedValue({ chunks: [], highWater: 7, hasMore: false });
+
+      await store.syncRunOutput('sess-1', 'r1', 0);
+
+      expect(store.runs.r1.outputHighWater).toBe(7);
+    });
+  });
+
+  describe('advanceOutputHighWater', () => {
+    it('raises the cursor and ignores stale sequences', () => {
+      const store = useCommandButtonsStore();
+      store.runs = { r1: { runId: 'r1', output: '', outputHighWater: 0 } };
+
+      store.advanceOutputHighWater('r1', 3);
+      store.advanceOutputHighWater('r1', 2);
+
+      expect(store.runs.r1.outputHighWater).toBe(3);
+    });
+
+    it('ignores runs that are not in the store', () => {
+      const store = useCommandButtonsStore();
+      store.runs = {};
+
+      expect(() => store.advanceOutputHighWater('missing', 3)).not.toThrow();
     });
   });
 

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -624,6 +624,30 @@ describe('CommandButtons Store', () => {
       expect(store.runs['run-1'].output).toBe('error output');
     });
 
+    it('appendOutput applies sequenced catch-up text that lands after completion', () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'run-1': { runId: 'run-1', status: 'success', output: 'LINE 67\n', outputTruncated: false },
+      };
+
+      // A resync issued while the run was still going can only resolve after
+      // the completion event; its chunks must still reach the rendered output.
+      store.appendOutput('run-1', 'LINE 68\n', { allowAfterCompletion: true });
+
+      expect(store.runs['run-1'].output).toBe('LINE 67\nLINE 68\n');
+    });
+
+    it('appendOutput applies sequenced catch-up text for errored runs too', () => {
+      const store = useCommandButtonsStore();
+      store.runs = {
+        'run-1': { runId: 'run-1', status: 'error', output: 'boom', outputTruncated: false },
+      };
+
+      store.appendOutput('run-1', ' trailing', { allowAfterCompletion: true });
+
+      expect(store.runs['run-1'].output).toBe('boom trailing');
+    });
+
     it('completeRun updates status and exit code', () => {
       const store = useCommandButtonsStore();
       store.runs = {

--- a/packages/web/src/stores/commandButtonsOutputBuffer.js
+++ b/packages/web/src/stores/commandButtonsOutputBuffer.js
@@ -20,6 +20,24 @@ export function truncateOutput(text) {
 }
 
 /**
+ * Resolve the client-side high-water cursor for a run entry.
+ *
+ * Client-side the cursor tracks how much output has actually been rendered, so
+ * the server's cursor only applies when its output snapshot does. Adopting it
+ * alongside an empty snapshot (lightweight queries exclude output) would make
+ * later catch-up reads skip the very chunks that still need to be displayed.
+ *
+ * @param {Object} run - The run data from API
+ * @param {Object|undefined} existing - Existing run entry if present
+ * @param {boolean} hasServerOutput - Whether the API response carried output
+ * @returns {number} The cursor to store
+ */
+function resolveOutputHighWater(run, existing, hasServerOutput) {
+  if (!hasServerOutput) return existing?.outputHighWater ?? 0;
+  return run.outputHighWater ?? existing?.outputHighWater ?? 0;
+}
+
+/**
  * Build a run entry, preserving existing output if API returned empty.
  * @param {Object} run - The run data from API
  * @param {string} runId - The resolved run ID
@@ -40,7 +58,7 @@ export function buildRunEntry(run, runId, existing) {
     startedAt: run.startedAt,
     completedAt: run.completedAt,
     hasOutput: run.hasOutput ?? existing?.hasOutput ?? Boolean(output),
-    outputHighWater: run.outputHighWater ?? existing?.outputHighWater ?? 0,
+    outputHighWater: resolveOutputHighWater(run, existing, Boolean(output)),
     outputTruncated: hasExistingOutput ? existing.outputTruncated : truncated,
   };
 }
@@ -181,7 +199,7 @@ export function processRunFromApi(run, sessionId, existing) {
     startedAt: run.startedAt,
     completedAt: run.completedAt,
     hasOutput: run.hasOutput ?? existing?.hasOutput ?? Boolean(resolvedOutput),
-    outputHighWater: run.outputHighWater ?? existing?.outputHighWater ?? 0,
+    outputHighWater: resolveOutputHighWater(run, existing, Boolean(output)),
     outputTruncated: resolvedTruncated,
   };
 }

--- a/packages/web/src/stores/commandButtonsOutputBuffer.js
+++ b/packages/web/src/stores/commandButtonsOutputBuffer.js
@@ -46,6 +46,25 @@ export function buildRunEntry(run, runId, existing) {
 }
 
 /**
+ * Append text to a run's rendered output immediately (no throttling buffer).
+ * @param {Object} store - The Pinia store instance
+ * @param {string} runId - The run ID
+ * @param {string} text - The text to append
+ */
+function patchRunOutput(store, runId, text) {
+  const { output, truncated } = truncateOutput(store.runs[runId].output + text);
+  store.$patch({
+    runs: {
+      [runId]: {
+        ...store.runs[runId],
+        output,
+        outputTruncated: store.runs[runId].outputTruncated || truncated,
+      },
+    },
+  });
+}
+
+/**
  * Flush buffered output to the run state.
  * Called on a timer to batch updates and reduce reactivity overhead.
  * @param {Object} store - The Pinia store instance (with runs, _outputBuffers, _flushTimers, $patch)
@@ -67,20 +86,8 @@ export function flushOutput(store, runId) {
     return;
   }
 
-  // Combine existing output with buffer
-  const combined = store.runs[runId].output + buffer;
-  const { output, truncated } = truncateOutput(combined);
-
-  // Update state in one batch
-  store.$patch({
-    runs: {
-      [runId]: {
-        ...store.runs[runId],
-        output,
-        outputTruncated: store.runs[runId].outputTruncated || truncated,
-      },
-    },
-  });
+  // Combine existing output with buffer in one batched state update
+  patchRunOutput(store, runId, buffer);
 
   // Clear the buffer
   delete store._outputBuffers[runId];
@@ -94,8 +101,14 @@ export function flushOutput(store, runId) {
  * @param {Object} store - The Pinia store instance
  * @param {string} runId - The run ID
  * @param {string} text - The text to append
+ * @param {Object} [options]
+ * @param {boolean} [options.allowAfterCompletion=false] - Set by callers that
+ *   dedupe by persisted sequence number (the command-run output subscription).
+ *   Their catch-up chunks may legitimately land after the completion event -
+ *   e.g. a resync issued because the socket was backpressured - and dropping
+ *   them would truncate the tail of the run permanently.
  */
-export function appendOutput(store, runId, text) {
+export function appendOutput(store, runId, text, { allowAfterCompletion = false } = {}) {
   if (!store.runs[runId]) {
     return;
   }
@@ -103,6 +116,9 @@ export function appendOutput(store, runId, text) {
   // Ignore output for completed runs to prevent duplication
   // (WS output events can arrive after the complete event due to race conditions)
   if (store.runs[runId].status !== 'running') {
+    // The throttled buffer path is finalized once a run completes, so
+    // sequenced catch-up text is applied straight to the rendered output.
+    if (allowAfterCompletion && text) patchRunOutput(store, runId, text);
     return;
   }
 

--- a/tests/e2e/circus-command-output-auto-tail.spec.ts
+++ b/tests/e2e/circus-command-output-auto-tail.spec.ts
@@ -126,6 +126,12 @@ test.describe('Circus Command Output Auto-Tail', () => {
     await page.locator('.output-text').dispatchEvent('scroll');
 
     await expect(page.locator('.status-running')).toBeHidden({ timeout: 15000 });
+    // The completion event and the final output chunks are separate messages,
+    // and a backpressure resync re-reads the stream over HTTP, so the tail can
+    // legitimately render just after the run is marked complete.
+    await expect
+      .poll(async () => latestLineMarker(page, '.output-text'), { timeout: 10000 })
+      .toBe(LINE_COUNT);
     await expect
       .poll(async () => distanceFromBottom(page, '.output-text'), { timeout: 5000 })
       .toBeLessThanOrEqual(OUTPUT_BOTTOM_TOLERANCE_PX);


### PR DESCRIPTION
## Summary

Documents `GET /api/providers` in the generated agent system prompt and reference documentation, so agents can discover currently available provider and model IDs before creating workspaces or sessions.

This PR also contains a cohesive command-run output-delivery hardening set that was already present on the branch. It remains here because its subscription, store, buffer, auto-tail, and regression tests are interdependent; splitting it after reconciliation would require transplanting coupled implementation and tests.

## Provider discovery

- Adds the `GET /api/providers` curl example and response shape (`kind`, `models[].modelId`, `displayName`, `tier`, `enabled`, `lifecycle`) to the generated prompt and its reference documentation.
- Describes the endpoint as the source of currently available/discoverable choices, not a complete validation contract. SDK tier aliases (`fable`, `opus`, `sonnet`, `haiku`) and retained historical model IDs may also validate.

## Command-output delivery hardening

- Retains the mainline invariant that a persisted final output chunk may arrive after `COMMAND_RUN_COMPLETE` and must still render.
- Tracks a per-run sequence high-water cursor, adopts progress rendered by concurrent snapshot/catch-up loaders, and queues a follow-up resync when a chunk arrives during an in-flight read.
- Keeps output bounded, prevents replay/duplicate delivery across live and persisted channels, and prevents snapshot reads from overwriting output rendered mid-request.
- Fixes auto-tail races: user scroll-away cancels a queued tail scroll, while the composable ignores its own delayed scroll event so growing output does not spuriously pause tailing.

## Regression surface

Focused tests cover late completion output, sequence/cursor deduplication and catch-up, concurrent output loading, bounded buffering, and auto-tail timing races.

## Verification

- Merged current `origin/main` and resolved the `commandButtonsOutputBuffer.js` conflict behaviorally.
- `yarn workspace @circuschief/web test --run src/stores/commandButtons.test.js src/composables/useCommandRunOutputSubscription.test.js src/composables/useOutputAutoTail.test.js`
- `yarn workspace @circuschief/server test --run src/services/sessionPrompts.test.js`
- `yarn lint`
- `yarn build`