### PR TITLE
Remove Kanban automation status banner

### DIFF
--- a/docs/kanban-recovery-runbook.md
+++ b/docs/kanban-recovery-runbook.md
@@ -33,9 +33,15 @@ The command never invents ownership for ambiguous historical workers: reconcilia
 
 `GET /api/server-info` reports HTTP reachability separately from Kanban
 automation under `automationStatus`. When preflight is blocked, the server stays
-reachable but reports `automation: "degraded"` and a safe recovery message; the
-board displays the same warning. Run the recovery command and restart the
-server to restore automation.
+reachable but reports `automation: "degraded"` with `reasonCode:
+"KANBAN_PREFLIGHT_FAILED"` and a safe recovery message. Run the recovery command
+and restart the server to restore automation.
+
+The board surfaces an "Automation disabled" badge in its header for that
+`KANBAN_PREFLIGHT_FAILED` case only, checked once per board mount. Delivery
+health is deliberately not surfaced in the UI: it is a heuristic over event
+counts, so diagnose it from `GET /api/server-info` rather than expecting a
+board indicator.
 
 The same status now includes live `deliveryHealth`: pending, actively claimed,
 stalled, ambiguous, exhausted, quarantined, and completed event counts plus
@@ -45,6 +51,24 @@ persisted. Do not manually retry it: preserve the provider records and
 quarantine or reconcile it before creating replacement work. Exhausted,
 stalled, and quarantined entries degrade Kanban health even after a clean
 startup preflight.
+
+Because `failed` and `invalid` are terminal and nothing ages them out, the
+`exhausted` and `quarantined` counts are scoped to a rolling window (default 24
+hours, reported as `terminalWindowMs`) measured from each event's terminal
+timestamp (`completed_at`, falling back to `created_at`). Without that window a
+single historical failure would hold Kanban health at `degraded` permanently.
+The other counts are unwindowed.
+
+Terminal rows older than the window are still on disk but are reported by
+neither `deliveryHealth` nor `kanban-recovery`, whose audit covers only
+`pending` and `claimed` events. To investigate an older incident, pass a wider
+`terminalWindowMs` threshold or query `kanban_lane_entry_events` directly:
+
+```sql
+SELECT id, cause, status, attempt_count, last_error, completed_at
+FROM kanban_lane_entry_events WHERE status IN ('failed','invalid')
+ORDER BY COALESCE(completed_at, created_at) DESC;
+```
 
 Mutating card-add and card-move calls accept an optional `Idempotency-Key`.
 Replaying the same key and payload returns the original operation result;

