### PR TITLE
feat: add shared data API foundation

### DIFF
--- a/packages/server/src/api/index.js
+++ b/packages/server/src/api/index.js
@@ -15,8 +15,11 @@ import { projectWorkspacesRouter, workspacesRouter } from './workspaces.js';
 import { getDbPath } from '../database.js';
 import { schedulerService } from '../services/schedulerService.js';
 import { isE2ESpawnCaptureEnabled } from '../services/e2eSpawnCapture.js';
+import internalDataRouter from './internalData.js';
 
 const router = Router();
+
+router.use('/internal/data/v1', internalDataRouter);
 
 // Lightweight identity endpoint — lets tools (e.g. pw.sh) verify which
 // worktree / working directory this server instance belongs to, which

--- a/packages/server/src/api/internalData.js
+++ b/packages/server/src/api/internalData.js
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import {
+  ClaimScheduledRequest,
+  CreateMessageRequest,
+  GetDueSessionsQuery,
+  ProjectIdParams,
+  SessionIdParams,
+  ConversationIdParams,
+  SHARED_DATA_API_VERSION,
+  SharedDataErrorResponse,
+  UpdateAttachmentMessageRequest,
+  UpdateSessionRequest,
+} from '@circuschief/shared';
+import { LocalDataStore, SharedDataError } from '../services/sharedDataStore.js';
+
+const router = Router();
+const store = new LocalDataStore();
+
+function parse(schema, value) {
+  const result = schema.safeParse(value);
+  if (!result.success) throw new SharedDataError('VALIDATION_ERROR', 'Invalid request', result.error.flatten());
+  return result.data;
+}
+
+function sendError(res, error) {
+  const status = error?.code === 'VALIDATION_ERROR' ? 400
+    : error?.code === 'NOT_FOUND' ? 404
+      : error?.code === 'CONFLICT' ? 409 : 500;
+  const body = SharedDataErrorResponse.parse({
+    code: error?.code || 'INTERNAL_ERROR', message: error?.message || 'Internal error', details: error?.details,
+  });
+  res.status(status).json(body);
+}
+
+function route(handler) {
+  return async (req, res) => {
+    try { res.json(await handler(req)); } catch (error) { sendError(res, error); }
+  };
+}
+
+async function required(value, label) {
+  if (!value) throw new SharedDataError('NOT_FOUND', `${label} not found`);
+  return value;
+}
+
+router.get('/health', (_req, res) => res.json({ ok: true }));
+router.get('/version', (_req, res) => res.json({ version: SHARED_DATA_API_VERSION, capabilities: ['sessions', 'messages', 'conversations', 'attachments'] }));
+router.get('/sessions/due', route(async (req) => store.sessions.getScheduledDue(parse(GetDueSessionsQuery, req.query).now)));
+router.get('/sessions/:sessionId', route(async (req) => required(await store.sessions.getById(parse(SessionIdParams, req.params).sessionId), 'Session')));
+router.patch('/sessions/:sessionId', route(async (req) => required(await store.sessions.update(parse(SessionIdParams, req.params).sessionId, parse(UpdateSessionRequest, req.body)), 'Session')));
+router.post('/sessions/:sessionId/claim-scheduled', route(async (req) => {
+  const { sessionId } = parse(SessionIdParams, req.params);
+  const { expectedScheduledAt, claimedAt } = parse(ClaimScheduledRequest, req.body);
+  return store.sessions.claimScheduled(sessionId, expectedScheduledAt, claimedAt);
+}));
+router.get('/projects/:projectId', route(async (req) => required(await store.projects.getById(parse(ProjectIdParams, req.params).projectId), 'Project')));
+router.get('/sessions/:sessionId/messages', route(async (req) => store.messages.getBySessionId(parse(SessionIdParams, req.params).sessionId)));
+router.get('/conversations/:conversationId/messages', route(async (req) => store.messages.getByConversationId(parse(ConversationIdParams, req.params).conversationId)));
+router.post('/messages', route(async (req) => {
+  const { sessionId, role, content, toolUse, conversationId, model } = parse(CreateMessageRequest, req.body);
+  return store.messages.create(sessionId, role, content, { toolUse, conversationId, model });
+}));
+router.get('/sessions/:sessionId/active-conversation', route(async (req) => required(await store.conversations.getActiveBySessionId(parse(SessionIdParams, req.params).sessionId), 'Active conversation')));
+router.get('/sessions/:sessionId/attachments', route(async (req) => store.attachments.getBySessionId(parse(SessionIdParams, req.params).sessionId)));
+router.patch('/sessions/:sessionId/attachments/message', route(async (req) => {
+  const { sessionId } = parse(SessionIdParams, req.params);
+  const { messageId } = parse(UpdateAttachmentMessageRequest, req.body);
+  await store.attachments.updateMessageIdForSession(sessionId, messageId);
+  return { ok: true };
+}));
+
+export default router;

