### PR TITLE
chore(deps): merge latest main + dependabot bumps (nanoid, js-yaml, dompurify)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,7 @@
     "http-proxy-middleware": "^3.0.7",
     "liquidjs": "^10.27.1",
     "multer": "^2.2.0",
-    "nanoid": "^3.3.0",
+    "nanoid": "^3.3.18",
     "openai": "^4.104.0",
     "ws": "^8.21.0",
     "yaml": "^2.8.3",

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -7,6 +7,10 @@ function setSessionActivity(sessionId, value) {
   databaseManager.get().prepare('UPDATE sessions SET last_activity_at = ? WHERE id = ?').run(value, sessionId);
 }
 
+function setProjectUpdatedAt(projectId, value) {
+  databaseManager.get().prepare('UPDATE projects SET updated_at = ? WHERE id = ?').run(value, projectId);
+}
+
 describe('ProjectRepository', () => {
   // Uses global setup from test/setup.js
   let repo;
@@ -265,6 +269,8 @@ describe('ProjectRepository', () => {
     it('preserves sessionCount, lastActivityAt and updatedAt ordering behaviour', () => {
       const p1 = repo.create('Project 1', '/tmp/1');
       const p2 = repo.create('Project 2', '/tmp/2');
+      setProjectUpdatedAt(p1.id, 1);
+      setProjectUpdatedAt(p2.id, 2);
       const sessionRepo = new SessionRepository();
       sessionRepo.create(p1.id, 'Session A', 'prompt');
       sessionRepo.create(p1.id, 'Session B', 'prompt');

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,7 +15,7 @@
     "@circuschief/shared": "1.0.0",
     "ansi-to-html": "^0.7.2",
     "date-fns": "^2.30.0",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "highlight.js": "^11.11.1",
     "markdown-it": "^14.2.0",
     "md-editor-v3": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,15 +3448,10 @@ multer@^2.2.0:
     concat-stream "^2.0.0"
     type-is "^1.6.18"
 
-nanoid@^3.3.0:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
-
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.16, nanoid@^3.3.18:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 napi-build-utils@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3045,9 +3045,9 @@ js-tokens@^10.0.0:
   integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
 
 js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2177,10 +2177,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dompurify@^3.3.1, dompurify@^3.4.12:
-  version "3.4.12"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
-  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
+dompurify@^3.3.1, dompurify@^3.4.13:
+  version "3.4.13"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
+  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Summary

Merges the latest `origin/main` plus three open Dependabot dependency bumps into this branch.

## Changes

- **Latest `origin/main`** — branch is at the tip of main (`673b74d4`).
- **nanoid** `3.3.11 → 3.3.18` (server) — from PR #1086
- **js-yaml** `4.3.0 → 4.3.1` (lockfile only) — from PR #1085
- **dompurify** `3.4.12 → 3.4.13` (web) — from PR #1082

## Validation

- All three Dependabot PRs were MERGEABLE/CLEAN with Lint + Unit Tests passing.
- After merging, `yarn install --frozen-lockfile` confirms the combined `yarn.lock` is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)