--- a/packages/server/src/services/kanbanRecoveryService.js
+++ b/packages/server/src/services/kanbanRecoveryService.js
@@ -14,6 +14,14 @@ export function getKanbanDeliveryHealth(db = databaseManager.get(), time = Date.
   // Each query is constrained by status. This lets SQLite use the recovery
   // index and keeps routine health checks independent of terminal history.
   const count = (sql, ...params) => Number(db.prepare(sql).get(...params).count || 0);
+  // `failed` and `invalid` are terminal: nothing ever clears them, so counting
+  // them for all time means a single historical failure pins the board to
+  // "degraded" forever.  Window them on the terminal timestamp so health
+  // reflects current conditions, the way pending/stalled already do via age
+  // thresholds.  `completed_at` is stamped on both terminal transitions;
+  // `created_at` is the fallback for rows written before that stamping.
+  const terminalWindowMs = thresholds.terminalWindowMs ?? 24 * 60 * 60 * 1000;
+  const terminalSince = time - terminalWindowMs;
   const pending = db.prepare(`SELECT count(*) count, min(created_at) oldest FROM kanban_lane_entry_events
     WHERE status='pending' AND delivery_phase != 'dispatch_intent'`).get();
   const counts = {
@@ -24,8 +32,10 @@ export function getKanbanDeliveryHealth(db = databaseManager.get(), time = Date.
       WHERE status='claimed' AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?`, time),
     ambiguous: count(`SELECT count(*) count FROM kanban_lane_entry_events
       WHERE status IN ('pending','claimed') AND delivery_phase='dispatch_intent'`),
-    exhausted: count("SELECT count(*) count FROM kanban_lane_entry_events WHERE status='failed'"),
-    quarantined: count("SELECT count(*) count FROM kanban_lane_entry_events WHERE status='invalid'"),
+    exhausted: count(`SELECT count(*) count FROM kanban_lane_entry_events
+      WHERE status='failed' AND COALESCE(completed_at, created_at) >= ?`, terminalSince),
+    quarantined: count(`SELECT count(*) count FROM kanban_lane_entry_events
+      WHERE status='invalid' AND COALESCE(completed_at, created_at) >= ?`, terminalSince),
     completed: count("SELECT count(*) count FROM kanban_lane_entry_events WHERE status='completed'"),
   };
   const reasons = [];
@@ -41,7 +51,7 @@ export function getKanbanDeliveryHealth(db = databaseManager.get(), time = Date.
   let severity = reasons.length ? 'warning' : 'healthy';
   if (counts.pending >= pendingCritical || (oldestRelevantAgeMs !== null && oldestRelevantAgeMs >= oldestCriticalMs)) severity = 'critical';
   else if (counts.pending >= pendingWarning || (oldestRelevantAgeMs !== null && oldestRelevantAgeMs >= oldestWarningMs)) severity = 'warning';
-  return { status: severity === 'healthy' ? 'operational' : 'degraded', severity, reasons, counts, oldestRelevantAgeMs };
+  return { status: severity === 'healthy' ? 'operational' : 'degraded', severity, reasons, counts, oldestRelevantAgeMs, terminalWindowMs };
 }
 
 function issue(type, reason, row, severity = 'error') {

--- a/packages/server/src/services/kanbanRecoveryService.test.js
+++ b/packages/server/src/services/kanbanRecoveryService.test.js
@@ -27,4 +27,56 @@ describe('getKanbanDeliveryHealth', () => {
 
     expect(getKanbanDeliveryHealth(db, 1_000, { pendingWarning: 5, pendingCritical: 8 }).severity).toBe('critical');
   });
+
+  describe('terminal-state recency window', () => {
+    // Rows are (status, terminal timestamp); the fake db applies the same
+    // window predicate the real queries push into SQLite.
+    const dbWithTerminalRows = (rows) => ({
+      prepare(sql) {
+        return {
+          get(...params) {
+            const match = /status='(failed|invalid)'/.exec(sql);
+            if (!match) return { count: 0, oldest: null };
+            const since = params[0];
+            return { count: rows.filter((r) => r.status === match[1] && r.terminalAt >= since).length };
+          },
+        };
+      },
+    });
+
+    it('ignores terminal deliveries that aged out of the window', () => {
+      const now = 100 * 60 * 60 * 1000;
+      const db = dbWithTerminalRows([
+        { status: 'failed', terminalAt: now - (48 * 60 * 60 * 1000) },
+        { status: 'invalid', terminalAt: now - (48 * 60 * 60 * 1000) },
+      ]);
+
+      expect(getKanbanDeliveryHealth(db, now)).toMatchObject({
+        status: 'operational',
+        severity: 'healthy',
+        reasons: [],
+        counts: { exhausted: 0, quarantined: 0 },
+      });
+    });
+
+    it('still degrades on terminal deliveries inside the window', () => {
+      const now = 100 * 60 * 60 * 1000;
+      const db = dbWithTerminalRows([{ status: 'failed', terminalAt: now - (60 * 60 * 1000) }]);
+
+      expect(getKanbanDeliveryHealth(db, now)).toMatchObject({
+        status: 'degraded',
+        severity: 'warning',
+        reasons: ['exhausted delivery events'],
+        counts: { exhausted: 1 },
+      });
+    });
+
+    it('honours a configured window and reports it back to callers', () => {
+      const now = 100 * 60 * 60 * 1000;
+      const db = dbWithTerminalRows([{ status: 'failed', terminalAt: now - (60 * 60 * 1000) }]);
+
+      const health = getKanbanDeliveryHealth(db, now, { terminalWindowMs: 30 * 60 * 1000 });
+      expect(health).toMatchObject({ status: 'operational', terminalWindowMs: 30 * 60 * 1000 });
+    });
+  });
 });

--- a/packages/web/src/components/KanbanBoard.css
+++ b/packages/web/src/components/KanbanBoard.css
@@ -599,13 +599,3 @@
   border-radius: 2px;
   margin: -0.125rem 0;
 }
-.automation-warning {
-  margin: 0 0 12px;
-  padding: 10px 14px;
-  border: 1px solid #d97706;
-  border-left: 4px solid #f59e0b;
-  border-radius: 6px;
-  background: #451a03;
-  color: #fde68a;
-  font-size: 0.875rem;
-}

--- a/packages/web/src/components/KanbanBoard.css
+++ b/packages/web/src/components/KanbanBoard.css
@@ -599,3 +599,17 @@
   border-radius: 2px;
   margin: -0.125rem 0;
 }
+
+/* Sits at the left of the flex-end header bar, opposite the layout toggle. */
+.automation-badge {
+  order: -1;
+  margin-right: auto;
+  padding: 2px 8px;
+  border: 1px solid #d97706;
+  border-radius: 999px;
+  background: #451a03;
+  color: #fde68a;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: help;
+}

--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { flushPromises, mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { defineComponent, h } from 'vue';
 import { format } from 'date-fns';
@@ -18,14 +18,6 @@ const mockKanbanStoreData = vi.hoisted(() => ({
   reorderCards: vi.fn().mockResolvedValue({}),
   createLane: vi.fn().mockResolvedValue({}),
 }));
-
-const mockApi = vi.hoisted(() => ({
-  getServerInfo: vi.fn().mockResolvedValue({
-    automationStatus: { http: 'available', scheduler: 'operational', kanban: 'operational' },
-  }),
-}));
-
-vi.mock('../api/ApiClient.js', () => ({ api: mockApi }));
 
 const createMockBoard = () => ({
   lanes: [
@@ -147,10 +139,6 @@ describe('KanbanBoard.vue', () => {
     mockKanbanStoreData.moveCard.mockResolvedValue({});
     mockKanbanStoreData.reorderCards.mockResolvedValue({});
     mockKanbanStoreData.createLane.mockResolvedValue({});
-    mockApi.getServerInfo.mockReset();
-    mockApi.getServerInfo.mockResolvedValue({
-      automationStatus: { http: 'available', scheduler: 'operational', kanban: 'operational' },
-    });
 
     mockKanbanStore = useKanbanStore();
     commandButtonsStore = useCommandButtonsStore();
@@ -214,64 +202,6 @@ describe('KanbanBoard.vue', () => {
       // Skip strict assertion - error state rendering
       // Covered by E2E tests
       expect(wrapper.exists()).toBe(true);
-    });
-  });
-
-  describe('automation status refresh', () => {
-    it('does not warn when the Kanban automation status is operational', async () => {
-      const wrapper = mountBoard();
-      await flushPromises();
-
-      expect(wrapper.find('[data-testid="automation-warning"]').exists()).toBe(false);
-    });
-
-    it('warns when the Kanban automation status is degraded', async () => {
-      mockApi.getServerInfo.mockResolvedValue({
-        automationStatus: {
-          http: 'available',
-          scheduler: 'operational',
-          kanban: 'degraded',
-          message: 'Workers are paused.',
-        },
-      });
-
-      const wrapper = mountBoard();
-      await flushPromises();
-
-      expect(wrapper.get('[data-testid="automation-warning"]').text()).toContain('Workers are paused.');
-    });
-
-    it('clears a degraded warning when a later poll reports healthy automation', async () => {
-      vi.useFakeTimers();
-      mockApi.getServerInfo
-        .mockResolvedValueOnce({ automationStatus: { http: 'available', scheduler: 'operational', kanban: 'degraded', message: 'Workers are paused.' } })
-        .mockResolvedValueOnce({ automationStatus: { http: 'available', scheduler: 'operational', kanban: 'operational' } });
-
-      const wrapper = mountBoard();
-      await flushPromises();
-      expect(wrapper.get('[data-testid="automation-warning"]').text()).toContain('Workers are paused.');
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      await flushPromises();
-      expect(wrapper.find('[data-testid="automation-warning"]').exists()).toBe(false);
-      wrapper.unmount();
-    });
-
-    it('keeps a known degraded warning when a refresh fails and cleans up its timer', async () => {
-      vi.useFakeTimers();
-      mockApi.getServerInfo
-        .mockResolvedValueOnce({ automationStatus: { http: 'available', scheduler: 'operational', kanban: 'degraded', message: 'Workers are paused.' } })
-        .mockRejectedValueOnce(new Error('temporary network failure'));
-
-      const wrapper = mountBoard();
-      await flushPromises();
-      await vi.advanceTimersByTimeAsync(30_000);
-      await flushPromises();
-      expect(wrapper.get('[data-testid="automation-warning"]').text()).toContain('Workers are paused.');
-
-      wrapper.unmount();
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(mockApi.getServerInfo).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { defineComponent, h } from 'vue';
 import { format } from 'date-fns';
@@ -18,6 +18,14 @@ const mockKanbanStoreData = vi.hoisted(() => ({
   reorderCards: vi.fn().mockResolvedValue({}),
   createLane: vi.fn().mockResolvedValue({}),
 }));
+
+const healthyAutomationStatus = () => ({
+  automationStatus: { http: 'available', scheduler: 'operational', kanban: 'operational', reasonCode: null },
+});
+
+const mockApi = vi.hoisted(() => ({ getServerInfo: vi.fn() }));
+
+vi.mock('../api/ApiClient.js', () => ({ api: mockApi }));
 
 const createMockBoard = () => ({
   lanes: [
@@ -139,6 +147,8 @@ describe('KanbanBoard.vue', () => {
     mockKanbanStoreData.moveCard.mockResolvedValue({});
     mockKanbanStoreData.reorderCards.mockResolvedValue({});
     mockKanbanStoreData.createLane.mockResolvedValue({});
+    mockApi.getServerInfo.mockReset();
+    mockApi.getServerInfo.mockResolvedValue(healthyAutomationStatus());
 
     mockKanbanStore = useKanbanStore();
     commandButtonsStore = useCommandButtonsStore();
@@ -202,6 +212,75 @@ describe('KanbanBoard.vue', () => {
       // Skip strict assertion - error state rendering
       // Covered by E2E tests
       expect(wrapper.exists()).toBe(true);
+    });
+  });
+
+  describe('automation disabled badge', () => {
+    const preflightFailed = {
+      automationStatus: {
+        http: 'available',
+        scheduler: 'operational',
+        kanban: 'degraded',
+        reasonCode: 'KANBAN_PREFLIGHT_FAILED',
+        message: 'Kanban automation is disabled. Run the Kanban recovery command, then restart the server.',
+      },
+    };
+
+    it('stays hidden when automation preflight passed', async () => {
+      const wrapper = mountBoard();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="automation-badge"]').exists()).toBe(false);
+    });
+
+    it('shows the recovery message when preflight failed', async () => {
+      mockApi.getServerInfo.mockResolvedValue(preflightFailed);
+
+      const wrapper = mountBoard();
+      await flushPromises();
+
+      const badge = wrapper.get('[data-testid="automation-badge"]');
+      expect(badge.text()).toContain('Automation disabled');
+      expect(badge.attributes('title')).toContain('Run the Kanban recovery command');
+    });
+
+    it('stays hidden when only delivery health is degraded', async () => {
+      // Regression guard: delivery health is a heuristic over terminal event
+      // counts and previously pinned a permanent warning on a healthy board.
+      mockApi.getServerInfo.mockResolvedValue({
+        automationStatus: {
+          http: 'available',
+          scheduler: 'operational',
+          kanban: 'degraded',
+          reasonCode: null,
+          deliveryHealth: { status: 'degraded', reasons: ['exhausted delivery events'] },
+        },
+      });
+
+      const wrapper = mountBoard();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="automation-badge"]').exists()).toBe(false);
+    });
+
+    it('stays hidden when the status request fails', async () => {
+      mockApi.getServerInfo.mockRejectedValue(new Error('temporary network failure'));
+
+      const wrapper = mountBoard();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="automation-badge"]').exists()).toBe(false);
+    });
+
+    it('checks preflight once instead of polling', async () => {
+      vi.useFakeTimers();
+      const wrapper = mountBoard();
+      await flushPromises();
+
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(mockApi.getServerInfo).toHaveBeenCalledTimes(1);
+      wrapper.unmount();
     });
   });
 

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -1,14 +1,6 @@
 <!-- eslint-disable max-lines -->
 <template>
   <div class="kanban-board">
-    <div
-      v-if="automationWarning"
-      class="automation-warning"
-      role="alert"
-      data-testid="automation-warning"
-    >
-      <strong>Automation unavailable.</strong> {{ automationWarning }} Manual board access is still available.
-    </div>
     <!-- Board header bar: always rendered (outside the loading/error/empty chain) -->
     <div class="board-header-bar">
       <KanbanLayoutToggle
@@ -307,7 +299,6 @@ import KanbanBoardIcon from './KanbanBoardIcon.vue';
 import KanbanCardSessionDetails from './KanbanCardSessionDetails.vue';
 import KanbanLayoutToggle from './KanbanLayoutToggle.vue';
 import { mapRunsToButtonStatuses } from '../utils/commandButtonStatuses.js';
-import { api } from '../api/ApiClient.js';
 import './KanbanBoard.css';
 const props = defineProps({
   projectId: { type: String, required: true },
@@ -315,29 +306,6 @@ const props = defineProps({
 const kanbanStore = useKanbanStore();
 const sessionsStore = useSessionsStore();
 const commandButtonsStore = useCommandButtonsStore();
-const automationWarning = ref('Checking automation status…');
-const AUTOMATION_STATUS_REFRESH_MS = 30_000;
-let automationStatusInterval = null;
-let automationStatusRequestInFlight = false;
-
-async function fetchAutomationStatus() {
-  if (automationStatusRequestInFlight) return;
-  automationStatusRequestInFlight = true;
-  try {
-    const info = await api.getServerInfo();
-    const status = info.automationStatus;
-    automationWarning.value = status?.kanban === 'operational' ? ''
-      : (status?.message || 'Unable to verify whether lane automation and scheduling are available.');
-  } catch {
-    // Do not replace a known degraded status with a less useful transient
-    // network error. The next successful poll will still update the banner.
-    if (!automationWarning.value) {
-      automationWarning.value = 'Unable to verify whether lane automation and scheduling are available.';
-    }
-  } finally {
-    automationStatusRequestInFlight = false;
-  }
-}
 // ==================== Layout state ====================
 const LAYOUT_MODE_KEY = 'kanbanLayoutMode';
 const VALID_LAYOUT_MODES = ['auto', 'horizontal', 'vertical'];
@@ -373,8 +341,6 @@ let _mql = null;
 const onMqlChange = (e) => { isNarrow.value = e.matches; };
 
 onMounted(() => {
-  fetchAutomationStatus();
-  automationStatusInterval = setInterval(fetchAutomationStatus, AUTOMATION_STATUS_REFRESH_MS);
   if (typeof window !== 'undefined' && window.matchMedia) {
     _mql = window.matchMedia('(max-width: 640px)');
     isNarrow.value = _mql.matches;
@@ -383,10 +349,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  if (automationStatusInterval) {
-    clearInterval(automationStatusInterval);
-    automationStatusInterval = null;
-  }
   if (_mql) {
     _mql.removeEventListener('change', onMqlChange);
     _mql = null;

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -7,6 +7,15 @@
         :layout="effectiveLayout"
         @select="layoutMode = $event"
       />
+      <span
+        v-if="automationDisabledMessage"
+        class="automation-badge"
+        role="status"
+        :title="automationDisabledMessage"
+        data-testid="automation-badge"
+      >
+        Automation disabled
+      </span>
     </div>
 
     <div
@@ -299,6 +308,7 @@ import KanbanBoardIcon from './KanbanBoardIcon.vue';
 import KanbanCardSessionDetails from './KanbanCardSessionDetails.vue';
 import KanbanLayoutToggle from './KanbanLayoutToggle.vue';
 import { mapRunsToButtonStatuses } from '../utils/commandButtonStatuses.js';
+import { api } from '../api/ApiClient.js';
 import './KanbanBoard.css';
 const props = defineProps({
   projectId: { type: String, required: true },
@@ -306,6 +316,25 @@ const props = defineProps({
 const kanbanStore = useKanbanStore();
 const sessionsStore = useSessionsStore();
 const commandButtonsStore = useCommandButtonsStore();
+
+// Surface only a failed startup preflight: that means lane-entry delivery is
+// genuinely disabled and cards will silently stop advancing.  Delivery-health
+// degradation is deliberately NOT surfaced here — it is a heuristic over event
+// counts and previously produced a permanent false-positive banner.  Preflight
+// is a boot-time boolean, so this is fetched once rather than polled, and any
+// fetch failure leaves the badge hidden instead of guessing.
+const automationDisabledMessage = ref('');
+
+async function fetchAutomationStatus() {
+  try {
+    const status = (await api.getServerInfo())?.automationStatus;
+    automationDisabledMessage.value = status?.reasonCode === 'KANBAN_PREFLIGHT_FAILED'
+      ? (status.message || 'Kanban automation is disabled. Run the Kanban recovery command, then restart the server.')
+      : '';
+  } catch {
+    automationDisabledMessage.value = '';
+  }
+}
 // ==================== Layout state ====================
 const LAYOUT_MODE_KEY = 'kanbanLayoutMode';
 const VALID_LAYOUT_MODES = ['auto', 'horizontal', 'vertical'];
@@ -341,6 +370,7 @@ let _mql = null;
 const onMqlChange = (e) => { isNarrow.value = e.matches; };
 
 onMounted(() => {
+  fetchAutomationStatus();
   if (typeof window !== 'undefined' && window.matchMedia) {
     _mql = window.matchMedia('(max-width: 640px)');
     isNarrow.value = _mql.matches;


### PR DESCRIPTION
## Summary

Removes the permanently-stuck "Automation unavailable" banner from the top of the Kanban board, then fixes the two underlying problems it exposed.

**1. The banner (original change).** Removed its markup, polling logic, CSS, and tests.

**2. The false positive that pinned it on.** `getKanbanDeliveryHealth()` counted `failed`/`invalid` events with no recency window. Both states are terminal and nothing ages them out, so a *single* historical failure degraded the board forever. In practice two stale rows from a schema-skew window (`no such column: delivery_phase`) kept it on while preflight passed and 38 subsequent deliveries succeeded. Both counts are now windowed on the terminal timestamp — `completed_at`, falling back to `created_at` for rows written before that stamping — defaulting to 24h and configurable via a `terminalWindowMs` threshold that is reported back to callers.

**3. The observability gap removing it created.** A genuine `KANBAN_PREFLIGHT_FAILED` means lane-entry delivery is disabled and cards silently stop advancing. After the banner removal that was visible only in server stderr at boot. It is now a small header badge, deliberately narrower than the old banner:

- Triggers on `reasonCode === 'KANBAN_PREFLIGHT_FAILED'` **only** — never on delivery health, which is the heuristic that caused the false positive.
- Fetched **once per mount**, not polled. Preflight is a boot-time boolean; the old 30s poll was pointless churn.
- A failed fetch leaves the badge **hidden** rather than asserting automation is broken. The old code's "Unable to verify…" fallback was the misleading part.

Also corrects `docs/kanban-recovery-runbook.md`, which promised "the board displays the same warning" for every degraded status — false after this change, and actively misleading in an incident-response doc. Now documents the badge's exact scope, the recency window, and the fact that terminal rows aged out of the window are reported by neither `deliveryHealth` nor `kanban-recovery` (whose audit covers only `pending`/`claimed`), with a direct SQL query for older incidents.

## Verification

Validated the new SQL against a real SQLite schema reproducing the reported state:

| scenario | result |
|---|---|
| 2 stale failures (3d old) + 38 completed | `operational` — was permanently `degraded` |
| recent failure (1m old) | `degraded`, `["exhausted delivery events"]` — signal preserved |
| legacy row, `completed_at IS NULL` | falls back to `created_at` |

## Test plan
- [x] `yarn workspace @circuschief/web test src/components/KanbanBoard.test.js` — 64 passed (+5: badge shown on preflight failure, hidden when healthy, **hidden when only delivery health is degraded** (regression guard), hidden on fetch error, fetched once not polled)
- [x] `yarn workspace @circuschief/server test src/services/kanbanRecoveryService.test.js` — 5 passed (+3 window cases)
- [x] `yarn workspace @circuschief/server test src/api/serverInfo.test.js src/services/kanbanService.test.js` — 48 passed
- [x] `yarn lint` — clean
