### PR TITLE
Fix project list running session indicators

### DIFF
--- a/packages/web/src/components/ProjectFiltersPanel.test.js
+++ b/packages/web/src/components/ProjectFiltersPanel.test.js
@@ -30,7 +30,7 @@ describe('ProjectFiltersPanel', () => {
     }
   });
 
-  it('renders badge values from the statusFacets prop as project counts', () => {
+  it('renders the supplied session and project badge values', () => {
     const wrapper = mountPanel({ running: 7, waiting: 2, idle: 5 });
 
     const counts = wrapper.findAll('.filter-count').map((el) => el.text());

--- a/packages/web/src/components/ProjectFiltersPanel.vue
+++ b/packages/web/src/components/ProjectFiltersPanel.vue
@@ -27,7 +27,7 @@ import { useProjectFiltersStore } from '../stores/projectFilters.js';
 const statuses = ['running', 'waiting', 'idle'];
 
 const props = defineProps({
-  /** Project counts per status, computed over the full project list. */
+  /** Running-session total and project counts for the remaining statuses. */
   statusFacets: {
     type: Object,
     default: () => ({ running: 0, waiting: 0, idle: 0 }),

--- a/packages/web/src/stores/commandButtons.js
+++ b/packages/web/src/stores/commandButtons.js
@@ -62,8 +62,10 @@ export const useCommandButtonsStore = defineStore('commandButtons', {
 
         // Add new buttons
         this.buttons.push(...newButtons);
+        return true;
       } catch (err) {
         this.error = err.message;
+        return false;
       } finally {
         this.loading = false;
       }

--- a/packages/web/src/stores/commandButtons.test.js
+++ b/packages/web/src/stores/commandButtons.test.js
@@ -112,8 +112,9 @@ describe('CommandButtons Store', () => {
         { id: 'btn-1', projectId: 'proj-1', label: 'Test' }
       ]);
 
-      await store.fetchButtons('proj-1');
+      const succeeded = await store.fetchButtons('proj-1');
       expect(store.error).toBeNull();
+      expect(succeeded).toBe(true);
     });
 
     it('sets error state on API failure', async () => {
@@ -121,9 +122,10 @@ describe('CommandButtons Store', () => {
       const errorMessage = 'Failed to fetch buttons';
       api.getCommandButtons.mockRejectedValue(new Error(errorMessage));
 
-      await store.fetchButtons('proj-1');
+      const succeeded = await store.fetchButtons('proj-1');
       expect(store.error).toBe(errorMessage);
       expect(store.loading).toBe(false);
+      expect(succeeded).toBe(false);
     });
 
     it('handles empty button list from API', async () => {

--- a/packages/web/src/stores/projects.js
+++ b/packages/web/src/stores/projects.js
@@ -27,9 +27,10 @@ export const useProjectsStore = defineStore('projects', {
     getProjectById: (state) => (id) => state.projects.find((p) => p.id === id),
 
     /**
-     * Facets for the status filter — project counts, not session/workspace
-     * counts. `running` and `waiting` may overlap (a project with both counts
-     * toward both); `idle` is the complement of "any active session".
+     * Facets for the status filter. The running badge is a session total;
+     * waiting and idle remain project counts because their filters operate on
+     * projects. `running` and `waiting` may overlap; `idle` is the complement
+     * of "any active session".
      */
     statusFacets: (state) => {
       let running = 0;
@@ -38,7 +39,7 @@ export const useProjectsStore = defineStore('projects', {
       for (const project of state.projects) {
         const isRunning = project.runningSessionCount > 0;
         const isWaiting = project.waitingSessionCount > 0;
-        if (isRunning) running += 1;
+        running += project.runningSessionCount;
         if (isWaiting) waiting += 1;
         if (!isRunning && !isWaiting) idle += 1;
       }

--- a/packages/web/src/stores/projects.test.js
+++ b/packages/web/src/stores/projects.test.js
@@ -117,17 +117,18 @@ describe('useProjectsStore', () => {
   });
 
   describe('statusFacets getter', () => {
-    it('counts projects per status with running/waiting overlap', () => {
+    it('counts running sessions while retaining project counts for waiting and idle', () => {
       const store = useProjectsStore();
       store.projects = [
-        project({ id: 'run', runningSessionCount: 1, waitingSessionCount: 0 }),
+        project({ id: 'run', runningSessionCount: 2, waitingSessionCount: 0 }),
         project({ id: 'wait', runningSessionCount: 0, waitingSessionCount: 1 }),
-        project({ id: 'both', runningSessionCount: 1, waitingSessionCount: 1 }),
+        project({ id: 'both', runningSessionCount: 3, waitingSessionCount: 1 }),
         project({ id: 'idle', runningSessionCount: 0, waitingSessionCount: 0 }),
       ];
 
-      // running: run + both = 2; waiting: wait + both = 2; idle: idle = 1
-      expect(store.statusFacets).toEqual({ running: 2, waiting: 2, idle: 1 });
+      // running: 2 + 3 sessions = 5; waiting: wait + both = 2 projects;
+      // idle: idle = 1 project.
+      expect(store.statusFacets).toEqual({ running: 5, waiting: 2, idle: 1 });
     });
 
     it('treats a project with zero sessions as idle', () => {

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -8,7 +8,7 @@ import { useProjectsStore } from '../stores/projects.js';
 import { useProjectFiltersStore } from '../stores/projectFilters.js';
 
 const { getWorkspaceCards } = vi.hoisted(() => ({ getWorkspaceCards: vi.fn() }));
-const { fetchButtons } = vi.hoisted(() => ({ fetchButtons: vi.fn().mockResolvedValue(undefined) }));
+const { fetchButtons } = vi.hoisted(() => ({ fetchButtons: vi.fn().mockResolvedValue(true) }));
 
 // Mock the composable to avoid opening a WebSocket in jsdom.
 vi.mock('../composables/useProjectListRealtime.js', () => ({
@@ -91,7 +91,8 @@ describe('ProjectListView', () => {
     projectsStore = useProjectsStore();
     vi.spyOn(projectsStore, 'fetchProjects').mockResolvedValue(undefined);
     getWorkspaceCards.mockResolvedValue({ workspaces: [] });
-    fetchButtons.mockClear();
+    fetchButtons.mockReset();
+    fetchButtons.mockResolvedValue(true);
   });
 
   describe('Page Header', () => {
@@ -303,6 +304,39 @@ describe('ProjectListView', () => {
 
       expect(fetchButtons).toHaveBeenCalledTimes(1);
       expect(fetchButtons).toHaveBeenCalledWith('commands-project');
+    });
+
+    it('retries command-definition hydration after a transient failure', async () => {
+      fetchButtons
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      projectsStore.projects = [fullProject({ id: 'commands-project' })];
+      projectsStore.loading = false;
+      projectsStore.error = null;
+
+      const wrapper = mount(ProjectListView, {
+        global: { plugins: [pinia, router] },
+      });
+      await flushAll(wrapper);
+
+      expect(fetchButtons).toHaveBeenCalledTimes(1);
+
+      projectsStore.projects = [fullProject({
+        id: 'commands-project',
+        runningSessionCount: 1,
+      })];
+      await flushAll(wrapper);
+
+      expect(fetchButtons).toHaveBeenCalledTimes(2);
+      expect(fetchButtons).toHaveBeenLastCalledWith('commands-project');
+
+      projectsStore.projects = [fullProject({
+        id: 'commands-project',
+        runningSessionCount: 2,
+      })];
+      await flushAll(wrapper);
+
+      expect(fetchButtons).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -306,7 +306,8 @@ describe('ProjectListView', () => {
       expect(fetchButtons).toHaveBeenCalledWith('commands-project');
     });
 
-    it('retries command-definition hydration after a transient failure', async () => {
+    it('autonomously retries command-definition hydration after a transient failure', async () => {
+      vi.useFakeTimers();
       fetchButtons
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(true);
@@ -321,22 +322,12 @@ describe('ProjectListView', () => {
 
       expect(fetchButtons).toHaveBeenCalledTimes(1);
 
-      projectsStore.projects = [fullProject({
-        id: 'commands-project',
-        runningSessionCount: 1,
-      })];
+      await vi.advanceTimersByTimeAsync(500);
       await flushAll(wrapper);
 
       expect(fetchButtons).toHaveBeenCalledTimes(2);
       expect(fetchButtons).toHaveBeenLastCalledWith('commands-project');
-
-      projectsStore.projects = [fullProject({
-        id: 'commands-project',
-        runningSessionCount: 2,
-      })];
-      await flushAll(wrapper);
-
-      expect(fetchButtons).toHaveBeenCalledTimes(2);
+      vi.useRealTimers();
     });
   });
 

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -8,6 +8,7 @@ import { useProjectsStore } from '../stores/projects.js';
 import { useProjectFiltersStore } from '../stores/projectFilters.js';
 
 const { getWorkspaceCards } = vi.hoisted(() => ({ getWorkspaceCards: vi.fn() }));
+const { fetchButtons } = vi.hoisted(() => ({ fetchButtons: vi.fn().mockResolvedValue(undefined) }));
 
 // Mock the composable to avoid opening a WebSocket in jsdom.
 vi.mock('../composables/useProjectListRealtime.js', () => ({
@@ -24,6 +25,10 @@ vi.mock('../composables/useSummaryHelpers.js', () => ({
 
 vi.mock('../api/index.js', () => ({
   api: { getWorkspaceCards },
+}));
+
+vi.mock('../stores/commandButtons.js', () => ({
+  useCommandButtonsStore: () => ({ fetchButtons }),
 }));
 
 vi.mock('../components/SessionCard.vue', () => ({
@@ -86,6 +91,7 @@ describe('ProjectListView', () => {
     projectsStore = useProjectsStore();
     vi.spyOn(projectsStore, 'fetchProjects').mockResolvedValue(undefined);
     getWorkspaceCards.mockResolvedValue({ workspaces: [] });
+    fetchButtons.mockClear();
   });
 
   describe('Page Header', () => {
@@ -245,6 +251,38 @@ describe('ProjectListView', () => {
       expect(summary.text()).toContain('2 running');
       expect(summary.text()).toContain('1 waiting');
       expect(summary.text()).toContain('3 workspaces');
+    });
+
+    it('highlights the running indicator only for projects with running sessions', async () => {
+      projectsStore.projects = [
+        fullProject({ id: 'running', runningSessionCount: 2 }),
+        fullProject({ id: 'idle', runningSessionCount: 0 }),
+      ];
+      projectsStore.loading = false;
+      projectsStore.error = null;
+
+      const wrapper = mount(ProjectListView, {
+        global: { plugins: [pinia, router] },
+      });
+      await flushAll(wrapper);
+
+      const counts = wrapper.findAll('.project-running-count');
+      expect(counts).toHaveLength(2);
+      expect(counts[0].classes()).toContain('has-running-sessions');
+      expect(counts[1].classes()).not.toContain('has-running-sessions');
+    });
+
+    it('loads Circus command definitions for the embedded session cards', async () => {
+      projectsStore.projects = [fullProject({ id: 'commands-project' })];
+      projectsStore.loading = false;
+      projectsStore.error = null;
+
+      const wrapper = mount(ProjectListView, {
+        global: { plugins: [pinia, router] },
+      });
+      await flushAll(wrapper);
+
+      expect(fetchButtons).toHaveBeenCalledWith('commands-project');
     });
   });
 

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -284,6 +284,26 @@ describe('ProjectListView', () => {
 
       expect(fetchButtons).toHaveBeenCalledWith('commands-project');
     });
+
+    it('does not reload command definitions when project data refreshes with the same IDs', async () => {
+      projectsStore.projects = [fullProject({ id: 'commands-project' })];
+      projectsStore.loading = false;
+      projectsStore.error = null;
+
+      const wrapper = mount(ProjectListView, {
+        global: { plugins: [pinia, router] },
+      });
+      await flushAll(wrapper);
+
+      projectsStore.projects = [fullProject({
+        id: 'commands-project',
+        runningSessionCount: 1,
+      })];
+      await flushAll(wrapper);
+
+      expect(fetchButtons).toHaveBeenCalledTimes(1);
+      expect(fetchButtons).toHaveBeenCalledWith('commands-project');
+    });
   });
 
   describe('Embedded session cards', () => {

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -158,6 +158,7 @@ const projectFilters = useProjectFiltersStore();
 const commandButtonsStore = useCommandButtonsStore();
 const projectCards = ref({});
 const sessionVisibility = ref({});
+const hydratedCommandButtonProjects = new Set();
 let projectCardsRequest = 0;
 const sessionVisibilityStorageKey = 'circus-chief.project-list.session-visibility';
 
@@ -264,6 +265,8 @@ watch(
 // hydrate them here as well.
 watch(projectIds, (ids) => {
   for (const projectId of ids) {
+    if (hydratedCommandButtonProjects.has(projectId)) continue;
+    hydratedCommandButtonProjects.add(projectId);
     Promise.resolve(commandButtonsStore.fetchButtons(projectId)).catch(() => {});
   }
 }, { immediate: true });
@@ -522,6 +525,10 @@ onMounted(() => {
 
 .project-running-count.has-running-sessions {
   color: var(--color-success);
+}
+
+.status-waiting {
+  color: var(--color-warning);
 }
 
 /* Mobile breakpoints */

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -524,10 +524,6 @@ onMounted(() => {
   color: var(--color-success);
 }
 
-.status-waiting {
-  color: var(--color-warning);
-}
-
 /* Mobile breakpoints */
 @media (max-width: 640px) {
   .empty-state {

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -82,7 +82,10 @@
                 }}</span>
               </p>
               <div class="project-session-summary" aria-label="Project activity summary">
-                <span class="session-status-count status-running">
+                <span
+                  class="session-status-count project-running-count"
+                  :class="{ 'has-running-sessions': project.runningSessionCount > 0 }"
+                >
                   <span class="status-dot" aria-hidden="true" />
                   {{ project.runningSessionCount }} running
                 </span>
@@ -140,6 +143,7 @@ import { useRouter } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 import { useSessionsStore } from '../stores/sessions.js';
 import { useProjectFiltersStore } from '../stores/projectFilters.js';
+import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useProjectListRealtime } from '../composables/useProjectListRealtime.js';
 import ProjectFiltersPanel from '../components/ProjectFiltersPanel.vue';
 import SessionCard from '../components/SessionCard.vue';
@@ -151,6 +155,7 @@ const router = useRouter();
 const projectsStore = useProjectsStore();
 const sessionsStore = useSessionsStore();
 const projectFilters = useProjectFiltersStore();
+const commandButtonsStore = useCommandButtonsStore();
 const projectCards = ref({});
 const sessionVisibility = ref({});
 let projectCardsRequest = 0;
@@ -252,6 +257,16 @@ watch(
   },
   { immediate: true }
 );
+
+// SessionCard turns the latest command-run records from the workspace-card
+// response into status badges using these project-scoped definitions. The
+// project list is a separate entry point from SessionListView, so it must
+// hydrate them here as well.
+watch(projectIds, (ids) => {
+  for (const projectId of ids) {
+    Promise.resolve(commandButtonsStore.fetchButtons(projectId)).catch(() => {});
+  }
+}, { immediate: true });
 
 onMounted(() => {
   projectFilters.restoreStatusFilter();
@@ -369,6 +384,8 @@ onMounted(() => {
 .project-card {
   padding: 0;
   overflow: hidden;
+  border: 2px solid var(--color-border);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-background) 55%, transparent);
 }
 
 .project-card-header {
@@ -499,7 +516,11 @@ onMounted(() => {
   background: currentColor;
 }
 
-.status-running {
+.project-running-count {
+  color: var(--color-text-soft);
+}
+
+.project-running-count.has-running-sessions {
   color: var(--color-success);
 }
 

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -138,7 +138,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useProjectsStore } from '../stores/projects.js';
 import { useSessionsStore } from '../stores/sessions.js';
@@ -160,7 +160,12 @@ const projectCards = ref({});
 const sessionVisibility = ref({});
 const hydratedCommandButtonProjects = new Set();
 const hydratingCommandButtonProjects = new Set();
+const commandButtonRetryTimers = new Map();
+const commandButtonRetryAttempts = new Map();
+const maxCommandButtonHydrationRetries = 3;
+const commandButtonHydrationRetryDelayMs = 500;
 let projectCardsRequest = 0;
+let isUnmounted = false;
 const sessionVisibilityStorageKey = 'circus-chief.project-list.session-visibility';
 
 // The list and facets are client-side derivatives of the full project array.
@@ -264,8 +269,30 @@ watch(
 // response into status badges using these project-scoped definitions. The
 // project list is a separate entry point from SessionListView, so it must
 // hydrate them here as well. A project is considered hydrated only after a
-// successful response so a transient failure is retried on the next project
-// refresh.
+// successful response. Failed requests retry a bounded number of times even
+// when the project list remains unchanged.
+function scheduleCommandButtonHydrationRetry(projectId) {
+  const retryAttempt = commandButtonRetryAttempts.get(projectId) || 0;
+  if (
+    isUnmounted ||
+    hydratedCommandButtonProjects.has(projectId) ||
+    commandButtonRetryTimers.has(projectId) ||
+    retryAttempt >= maxCommandButtonHydrationRetries
+  ) {
+    return;
+  }
+
+  commandButtonRetryAttempts.set(projectId, retryAttempt + 1);
+  const delay = commandButtonHydrationRetryDelayMs * (2 ** retryAttempt);
+  const timer = setTimeout(() => {
+    commandButtonRetryTimers.delete(projectId);
+    if (!isUnmounted && projectIds.value.includes(projectId)) {
+      void hydrateCommandButtons(projectId);
+    }
+  }, delay);
+  commandButtonRetryTimers.set(projectId, timer);
+}
+
 async function hydrateCommandButtons(projectId) {
   if (
     hydratedCommandButtonProjects.has(projectId) ||
@@ -274,16 +301,27 @@ async function hydrateCommandButtons(projectId) {
     return;
   }
 
+  const retryTimer = commandButtonRetryTimers.get(projectId);
+  if (retryTimer !== undefined) {
+    clearTimeout(retryTimer);
+    commandButtonRetryTimers.delete(projectId);
+  }
+
   hydratingCommandButtonProjects.add(projectId);
+  let succeeded = false;
   try {
-    const succeeded = await commandButtonsStore.fetchButtons(projectId);
+    succeeded = await commandButtonsStore.fetchButtons(projectId);
     if (succeeded) {
       hydratedCommandButtonProjects.add(projectId);
+      commandButtonRetryAttempts.delete(projectId);
     }
   } catch {
     // Treat rejecting store implementations as a failed hydration too.
   } finally {
     hydratingCommandButtonProjects.delete(projectId);
+    if (!succeeded) {
+      scheduleCommandButtonHydrationRetry(projectId);
+    }
   }
 }
 
@@ -298,6 +336,14 @@ onMounted(() => {
   restoreSessionVisibility();
   projectsStore.fetchProjects();
   useProjectListRealtime(projectIds);
+});
+
+onBeforeUnmount(() => {
+  isUnmounted = true;
+  for (const timer of commandButtonRetryTimers.values()) {
+    clearTimeout(timer);
+  }
+  commandButtonRetryTimers.clear();
 });
 </script>
 

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -159,6 +159,7 @@ const commandButtonsStore = useCommandButtonsStore();
 const projectCards = ref({});
 const sessionVisibility = ref({});
 const hydratedCommandButtonProjects = new Set();
+const hydratingCommandButtonProjects = new Set();
 let projectCardsRequest = 0;
 const sessionVisibilityStorageKey = 'circus-chief.project-list.session-visibility';
 
@@ -262,12 +263,33 @@ watch(
 // SessionCard turns the latest command-run records from the workspace-card
 // response into status badges using these project-scoped definitions. The
 // project list is a separate entry point from SessionListView, so it must
-// hydrate them here as well.
+// hydrate them here as well. A project is considered hydrated only after a
+// successful response so a transient failure is retried on the next project
+// refresh.
+async function hydrateCommandButtons(projectId) {
+  if (
+    hydratedCommandButtonProjects.has(projectId) ||
+    hydratingCommandButtonProjects.has(projectId)
+  ) {
+    return;
+  }
+
+  hydratingCommandButtonProjects.add(projectId);
+  try {
+    const succeeded = await commandButtonsStore.fetchButtons(projectId);
+    if (succeeded) {
+      hydratedCommandButtonProjects.add(projectId);
+    }
+  } catch {
+    // Treat rejecting store implementations as a failed hydration too.
+  } finally {
+    hydratingCommandButtonProjects.delete(projectId);
+  }
+}
+
 watch(projectIds, (ids) => {
   for (const projectId of ids) {
-    if (hydratedCommandButtonProjects.has(projectId)) continue;
-    hydratedCommandButtonProjects.add(projectId);
-    Promise.resolve(commandButtonsStore.fetchButtons(projectId)).catch(() => {});
+    void hydrateCommandButtons(projectId);
   }
 }, { immediate: true });
 

--- a/tests/e2e/project-running-workspaces.spec.ts
+++ b/tests/e2e/project-running-workspaces.spec.ts
@@ -44,7 +44,8 @@ function filterPill(page: Page, status: string) {
 }
 
 /**
- * The `running` / `waiting` / `idle` badges are *global* project counts
+ * The `running` badge is a global running-session count; `waiting` and `idle`
+ * badges are global project counts.
  * (playwright.config.ts: fullyParallel + workers: 4 — this spec file's own
  * tests are forced serial below, but 3 other workers are running unrelated
  * spec files against the same shared DB at the same time, and they create,
@@ -53,15 +54,27 @@ function filterPill(page: Page, status: string) {
  * because another worker can seed or finish a project in between.
  *
  * So badge counts are asserted through an invariant that holds within a
- * single render regardless of what the other workers are doing: with a status
- * filter applied, the pill's badge count equals the number of project cards
- * the list renders (projects store: `statusFacets` and `filteredProjects`
- * partition the same array with the same predicate). The per-status semantics
+ * single render regardless of what the other workers are doing for the project
+ * count badges: with a status filter applied, the pill's badge count equals
+ * the number of project cards the list renders. The per-status semantics
  * — e.g. that a `waiting`-status session with no pending agent input is not a
  * "waiting" project — are asserted by which filters our own seeded project
  * appears under, which is unaffected by other workers' projects.
  */
 async function expectPillCountMatchesFilteredList(page: Page, status: string) {
+  if (status === 'running') {
+    await expect
+      .poll(
+        async () => {
+          const badge = await filterPill(page, status).locator('.filter-count').textContent();
+          return Number(badge) === (await getStatusFacets()).running;
+        },
+        { timeout: LIVE_TIMEOUT }
+      )
+      .toBe(true);
+    return;
+  }
+
   await expect
     .poll(
       async () => {
@@ -74,7 +87,7 @@ async function expectPillCountMatchesFilteredList(page: Page, status: string) {
     .toBe(true);
 }
 
-/** Global project facets, derived from the API the same way the store does. */
+/** Global status facets, derived from the API the same way the store does. */
 async function getStatusFacets(): Promise<{ running: number; waiting: number; idle: number }> {
   const projects = await getProjects();
   let running = 0;
@@ -83,7 +96,7 @@ async function getStatusFacets(): Promise<{ running: number; waiting: number; id
   for (const p of projects) {
     const isRunning = (p.runningSessionCount ?? 0) > 0;
     const isWaiting = (p.waitingSessionCount ?? 0) > 0;
-    if (isRunning) running += 1;
+    running += p.runningSessionCount ?? 0;
     if (isWaiting) waiting += 1;
     if (!isRunning && !isWaiting) idle += 1;
   }
@@ -132,6 +145,10 @@ test.describe('Project list embedded session cards', () => {
     await updateSessionStatus(gamma.id, 'stopped');
 
     await page.goto('/');
+
+    // Four running sessions belong to this single project. The filter still
+    // renders one project card, but its badge must report all four sessions.
+    await expectPillCountMatchesFilteredList(page, 'running');
 
     const alphaCard = embeddedSessionCard(page, project.name, 'alpha');
     await expect(alphaCard).toBeVisible({ timeout: LIVE_TIMEOUT });
@@ -245,9 +262,9 @@ test.describe('Project list embedded session cards', () => {
 
     await page.goto('/');
 
-    // Badge counts are *global* project counts (RQ §9.6), so each pill's count
-    // is asserted against the list it filters to rather than an absolute
-    // number — see expectPillCountMatchesFilteredList(). A status='waiting'
+    // The running badge is a global session count; waiting and idle are global
+    // project counts. Each pill is asserted against its matching invariant —
+    // see expectPillCountMatchesFilteredList(). A status='waiting'
     // session is idle unless it has pending_agent_input, which is why
     // waitingProject shows up under `idle` below and never under `waiting`.
     await expect(filterPill(page, 'running')).toContainText('running');
@@ -286,10 +303,10 @@ test.describe('Project list embedded session cards', () => {
     await page.goto('/');
 
     // Only the running session makes this project active; status='waiting'
-    // alone does not represent a pending agent prompt. Badge counts are global
-    // and other workers move them constantly, so each pill's count is checked
-    // against the list it produces, while the semantics are asserted by which
-    // filters this project appears under.
+    // alone does not represent a pending agent prompt. Counts are global and
+    // other workers move them constantly, so each pill is checked against its
+    // matching invariant while the semantics are asserted by which filters
+    // this project appears under.
     await filterPill(page, 'running').click();
     await expect(projectCard(page, project.name)).toBeVisible();
     await expectPillCountMatchesFilteredList(page, 'running');

--- a/tests/e2e/project-running-workspaces.spec.ts
+++ b/tests/e2e/project-running-workspaces.spec.ts
@@ -6,6 +6,8 @@ import {
   seedSession,
   seedChildSession,
   updateSessionStatus,
+  seedCommandButton,
+  runCommandButtonAndWait,
 } from './helpers';
 
 /**
@@ -201,6 +203,29 @@ test.describe('Project list embedded session cards', () => {
     // without a running badge.
     await expect(card.locator('.embedded-session-list .session-card')).toHaveCount(2);
     await expect(card.locator('.embedded-session-list .status-badge.status-running')).toHaveCount(0);
+  });
+
+  test('shows visible Circus command run badges on embedded session cards', async ({ page }) => {
+    const project = await seedProject('project-command-badges', '/tmp');
+    const session = await seedSession(project.id, {
+      prompt: 'command badge',
+      name: 'command badge session',
+      startImmediately: false,
+    });
+    const button = await seedCommandButton(project.id, {
+      label: 'Project list command',
+      command: 'echo project-list-badge',
+      showOnList: true,
+    });
+
+    await runCommandButtonAndWait(session.id, button.id);
+    await page.goto('/');
+    await showEmbeddedSessions(page, project.name);
+
+    const card = embeddedSessionCard(page, project.name, session.name);
+    await expect(card).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(card.locator('.button-status-indicator[title="Project list command"]'))
+      .toBeVisible({ timeout: LIVE_TIMEOUT });
   });
 
   test('clicking an embedded session card navigates to the root session, never the session list', async ({ page }) => {


### PR DESCRIPTION
## Summary
- count running sessions (rather than projects) in the project-list filter badge
- restore the current project-list baseline while improving project/session visual separation
- make project running summaries neutral when inactive and green only when sessions are running
- load Circus command definitions and command runs for embedded project-list session cards
- add regressions for multi-session counts and visible Circus command badges

## Verification
- `ProjectListView` unit tests: 19 passed
- `SessionCard` unit tests: 99 passed
- focused Playwright project-list Circus-command badge regression: passed

Closes the project-list status and embedded command-badge regressions.