### PR TITLE
Fix registration of durable Kanban migrations

### DIFF
--- a/packages/server/src/db/migrations/index.js
+++ b/packages/server/src/db/migrations/index.js
@@ -340,4 +340,13 @@ export const allMigrations = validateMigrations([
 
   // --- Kanban hard cutover: lane configuration is the only execution mode ---
   k.get('kanban-drop-completion-mode-hard-cutover'),
+
+  // --- Durable Kanban delivery, observability, and API operation ownership ---
+  // Keep these after the lane-run tables are created. Existing databases need
+  // the additive delivery columns even though fresh databases get them from
+  // schema.sql.
+  k.get('kanban-lane-entry-retry-schedule'),
+  k.get('kanban-durable-delivery-and-api-operations'),
+  k.get('kanban-delivery-health-status-index'),
+  k.get('kanban-api-operation-leases-and-canonical-responses'),
 ]);

--- a/packages/server/src/db/migrations/registration.test.js
+++ b/packages/server/src/db/migrations/registration.test.js
@@ -12,4 +12,20 @@ describe('migration registration', () => {
     expect(workflowIndex).toBeGreaterThanOrEqual(0);
     expect(workflowIndex).toBeLessThan(immutableParentageIndex);
   });
+
+  it('registers durable delivery migrations after the lane-run workflow', () => {
+    const names = allMigrations.map(({ name }) => name);
+    const workflowIndex = names.indexOf('kanban-add-lane-run-workflow');
+    const durableDeliveryMigrations = [
+      'kanban-lane-entry-retry-schedule',
+      'kanban-durable-delivery-and-api-operations',
+      'kanban-delivery-health-status-index',
+      'kanban-api-operation-leases-and-canonical-responses',
+    ];
+
+    for (const name of durableDeliveryMigrations) {
+      expect(names).toContain(name);
+      expect(names.indexOf(name)).toBeGreaterThan(workflowIndex);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- register the durable Kanban delivery migrations in the central migration list
- preserve their required ordering after the lane-run workflow migration
- add regression coverage so omitted migration registrations are caught

## Context

Existing SQLite databases did not receive the `delivery_phase` column because its migration existed but was absent from `allMigrations`. The related follow-on migrations were also unregistered. This caused lane-entry automation to fail at runtime with `SqliteError: no such column: delivery_phase`.

## Validation

- 5 focused test files passed (62 tests)
- `git diff --check` passed
