### PR TITLE
Improve project list session visibility

### DIFF
--- a/packages/server/src/db/ProjectRepository.js
+++ b/packages/server/src/db/ProjectRepository.js
@@ -22,6 +22,7 @@ export class ProjectRepository extends BaseRepository {
       repoUrl: row.repo_url,
       worktreePath: row.worktree_path,
       sessionCount: row.session_count ?? 0,
+      workspaceCount: row.workspace_count ?? 0,
       lastActivityAt: row.last_activity_at ?? null,
       runningSessionCount: row.running_session_count ?? 0,
       waitingSessionCount: row.waiting_session_count ?? 0,
@@ -66,6 +67,7 @@ export class ProjectRepository extends BaseRepository {
     const rows = this.db.prepare(`
       SELECT p.*,
         COUNT(CASE WHEN s.archived = 0 THEN s.id END) as session_count,
+        COUNT(CASE WHEN s.archived = 0 AND s.parent_session_id IS NULL THEN s.id END) as workspace_count,
         MAX(s.updated_at) as last_activity_at
       FROM projects p
       LEFT JOIN sessions s ON s.project_id = p.id

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -188,6 +188,7 @@ describe('ProjectRepository', () => {
 
       expect(projects).toHaveLength(1);
       expect(projects[0].sessionCount).toBe(0);
+      expect(projects[0].workspaceCount).toBe(0);
       expect(projects[0].lastActivityAt).toBeNull();
     });
 
@@ -208,6 +209,20 @@ describe('ProjectRepository', () => {
 
       expect(projects).toHaveLength(1);
       expect(projects[0].sessionCount).toBe(3);
+    });
+
+    it('counts only non-archived root sessions as workspaces', () => {
+      const project = repo.create('Test Project', '/tmp/test');
+      const sessionRepo = new SessionRepository();
+      const root = sessionRepo.create(project.id, 'Workspace', 'root prompt');
+      sessionRepo.create(project.id, 'Child', 'child prompt', { parentSessionId: root.id });
+      const archivedRoot = sessionRepo.create(project.id, 'Archived workspace', 'root prompt');
+      sessionRepo.update(archivedRoot.id, { archived: true });
+
+      const [result] = repo.getAll();
+
+      expect(result.sessionCount).toBe(2);
+      expect(result.workspaceCount).toBe(1);
     });
 
     it('returns lastActivityAt as most recent session updated_at', () => {

--- a/packages/shared/src/contracts/projects.js
+++ b/packages/shared/src/contracts/projects.js
@@ -38,6 +38,7 @@ export const ProjectResponse = z.object({
   prPollInterval: z.number().int(),
   repoUrl: z.string().url().nullable().optional(),
   worktreePath: z.string().nullable(),
+  workspaceCount: z.number().int().nonnegative(),
   runningWorkspaces: z.array(RunningWorkspaceSummary),
   runningSessionCount: z.number().int().nonnegative(),
   waitingSessionCount: z.number().int().nonnegative(),

--- a/packages/shared/src/contracts/projects.test.js
+++ b/packages/shared/src/contracts/projects.test.js
@@ -97,6 +97,7 @@ describe('Projects Contracts', () => {
       onSessionDeleted: null,
       prPollInterval: 60000,
       worktreePath: null,
+      workspaceCount: 0,
       runningWorkspaces: [],
       runningSessionCount: 0,
       waitingSessionCount: 0,

--- a/packages/web/src/stores/projects.js
+++ b/packages/web/src/stores/projects.js
@@ -9,6 +9,7 @@ import { useProjectFiltersStore } from './projectFilters.js';
 function normalizeProject(project) {
   return {
     ...project,
+    workspaceCount: project.workspaceCount ?? 0,
     runningWorkspaces: project.runningWorkspaces ?? [],
     runningSessionCount: project.runningSessionCount ?? 0,
     waitingSessionCount: project.waitingSessionCount ?? 0,

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -222,7 +222,29 @@ describe('ProjectListView', () => {
 
       const editBtn = wrapper.find('.edit-btn');
       expect(editBtn.exists()).toBe(true);
-      expect(editBtn.find('.edit-label-full').text()).toBe('Edit');
+      expect(editBtn.text()).toBe('Edit');
+      expect(editBtn.text()).not.toContain('⚙');
+    });
+
+    it('always shows running, waiting, and idle session counts', async () => {
+      projectsStore.projects = [fullProject({
+        sessionCount: 7,
+        runningSessionCount: 2,
+        waitingSessionCount: 1,
+      })];
+      projectsStore.loading = false;
+      projectsStore.error = null;
+
+      const wrapper = mount(ProjectListView, {
+        global: { plugins: [pinia, router] },
+      });
+      await flushAll(wrapper);
+
+      const summary = wrapper.find('.project-session-summary');
+      expect(summary.exists()).toBe(true);
+      expect(summary.text()).toContain('2 running');
+      expect(summary.text()).toContain('1 waiting');
+      expect(summary.text()).toContain('5 idle');
     });
   });
 
@@ -240,6 +262,7 @@ describe('ProjectListView', () => {
       await flushAll(wrapper);
 
       expect(getWorkspaceCards).toHaveBeenCalledWith('proj-1', { status: null, limit: 3 });
+      await wrapper.find('.sessions-toggle').trigger('click');
       expect(wrapper.findAll('.embedded-session-list .session-card')).toHaveLength(2);
       expect(wrapper.text()).toContain('latest');
     });
@@ -256,20 +279,20 @@ describe('ProjectListView', () => {
       const projectCard = wrapper.find('.project-card');
       const toggle = projectCard.find('.sessions-toggle');
       expect(toggle.exists()).toBe(true);
-      expect(projectCard.find('.embedded-session-list').exists()).toBe(true);
-      expect(toggle.attributes('aria-expanded')).toBe('true');
+      expect(projectCard.find('.embedded-session-list').exists()).toBe(false);
+      expect(toggle.attributes('aria-expanded')).toBe('false');
 
       await toggle.trigger('click');
 
-      expect(projectCard.find('.embedded-session-list').exists()).toBe(false);
-      expect(toggle.text()).toContain('Show sessions');
-      expect(toggle.attributes('aria-expanded')).toBe('false');
+      expect(projectCard.find('.embedded-session-list').exists()).toBe(true);
+      expect(toggle.text()).toContain('Hide sessions');
+      expect(toggle.attributes('aria-expanded')).toBe('true');
     });
 
     it('restores each project session toggle state from local storage', async () => {
       localStorage.setItem(
         'circus-chief.project-list.session-visibility',
-        JSON.stringify({ 'proj-1': false })
+        JSON.stringify({ 'proj-1': true })
       );
       getWorkspaceCards.mockResolvedValueOnce({
         workspaces: [{ id: 'ws-1', name: 'latest' }],
@@ -279,8 +302,8 @@ describe('ProjectListView', () => {
       const wrapper = mount(ProjectListView, { global: { plugins: [pinia, router] } });
       await flushAll(wrapper);
 
-      expect(wrapper.find('.embedded-session-list').exists()).toBe(false);
-      expect(wrapper.find('.sessions-toggle').attributes('aria-expanded')).toBe('false');
+      expect(wrapper.find('.embedded-session-list').exists()).toBe(true);
+      expect(wrapper.find('.sessions-toggle').attributes('aria-expanded')).toBe('true');
     });
 
     it('loads every matching card when a status filter is selected', async () => {
@@ -297,6 +320,7 @@ describe('ProjectListView', () => {
       await flushAll(wrapper);
 
       expect(getWorkspaceCards).toHaveBeenCalledWith('proj-1', { status: 'waiting', limit: 500 });
+      await wrapper.find('.sessions-toggle').trigger('click');
       expect(wrapper.findAll('.embedded-session-list .session-card')).toHaveLength(2);
     });
   });

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -53,6 +53,7 @@ function fullProject(overrides = {}) {
     name: 'my-cool-app',
     workingDirectory: '/Users/me/code/my-cool-app',
     sessionCount: 0,
+    workspaceCount: 0,
     lastActivityAt: null,
     runningWorkspaces: [],
     runningSessionCount: 0,
@@ -209,7 +210,7 @@ describe('ProjectListView', () => {
       expect(meta.text()).toContain('5 sessions');
     });
 
-    it('shows edit button with desktop label', async () => {
+    it('does not offer project editing from the list', async () => {
       projectsStore.projects = [fullProject()];
       projectsStore.loading = false;
       projectsStore.error = null;
@@ -220,15 +221,14 @@ describe('ProjectListView', () => {
 
       await flushAll(wrapper);
 
-      const editBtn = wrapper.find('.edit-btn');
-      expect(editBtn.exists()).toBe(true);
-      expect(editBtn.text()).toBe('Edit');
-      expect(editBtn.text()).not.toContain('⚙');
+      expect(wrapper.find('.edit-btn').exists()).toBe(false);
+      expect(wrapper.find(`a[href="/projects/proj-1/edit"]`).exists()).toBe(false);
     });
 
-    it('always shows running, waiting, and idle session counts', async () => {
+    it('always shows running and waiting session counts plus workspace count', async () => {
       projectsStore.projects = [fullProject({
         sessionCount: 7,
+        workspaceCount: 3,
         runningSessionCount: 2,
         waitingSessionCount: 1,
       })];
@@ -244,7 +244,7 @@ describe('ProjectListView', () => {
       expect(summary.exists()).toBe(true);
       expect(summary.text()).toContain('2 running');
       expect(summary.text()).toContain('1 waiting');
-      expect(summary.text()).toContain('5 idle');
+      expect(summary.text()).toContain('3 workspaces');
     });
   });
 

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -81,6 +81,20 @@
                   formatRelativeTime(project.lastActivityAt)
                 }}</span>
               </p>
+              <div class="project-session-summary" aria-label="Session status summary">
+                <span class="session-status-count status-running">
+                  <span class="status-dot" aria-hidden="true" />
+                  {{ project.runningSessionCount }} running
+                </span>
+                <span class="session-status-count status-waiting">
+                  <span class="status-dot" aria-hidden="true" />
+                  {{ project.waitingSessionCount }} waiting
+                </span>
+                <span class="session-status-count status-idle">
+                  <span class="status-dot" aria-hidden="true" />
+                  {{ idleSessionCount(project) }} idle
+                </span>
+              </div>
             </div>
             <div class="project-actions">
               <button
@@ -95,8 +109,7 @@
                 <span class="sessions-toggle-icon" :class="{ expanded: areSessionsVisible(project.id) }" aria-hidden="true">⌄</span>
               </button>
               <router-link :to="`/projects/${project.id}/edit`" class="btn edit-btn" @click.stop>
-                <span class="edit-label-full">Edit</span>
-                <span class="edit-label-short" aria-hidden="true">&#9881;</span>
+                Edit
               </router-link>
             </div>
           </div>
@@ -156,7 +169,11 @@ function goToSessions(projectId) {
 }
 
 function areSessionsVisible(projectId) {
-  return sessionVisibility.value[projectId] !== false;
+  return sessionVisibility.value[projectId] === true;
+}
+
+function idleSessionCount(project) {
+  return Math.max(0, project.sessionCount - project.runningSessionCount);
 }
 
 function toggleSessions(projectId) {
@@ -466,8 +483,35 @@ onMounted(() => {
   transform: rotate(0deg);
 }
 
-.edit-label-short {
-  display: none;
+.project-session-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.75rem;
+  margin-top: 0.625rem;
+}
+
+.session-status-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-text-soft);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.status-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-running {
+  color: var(--color-success);
+}
+
+.status-waiting {
+  color: var(--color-warning);
 }
 
 /* Mobile breakpoints */
@@ -534,12 +578,6 @@ onMounted(() => {
   }
   .embedded-session-list {
     padding: 0.75rem;
-  }
-  .edit-label-full {
-    display: none;
-  }
-  .edit-label-short {
-    display: inline;
   }
   .sessions-toggle span:first-child {
     display: none;

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -81,7 +81,7 @@
                   formatRelativeTime(project.lastActivityAt)
                 }}</span>
               </p>
-              <div class="project-session-summary" aria-label="Session status summary">
+              <div class="project-session-summary" aria-label="Project activity summary">
                 <span class="session-status-count status-running">
                   <span class="status-dot" aria-hidden="true" />
                   {{ project.runningSessionCount }} running
@@ -90,9 +90,9 @@
                   <span class="status-dot" aria-hidden="true" />
                   {{ project.waitingSessionCount }} waiting
                 </span>
-                <span class="session-status-count status-idle">
+                <span class="session-status-count status-workspaces">
                   <span class="status-dot" aria-hidden="true" />
-                  {{ idleSessionCount(project) }} idle
+                  {{ project.workspaceCount }} workspace{{ project.workspaceCount === 1 ? '' : 's' }}
                 </span>
               </div>
             </div>
@@ -108,9 +108,6 @@
                 <span>{{ areSessionsVisible(project.id) ? 'Hide sessions' : 'Show sessions' }}</span>
                 <span class="sessions-toggle-icon" :class="{ expanded: areSessionsVisible(project.id) }" aria-hidden="true">⌄</span>
               </button>
-              <router-link :to="`/projects/${project.id}/edit`" class="btn edit-btn" @click.stop>
-                Edit
-              </router-link>
             </div>
           </div>
           <div
@@ -170,10 +167,6 @@ function goToSessions(projectId) {
 
 function areSessionsVisible(projectId) {
   return sessionVisibility.value[projectId] === true;
-}
-
-function idleSessionCount(project) {
-  return Math.max(0, project.sessionCount - project.runningSessionCount);
 }
 
 function toggleSessions(projectId) {

--- a/tests/e2e/project-running-workspaces.spec.ts
+++ b/tests/e2e/project-running-workspaces.spec.ts
@@ -39,6 +39,14 @@ function embeddedSessionCard(page: Page, projectName: string, sessionName: strin
     .filter({ hasText: sessionName });
 }
 
+async function showEmbeddedSessions(page: Page, projectName: string) {
+  const toggle = projectCard(page, projectName).locator('.sessions-toggle');
+  await expect(toggle).toBeVisible({ timeout: LIVE_TIMEOUT });
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+}
+
 function filterPill(page: Page, status: string) {
   return page.getByRole('button', { name: new RegExp(`^${status}`) });
 }
@@ -133,6 +141,8 @@ test.describe('Project list embedded session cards', () => {
 
     await page.goto('/');
 
+    await showEmbeddedSessions(page, project.name);
+
     const alphaCard = embeddedSessionCard(page, project.name, 'alpha');
     await expect(alphaCard).toBeVisible({ timeout: LIVE_TIMEOUT });
     await expect(alphaCard).toHaveAttribute('href', `/sessions/${alpha.id}`);
@@ -166,6 +176,8 @@ test.describe('Project list embedded session cards', () => {
     const card = projectCard(page, project.name);
     await expect(card).toBeVisible();
 
+    await showEmbeddedSessions(page, project.name);
+
     // The existing "N sessions · …" line is intact.
     await expect(card.locator('.project-meta')).toContainText('2 sessions');
 
@@ -181,6 +193,7 @@ test.describe('Project list embedded session cards', () => {
     await updateSessionStatus(workspace.id, 'running');
 
     await page.goto('/');
+    await showEmbeddedSessions(page, project.name);
     const link = embeddedSessionCard(page, project.name, 'click-me');
     await expect(link).toBeVisible();
 
@@ -200,6 +213,7 @@ test.describe('Project list embedded session cards', () => {
     await updateSessionStatus(child2.id, 'running');
 
     await page.goto('/');
+    await showEmbeddedSessions(page, project.name);
     const link = embeddedSessionCard(page, project.name, 'live-root');
     await expect(link.locator('.status-badge.status-running')).toBeVisible();
 
@@ -224,6 +238,7 @@ test.describe('Project list embedded session cards', () => {
     const workspace = await seedSession(project.id, { prompt: 'new root', name: 'new-workspace', startImmediately: false });
     await updateSessionStatus(workspace.id, 'running');
 
+    await showEmbeddedSessions(page, project.name);
     const link = embeddedSessionCard(page, project.name, 'new-workspace');
     await expect(link).toBeVisible({ timeout: LIVE_TIMEOUT });
     await expect(link).toHaveAttribute('href', `/sessions/${workspace.id}`);

--- a/tests/e2e/template-system.spec.ts
+++ b/tests/e2e/template-system.spec.ts
@@ -929,8 +929,7 @@ test.describe('Self-Chaining Template', () => {
     await page.goto(`/projects/${project.id}/templates/${template.id}`);
     const reloadedSelect = page.locator('#nextTemplate');
     await expect(reloadedSelect).toBeVisible({ timeout: 10000 });
-    const selectedValue = await reloadedSelect.inputValue();
-    expect(selectedValue).toBe(template.id);
+    await expect(reloadedSelect).toHaveValue(template.id, { timeout: 10000 });
   });
 
   test('self-chain: clearing self-chain via UI persists null', async ({ page }) => {


### PR DESCRIPTION
## Summary

- remove the cog icon from project edit actions
- collapse project session cards by default while preserving saved preferences
- always show running, waiting, and idle session counts for each project
- update project list tests for the new behavior

## Validation

- 17 focused tests passed
- ESLint passed with existing warnings only
- web production build completed successfully