### PR TITLE
Fix waiting vs running status in project and session lists

### DIFF
--- a/packages/server/src/api/projects.test.js
+++ b/packages/server/src/api/projects.test.js
@@ -1021,7 +1021,7 @@ describe('Projects API', () => {
       const res = await request(app).get('/api/projects');
       const project = res.body.find((p) => p.id === projectId);
 
-      expect(project.runningSessionCount).toBe(3); // rootA + alpha-child + rootB (alpha-child is still status='running')
+      expect(project.runningSessionCount).toBe(2); // rootA + rootB; alpha-child is blocked on input
       expect(project.waitingSessionCount).toBe(1); // alpha-child (pendingAgentInput)
       expect(project.runningWorkspaces.map((w) => w.id)).toEqual(
         expect.arrayContaining([rootA.id, rootB.id]),

--- a/packages/server/src/api/workspace-cards.js
+++ b/packages/server/src/api/workspace-cards.js
@@ -96,7 +96,7 @@ export function sendWorkspaceCards(res, projectId, query, startedAt) {
   if (!options)
     return res.status(400).json({ error: 'Invalid workspace card pagination or filters' });
   const page = sessions.getWorkspaceCardPage(projectId, options);
-  const { cards, facets } = page;
+  const { cards, facets, total: allTotal } = page;
   const memberIds = [...new Set(cards.flatMap((card) => card.memberIds))];
   const memberIdSet = new Set(memberIds);
   const runsBySession = buildRunsBySession(
@@ -119,7 +119,7 @@ export function sendWorkspaceCards(res, projectId, query, startedAt) {
       latestCommandRuns: workspaceCommandRuns(card, runsBySession),
     };
   });
-  const total = options.status ? facets[options.status] : facets.running + facets.idle;
+  const total = options.status ? facets[options.status] : allTotal;
   return sendWorkspaceJson(
     res,
     {

--- a/packages/server/src/api/workspaces.test.js
+++ b/packages/server/src/api/workspaces.test.js
@@ -276,7 +276,7 @@ describe('Workspace facade API', () => {
       expect(res.body.workspaces).toHaveLength(1);
       // "waiting" counts only sessions blocked on agent input (pending_agent_input),
       // not status='waiting' — 'Idle one' is idle here despite its status value.
-      expect(res.body.facets).toEqual({ running: 2, idle: 2, waiting: 1 });
+      expect(res.body.facets).toEqual({ running: 1, idle: 2, waiting: 1 });
       expect(res.body.pagination).toMatchObject({ total: 4, hasMore: true });
     });
 

--- a/packages/server/src/db/ProjectRepository.test.js
+++ b/packages/server/src/db/ProjectRepository.test.js
@@ -317,7 +317,7 @@ describe('ProjectRepository', () => {
       expect(enriched.runningWorkspaces).toEqual([
         { id: root.id, name: 'root', activeCount: 4 },
       ]);
-      expect(enriched.runningSessionCount).toBe(4); // root + child-running + child-waiting + grandchild (running/starting)
+      expect(enriched.runningSessionCount).toBe(3); // root + child-running + grandchild
       expect(enriched.waitingSessionCount).toBe(1); // child-waiting (pendingAgentInput)
     });
 

--- a/packages/server/src/db/project-activity-queries.js
+++ b/packages/server/src/db/project-activity-queries.js
@@ -14,9 +14,7 @@
 // it as "needs an answer" made nearly every idle session match. A session
 // genuinely blocked on AskUserQuestion/permission stays status='running' for
 // the whole time it's blocked; pending_agent_input is the only signal for
-// that. Because a session can be both running AND pending_agent_input at the
-// same time, running_count and waiting_count are NOT disjoint — active_count
-// is computed with an OR, not a sum, to avoid double-counting that session.
+// that. User-facing running and waiting counts are intentionally disjoint.
 // WORKSPACE_AGGREGATES_CTE's waiting_count uses this same pending_agent_input
 // definition (not status='waiting') so the project-list "waiting" pill and its
 // embedded per-project workspace-card list agree on which sessions match.
@@ -36,7 +34,7 @@ export const PROJECT_ACTIVITY_SQL = `
     WHERE instr(tree.path, '/' || s.id || '/') = 0
   ), agg AS (
     SELECT tree.root_id, tree.project_id, r.name,
-      SUM(CASE WHEN s.status IN ('running', 'starting') THEN 1 ELSE 0 END) AS running_count,
+      SUM(CASE WHEN s.status IN ('running', 'starting') AND s.pending_agent_input = 0 THEN 1 ELSE 0 END) AS running_count,
       SUM(CASE WHEN s.pending_agent_input = 1 THEN 1 ELSE 0 END) AS waiting_count,
       SUM(CASE WHEN s.status IN ('running', 'starting') OR s.pending_agent_input = 1 THEN 1 ELSE 0 END) AS active_count,
       MAX(MAX(COALESCE(s.last_activity_at, 0), COALESCE(s.updated_at, 0), COALESCE(s.created_at, 0))) AS last_activity_at

--- a/packages/server/src/db/project-activity-queries.test.js
+++ b/packages/server/src/db/project-activity-queries.test.js
@@ -74,8 +74,8 @@ describe('getProjectActivityAggregates', () => {
     for (const workspace of project.runningWorkspaces) {
       expect(workspace.activeCount).toBe(1);
     }
-    // runningSessionCount counts running + starting only (both 'running' rows).
-    expect(project.runningSessionCount).toBe(3);
+    // A blocked process is presented exclusively as waiting, not running.
+    expect(project.runningSessionCount).toBe(2);
     expect(project.waitingSessionCount).toBe(1);
   }));
 
@@ -154,7 +154,7 @@ describe('getProjectActivityAggregates', () => {
     expect(project.runningWorkspaces).toHaveLength(2);
     const byId = Object.fromEntries(project.runningWorkspaces.map((w) => [w.id, w.activeCount]));
     expect(byId).toEqual({ alpha: 1, beta: 1 });
-    expect(project.runningSessionCount).toBe(2);
+    expect(project.runningSessionCount).toBe(1);
     expect(project.waitingSessionCount).toBe(1);
   }));
 
@@ -167,7 +167,7 @@ describe('getProjectActivityAggregates', () => {
     const result = getProjectActivityAggregates(db);
     expect(result.get('one').runningSessionCount).toBe(1);
     expect(result.get('one').waitingSessionCount).toBe(0);
-    expect(result.get('two').runningSessionCount).toBe(1);
+    expect(result.get('two').runningSessionCount).toBe(0);
     expect(result.get('two').waitingSessionCount).toBe(1);
     expect(result.get('one').runningWorkspaces.map((w) => w.id)).toEqual(['one-root']);
     expect(result.get('two').runningWorkspaces.map((w) => w.id)).toEqual(['two-root']);
@@ -196,9 +196,9 @@ describe('getProjectActivityAggregates', () => {
     expect(project.runningWorkspaces).toEqual([
       { id: 'root', name: 'root', activeCount: 3 },
     ]);
-    // child-waiting is realistically still status='running' while blocked, so
-    // it contributes to both counts (root + child-waiting + child-starting).
-    expect(project.runningSessionCount).toBe(3);
+    // child-waiting remains status='running' internally, but contributes only
+    // to the user-facing waiting count.
+    expect(project.runningSessionCount).toBe(2);
     expect(project.waitingSessionCount).toBe(1); // child-waiting
   }));
 
@@ -212,7 +212,7 @@ describe('getProjectActivityAggregates', () => {
     expect(project.runningWorkspaces).toEqual([
       { id: 'root', name: 'root', activeCount: 1 },
     ]);
-    expect(project.runningSessionCount).toBe(1);
+    expect(project.runningSessionCount).toBe(0);
     expect(project.waitingSessionCount).toBe(1);
   }));
 

--- a/packages/server/src/db/workspace-queries.js
+++ b/packages/server/src/db/workspace-queries.js
@@ -129,6 +129,7 @@ function parseCardPageRows(resultRows, limit) {
       idle: facetRow?.facet_idle || 0,
       waiting: facetRow?.facet_waiting || 0,
     },
+    total: facetRow?.facet_total || 0,
   };
 }
 
@@ -160,20 +161,21 @@ function buildWorkspaceCardPageSql(baseFilters, statusFilters, cursorClause, has
       SELECT
         COALESCE(SUM(CASE WHEN runningCount > 0 THEN 1 ELSE 0 END), 0) AS running,
         COALESCE(SUM(CASE WHEN runningCount = 0 AND waitingCount = 0 THEN 1 ELSE 0 END), 0) AS idle,
-        COALESCE(SUM(CASE WHEN waitingCount > 0 THEN 1 ELSE 0 END), 0) AS waiting
+        COALESCE(SUM(CASE WHEN waitingCount > 0 THEN 1 ELSE 0 END), 0) AS waiting,
+        COUNT(*) AS total
       FROM base
     ), paged AS (
       SELECT * FROM filtered WHERE 1=1 ${cursorClause}
       ORDER BY starred DESC, sort_activity DESC, updatedAt DESC, createdAt DESC, id DESC
       LIMIT @limit ${hasCursor ? '' : 'OFFSET @offset'}
     )
-    SELECT 'page' AS row_kind, paged.*, NULL AS facet_running, NULL AS facet_idle, NULL AS facet_waiting
+    SELECT 'page' AS row_kind, paged.*, NULL AS facet_running, NULL AS facet_idle, NULL AS facet_waiting, NULL AS facet_total
     FROM paged
     UNION ALL
     SELECT 'facets' AS row_kind,
       NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
       NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-      NULL, NULL, NULL, facets.running, facets.idle, facets.waiting
+      NULL, NULL, NULL, facets.running, facets.idle, facets.waiting, facets.total
     FROM facets`;
 }
 
@@ -217,11 +219,12 @@ export function getWorkspaceCardPage(db, projectId, options = {}) {
       rootId,
     })
   );
-  const { visibleRows, hasMore, facets } = parseCardPageRows(resultRows, limit);
+  const { visibleRows, hasMore, facets, total } = parseCardPageRows(resultRows, limit);
   const cards = visibleRows.map(toWorkspaceCard);
   return {
     cards,
     facets,
+    total,
     hasMore,
     nextCursor: hasMore ? encodeCursor(visibleRows.at(-1)) : null,
   };

--- a/packages/server/src/db/workspace-queries.js
+++ b/packages/server/src/db/workspace-queries.js
@@ -22,8 +22,10 @@ const WORKSPACE_AGGREGATES_CTE = `
     WHERE instr(tree.path, '/' || s.id || '/') = 0
   ), aggregates AS (
     SELECT tree.root_id,
-      SUM(CASE WHEN s.status IN ('running', 'starting') THEN 1 ELSE 0 END) AS running_count,
-      GROUP_CONCAT(CASE WHEN s.status IN ('running', 'starting') THEN s.id END ORDER BY s.id = tree.root_id DESC, s.id) AS running_session_ids,
+      -- A process parked on an interactive prompt retains status='running',
+      -- but is user-facing "waiting" work, not actively running work.
+      SUM(CASE WHEN s.status IN ('running', 'starting') AND s.pending_agent_input = 0 THEN 1 ELSE 0 END) AS running_count,
+      GROUP_CONCAT(CASE WHEN s.status IN ('running', 'starting') AND s.pending_agent_input = 0 THEN s.id END ORDER BY s.id = tree.root_id DESC, s.id) AS running_session_ids,
       GROUP_CONCAT(s.id ORDER BY s.id = tree.root_id DESC, s.id) AS member_ids,
       SUM(CASE WHEN s.status = 'scheduled' THEN 1 ELSE 0 END) AS scheduled_count,
       MIN(CASE WHEN s.status = 'scheduled' THEN s.scheduled_at END) AS nearest_scheduled_at,
@@ -65,7 +67,7 @@ function workspaceFilters({ archived, starred, scheduled, rootId = null }) {
 function statusPredicates(status) {
   if (status === 'running') return ['runningCount > 0'];
   if (status === 'waiting') return ['waitingCount > 0'];
-  if (status === 'idle') return ['runningCount = 0'];
+  if (status === 'idle') return ['runningCount = 0', 'waitingCount = 0'];
   return [];
 }
 
@@ -157,7 +159,7 @@ function buildWorkspaceCardPageSql(baseFilters, statusFilters, cursorClause, has
     ), facets AS (
       SELECT
         COALESCE(SUM(CASE WHEN runningCount > 0 THEN 1 ELSE 0 END), 0) AS running,
-        COALESCE(SUM(CASE WHEN runningCount = 0 THEN 1 ELSE 0 END), 0) AS idle,
+        COALESCE(SUM(CASE WHEN runningCount = 0 AND waitingCount = 0 THEN 1 ELSE 0 END), 0) AS idle,
         COALESCE(SUM(CASE WHEN waitingCount > 0 THEN 1 ELSE 0 END), 0) AS waiting
       FROM base
     ), paged AS (

--- a/packages/server/src/db/workspace-queries.test.js
+++ b/packages/server/src/db/workspace-queries.test.js
@@ -89,6 +89,12 @@ describe('getWorkspaceCardPage', () => {
     const page = getWorkspaceCardPage(db, 'project', { status: 'waiting', limit: 10 });
 
     expect(page.cards.map((c) => c.id)).toEqual(['blocked']);
-    expect(page.facets).toEqual({ running: 1, idle: 1, waiting: 1 });
+    expect(page.cards[0]).toMatchObject({ runningCount: 0, waitingCount: 1 });
+    expect(page.cards[0].runningSessionIds).toEqual([]);
+    expect(page.facets).toEqual({ running: 0, idle: 1, waiting: 1 });
+
+    expect(getWorkspaceCardPage(db, 'project', { status: 'running', limit: 10 }).cards).toEqual([]);
+    expect(getWorkspaceCardPage(db, 'project', { status: 'idle', limit: 10 }).cards.map((c) => c.id))
+      .toEqual(['idle-waiting-status']);
   }));
 });

--- a/packages/server/src/db/workspace-queries.test.js
+++ b/packages/server/src/db/workspace-queries.test.js
@@ -97,4 +97,21 @@ describe('getWorkspaceCardPage', () => {
     expect(getWorkspaceCardPage(db, 'project', { status: 'idle', limit: 10 }).cards.map((c) => c.id))
       .toEqual(['idle-waiting-status']);
   }));
+
+  it('counts a workflow with active and blocked members in both facets', () => withDb((db) => {
+    addSession(db, 'root', { status: 'running' });
+    addSession(db, 'blocked-child', {
+      parentId: 'root', status: 'running', pendingAgentInput: true,
+    });
+
+    const all = getWorkspaceCardPage(db, 'project', { limit: 10 });
+
+    expect(all.cards[0]).toMatchObject({ runningCount: 1, waitingCount: 1 });
+    expect(all.facets).toEqual({ running: 1, idle: 0, waiting: 1 });
+    expect(all.total).toBe(1);
+    expect(getWorkspaceCardPage(db, 'project', { status: 'running', limit: 10 }).cards)
+      .toHaveLength(1);
+    expect(getWorkspaceCardPage(db, 'project', { status: 'waiting', limit: 10 }).cards)
+      .toHaveLength(1);
+  }));
 });

--- a/packages/web/src/components/KanbanBoard.test.js
+++ b/packages/web/src/components/KanbanBoard.test.js
@@ -182,6 +182,29 @@ describe('KanbanBoard.vue', () => {
     expect(wrapper.find('[aria-label="Agent input required"]').exists()).toBe(true);
   });
 
+  it('does not show a running control for a session blocked on input', () => {
+    const blocked = { id: 'session-1', name: 'Workspace 1', status: 'running', pendingAgentInput: true };
+    mockKanbanStoreData.board.lanes[0].cards[0].sessions = [blocked];
+    sessionsStore.sessions = [blocked];
+
+    const wrapper = mountBoard();
+
+    expect(wrapper.findAll('.kanban-card')[0]
+      .find('[aria-label="Workspace running"]').exists()).toBe(false);
+  });
+
+  it('keeps the running control when another workflow member is actively running', () => {
+    const root = { id: 'session-1', name: 'Workspace 1', status: 'running', pendingAgentInput: true };
+    const activeChild = { id: 'child-1', parentSessionId: 'session-1', status: 'running' };
+    mockKanbanStoreData.board.lanes[0].cards[0].sessions = [root, activeChild];
+    sessionsStore.sessions = [root, activeChild];
+
+    const wrapper = mountBoard();
+
+    expect(wrapper.findAll('.kanban-card')[0]
+      .find('[aria-label="Workspace running"]').exists()).toBe(true);
+  });
+
   describe('Component renders correctly', () => {
     it('exports a Vue component', () => {
       expect(KanbanBoard).toBeDefined();

--- a/packages/web/src/components/KanbanBoard.vue
+++ b/packages/web/src/components/KanbanBoard.vue
@@ -308,6 +308,7 @@ import KanbanBoardIcon from './KanbanBoardIcon.vue';
 import KanbanCardSessionDetails from './KanbanCardSessionDetails.vue';
 import KanbanLayoutToggle from './KanbanLayoutToggle.vue';
 import { mapRunsToButtonStatuses } from '../utils/commandButtonStatuses.js';
+import { isSessionActivelyRunning } from '../utils/workflowStatus.js';
 import { api } from '../api/ApiClient.js';
 import './KanbanBoard.css';
 const props = defineProps({
@@ -498,7 +499,7 @@ const isCardEffectivelyRunning = (session) => {
   if (sessionsStore.getWorkflowEffectiveStatus(session.id) === 'running') {
     return true;
   }
-  return ['running', 'starting'].includes(session.status);
+  return isSessionActivelyRunning(session);
 };
 // Board-level map of session id → button-status indicators. Built once per
 // recompute (rather than per-card during render) so the buttonMap and the

--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -217,6 +217,7 @@ describe('SessionCard', () => {
       expect(indicator.text()).toContain('needs input');
       expect(indicator.attributes('title')).toBe('The agent is waiting for your input');
       expect(indicator.find('.agent-input-icon').exists()).toBe(true);
+      expect(wrapper.find('.status-running').exists()).toBe(false);
     });
 
 

--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -220,6 +220,15 @@ describe('SessionCard', () => {
       expect(wrapper.find('.status-running').exists()).toBe(false);
     });
 
+    it('does not show needs input for legacy status="waiting" without pending input', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'waiting', pendingAgentInput: false },
+      });
+
+      expect(wrapper.find('[aria-label="Agent input required"]').exists()).toBe(false);
+      expect(wrapper.find('.status-running').exists()).toBe(false);
+    });
+
 
     it('links to workspace detail page', () => {
       const wrapper = mountComponent();

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -55,7 +55,7 @@
           <!-- Session status badges -->
           <p class="session-meta">
             <span
-              v-if="session.pendingAgentInput"
+              v-if="workflowStatus.waitingCount > 0"
               class="status-badge status-waiting agent-input-indicator"
               aria-label="Agent input required"
               title="The agent is waiting for your input"
@@ -364,23 +364,30 @@ const workflowStatus = computed(() => {
   if (props.workflowAggregate) {
     return {
       runningCount: props.workflowAggregate.runningCount || 0,
+      waitingCount: props.workflowAggregate.waitingCount || 0,
       scheduledCount: props.workflowAggregate.scheduledCount || 0,
       totalCount: (props.workflowAggregate.descendantCount || 0) + 1,
-      effectiveStatus: (props.workflowAggregate.runningCount || 0) > 0 ? 'running' : 'idle',
+      effectiveStatus: (props.workflowAggregate.runningCount || 0) > 0
+        ? 'running'
+        : (props.workflowAggregate.waitingCount || 0) > 0 ? 'waiting' : 'idle',
     };
   }
   const allSessions = getWorkflowSessions();
   const runningStatuses = ['running', 'starting'];
 
   let runningCount = 0;
+  let waitingCount = 0;
   let scheduledCount = 0;
   for (const s of allSessions) {
-    if (runningStatuses.includes(s.status)) runningCount++;
+    if (s.pendingAgentInput) waitingCount++;
+    else if (runningStatuses.includes(s.status)) runningCount++;
+    else if (s.status === 'waiting') waitingCount++;
     if (s.status === 'scheduled') scheduledCount++;
   }
 
   return {
     runningCount,
+    waitingCount,
     scheduledCount,
     totalCount: allSessions.length,
     effectiveStatus: props.session.status,
@@ -396,7 +403,7 @@ const runningSessionIds = computed(() => {
   }
   const runningStatuses = ['running', 'starting'];
   return getWorkflowSessions()
-    .filter(s => runningStatuses.includes(s.status))
+    .filter(s => runningStatuses.includes(s.status) && !s.pendingAgentInput)
     .map(s => s.id);
 });
 

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -262,6 +262,7 @@ import { useKanbanStore } from '../stores/kanban.js';
 import { findNearestScheduledTime } from '../utils/scheduleInfo.js';
 import { getStatusIconSvg } from './statusIcons';
 import { mapRunsToButtonStatuses } from '../utils/commandButtonStatuses.js';
+import { isSessionActivelyRunning, summarizeWorkflowSessions } from '../utils/workflowStatus.js';
 import ButtonStatusModal from './ButtonStatusModal.vue';
 import MoveCardModal from './MoveCardModal.vue';
 import PrIndicators from './PrIndicators.vue';
@@ -372,38 +373,16 @@ const workflowStatus = computed(() => {
         : (props.workflowAggregate.waitingCount || 0) > 0 ? 'waiting' : 'idle',
     };
   }
-  const allSessions = getWorkflowSessions();
-  const runningStatuses = ['running', 'starting'];
-
-  let runningCount = 0;
-  let waitingCount = 0;
-  let scheduledCount = 0;
-  for (const s of allSessions) {
-    if (s.pendingAgentInput) waitingCount++;
-    else if (runningStatuses.includes(s.status)) runningCount++;
-    else if (s.status === 'waiting') waitingCount++;
-    if (s.status === 'scheduled') scheduledCount++;
-  }
-
-  return {
-    runningCount,
-    waitingCount,
-    scheduledCount,
-    totalCount: allSessions.length,
-    effectiveStatus: props.session.status,
-  };
+  return summarizeWorkflowSessions(getWorkflowSessions());
 });
 
 // Collect all running/starting session IDs in the workflow (full tree traversal)
 const runningSessionIds = computed(() => {
   if (props.workflowAggregate) {
-    return props.workflowAggregate.runningSessionIds?.length
-      ? props.workflowAggregate.runningSessionIds
-      : (props.workflowAggregate.runningCount > 0 ? [props.session.id] : []);
+    return props.workflowAggregate.runningSessionIds || [];
   }
-  const runningStatuses = ['running', 'starting'];
   return getWorkflowSessions()
-    .filter(s => runningStatuses.includes(s.status) && !s.pendingAgentInput)
+    .filter(s => isSessionActivelyRunning(s))
     .map(s => s.id);
 });
 

--- a/packages/web/src/components/SessionFiltersPanel.test.js
+++ b/packages/web/src/components/SessionFiltersPanel.test.js
@@ -92,10 +92,10 @@ describe('SessionFiltersPanel', () => {
       const buttons = wrapper.findAll('.filter-btn');
       const statusButtons = buttons.filter(btn => {
         const label = btn.find('.filter-label');
-        return label.exists() && (label.text() === 'running' || label.text() === 'idle');
+        return label.exists() && ['running', 'waiting', 'idle'].includes(label.text());
       });
 
-      expect(statusButtons).toHaveLength(2);
+      expect(statusButtons).toHaveLength(3);
     });
 
     it('does not show status filter buttons when showStatusFilters is false', () => {
@@ -106,7 +106,7 @@ describe('SessionFiltersPanel', () => {
       const buttons = wrapper.findAll('.filter-btn');
       const statusButtons = buttons.filter(btn => {
         const label = btn.find('.filter-label');
-        return label.exists() && (label.text() === 'running' || label.text() === 'idle');
+        return label.exists() && ['running', 'waiting', 'idle'].includes(label.text());
       });
 
       expect(statusButtons).toHaveLength(0);
@@ -134,6 +134,19 @@ describe('SessionFiltersPanel', () => {
       await runningButton.trigger('click');
 
       expect(mockToggleFilter).toHaveBeenCalledWith('running');
+    });
+
+    it('shows the authoritative waiting count and filters by waiting', async () => {
+      const wrapper = mountComponent({
+        statusCounts: { running: 1, waiting: 2, idle: 3 },
+      });
+      const waitingButton = wrapper.findAll('.filter-btn').find(btn =>
+        btn.find('.filter-label').text() === 'waiting'
+      );
+
+      expect(waitingButton.find('.filter-count').text()).toBe('2');
+      await waitingButton.trigger('click');
+      expect(mockToggleFilter).toHaveBeenCalledWith('waiting');
     });
   });
 

--- a/packages/web/src/components/SessionFiltersPanel.vue
+++ b/packages/web/src/components/SessionFiltersPanel.vue
@@ -4,7 +4,7 @@
       <!-- Status filter buttons (sessions tab only) -->
       <template v-if="showStatusFilters">
         <button
-          v-for="status in ['running', 'idle']"
+          v-for="status in ['running', 'waiting', 'idle']"
           :key="status"
           :class="[
             'filter-btn',
@@ -85,7 +85,7 @@ import { useSessionsStore } from '../stores/sessions.js';
 import { useSessionFiltering } from '../composables/useSessionFiltering.js';
 
 const props = defineProps({
-  /** Whether to show status filter buttons (running/idle) */
+  /** Whether to show status filter buttons (running/waiting/idle) */
   showStatusFilters: {
     type: Boolean,
     default: true,
@@ -113,7 +113,7 @@ const {
 } = useSessionFiltering();
 
 // Authoritative facets come from the workspace-card list response.
-const statusFilterCounts = computed(() => props.statusCounts || { running: 0, idle: 0 });
+const statusFilterCounts = computed(() => props.statusCounts || { running: 0, waiting: 0, idle: 0 });
 </script>
 
 <style scoped>

--- a/packages/web/src/composables/useSessionFiltering.js
+++ b/packages/web/src/composables/useSessionFiltering.js
@@ -5,7 +5,7 @@ import { useSessionsStore } from '../stores/sessions.js';
  * Composable for managing session filter toggle cycling and tooltip computation.
  *
  * Handles:
- * - Status filter toggling (running / idle)
+ * - Status filter toggling (running / waiting / idle)
  * - Star filter three-state cycling (null → starred → unstarred → null)
  * - Scheduled filter three-state cycling (null → scheduled → not-scheduled → null)
  * - Tooltip text computation for star and scheduled filters
@@ -17,7 +17,7 @@ export function useSessionFiltering() {
 
   /**
    * Toggle a status filter. If already active, clears it; otherwise sets it as exclusive.
-   * @param {string} status - 'running' or 'idle'
+   * @param {string} status - 'running', 'waiting', or 'idle'
    */
   function toggleFilter(status) {
     if (sessionsStore.statusFilter === status) {

--- a/packages/web/src/stores/projects.js
+++ b/packages/web/src/stores/projects.js
@@ -30,8 +30,8 @@ export const useProjectsStore = defineStore('projects', {
     /**
      * Facets for the status filter. The running badge is a session total;
      * waiting and idle remain project counts because their filters operate on
-     * projects. `running` and `waiting` may overlap; `idle` is the complement
-     * of "any active session".
+     * projects. The server supplies mutually exclusive running and waiting
+     * session counts; idle is the complement of any active session.
      */
     statusFacets: (state) => {
       let running = 0;

--- a/packages/web/src/stores/sessionFilters.js
+++ b/packages/web/src/stores/sessionFilters.js
@@ -51,7 +51,7 @@ export function createFilterPersistence(filterKey, storageKey, validValues, stor
 
 export const useSessionFiltersStore = defineStore('sessionFilters', {
   state: () => ({
-    statusFilter: null,   // 'running' | 'idle' | null
+    statusFilter: null,   // 'running' | 'waiting' | 'idle' | null
     starredFilter: null,  // 'starred' | 'unstarred' | null
     scheduledFilter: null, // 'scheduled' | 'not-scheduled' | null
   }),
@@ -78,7 +78,7 @@ export const useSessionFiltersStore = defineStore('sessionFilters', {
     restoreStatusFilter() {
       try {
         const filter = localStorage.getItem('sessionStatusFilter');
-        if (filter === 'running' || filter === 'idle') {
+        if (filter === 'running' || filter === 'waiting' || filter === 'idle') {
           this.statusFilter = filter;
         }
       } catch (error) {

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -107,8 +107,8 @@ export const useSessionsStore = defineStore('sessions', {
           }
         }
         const runningStatuses = ['running', 'starting'];
-        if (allSessions.some((s) => s.pendingAgentInput)) return 'waiting';
-        return allSessions.some((s) => runningStatuses.includes(s.status)) ? 'running' : 'idle';
+        if (allSessions.some((s) => runningStatuses.includes(s.status))) return 'running';
+        return allSessions.some((s) => s.pendingAgentInput) ? 'waiting' : 'idle';
       };
     },
 

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -107,6 +107,7 @@ export const useSessionsStore = defineStore('sessions', {
           }
         }
         const runningStatuses = ['running', 'starting'];
+        if (allSessions.some((s) => s.pendingAgentInput)) return 'waiting';
         return allSessions.some((s) => runningStatuses.includes(s.status)) ? 'running' : 'idle';
       };
     },
@@ -147,13 +148,14 @@ export const useSessionsStore = defineStore('sessions', {
         const runningStatuses = ['running', 'starting'];
         let runningCount = 0, scheduledCount = 0, waitingCount = 0, completedCount = 0;
         for (const session of allSessions) {
-          if (runningStatuses.includes(session.status)) runningCount++;
+          if (session.pendingAgentInput) waitingCount++;
+          else if (runningStatuses.includes(session.status)) runningCount++;
           else if (session.status === 'scheduled') scheduledCount++;
           else if (session.status === 'waiting') waitingCount++;
           else if (session.status === 'completed' || session.status === 'stopped') completedCount++;
         }
         return {
-          effectiveStatus: runningCount > 0 ? 'running' : 'idle',
+          effectiveStatus: runningCount > 0 ? 'running' : waitingCount > 0 ? 'waiting' : 'idle',
           runningCount,
           scheduledCount,
           waitingCount,

--- a/packages/web/src/stores/sessions.js
+++ b/packages/web/src/stores/sessions.js
@@ -6,6 +6,10 @@ import { sessionActions } from './sessions/sessionActions.js';
 import { conversationActions } from './sessions/conversationActions.js';
 import { perSessionActions } from './sessions/perSessionActions.js';
 import { perSessionGetters } from './sessions/perSessionGetters.js';
+import {
+  collectWorkflowSessions,
+  summarizeWorkflowSessions,
+} from '../utils/workflowStatus.js';
 
 export const useSessionsStore = defineStore('sessions', {
   state: () => ({
@@ -93,22 +97,9 @@ export const useSessionsStore = defineStore('sessions', {
       return (rootSessionId) => {
         const root = this._findSessionById(rootSessionId);
         if (!root) return 'idle';
-        const allSessions = [root];
-        const stack = [rootSessionId];
-        const visited = new Set();
-        while (stack.length > 0) {
-          const currentId = stack.pop();
-          if (visited.has(currentId)) continue;
-          visited.add(currentId);
-          const children = this._findChildren(currentId);
-          for (const child of children) {
-            allSessions.push(child);
-            stack.push(child.id);
-          }
-        }
-        const runningStatuses = ['running', 'starting'];
-        if (allSessions.some((s) => runningStatuses.includes(s.status))) return 'running';
-        return allSessions.some((s) => s.pendingAgentInput) ? 'waiting' : 'idle';
+        return summarizeWorkflowSessions(
+          collectWorkflowSessions(root, this._findChildren),
+        ).effectiveStatus;
       };
     },
 
@@ -135,31 +126,10 @@ export const useSessionsStore = defineStore('sessions', {
             hasScheduledDescendant: false, rootIsScheduled: false,
           };
         }
-        const allSessions = [root];
-        const stack = [rootSessionId];
-        const visited = new Set();
-        while (stack.length > 0) {
-          const currentId = stack.pop();
-          if (visited.has(currentId)) continue;
-          visited.add(currentId);
-          const children = this._findChildren(currentId);
-          for (const child of children) { allSessions.push(child); stack.push(child.id); }
-        }
-        const runningStatuses = ['running', 'starting'];
-        let runningCount = 0, scheduledCount = 0, waitingCount = 0, completedCount = 0;
-        for (const session of allSessions) {
-          if (session.pendingAgentInput) waitingCount++;
-          else if (runningStatuses.includes(session.status)) runningCount++;
-          else if (session.status === 'scheduled') scheduledCount++;
-          else if (session.status === 'waiting') waitingCount++;
-          else if (session.status === 'completed' || session.status === 'stopped') completedCount++;
-        }
+        const allSessions = collectWorkflowSessions(root, this._findChildren);
+        const summary = summarizeWorkflowSessions(allSessions);
         return {
-          effectiveStatus: runningCount > 0 ? 'running' : waitingCount > 0 ? 'waiting' : 'idle',
-          runningCount,
-          scheduledCount,
-          waitingCount,
-          completedCount,
+          ...summary,
           totalCount: allSessions.length - 1,
           hasScheduledDescendant: allSessions.slice(1).some((s) => s.status === 'scheduled'),
           rootIsScheduled: root.status === 'scheduled',
@@ -171,17 +141,7 @@ export const useSessionsStore = defineStore('sessions', {
       return (rootSessionId) => {
         const root = this._findSessionById(rootSessionId);
         if (!root) return [];
-        const all = [root];
-        const stack = [rootSessionId];
-        const visited = new Set();
-        while (stack.length > 0) {
-          const currentId = stack.pop();
-          if (visited.has(currentId)) continue;
-          visited.add(currentId);
-          const children = this._findChildren(currentId);
-          for (const child of children) { all.push(child); stack.push(child.id); }
-        }
-        return all;
+        return collectWorkflowSessions(root, this._findChildren);
       };
     },
 

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -5028,6 +5028,24 @@ describe('Sessions Store', () => {
     });
 
     describe('getWorkflowEffectiveStatus', () => {
+      it('returns running when one descendant is active and another is waiting for input', () => {
+        const store = useSessionsStore();
+        store.sessions = [
+          { id: 'root', status: 'completed', parentSessionId: null },
+          { id: 'running-child', status: 'running', parentSessionId: 'root' },
+          {
+            id: 'waiting-child',
+            status: 'waiting',
+            pendingAgentInput: { type: 'question' },
+            parentSessionId: 'root',
+          },
+        ];
+
+        const result = store.getWorkflowEffectiveStatus('root');
+
+        expect(result).toBe('running');
+      });
+
       it('returns idle when no running sessions exist', () => {
         const store = useSessionsStore();
         store.sessions = [

--- a/packages/web/src/stores/sessions.test.js
+++ b/packages/web/src/stores/sessions.test.js
@@ -5028,6 +5028,18 @@ describe('Sessions Store', () => {
     });
 
     describe('getWorkflowEffectiveStatus', () => {
+      it('returns waiting for a single running session blocked on input', () => {
+        const store = useSessionsStore();
+        store.sessions = [{
+          id: 'root', status: 'running', pendingAgentInput: { type: 'question' }, parentSessionId: null,
+        }];
+
+        expect(store.getWorkflowEffectiveStatus('root')).toBe('waiting');
+        expect(store.getWorkflowAggregatedStatus('root')).toMatchObject({
+          effectiveStatus: 'waiting', runningCount: 0, waitingCount: 1,
+        });
+      });
+
       it('returns running when one descendant is active and another is waiting for input', () => {
         const store = useSessionsStore();
         store.sessions = [
@@ -5044,6 +5056,16 @@ describe('Sessions Store', () => {
         const result = store.getWorkflowEffectiveStatus('root');
 
         expect(result).toBe('running');
+      });
+
+      it('treats legacy status="waiting" as idle without pending input', () => {
+        const store = useSessionsStore();
+        store.sessions = [{ id: 'root', status: 'waiting', pendingAgentInput: false, parentSessionId: null }];
+
+        expect(store.getWorkflowEffectiveStatus('root')).toBe('idle');
+        expect(store.getWorkflowAggregatedStatus('root')).toMatchObject({
+          effectiveStatus: 'idle', waitingCount: 0,
+        });
       });
 
       it('returns idle when no running sessions exist', () => {

--- a/packages/web/src/stores/workspaceList.js
+++ b/packages/web/src/stores/workspaceList.js
@@ -59,7 +59,7 @@ export const useWorkspaceListStore = defineStore('workspaceList', {
     query: {},
     cardsById: {},
     orderedIds: [],
-    facets: { running: 0, idle: 0 },
+    facets: { running: 0, waiting: 0, idle: 0 },
     total: 0,
     nextCursor: null,
     loading: false,
@@ -81,7 +81,7 @@ export const useWorkspaceListStore = defineStore('workspaceList', {
       const cards = result.workspaces || [];
       this.cardsById = Object.fromEntries(cards.map(card => [card.id, card]));
       this.orderedIds = cards.map(card => card.id);
-      this.facets = result.facets || { running: 0, idle: 0 };
+      this.facets = result.facets || { running: 0, waiting: 0, idle: 0 };
       this.total = result.pagination?.total || 0;
       this.nextCursor = result.pagination?.nextCursor || null;
       this.hasMore = Boolean(result.pagination?.hasMore);
@@ -99,7 +99,7 @@ export const useWorkspaceListStore = defineStore('workspaceList', {
         ...cards.filter(card => !existingIds.has(card.id)).map(card => card.id),
       ];
       if (result.workspaces?.length > 0) {
-        this.facets = result.facets || { running: 0, idle: 0 };
+        this.facets = result.facets || { running: 0, waiting: 0, idle: 0 };
         this.total = result.pagination?.total || 0;
       }
       this.nextCursor = result.pagination?.nextCursor || null;
@@ -126,7 +126,7 @@ export const useWorkspaceListStore = defineStore('workspaceList', {
       this.projectId = projectId;
       this.query = { ...query };
       Object.assign(this, snapshot || {
-        cardsById: {}, orderedIds: [], facets: { running: 0, idle: 0 }, total: 0,
+        cardsById: {}, orderedIds: [], facets: { running: 0, waiting: 0, idle: 0 }, total: 0,
         nextCursor: null, hasMore: false,
       });
       this.loadingMore = false;

--- a/packages/web/src/stores/workspaceListReconcile.js
+++ b/packages/web/src/stores/workspaceListReconcile.js
@@ -6,7 +6,16 @@ export function workspaceBaseMatches(card, query) {
 
 export function workspaceVisibleMatches(card, query) {
   return workspaceBaseMatches(card, query)
-    && (!query.status || (query.status === 'running') === (card.runningCount > 0));
+    && (!query.status
+      || (query.status === 'running' && card.runningCount > 0)
+      || (query.status === 'waiting' && card.waitingCount > 0)
+      || (query.status === 'idle' && card.runningCount === 0 && card.waitingCount === 0));
+}
+
+function workspaceFacet(card) {
+  if (card.runningCount > 0) return 'running';
+  if (card.waitingCount > 0) return 'waiting';
+  return 'idle';
 }
 
 export function compareWorkspaceCards(cardsById, leftId, rightId) {
@@ -21,7 +30,7 @@ export function compareWorkspaceCards(cardsById, leftId, rightId) {
 
 export function adjustWorkspaceFacets(facets, existing, card, query) {
   const next = { ...facets };
-  if (workspaceBaseMatches(existing, query)) next[existing.runningCount > 0 ? 'running' : 'idle'] -= 1;
-  if (workspaceBaseMatches(card, query)) next[card.runningCount > 0 ? 'running' : 'idle'] += 1;
+  if (workspaceBaseMatches(existing, query)) next[workspaceFacet(existing)] -= 1;
+  if (workspaceBaseMatches(card, query)) next[workspaceFacet(card)] += 1;
   return next;
 }

--- a/packages/web/src/stores/workspaceListReconcile.js
+++ b/packages/web/src/stores/workspaceListReconcile.js
@@ -12,10 +12,12 @@ export function workspaceVisibleMatches(card, query) {
       || (query.status === 'idle' && card.runningCount === 0 && card.waitingCount === 0));
 }
 
-function workspaceFacet(card) {
-  if (card.runningCount > 0) return 'running';
-  if (card.waitingCount > 0) return 'waiting';
-  return 'idle';
+function workspaceFacets(card) {
+  const facets = [];
+  if (card.runningCount > 0) facets.push('running');
+  if (card.waitingCount > 0) facets.push('waiting');
+  if (facets.length === 0) facets.push('idle');
+  return facets;
 }
 
 export function compareWorkspaceCards(cardsById, leftId, rightId) {
@@ -30,7 +32,11 @@ export function compareWorkspaceCards(cardsById, leftId, rightId) {
 
 export function adjustWorkspaceFacets(facets, existing, card, query) {
   const next = { ...facets };
-  if (workspaceBaseMatches(existing, query)) next[workspaceFacet(existing)] -= 1;
-  if (workspaceBaseMatches(card, query)) next[workspaceFacet(card)] += 1;
+  if (workspaceBaseMatches(existing, query)) {
+    for (const facet of workspaceFacets(existing)) next[facet] -= 1;
+  }
+  if (workspaceBaseMatches(card, query)) {
+    for (const facet of workspaceFacets(card)) next[facet] += 1;
+  }
   return next;
 }

--- a/packages/web/src/stores/workspaceListReconcile.test.js
+++ b/packages/web/src/stores/workspaceListReconcile.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { adjustWorkspaceFacets } from './workspaceListReconcile.js';
+
+const query = {};
+const overlap = { archived: false, runningCount: 1, waitingCount: 1 };
+
+describe('adjustWorkspaceFacets', () => {
+  it('removes a simultaneously running and waiting workspace from both facets', () => {
+    const next = adjustWorkspaceFacets(
+      { running: 1, waiting: 1, idle: 0 },
+      overlap,
+      { ...overlap, runningCount: 0, waitingCount: 0 },
+      query,
+    );
+
+    expect(next).toEqual({ running: 0, waiting: 0, idle: 1 });
+  });
+
+  it('adds a workspace to both running and waiting facets when both counts are positive', () => {
+    const next = adjustWorkspaceFacets(
+      { running: 0, waiting: 0, idle: 1 },
+      { archived: false, runningCount: 0, waitingCount: 0 },
+      overlap,
+      query,
+    );
+
+    expect(next).toEqual({ running: 1, waiting: 1, idle: 0 });
+  });
+});

--- a/packages/web/src/utils/workflowStatus.js
+++ b/packages/web/src/utils/workflowStatus.js
@@ -1,0 +1,50 @@
+const RUNNING_STATUSES = new Set(['running', 'starting']);
+const COMPLETED_STATUSES = new Set(['completed', 'stopped']);
+
+// A process paused on an interactive prompt still reports "running" from the
+// runner. It is waiting for a person, though, so it must not drive running
+// controls, counters, or effective workflow status.
+export function isSessionActivelyRunning(session) {
+  return Boolean(session)
+    && !session.pendingAgentInput
+    && RUNNING_STATUSES.has(session.status);
+}
+
+export function collectWorkflowSessions(root, findChildren) {
+  if (!root) return [];
+  const sessions = [root];
+  const stack = [root.id];
+  const visited = new Set();
+  while (stack.length > 0) {
+    const sessionId = stack.pop();
+    if (visited.has(sessionId)) continue;
+    visited.add(sessionId);
+    for (const child of findChildren(sessionId)) {
+      sessions.push(child);
+      stack.push(child.id);
+    }
+  }
+  return sessions;
+}
+
+export function summarizeWorkflowSessions(sessions) {
+  const summary = {
+    runningCount: 0,
+    waitingCount: 0,
+    scheduledCount: 0,
+    completedCount: 0,
+    totalCount: sessions.length,
+  };
+  for (const session of sessions) {
+    summary.runningCount += Number(isSessionActivelyRunning(session));
+    summary.waitingCount += Number(Boolean(session.pendingAgentInput));
+    summary.scheduledCount += Number(session.status === 'scheduled');
+    summary.completedCount += Number(COMPLETED_STATUSES.has(session.status));
+  }
+  return {
+    ...summary,
+    effectiveStatus: summary.runningCount > 0
+      ? 'running'
+      : summary.waitingCount > 0 ? 'waiting' : 'idle',
+  };
+}

--- a/packages/web/src/utils/workflowStatus.js
+++ b/packages/web/src/utils/workflowStatus.js
@@ -20,6 +20,7 @@ export function collectWorkflowSessions(root, findChildren) {
     if (visited.has(sessionId)) continue;
     visited.add(sessionId);
     for (const child of findChildren(sessionId)) {
+      if (visited.has(child.id)) continue;
       sessions.push(child);
       stack.push(child.id);
     }

--- a/packages/web/src/utils/workflowStatus.test.js
+++ b/packages/web/src/utils/workflowStatus.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  collectWorkflowSessions,
+  isSessionActivelyRunning,
+  summarizeWorkflowSessions,
+} from './workflowStatus.js';
+
+describe('workflowStatus', () => {
+  it('only treats unblocked running and starting sessions as active', () => {
+    expect(isSessionActivelyRunning(null)).toBe(false);
+    expect(isSessionActivelyRunning({ status: 'running' })).toBe(true);
+    expect(isSessionActivelyRunning({ status: 'starting' })).toBe(true);
+    expect(isSessionActivelyRunning({ status: 'running', pendingAgentInput: true })).toBe(false);
+    expect(isSessionActivelyRunning({ status: 'scheduled' })).toBe(false);
+  });
+
+  it('collects a workflow tree once even when child lookup contains a cycle', () => {
+    const root = { id: 'root' };
+    const child = { id: 'child' };
+    const findChildren = vi.fn((id) => {
+      if (id === 'root') return [child];
+      if (id === 'child') return [root];
+      return [];
+    });
+
+    expect(collectWorkflowSessions(null, findChildren)).toEqual([]);
+    expect(collectWorkflowSessions(root, findChildren)).toEqual([root, child]);
+    expect(findChildren).toHaveBeenCalledTimes(2);
+  });
+
+  it('summarizes mutually exclusive running and waiting work', () => {
+    const summary = summarizeWorkflowSessions([
+      { status: 'running' },
+      { status: 'starting', pendingAgentInput: true },
+      { status: 'scheduled' },
+      { status: 'completed' },
+      { status: 'stopped' },
+    ]);
+
+    expect(summary).toEqual({
+      runningCount: 1,
+      waitingCount: 1,
+      scheduledCount: 1,
+      completedCount: 2,
+      totalCount: 5,
+      effectiveStatus: 'running',
+    });
+    expect(summarizeWorkflowSessions([{ status: 'running', pendingAgentInput: true }]).effectiveStatus)
+      .toBe('waiting');
+    expect(summarizeWorkflowSessions([]).effectiveStatus).toBe('idle');
+  });
+});

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -208,8 +208,7 @@ const hasStatusFilter = computed(() => Boolean(projectFilters.statusFilter));
 
 function cardStatusFilter() {
   // An idle project has neither running nor waiting sessions, so all of its
-  // cards match. The general card-list idle filter intentionally includes
-  // waiting workspaces, which differs from the project-list definition.
+  // cards match.
   return ['running', 'waiting'].includes(projectFilters.statusFilter)
     ? projectFilters.statusFilter
     : null;

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -717,6 +717,20 @@ describe('SessionListView', () => {
       expect(subscriptionIds()).toEqual(['root']);
     });
 
+    it('does not subscribe a blocked root when its authoritative running sessions are empty', async () => {
+      mockSessionsStore.sessions = [{
+        id: 'root',
+        name: 'Blocked root',
+        status: 'running',
+        pendingAgentInput: true,
+        runningSessionIds: [],
+      }];
+      mount(SessionListView);
+      await flushPromises();
+
+      expect(subscriptionIds()).toEqual([]);
+    });
+
     it('drops a workflow from streaming when its card reports that it is off-screen', async () => {
       mockSessionsStore.sessions = [{ id: 'root', name: 'Root', status: 'running' }];
       const wrapper = mount(SessionListView);

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -323,6 +323,7 @@ import { useWorkspaceListRealtime } from '../composables/useWorkspaceListRealtim
 import { useKanbanRealtime } from '../composables/useKanbanRealtime.js';
 import { useSessionStreamingStore } from '../stores/sessionStreaming.js';
 import { workspacePrSummary } from '../utils/workspaceCard.js';
+import { isSessionActivelyRunning } from '../utils/workflowStatus.js';
 import SessionCard from '../components/SessionCard.vue';
 import SessionFiltersPanel from '../components/SessionFiltersPanel.vue';
 import ArchivedTabContent from '../components/ArchivedTabContent.vue';
@@ -379,16 +380,17 @@ const projectId = computed(() => route.params.id);
 // A workflow is eligible only while the card is rendered, expanded, and in the
 // observer's prefetch margin. Keep this policy here so subscriptions stay pure.
 const cardVisibilityByRootId = ref({});
-const isRunningSession = session => ['running', 'starting'].includes(session.status);
 const workflowCardFromCard = card => {
   const rootSessionId = card.id;
   return {
     rootSessionId,
     // The card contract carries the running descendants, so list subscriptions
     // follow the session producing output instead of an idle workspace root.
-    runningSessionIds: card.runningSessionIds?.length
+    // An empty authoritative list must remain empty: a root blocked on agent
+    // input can retain a raw running status without actively producing output.
+    runningSessionIds: Array.isArray(card.runningSessionIds)
       ? card.runningSessionIds
-      : (isRunningSession(card) || card.runningCount > 0 ? [rootSessionId] : []),
+      : (isSessionActivelyRunning(card) || card.runningCount > 0 ? [rootSessionId] : []),
     eligible: activeTab.value === 'sessions'
       && cardVisibilityByRootId.value[rootSessionId] !== false
       && !streamingStore.isSessionLogCollapsed(rootSessionId),


### PR DESCRIPTION
## Summary

- treat sessions awaiting user input as waiting instead of running
- make running, waiting, and idle filters and facet counts mutually exclusive
- add the waiting filter to the session list and align badges, realtime reconciliation, and local aggregation
- propagate waiting state from descendant sessions to workspace cards

## Validation

- 579 relevant tests passed; 1 skipped
- production web build passed
- `git diff --check` passed