### PR TITLE
feat(server): configure bind address via --host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Dark mode only using Tailwind CSS. Key colors:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `5000` | Server port |
+| `HOST` | `127.0.0.1` | Server bind address |
 | `DB_PATH` | `~/.circuschief/circuschief.db` | SQLite database path |
 | `VITE_API_URL` | `http://localhost:5000` | Backend API URL (frontend) |
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npx circuschief
 | Flag | Description |
 |------|-------------|
 | `-p, --port <number>` | Port to listen on (default: `5000`) |
+| `-H, --host <address>` | Network address to bind to (default: `127.0.0.1`). For LAN, Docker, or remote access, use `--host 0.0.0.0`. |
 | `--no-analytics` | Disable anonymous usage analytics |
 | `-h, --help` | Show help message |
 | `-v, --version` | Show version number |

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,7 @@ yarn workspace @circuschief/web test         # Web tests only
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `5000` | Server port |
+| `HOST` | `127.0.0.1` | Server bind address |
 | `NODE_ENV` | `development` | Environment mode |
 | `DB_PATH` | `~/.circuschief/circuschief.db` | SQLite database path. `./scripts/pw.sh test`/`debug` overrides this to a worktree-local `$PROJECT_ROOT/.circuschief-test.db` so E2E tests never touch the real user DB; `pw.sh test-package` lets `start-package-server.sh` pick a per-run mktemp path instead. See [E2E testing — DB isolation](./e2e-testing.md#db-isolation-and-server-info). |
 | `VCR_MODE` | *(unset)* | When set (e.g. `replay`, `record`, `auto`), disables the scheduler service at server boot so E2E test servers never pick up real scheduled sessions. See [E2E testing — VCR modes](./e2e-testing.md#vcr-modes). |

--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -2,7 +2,7 @@ import { parseArgs } from 'node:util';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { DEFAULT_SERVER_PORT } from '@circuschief/shared';
+import { DEFAULT_SERVER_PORT, DEFAULT_SERVER_HOST } from '@circuschief/shared';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,6 +12,7 @@ function showHelp() {
 
 Options:
   -p, --port <number>  Port to listen on (env: PORT, default: ${DEFAULT_SERVER_PORT})
+  -H, --host <address> Network address to bind to (env: HOST, default: ${DEFAULT_SERVER_HOST})
   --no-analytics       Disable anonymous usage analytics
   -h, --help           Show this help message
   -V, --version        Show version number`);
@@ -39,6 +40,11 @@ export function parseCliOptions(argv = process.argv) {
           type: 'string',
           short: 'p',
           default: process.env.PORT || String(DEFAULT_SERVER_PORT),
+        },
+        host: {
+          type: 'string',
+          short: 'H',
+          default: process.env.HOST || DEFAULT_SERVER_HOST,
         },
         help: {
           type: 'boolean',
@@ -78,5 +84,24 @@ export function parseCliOptions(argv = process.argv) {
     process.exit(1);
   }
 
-  return { port, disableAnalytics: values['no-analytics'] };
+  const host = values.host.trim();
+  if (host === '') {
+    console.error(`Error: Invalid host "${values.host}". Must be a non-empty address.`);
+    process.exit(1);
+  }
+
+  return { port, host, disableAnalytics: values['no-analytics'] };
+}
+
+const WILDCARD_HOSTS = new Set(['0.0.0.0', '::']);
+
+/**
+ * Return a URL-safe representation of a server bind address.
+ *
+ * @returns {{ urlHost: string, wildcard: boolean }}
+ */
+export function describeBindHost(host) {
+  if (WILDCARD_HOSTS.has(host)) return { urlHost: 'localhost', wildcard: true };
+
+  return { urlHost: host.includes(':') ? `[${host}]` : host, wildcard: false };
 }

--- a/packages/server/src/cli.test.js
+++ b/packages/server/src/cli.test.js
@@ -6,7 +6,7 @@ vi.mock('fs', async (importOriginal) => {
 });
 
 import { readFileSync } from 'fs';
-import { parseCliOptions } from './cli.js';
+import { describeBindHost, parseCliOptions } from './cli.js';
 
 describe('parseCliOptions', () => {
   let exitSpy;
@@ -22,6 +22,7 @@ describe('parseCliOptions', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     process.env = { ...originalEnv };
     delete process.env.PORT;
+    delete process.env.HOST;
   });
 
   afterEach(() => {
@@ -31,17 +32,17 @@ describe('parseCliOptions', () => {
 
   it('returns default port when no arguments provided', () => {
     const result = parseCliOptions(['node', 'cli.js']);
-    expect(result).toEqual({ port: 5000, disableAnalytics: false });
+    expect(result).toEqual({ port: 5000, host: '127.0.0.1', disableAnalytics: false });
   });
 
   it('parses custom port with -p flag', () => {
     const result = parseCliOptions(['node', 'cli.js', '-p', '8080']);
-    expect(result).toEqual({ port: 8080, disableAnalytics: false });
+    expect(result).toEqual({ port: 8080, host: '127.0.0.1', disableAnalytics: false });
   });
 
   it('parses custom port with --port flag', () => {
     const result = parseCliOptions(['node', 'cli.js', '--port', '3000']);
-    expect(result).toEqual({ port: 3000, disableAnalytics: false });
+    expect(result).toEqual({ port: 3000, host: '127.0.0.1', disableAnalytics: false });
   });
 
   it('exits with error for non-numeric port', () => {
@@ -116,25 +117,25 @@ describe('parseCliOptions', () => {
 
   it('accepts minimum valid port (1)', () => {
     const result = parseCliOptions(['node', 'cli.js', '-p', '1']);
-    expect(result).toEqual({ port: 1, disableAnalytics: false });
+    expect(result).toEqual({ port: 1, host: '127.0.0.1', disableAnalytics: false });
   });
 
   it('accepts maximum valid port (65535)', () => {
     const result = parseCliOptions(['node', 'cli.js', '-p', '65535']);
-    expect(result).toEqual({ port: 65535, disableAnalytics: false });
+    expect(result).toEqual({ port: 65535, host: '127.0.0.1', disableAnalytics: false });
   });
 
   describe('PORT environment variable', () => {
     it('respects PORT env var when no CLI flag is given', () => {
       process.env.PORT = '8080';
       const result = parseCliOptions(['node', 'cli.js']);
-      expect(result).toEqual({ port: 8080, disableAnalytics: false });
+      expect(result).toEqual({ port: 8080, host: '127.0.0.1', disableAnalytics: false });
     });
 
     it('CLI --port flag takes precedence over PORT env var', () => {
       process.env.PORT = '8080';
       const result = parseCliOptions(['node', 'cli.js', '--port', '3000']);
-      expect(result).toEqual({ port: 3000, disableAnalytics: false });
+      expect(result).toEqual({ port: 3000, host: '127.0.0.1', disableAnalytics: false });
     });
 
     it('exits with error for invalid PORT env var', () => {
@@ -160,7 +161,74 @@ describe('parseCliOptions', () => {
 
     it('can combine --no-analytics with --port', () => {
       const result = parseCliOptions(['node', 'cli.js', '-p', '8080', '--no-analytics']);
-      expect(result).toEqual({ port: 8080, disableAnalytics: true });
+      expect(result).toEqual({ port: 8080, host: '127.0.0.1', disableAnalytics: true });
+    });
+  });
+
+  describe('--host flag', () => {
+    it.each([
+      ['--host', '0.0.0.0'],
+      ['-H', '0.0.0.0'],
+    ])('parses %s', (flag, host) => {
+      const result = parseCliOptions(['node', 'cli.js', flag, host]);
+      expect(result.host).toBe(host);
+    });
+
+    it.each(['::', '::1', '192.168.1.50', 'myhost.local'])(
+      'passes through %s unchanged',
+      (host) => {
+        expect(parseCliOptions(['node', 'cli.js', '--host', host]).host).toBe(host);
+      }
+    );
+
+    it('trims whitespace', () => {
+      expect(parseCliOptions(['node', 'cli.js', '--host', '  ::1  ']).host).toBe('::1');
+    });
+
+    it.each(['', '   '])('rejects an empty host', (host) => {
+      expect(() => parseCliOptions(['node', 'cli.js', '--host', host])).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid host'));
+    });
+
+    it('combines with the other options', () => {
+      expect(parseCliOptions(['node', 'cli.js', '-p', '8080', '-H', '0.0.0.0', '--no-analytics']))
+        .toEqual({ port: 8080, host: '0.0.0.0', disableAnalytics: true });
+    });
+
+    it('includes host configuration in help text', () => {
+      expect(() => parseCliOptions(['node', 'cli.js', '--help'])).toThrow('process.exit');
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('--host'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('env: HOST'));
+    });
+  });
+
+  describe('HOST environment variable', () => {
+    it('respects HOST when no CLI flag is given', () => {
+      process.env.HOST = '0.0.0.0';
+      expect(parseCliOptions(['node', 'cli.js']).host).toBe('0.0.0.0');
+    });
+
+    it('gives --host precedence over HOST', () => {
+      process.env.HOST = '0.0.0.0';
+      expect(parseCliOptions(['node', 'cli.js', '--host', '::1']).host).toBe('::1');
+    });
+
+    it('falls back to the default when HOST is empty', () => {
+      process.env.HOST = '';
+      expect(parseCliOptions(['node', 'cli.js']).host).toBe('127.0.0.1');
+    });
+  });
+
+  describe('describeBindHost', () => {
+    it.each([
+      ['127.0.0.1', { urlHost: '127.0.0.1', wildcard: false }],
+      ['192.168.1.50', { urlHost: '192.168.1.50', wildcard: false }],
+      ['::1', { urlHost: '[::1]', wildcard: false }],
+      ['0.0.0.0', { urlHost: 'localhost', wildcard: true }],
+      ['::', { urlHost: 'localhost', wildcard: true }],
+    ])('describes %s', (host, expected) => {
+      expect(describeBindHost(host)).toEqual(expected);
     });
   });
 

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -5,7 +5,7 @@ import { dirname } from 'path';
 import { createApp } from './app.js';
 import { initDatabase, commandRuns, sessions } from './database.js';
 import { initWebSocket, webSocketManager, setCommandRunOutputAuthorizer } from './websocket.js';
-import { parseCliOptions } from './cli.js';
+import { describeBindHost, parseCliOptions } from './cli.js';
 import { settings } from './db/index.js';
 import * as prStatusService from './services/prStatusService.js';
 import * as systemMonitor from './services/systemMonitor.js';
@@ -38,7 +38,7 @@ function validateNodeEnvironment() {
   }
 }
 
-const { port, disableAnalytics } = parseCliOptions();
+const { port, host, disableAnalytics } = parseCliOptions();
 process.env.PORT = String(port);
 const production = process.env.NODE_ENV === 'production';
 const dbPath = process.env.DB_PATH || getDefaultDbPath();
@@ -148,8 +148,19 @@ async function shutdown(signal) {
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 process.on('SIGINT', () => shutdown('SIGINT'));
 
-// Start server on all interfaces
-server.listen(port, '0.0.0.0', () => {
-  console.log(`Circus Chief running on http://localhost:${port}`);
-  console.log(`WebSocket available at ws://localhost:${port}/ws`);
+const { urlHost, wildcard } = describeBindHost(host);
+
+server.on('error', (err) => {
+  console.error(`Error: failed to bind to ${host}:${port} — ${err.code || err.message}`);
+  process.exit(1);
+});
+
+server.listen(port, host, () => {
+  console.log(`Circus Chief running on http://${urlHost}:${port}`);
+  console.log(`WebSocket available at ws://${urlHost}:${port}/ws`);
+  if (wildcard) {
+    console.warn(
+      `Warning: bound to all interfaces (${host}) — the server is reachable from the network.`
+    );
+  }
 });

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -1,4 +1,5 @@
 export const DEFAULT_SERVER_PORT = 5000;
+export const DEFAULT_SERVER_HOST = '127.0.0.1';
 
 export const API_PREFIX = '/api';
 export const WS_PATH = '/ws';

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -199,7 +199,7 @@ echo "$SELECTED_PORT" > "$PORT_FILE"
 # Write VCR mode for pw.sh to detect mismatches
 echo "${VCR_MODE:-}" > "$PROJECT_ROOT/.vcr-mode"
 
-# Forward DB_PATH explicitly so inherited env can't be accidentally overridden
-# by something in the user's shell.
+# Forward DB_PATH and HOST explicitly so inherited environment cannot alter
+# the development server's database or network exposure.
 NODE_ENV=production VCR_MODE="${VCR_MODE:-}" DB_PATH="${DB_PATH:-}" \
-    node packages/server/src/index.js -p ${SELECTED_PORT}
+    node packages/server/src/index.js -p ${SELECTED_PORT} -H 127.0.0.1


### PR DESCRIPTION
## Summary
- Allow the server bind address to be configured via a `--host` CLI flag (in addition to `HOST` env var), so users can specify the interface the server listens on.

## Test plan
- [x] Playwright E2E suite (`./scripts/pw.sh test`): 1173 passed, 2 flaky (passed on retry), 19 skipped, 0 failed.