### PR TITLE
fix(web): preserve line breaks in canvas markdown code blocks

### DIFF
--- a/packages/web/src/components/MarkdownViewer.vue
+++ b/packages/web/src/components/MarkdownViewer.vue
@@ -177,6 +177,7 @@ const renderedContent = computed(() => renderMarkdown(props.content));
 
 .markdown-viewer :deep(pre code) {
   display: block;
+  white-space: pre;
   min-width: max-content;
   padding: 0;
   background-color: transparent;


### PR DESCRIPTION
## Summary

Fenced code blocks in the canvas markdown viewer (`MarkdownViewer`) rendered as a single line: the inline `code` rule's `white-space: normal` leaked onto block `pre code`, which reset wrapping but never reset `white-space`.

## Fix

Add `white-space: pre` to `.markdown-viewer pre code` so fenced code (and ASCII art like wireframes) preserves newlines and monospace alignment. Long lines scroll horizontally via the existing `overflow-x: auto` + `min-width: max-content`.

## Scope

- `packages/web/src/components/MarkdownViewer.vue` (1 line)

## Testing

CSS-only change; no unit test updates. No behavior change for inline code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