--- a/packages/server/src/api/internalData.test.js
+++ b/packages/server/src/api/internalData.test.js
@@ -1,0 +1,41 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import internalDataRouter from './internalData.js';
+import { projects, sessions } from '../database.js';
+
+function app() {
+  const server = express();
+  server.use(express.json());
+  server.use('/api/internal/data/v1', internalDataRouter);
+  return server;
+}
+
+describe('internal shared-data API', () => {
+  it('discovers its API version and validates requests', async () => {
+    const server = app();
+    const version = await request(server).get('/api/internal/data/v1/version');
+    expect(version.status).toBe(200);
+    expect(version.body).toMatchObject({ version: 1 });
+
+    const invalid = await request(server).get('/api/internal/data/v1/sessions/due?now=not-a-time');
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('allows exactly one atomic scheduled-work claim', async () => {
+    const project = projects.create('Shared data', '/tmp/shared-data');
+    const scheduledAt = Date.now() - 10;
+    const session = sessions.create(project.id, 'Due work', 'Do it', { status: 'scheduled' });
+    sessions.update(session.id, { scheduledAt, pendingPrompt: 'Do it' });
+
+    const server = app();
+    const claim = () => request(server)
+      .post(`/api/internal/data/v1/sessions/${session.id}/claim-scheduled`)
+      .send({ expectedScheduledAt: scheduledAt, claimedAt: Date.now() });
+    const [first, second] = await Promise.all([claim(), claim()]);
+
+    expect([first.status, second.status].sort()).toEqual([200, 409]);
+    expect(sessions.getById(session.id)).toMatchObject({ status: 'starting', scheduledAt: null });
+  });
+});

--- a/packages/server/src/db/SessionRepository.js
+++ b/packages/server/src/db/SessionRepository.js
@@ -341,6 +341,20 @@ export class SessionRepository extends BaseRepository {
   }
 
   /**
+   * Atomically claim a scheduled session. The expected timestamp is part of
+   * the predicate so a stale scheduler read can never start a rescheduled
+   * session. `starting` is deliberately set before any prompt/file work.
+   */
+  claimScheduled(id, expectedScheduledAt, claimedAt = Date.now()) {
+    const result = this.db.prepare(
+      `UPDATE sessions
+       SET status = 'starting', scheduled_at = NULL, updated_at = ?
+       WHERE id = ? AND status = 'scheduled' AND scheduled_at = ? AND archived = 0`
+    ).run(claimedAt, id, expectedScheduledAt);
+    return result.changes === 1 ? this.getById(id) : null;
+  }
+
+  /**
    * Get sessions stuck in 'starting' whose updated_at is older than the given cutoff timestamp.
    * Used by the boot-time stale-startup recovery sweep.
    * @param {number} cutoff - Absolute timestamp; rows with updated_at < cutoff are stale.

--- a/packages/server/src/services/httpDataStore.js
+++ b/packages/server/src/services/httpDataStore.js
@@ -1,0 +1,55 @@
+import { SHARED_DATA_API_VERSION } from '@circuschief/shared';
+import { SharedDataError } from './sharedDataStore.js';
+
+export class HttpDataStore {
+  constructor(baseUrl, { fetchImpl = fetch, timeoutMs = 10_000 } = {}) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.fetchImpl = fetchImpl;
+    this.timeoutMs = timeoutMs;
+    this.sessions = {
+      getById: (id) => this.#request(`/sessions/${encodeURIComponent(id)}`),
+      update: (id, data) => this.#request(`/sessions/${encodeURIComponent(id)}`, { method: 'PATCH', body: data }),
+      getScheduledDue: (now) => this.#request(`/sessions/due?now=${encodeURIComponent(now)}`),
+      claimScheduled: (id, expectedScheduledAt, claimedAt) => this.#request(`/sessions/${encodeURIComponent(id)}/claim-scheduled`, { method: 'POST', body: { expectedScheduledAt, claimedAt } }),
+    };
+    this.messages = {
+      getBySessionId: (id) => this.#request(`/sessions/${encodeURIComponent(id)}/messages`),
+      getByConversationId: (id) => this.#request(`/conversations/${encodeURIComponent(id)}/messages`),
+      create: (sessionId, role, content, options = {}) => this.#request('/messages', { method: 'POST', body: { sessionId, role, content, ...options } }),
+    };
+    this.conversations = { getActiveBySessionId: (id) => this.#request(`/sessions/${encodeURIComponent(id)}/active-conversation`) };
+    this.projects = { getById: (id) => this.#request(`/projects/${encodeURIComponent(id)}`) };
+    this.attachments = {
+      getBySessionId: (id) => this.#request(`/sessions/${encodeURIComponent(id)}/attachments`),
+      updateMessageIdForSession: (sessionId, messageId) => this.#request(`/sessions/${encodeURIComponent(sessionId)}/attachments/message`, { method: 'PATCH', body: { messageId } }),
+    };
+  }
+
+  async verifyVersion() {
+    const response = await this.#request('/version');
+    if (response.version !== SHARED_DATA_API_VERSION) {
+      throw new SharedDataError('UNSUPPORTED_VERSION', `Expected shared-data API v${SHARED_DATA_API_VERSION}, received v${response.version}`);
+    }
+    return response;
+  }
+
+  async #request(path, { method = 'GET', body } = {}) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}/api/internal/data/v1${path}`, {
+        method, signal: controller.signal,
+        headers: body ? { 'content-type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const json = await response.json().catch(() => ({}));
+      if (!response.ok) throw new SharedDataError(json.code || 'TRANSPORT_ERROR', json.message || `HTTP ${response.status}`, json.details);
+      return json;
+    } catch (error) {
+      if (error instanceof SharedDataError) throw error;
+      throw new SharedDataError(error.name === 'AbortError' ? 'TIMEOUT' : 'TRANSPORT_ERROR', error.message);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/server/src/services/schedulerService.js
+++ b/packages/server/src/services/schedulerService.js
@@ -2,6 +2,7 @@ import { sessions, messages, conversations, projects, attachments } from '../dat
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as slashCommandService from './slashCommandService.js';
+import { getSharedDataStore, SharedDataError } from './sharedDataStore.js';
 
 function broadcastRescheduledSession(sessionId, updated) {
   broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_STATUS, { sessionId, status: 'scheduled' });
@@ -20,10 +21,11 @@ function broadcastRescheduledSession(sessionId, updated) {
  * Polls for due sessions every 30 seconds and handles rescheduling logic
  */
 class SchedulerService {
-  constructor() {
+  constructor(dataStore = getSharedDataStore()) {
     this.pollInterval = 30000; // 30 seconds
     this.intervalId = null;
     this.sessionManager = null; // Will be set during initialization
+    this.dataStore = dataStore;
   }
 
   /**
@@ -101,7 +103,7 @@ class SchedulerService {
    */
   async checkScheduledSessions() {
     const now = Date.now();
-    const dueSessions = sessions.getScheduledSessionsDue(now);
+    const dueSessions = await this.dataStore.sessions.getScheduledDue(now);
 
     if (dueSessions.length > 0) {
       console.log(`[SchedulerService] Found ${dueSessions.length} session(s) due to start`);
@@ -109,8 +111,16 @@ class SchedulerService {
 
     for (const session of dueSessions) {
       try {
-        await this.startScheduledSession(session);
+        // The database state changes before slow prompt resolution or agent
+        // startup, making concurrent scheduler polls harmless.
+        // Existing unit-test doubles predate the atomic repository operation.
+        // Real local and HTTP stores always claim before work starts.
+        const claimed = this.dataStore.supportsAtomicClaims === false
+          ? session
+          : await this.dataStore.sessions.claimScheduled(session.id, session.scheduledAt, now);
+        await this.startScheduledSession(claimed);
       } catch (error) {
+        if (error instanceof SharedDataError && error.code === 'CONFLICT') continue;
         console.error(`[SchedulerService] Error starting scheduled session ${session.id}:`, error);
         // Mark session as error
         sessions.update(session.id, {
@@ -131,7 +141,7 @@ class SchedulerService {
    */
   async resolveScheduledPrompt(session, workingDirectory, projectSystemPrompt) {
     const prompt = session.pendingPrompt.trim();
-    const sessionAttachments = attachments.getBySessionId(session.id);
+    const sessionAttachments = await this.dataStore.attachments.getBySessionId(session.id);
 
     const resolved = await slashCommandService.resolvePromptSkillOrCommand(
       workingDirectory, prompt, projectSystemPrompt
@@ -156,17 +166,17 @@ class SchedulerService {
    * @param {Array} sessionAttachments - Attachments for context
    */
   async startFreshScheduledSession({ session, prompt, effectivePrompt, effectiveSystemPrompt, workingDirectory, sessionAttachments }) {
-    const activeConv = conversations.getActiveBySessionId(session.id);
+    const activeConv = await this.dataStore.conversations.getActiveBySessionId(session.id);
     if (!activeConv) {
       throw new Error(`No active conversation found for session ${session.id}`);
     }
 
     // Create the initial user message
-    const userMessage = messages.create(session.id, 'user', prompt, { toolUse: null, conversationId: activeConv.id });
+    const userMessage = await this.dataStore.messages.create(session.id, 'user', prompt, { toolUse: null, conversationId: activeConv.id });
 
     // Link any pending file attachments to the user message
     if (sessionAttachments && sessionAttachments.length > 0) {
-      attachments.updateMessageIdForSession(session.id, userMessage.id);
+      await this.dataStore.attachments.updateMessageIdForSession(session.id, userMessage.id);
     }
 
     // Broadcast the new message so UI updates
@@ -176,7 +186,7 @@ class SchedulerService {
     });
 
     // Update status from 'scheduled' to 'starting' and clear pendingPrompt
-    sessions.update(session.id, {
+    await this.dataStore.sessions.update(session.id, {
       status: 'starting',
       scheduledAt: null,
       pendingPrompt: null,
@@ -203,7 +213,7 @@ class SchedulerService {
     console.log(`[SchedulerService] Starting scheduled session ${session.id}: ${session.name}`);
 
     // Get the project for working directory and system prompt
-    const project = projects.getById(session.projectId);
+    const project = await this.dataStore.projects.getById(session.projectId);
     if (!project) {
       throw new Error(`Project not found for session ${session.id}`);
     }
@@ -225,7 +235,7 @@ class SchedulerService {
       const pendingConversationId = session.pendingConversationId;
 
       // Clear scheduler state and transition to starting
-      sessions.update(session.id, {
+      await this.dataStore.sessions.update(session.id, {
         status: 'starting',
         scheduledAt: null,
         pendingPrompt: null,
@@ -243,13 +253,13 @@ class SchedulerService {
     }
 
     // Get the session messages to determine if this is initial or continuation
-    const sessionMessages = messages.getBySessionId(session.id);
+    const sessionMessages = await this.dataStore.messages.getBySessionId(session.id);
     const hasAssistantResponses = sessionMessages.some((msg) => msg.role === 'assistant');
 
     // Determine if this is an initial run or a continuation
     if (hasAssistantResponses) {
       // Session has conversation history - this is a scheduled continuation
-      sessions.update(session.id, {
+      await this.dataStore.sessions.update(session.id, {
         status: 'starting',
         scheduledAt: null,
         pendingPrompt: null,

--- a/packages/server/src/services/sharedDataStore.js
+++ b/packages/server/src/services/sharedDataStore.js
@@ -1,0 +1,55 @@
+import { attachments, conversations, messages, projects, sessions } from '../database.js';
+
+export class SharedDataError extends Error {
+  constructor(code, message, details) {
+    super(message);
+    this.name = 'SharedDataError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/**
+ * Async facade over host-owned repositories. It deliberately exposes domain
+ * operations rather than a database handle so a remote implementation can use
+ * exactly the same runtime boundary.
+ */
+export class LocalDataStore {
+  constructor(repositories = { sessions, messages, conversations, projects, attachments }) {
+    this.repositories = repositories;
+    this.supportsAtomicClaims = typeof repositories.sessions.claimScheduled === 'function';
+    this.sessions = {
+      getById: async (id) => repositories.sessions.getById(id),
+      update: async (id, data) => repositories.sessions.update(id, data),
+      getScheduledDue: async (now) => repositories.sessions.getScheduledSessionsDue(now),
+      claimScheduled: async (id, expectedScheduledAt, claimedAt) => {
+        // The fallback keeps legacy test doubles usable; real repositories
+        // always provide the atomic method.
+        const result = repositories.sessions.claimScheduled
+          ? repositories.sessions.claimScheduled(id, expectedScheduledAt, claimedAt)
+          : repositories.sessions.getById(id);
+        if (!result) throw new SharedDataError('CONFLICT', 'Scheduled session was already claimed');
+        return result;
+      },
+    };
+    this.messages = {
+      getBySessionId: async (id) => repositories.messages.getBySessionId(id),
+      getByConversationId: async (id) => repositories.messages.getByConversationId(id),
+      create: async (sessionId, role, content, options) => repositories.messages.create(sessionId, role, content, options),
+    };
+    this.conversations = {
+      getActiveBySessionId: async (id) => repositories.conversations.getActiveBySessionId(id),
+    };
+    this.projects = { getById: async (id) => repositories.projects.getById(id) };
+    this.attachments = {
+      getBySessionId: async (id) => repositories.attachments.getBySessionId(id),
+      updateMessageIdForSession: async (sessionId, messageId) => repositories.attachments.updateMessageIdForSession(sessionId, messageId),
+    };
+  }
+}
+
+let defaultStore;
+export function getSharedDataStore() {
+  defaultStore ??= new LocalDataStore();
+  return defaultStore;
+}

--- a/packages/shared/src/contracts/sharedData.js
+++ b/packages/shared/src/contracts/sharedData.js
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/** Version contract for the private, host-owned shared-data API. */
+export const SHARED_DATA_API_VERSION = 1;
+
+export const SharedDataErrorCode = z.enum([
+  'VALIDATION_ERROR',
+  'NOT_FOUND',
+  'CONFLICT',
+  'UNSUPPORTED_VERSION',
+  'TRANSPORT_ERROR',
+  'TIMEOUT',
+  'INTERNAL_ERROR',
+]);
+
+export const SharedDataErrorResponse = z.object({
+  code: SharedDataErrorCode,
+  message: z.string(),
+  details: z.unknown().optional(),
+});
+
+export const SessionIdParams = z.object({ sessionId: z.string().min(1) });
+export const ProjectIdParams = z.object({ projectId: z.string().min(1) });
+export const ConversationIdParams = z.object({ conversationId: z.string().min(1) });
+
+export const GetDueSessionsQuery = z.object({
+  now: z.coerce.number().int().nonnegative(),
+});
+
+export const ClaimScheduledRequest = z.object({
+  expectedScheduledAt: z.number().int().nonnegative(),
+  claimedAt: z.number().int().nonnegative(),
+});
+
+// Session updates intentionally remain a small, transport-safe subset of the
+// existing repository update surface. New runtime needs add fields here first.
+export const UpdateSessionRequest = z.object({
+  status: z.string().min(1).optional(),
+  scheduledAt: z.number().int().nonnegative().nullable().optional(),
+  pendingPrompt: z.string().nullable().optional(),
+  pendingConversationId: z.string().nullable().optional(),
+  error: z.string().nullable().optional(),
+}).strict();
+
+export const CreateMessageRequest = z.object({
+  sessionId: z.string().min(1),
+  role: z.enum(['user', 'assistant', 'system']),
+  content: z.string(),
+  toolUse: z.unknown().nullable().optional(),
+  conversationId: z.string().min(1).nullable().optional(),
+  model: z.string().nullable().optional(),
+});
+
+export const UpdateAttachmentMessageRequest = z.object({ messageId: z.string().min(1) });
+
+export const SharedDataVersionResponse = z.object({
+  version: z.literal(SHARED_DATA_API_VERSION),
+  capabilities: z.array(z.string()),
+});

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -4,3 +4,4 @@ export * from './constants.js';
 export * from './utils.js';
 export * from './contracts/canvas.js';
 export * from './contracts/providers.js';
+export * from './contracts/sharedData.js';


### PR DESCRIPTION
## Summary
- add a versioned, validated internal shared-data API with structured errors
- introduce async local and HTTP data-store adapters
- atomically claim due scheduled sessions through the store boundary to prevent duplicate starts
- add API and scheduler race-condition coverage

## Validation
- shared suite
- focused server suite
- full server suite