### PR TITLE
Fix rescheduling for terminal result errors

### DIFF
--- a/packages/server/src/api/settings.test.js
+++ b/packages/server/src/api/settings.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { DEFAULT_TOKEN_COST_WEIGHTS } from '@circuschief/shared';
@@ -9,13 +9,11 @@ import settingsRouter from './settings.js';
 // where GC pressure and event-loop contention cause sporadic slowdowns.
 describe('Settings API', { timeout: 30_000 }, () => {
   let app;
-  let server;
 
   beforeEach(() => {
     app = express();
     app.use(express.json());
     app.use('/api/settings', settingsRouter);
-    server = app.listen(0);
 
     // Remove any instance-property overrides that may have leaked from a prior
     // test (e.g. the "handles errors gracefully" mock replacement).  Deleting
@@ -32,13 +30,9 @@ describe('Settings API', { timeout: 30_000 }, () => {
     settings.resetSummarySettings();
   });
 
-  afterEach(async () => {
-    await new Promise((resolve) => server.close(resolve));
-  });
-
   describe('Summary settings', () => {
     it('returns expanded summary defaults', async () => {
-      const res = await request(server).get('/api/settings/summary');
+      const res = await request(app).get('/api/settings/summary');
 
       expect(res.status).toBe(200);
       expect(res.body).toMatchObject({
@@ -51,7 +45,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('rejects a summary body without summaryModel', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: true,
@@ -64,7 +58,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('rejects a summary body without summaryProviderId', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: true,
@@ -77,7 +71,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('accepts auto mode with an empty model and null provider', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: true,
@@ -99,7 +93,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       const provider = modelProviders.getById('openai-default');
       const model = provider.models[0].modelId;
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: false,
@@ -116,7 +110,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('rejects provider/model ownership mismatches', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: false,
@@ -133,7 +127,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       const provider = modelProviders.getById('openai-default');
       const model = provider.models[0].modelId;
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: false,
@@ -150,7 +144,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       const provider = modelProviders.getById('openai-default');
       const model = provider.models[0].modelId;
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: false,
@@ -164,7 +158,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('rejects provider-only auto mode', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/summary')
         .send({
           disableSessionSummaries: false,
@@ -180,7 +174,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
 
   describe('GET /api/settings/token-weights', () => {
     it('returns default weights when not customized', async () => {
-      const res = await request(server).get('/api/settings/token-weights');
+      const res = await request(app).get('/api/settings/token-weights');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(DEFAULT_TOKEN_COST_WEIGHTS);
@@ -195,7 +189,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
       settings.setTokenCostWeights(customWeights);
 
-      const res = await request(server).get('/api/settings/token-weights');
+      const res = await request(app).get('/api/settings/token-weights');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(customWeights);
@@ -208,7 +202,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
 
       try {
-        const res = await request(server).get('/api/settings/token-weights');
+        const res = await request(app).get('/api/settings/token-weights');
 
         expect(res.status).toBe(500);
         expect(res.body.error).toBe('Failed to get token weights');
@@ -227,7 +221,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         cacheCreation: 1.5,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(newWeights);
 
@@ -247,7 +241,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         cacheCreation: 1.25,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(invalidWeights);
 
@@ -262,7 +256,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         // missing cacheRead and cacheCreation
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(incompleteWeights);
 
@@ -278,7 +272,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         cacheCreation: 1.25,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(negativeWeights);
 
@@ -296,7 +290,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         cacheCreation: 0,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(zeroWeights);
 
@@ -313,7 +307,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         cacheCreation: 1.456,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(decimalWeights);
 
@@ -327,7 +321,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
 
       try {
-        const res = await request(server)
+        const res = await request(app)
           .put('/api/settings/token-weights')
           .send(DEFAULT_TOKEN_COST_WEIGHTS);
 
@@ -339,7 +333,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('rejects request with missing body', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send({});
 
@@ -356,7 +350,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         extraField: 'ignored',
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/token-weights')
         .send(weightsWithExtra);
 
@@ -381,7 +375,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       });
 
       // Then reset
-      const res = await request(server).delete('/api/settings/token-weights');
+      const res = await request(app).delete('/api/settings/token-weights');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(DEFAULT_TOKEN_COST_WEIGHTS);
@@ -392,7 +386,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('returns defaults even if no custom weights were set', async () => {
-      const res = await request(server).delete('/api/settings/token-weights');
+      const res = await request(app).delete('/api/settings/token-weights');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(DEFAULT_TOKEN_COST_WEIGHTS);
@@ -404,7 +398,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
 
       try {
-        const res = await request(server).delete('/api/settings/token-weights');
+        const res = await request(app).delete('/api/settings/token-weights');
 
         expect(res.status).toBe(500);
         expect(res.body.error).toBe('Failed to reset token weights');
@@ -417,7 +411,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
   describe('Integration: Full lifecycle', () => {
     it('GET -> PUT -> GET -> DELETE -> GET', async () => {
       // 1. Get defaults
-      let res = await request(server).get('/api/settings/token-weights');
+      let res = await request(app).get('/api/settings/token-weights');
       expect(res.status).toBe(200);
       expect(res.body).toEqual(DEFAULT_TOKEN_COST_WEIGHTS);
 
@@ -428,24 +422,24 @@ describe('Settings API', { timeout: 30_000 }, () => {
         cacheRead: 0.4,
         cacheCreation: 2.5,
       };
-      res = await request(server)
+      res = await request(app)
         .put('/api/settings/token-weights')
         .send(customWeights);
       expect(res.status).toBe(200);
       expect(res.body).toEqual(customWeights);
 
       // 3. Get custom
-      res = await request(server).get('/api/settings/token-weights');
+      res = await request(app).get('/api/settings/token-weights');
       expect(res.status).toBe(200);
       expect(res.body).toEqual(customWeights);
 
       // 4. Reset to defaults
-      res = await request(server).delete('/api/settings/token-weights');
+      res = await request(app).delete('/api/settings/token-weights');
       expect(res.status).toBe(200);
       expect(res.body).toEqual(DEFAULT_TOKEN_COST_WEIGHTS);
 
       // 5. Get defaults again
-      res = await request(server).get('/api/settings/token-weights');
+      res = await request(app).get('/api/settings/token-weights');
       expect(res.status).toBe(200);
       expect(res.body).toEqual(DEFAULT_TOKEN_COST_WEIGHTS);
     });
@@ -453,7 +447,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
 
   describe('GET /api/settings/general', () => {
     it('returns default settings when not customized', async () => {
-      const res = await request(server).get('/api/settings/general');
+      const res = await request(app).get('/api/settings/general');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
@@ -467,7 +461,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
       settings.setGeneralSettings(customSettings);
 
-      const res = await request(server).get('/api/settings/general');
+      const res = await request(app).get('/api/settings/general');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(customSettings);
@@ -480,7 +474,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
 
       try {
-        const res = await request(server).get('/api/settings/general');
+        const res = await request(app).get('/api/settings/general');
 
         expect(res.status).toBe(500);
         expect(res.body.error).toBe('Failed to get general settings');
@@ -496,7 +490,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         disableAnalytics: true,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/general')
         .send(newSettings);
 
@@ -513,7 +507,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         disableAnalytics: 'not-a-boolean',
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/general')
         .send(invalidSettings);
 
@@ -526,7 +520,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         disableAnalytics: false,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/general')
         .send(newSettings);
 
@@ -539,7 +533,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         disableAnalytics: true,
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/general')
         .send(newSettings);
 
@@ -553,7 +547,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
 
       try {
-        const res = await request(server)
+        const res = await request(app)
           .put('/api/settings/general')
           .send({ disableAnalytics: false });
 
@@ -565,7 +559,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('rejects request with missing body', async () => {
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/general')
         .send({});
 
@@ -579,7 +573,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
         extraField: 'ignored',
       };
 
-      const res = await request(server)
+      const res = await request(app)
         .put('/api/settings/general')
         .send(settingsWithExtra);
 
@@ -598,7 +592,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       });
 
       // Then reset
-      const res = await request(server).delete('/api/settings/general');
+      const res = await request(app).delete('/api/settings/general');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
@@ -613,7 +607,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
     });
 
     it('returns defaults even if no custom settings were set', async () => {
-      const res = await request(server).delete('/api/settings/general');
+      const res = await request(app).delete('/api/settings/general');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
@@ -627,7 +621,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
       };
 
       try {
-        const res = await request(server).delete('/api/settings/general');
+        const res = await request(app).delete('/api/settings/general');
 
         expect(res.status).toBe(500);
         expect(res.body.error).toBe('Failed to reset general settings');
@@ -640,7 +634,7 @@ describe('Settings API', { timeout: 30_000 }, () => {
   describe('Integration: General settings full lifecycle', () => {
     it('GET -> PUT -> GET -> DELETE -> GET', async () => {
       // 1. Get defaults
-      let res = await request(server).get('/api/settings/general');
+      let res = await request(app).get('/api/settings/general');
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         disableAnalytics: false,
@@ -650,26 +644,26 @@ describe('Settings API', { timeout: 30_000 }, () => {
       const customSettings = {
         disableAnalytics: true,
       };
-      res = await request(server)
+      res = await request(app)
         .put('/api/settings/general')
         .send(customSettings);
       expect(res.status).toBe(200);
       expect(res.body).toEqual(customSettings);
 
       // 3. Get custom
-      res = await request(server).get('/api/settings/general');
+      res = await request(app).get('/api/settings/general');
       expect(res.status).toBe(200);
       expect(res.body).toEqual(customSettings);
 
       // 4. Reset to defaults
-      res = await request(server).delete('/api/settings/general');
+      res = await request(app).delete('/api/settings/general');
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         disableAnalytics: false,
       });
 
       // 5. Get defaults again
-      res = await request(server).get('/api/settings/general');
+      res = await request(app).get('/api/settings/general');
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         disableAnalytics: false,

--- a/packages/server/src/services/sessionExecution.js
+++ b/packages/server/src/services/sessionExecution.js
@@ -136,12 +136,40 @@ export async function _executeSession({
       return;
     }
     // Handle post-turn completion (work log association, status transition, summary, etc.)
-    const { wasRescheduled, heldForLimit } = await handleTurnCompletion(
+    const { wasRescheduled, heldForLimit, terminalError } = await handleTurnCompletion(
       sessionId,
       workingDirectory,
       { handleTemplateTriggerIfNeeded, checkProactiveReschedule: _checkProactiveReschedule, handleAutoSendIfNeeded },
       { controller },
     );
+    // Some providers report terminal failures as a final stream event and then
+    // close their generator normally. Route that outcome through the same retry
+    // policy as a rejected execute() call; otherwise the normal completion path
+    // would incorrectly close the workflow obligation as successful.
+    if (terminalError) {
+      const rescheduled = await handleSessionError(sessionId, terminalError, {
+        controller,
+        shouldRescheduleOnError,
+        schedulerService,
+        broadcastConversationState: broadcastConversationStateOnError,
+        errorLabel,
+        handleTemplateTriggerIfNeeded,
+        errorAlreadyRecorded: true,
+      });
+      discardDeferredCardMoveForTurn(
+        sessionId,
+        workflowTurn?.turnToken,
+        rescheduled ? 'turn_retrying' : 'turn_failed',
+      );
+      if (rescheduled) {
+        markExecutionState(sessionId, 'retrying');
+        return;
+      }
+      closeOwnWork(sessionId, 'closed_failed', terminalError.message, {
+        turnToken: workflowTurn?.turnToken,
+      });
+      return;
+    }
     // FR-4/FR-5: a self-scheduled continuation is an open obligation, not success.
     if (wasRescheduled) {
       discardDeferredCardMoveForTurn(sessionId, workflowTurn?.turnToken, 'turn_rescheduled');

--- a/packages/server/src/services/sessionExecution.js
+++ b/packages/server/src/services/sessionExecution.js
@@ -9,17 +9,10 @@ import { buildAgentConfig, buildAgentEnv } from './sessionAgentConfig.js';
 export { buildAgentEnv } from './sessionAgentConfig.js';
 export { buildQueryParams } from './queryParamBuilder.js';
 import { buildQueryParams } from './queryParamBuilder.js';
+import { buildPromptWithAttachments } from './sessionPrompts.js';
 import {
-  buildPromptWithAttachments,
-} from './sessionPrompts.js';
-import {
-  activeSessions,
-  activeConversationIds,
-  handleStreamEvent,
-  handleTurnCompletion,
-  handleSessionError,
-  cleanupSessionState,
-  broadcastSessionStatus,
+  activeSessions, activeConversationIds, handleStreamEvent, handleTurnCompletion,
+  handleSessionError, cleanupSessionState, broadcastSessionStatus,
 } from './streamEventHandler.js';
 import { shouldRescheduleOnError, _checkProactiveReschedule } from './sessionErrors.js';
 import { schedulerService } from './schedulerService.js';

--- a/packages/server/src/services/sessionExecution.workflowFailure.test.js
+++ b/packages/server/src/services/sessionExecution.workflowFailure.test.js
@@ -83,6 +83,20 @@ describe('W4: failure/cancellation propagation through _executeSession', () => {
     return stubAgent;
   }
 
+  function stubResultErrorAgent(message) {
+    const stubAgent = {
+      // Codex reports some terminal failures as a final stream event and then
+      // closes the generator normally instead of rejecting execute().
+      execute: vi.fn(async function* () {
+        yield { type: 'result', subtype: 'error', is_error: true, error: message };
+      }),
+      supportsResume: () => false,
+      needsConversationContext: () => true,
+    };
+    createAgentSpy = vi.spyOn(agentGateway, 'createAgent').mockReturnValue(stubAgent);
+    return stubAgent;
+  }
+
   it('a permanent execution failure fails the run and does not move the card (AC-8)', async () => {
     stubThrowingAgent('boom: permanent failure');
 
@@ -107,6 +121,40 @@ describe('W4: failure/cancellation propagation through _executeSession', () => {
     expect(updated.ownWorkState).toBe('open');
     expect(updated.executionState).toBe('retrying');
     expect(getRun(run.id).status).toBe('open');
+    expect(cardRepo.getById(card.id).laneId).toBe(source.id);
+  });
+
+  it('a terminal result event for a token limit is automatically rescheduled and keeps the run open', async () => {
+    sessionRepo.update(root.id, {
+      autoRescheduleEnabled: true,
+      rescheduleOnTokenLimit: true,
+      rescheduleDelayMinutes: 15,
+    });
+    stubResultErrorAgent("You've hit your usage limit. Try again later.");
+
+    await runSession(root.id, 'do work', tempDir);
+
+    const updated = sessionRepo.getById(root.id);
+    expect(updated.ownWorkState).toBe('open');
+    expect(updated.status).toBe('scheduled');
+    expect(updated.scheduledAt).toEqual(expect.any(Number));
+    expect(updated.rescheduleCount).toBe(1);
+    expect(updated.executionState).toBe('retrying');
+    expect(getRun(run.id).status).toBe('open');
+    expect(cardRepo.getById(card.id).laneId).toBe(source.id);
+  });
+
+  it('a non-retryable terminal result event fails rather than successfully completing the run', async () => {
+    stubResultErrorAgent('boom: permanent result failure');
+
+    await runSession(root.id, 'do work', tempDir);
+
+    const updated = sessionRepo.getById(root.id);
+    expect(updated.status).toBe('error');
+    expect(updated.ownWorkState).toBe('closed_failed');
+    expect(updated.workflowReason).toBe('boom: permanent result failure');
+    expect(updated.executionState).toBe('stopped');
+    expect(getRun(run.id).status).toBe('failed');
     expect(cardRepo.getById(card.id).laneId).toBe(source.id);
   });
 });

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -140,7 +140,12 @@ export async function handleTurnCompletion(sessionId, workingDirectory, callback
   // Sessions with final errors should not transition to waiting
   if (finalErrorSessionIds.has(sessionId)) {
     finalErrorSessionIds.delete(sessionId);
-    return { wasRescheduled: false, heldForLimit: false };
+    const session = sessions.getById(sessionId);
+    return {
+      wasRescheduled: false,
+      heldForLimit: false,
+      terminalError: new Error(session?.error || 'Provider turn ended with an error'),
+    };
   }
 
   // Session ready for follow-up - set to waiting instead of completed
@@ -297,7 +302,7 @@ async function safeTriggerTemplate(sessionId, handleTemplateTriggerIfNeeded) {
  * Encapsulates the duplicated error handling block from runSession/continueSession/continueSessionWithExistingMessage
  * @param {string} sessionId
  * @param {Error} error
- * @param {{ controller: AbortController, shouldRescheduleOnError: Function, schedulerService: Object, errorLabel?: string, broadcastConversationState?: boolean, handleTemplateTriggerIfNeeded?: Function }} options
+ * @param {{ controller: AbortController, shouldRescheduleOnError: Function, schedulerService: Object, errorLabel?: string, broadcastConversationState?: boolean, handleTemplateTriggerIfNeeded?: Function, errorAlreadyRecorded?: boolean }} options
  */
 export async function handleSessionError(sessionId, error, options = {}) {
   const { controller, shouldRescheduleOnError, schedulerService } = options;
@@ -327,6 +332,14 @@ export async function handleSessionError(sessionId, error, options = {}) {
   const rescheduled = await tryRescheduleOnError(sessionId, error, shouldRescheduleOnError, schedulerService);
   if (rescheduled) {
     return true;
+  }
+
+  // A terminal result event is recorded and broadcast while the stream is
+  // still being consumed. Its completion path calls this function only to
+  // apply the shared retry policy; do not create a second visible error or
+  // repeat terminal side effects when no retry applies.
+  if (options.errorAlreadyRecorded) {
+    return false;
   }
 
   // Normal error handling (no reschedule or reschedule limits reached)

--- a/packages/server/src/services/streamEventCallbacks.js
+++ b/packages/server/src/services/streamEventCallbacks.js
@@ -352,6 +352,24 @@ async function safeTriggerTemplate(sessionId, handleTemplateTriggerIfNeeded) {
 }
 
 /**
+ * Persist and broadcast an unrecoverable session error.
+ * @param {string} sessionId
+ * @param {Error} error
+ * @param {{ broadcastConversationState?: boolean, handleTemplateTriggerIfNeeded?: Function }} options
+ */
+async function finalizeSessionError(sessionId, error, options) {
+  sessions.update(sessionId, { status: 'error', error: error.message });
+  createVisibleFinalErrorMessage(sessionId, error, activeConversationIds);
+  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
+  if (options.broadcastConversationState) broadcastFinalConversationState(sessionId);
+  summaryService.extractPrUrlIfNeeded(sessionId);
+  summaryService.onSessionComplete(sessionId);
+  if (options.handleTemplateTriggerIfNeeded) {
+    await safeTriggerTemplate(sessionId, options.handleTemplateTriggerIfNeeded);
+  }
+}
+
+/**
  * Handle session error with optional rescheduling
  * Encapsulates the duplicated error handling block from runSession/continueSession/continueSessionWithExistingMessage
  * @param {string} sessionId
@@ -402,24 +420,7 @@ export async function handleSessionError(sessionId, error, options = {}) {
   }
 
   // Normal error handling (no reschedule or reschedule limits reached)
-  sessions.update(sessionId, { status: 'error', error: error.message });
-  createVisibleFinalErrorMessage(sessionId, error, activeConversationIds);
-  broadcastToSession(sessionId, WS_MESSAGE_TYPES.SESSION_ERROR, { sessionId, error: error.message });
-
-  // Optionally broadcast final conversation state (continueSession does this)
-  if (options.broadcastConversationState) {
-    broadcastFinalConversationState(sessionId);
-  }
-
-  // Extract PR URL before generating summary (PR may have been created before error)
-  summaryService.extractPrUrlIfNeeded(sessionId);
-  // Trigger summary generation on error
-  summaryService.onSessionComplete(sessionId);
-
-  // Trigger next template if configured (e.g., session completed work but process exited with error code)
-  if (options.handleTemplateTriggerIfNeeded) {
-    await safeTriggerTemplate(sessionId, options.handleTemplateTriggerIfNeeded);
-  }
+  await finalizeSessionError(sessionId, error, options);
 
   return false; // Not rescheduled
 }

--- a/packages/server/src/services/streamEventHandler.test.js
+++ b/packages/server/src/services/streamEventHandler.test.js
@@ -898,7 +898,11 @@ describe('streamEventHandler', () => {
       activeSessions.set('sess-1', { controller: { signal: { aborted: false } } });
       activeConversationIds.set('sess-1', 'conv-1');
       lastMessageIds.set('sess-1', 'msg-last');
-      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      sessions.getById.mockReturnValue({
+        agentType: 'codex',
+        projectId: 'proj-1',
+        error: 'usage limit reached',
+      });
       messages.getByConversationId.mockReturnValue([
         { id: 'msg-user', sessionId: 'sess-1', conversationId: 'conv-1', role: 'user', content: 'continue' },
       ]);
@@ -912,7 +916,11 @@ describe('streamEventHandler', () => {
 
       vi.clearAllMocks();
       workLogs.associatePendingLogs.mockReturnValue(1);
-      sessions.getById.mockReturnValue({ agentType: 'codex', projectId: 'proj-1' });
+      sessions.getById.mockReturnValue({
+        agentType: 'codex',
+        projectId: 'proj-1',
+        error: 'usage limit reached',
+      });
 
       const mockCheckReschedule = vi.fn().mockResolvedValue(false);
       const mockHandleTemplate = vi.fn().mockResolvedValue(undefined);
@@ -924,7 +932,9 @@ describe('streamEventHandler', () => {
         handleAutoSendIfNeeded: mockAutoSend,
       });
 
-      expect(result).toEqual({ wasRescheduled: false, heldForLimit: false });
+      expect(result).toMatchObject({ wasRescheduled: false, heldForLimit: false });
+      expect(result.terminalError).toBeInstanceOf(Error);
+      expect(result.terminalError.message).toBe('usage limit reached');
       expect(workLogs.associatePendingLogs).toHaveBeenCalledWith('sess-1', 'msg-last');
       expect(lastMessageIds.has('sess-1')).toBe(false);
       expect(sessions.update).not.toHaveBeenCalledWith('sess-1', { status: 'waiting', error: null });


### PR DESCRIPTION
## Summary

- route in-band provider terminal errors through the existing session retry policy
- keep workflow ownership open when token or usage limits schedule a retry
- close non-retryable terminal errors as failed instead of successful
- avoid duplicating errors already recorded from the terminal stream event

## Root cause

Some providers emit a final `result` event with `subtype: error` and then close their generator normally. The stream callback recorded the error, but `_executeSession()` continued through its success path and finalized workflow ownership as `closed_successfully`. This bypassed automatic rescheduling even when the error matched the token-limit policy.

## Tests

- terminal usage-limit result schedules a retry and keeps the lane run open
- permanent terminal result closes workflow ownership as failed
- completion callback exposes the recorded terminal error
- focused session lifecycle and callback suites: 107/107 passing
- `git diff --check` passing

## Verification note

The full server suite progressed without a reported failure but did not terminate after several minutes in Git integration coverage, so it was stopped. The focused 107-test lifecycle surface is green.