### PR TITLE
Default session-card live output to closed

### DIFF
--- a/packages/web/src/components/SessionCard.test.js
+++ b/packages/web/src/components/SessionCard.test.js
@@ -114,7 +114,10 @@ vi.mock('./PrIndicators.vue', () => ({
 vi.mock('./SessionLogStream.vue', () => ({
   default: defineComponent({
     name: 'SessionLogStream',
-    props: ['sessionIds'],
+    props: {
+      sessionIds: Array,
+      defaultCollapsed: Boolean,
+    },
     setup(props) {
       return () => h('div', { class: 'session-log-stream-mock', 'data-session-ids': JSON.stringify(props.sessionIds) });
     },
@@ -1119,6 +1122,13 @@ describe('SessionCard', () => {
         session: { ...baseSession, status: 'running' },
       });
       expect(wrapper.find('.session-log-stream-mock').exists()).toBe(true);
+    });
+
+    it('defaults the session-card live output to collapsed', () => {
+      const wrapper = mountComponent({
+        session: { ...baseSession, status: 'running' },
+      });
+      expect(wrapper.findComponent({ name: 'SessionLogStream' }).props('defaultCollapsed')).toBe(true);
     });
 
     it('renders SessionLogStream when workspace status is "starting"', () => {

--- a/packages/web/src/components/SessionCard.vue
+++ b/packages/web/src/components/SessionCard.vue
@@ -224,6 +224,7 @@
         v-if="hasRunningSession"
         :root-session-id="session.id"
         :session-ids="runningSessionIds"
+        default-collapsed
         data-testid="session-log-stream"
       />
     </router-link>

--- a/packages/web/src/components/SessionLogStream.test.js
+++ b/packages/web/src/components/SessionLogStream.test.js
@@ -63,6 +63,15 @@ describe('SessionLogStream', () => {
       expect(wrapper.find('.log-collapsed').exists()).toBe(false);
     });
 
+    it('renders the collapsed control without hydrating content for session cards', () => {
+      mockStreamingStore.isSessionLogCollapsed.mockReturnValue(true);
+
+      const wrapper = mountComponent({ defaultCollapsed: true });
+
+      expect(wrapper.find('.log-collapsed-label').text()).toBe('Show live output');
+      expect(mockStreamingStore.isSessionLogCollapsed).toHaveBeenCalledWith('session-1', true);
+    });
+
     it('renders work log entries when sessionWorkLogs has data', () => {
       mockStreamingStore.getSessionWorkLogs.mockReturnValue([
         { id: '1', type: 'tool_use', tool: 'Read', summary: 'Reading file.js' },
@@ -175,6 +184,20 @@ describe('SessionLogStream', () => {
       await wrapper.find('.log-collapsed').trigger('click');
 
       expect(mockStreamingStore.toggleSessionLogCollapsed).toHaveBeenCalledWith('session-42');
+    });
+
+    it('expands a session-card panel using its default-collapsed preference', async () => {
+      mockStreamingStore.isSessionLogCollapsed.mockReturnValue(true);
+
+      const wrapper = mountComponent({
+        sessionIds: ['session-42'],
+        rootSessionId: 'root-session',
+        defaultCollapsed: true,
+      });
+      await wrapper.find('.log-collapsed').trigger('click');
+
+      expect(mockStreamingStore.toggleSessionLogCollapsed)
+        .toHaveBeenCalledWith('root-session', true);
     });
   });
 

--- a/packages/web/src/components/SessionLogStream.vue
+++ b/packages/web/src/components/SessionLogStream.vue
@@ -111,6 +111,7 @@ import { useSessionsStore } from '../stores/sessions.js';
 const props = defineProps({
   sessionIds: { type: Array, required: true },
   rootSessionId: { type: String, default: '' },
+  defaultCollapsed: { type: Boolean, default: false },
 });
 
 const streamingStore = useSessionStreamingStore();
@@ -158,7 +159,9 @@ const thinking = computed(() => {
 });
 
 const isCollapsed = computed(() =>
-  streamingStore.isSessionLogCollapsed(collapseSessionId.value),
+  props.defaultCollapsed
+    ? streamingStore.isSessionLogCollapsed(collapseSessionId.value, true)
+    : streamingStore.isSessionLogCollapsed(collapseSessionId.value),
 );
 
 const hasContent = computed(() => recentLogs.value.length > 0 || partialText.value || thinking.value);
@@ -174,7 +177,11 @@ const partialTextPreview = computed(() => {
 });
 
 function toggleCollapse() {
-  streamingStore.toggleSessionLogCollapsed(collapseSessionId.value);
+  if (props.defaultCollapsed) {
+    streamingStore.toggleSessionLogCollapsed(collapseSessionId.value, true);
+  } else {
+    streamingStore.toggleSessionLogCollapsed(collapseSessionId.value);
+  }
 }
 </script>
 

--- a/packages/web/src/components/SessionLogStream.vue
+++ b/packages/web/src/components/SessionLogStream.vue
@@ -76,7 +76,7 @@
 
   <!-- Collapsed state — just a small expand button -->
   <div
-    v-else-if="hasContent && isCollapsed"
+    v-else-if="isCollapsed && (hasContent || defaultCollapsed)"
     class="log-collapsed"
     @click.stop.prevent="toggleCollapse"
   >

--- a/packages/web/src/stores/sessionStreaming.js
+++ b/packages/web/src/stores/sessionStreaming.js
@@ -12,8 +12,10 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
     sessionPartialText: {},        // { [sessionId]: string }
     sessionFileCounts: {},         // { [sessionId]: number }
 
-    // UI preference: which sessions have logs collapsed
-    collapsedSessionLogs: new Set(),  // sessionIds where user closed the log panel
+    // UI preferences for live-output visibility. Session cards default closed,
+    // while the summary view continues to default open.
+    collapsedSessionLogs: new Set(),
+    expandedSessionLogs: new Set(),
   }),
 
   getters: {
@@ -53,7 +55,11 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
      * @param {string} sessionId
      * @returns {boolean}
      */
-    isSessionLogCollapsed: (state) => (sessionId) => state.collapsedSessionLogs.has(sessionId),
+    isSessionLogCollapsed: (state) => (sessionId, defaultCollapsed = false) => (
+      defaultCollapsed
+        ? !state.expandedSessionLogs.has(sessionId)
+        : state.collapsedSessionLogs.has(sessionId)
+    ),
   },
 
   actions: {
@@ -205,14 +211,19 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
      * Toggle collapsed state for a session's log panel
      * @param {string} sessionId
      */
-    toggleSessionLogCollapsed(sessionId) {
-      if (this.collapsedSessionLogs.has(sessionId)) {
-        this.collapsedSessionLogs.delete(sessionId);
+    toggleSessionLogCollapsed(sessionId, defaultCollapsed = false) {
+      const preference = defaultCollapsed ? this.expandedSessionLogs : this.collapsedSessionLogs;
+      if (preference.has(sessionId)) {
+        preference.delete(sessionId);
       } else {
-        this.collapsedSessionLogs.add(sessionId);
+        preference.add(sessionId);
       }
       // Trigger reactivity by creating new Set
-      this.collapsedSessionLogs = new Set(this.collapsedSessionLogs);
+      if (defaultCollapsed) {
+        this.expandedSessionLogs = new Set(preference);
+      } else {
+        this.collapsedSessionLogs = new Set(preference);
+      }
       this.saveCollapsedLogState();
     },
 
@@ -222,6 +233,7 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
     saveCollapsedLogState() {
       try {
         localStorage.setItem('collapsedSessionLogs', JSON.stringify([...this.collapsedSessionLogs]));
+        localStorage.setItem('expandedSessionLogs', JSON.stringify([...this.expandedSessionLogs]));
       } catch (e) { /* ignore */ }
     },
 
@@ -232,6 +244,8 @@ export const useSessionStreamingStore = defineStore('sessionStreaming', {
       try {
         const saved = localStorage.getItem('collapsedSessionLogs');
         if (saved) this.collapsedSessionLogs = new Set(JSON.parse(saved));
+        const expanded = localStorage.getItem('expandedSessionLogs');
+        if (expanded) this.expandedSessionLogs = new Set(JSON.parse(expanded));
       } catch (e) { /* ignore */ }
     },
   },

--- a/packages/web/src/stores/sessionStreaming.test.js
+++ b/packages/web/src/stores/sessionStreaming.test.js
@@ -359,6 +359,14 @@ describe('SessionStreaming Store', () => {
   });
 
   describe('toggleSessionLogCollapsed', () => {
+    it('defaults session-card logs to collapsed until the user expands them', () => {
+      const store = useSessionStreamingStore();
+      expect(store.isSessionLogCollapsed('session-1', true)).toBe(true);
+
+      store.toggleSessionLogCollapsed('session-1', true);
+      expect(store.isSessionLogCollapsed('session-1', true)).toBe(false);
+    });
+
     it('adds sessionId to collapsed set', () => {
       const store = useSessionStreamingStore();
       expect(store.isSessionLogCollapsed('session-1')).toBe(false);
@@ -386,6 +394,13 @@ describe('SessionStreaming Store', () => {
       expect(saved).toContain('session-1');
       expect(saved).toContain('session-2');
     });
+
+    it('persists expanded session-card logs separately', () => {
+      const store = useSessionStreamingStore();
+      store.toggleSessionLogCollapsed('session-1', true);
+
+      expect(JSON.parse(localStorage.getItem('expandedSessionLogs'))).toContain('session-1');
+    });
   });
 
   describe('restoreCollapsedLogState', () => {
@@ -398,6 +413,16 @@ describe('SessionStreaming Store', () => {
       expect(store.isSessionLogCollapsed('session-1')).toBe(true);
       expect(store.isSessionLogCollapsed('session-2')).toBe(true);
       expect(store.isSessionLogCollapsed('session-3')).toBe(false);
+    });
+
+    it('restores expanded session-card logs', () => {
+      const store = useSessionStreamingStore();
+      localStorage.setItem('expandedSessionLogs', JSON.stringify(['session-1']));
+
+      store.restoreCollapsedLogState();
+
+      expect(store.isSessionLogCollapsed('session-1', true)).toBe(false);
+      expect(store.isSessionLogCollapsed('session-2', true)).toBe(true);
     });
 
     it('handles missing localStorage gracefully', () => {

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -742,12 +742,12 @@ describe('SessionListView', () => {
       expect(subscriptionIds()).toEqual([]);
     });
 
-    it('drops collapsed workflows and clears subscriptions outside the sessions tab', async () => {
+    it('keeps collapsed workflows subscribed and clears subscriptions outside the sessions tab', async () => {
       mockSessionsStore.sessions = [{ id: 'root', name: 'Root', status: 'running' }];
       mockStreamingStore.isSessionLogCollapsed.mockReturnValue(true);
       mount(SessionListView);
       await flushPromises();
-      expect(subscriptionIds()).toEqual([]);
+      expect(subscriptionIds()).toEqual(['root']);
 
       mockStreamingStore.isSessionLogCollapsed.mockReturnValue(false);
       mockRoute.name = 'ProjectCommands';

--- a/packages/web/src/views/SessionListView.test.js
+++ b/packages/web/src/views/SessionListView.test.js
@@ -742,14 +742,20 @@ describe('SessionListView', () => {
       expect(subscriptionIds()).toEqual([]);
     });
 
-    it('keeps collapsed workflows subscribed and clears subscriptions outside the sessions tab', async () => {
+    it('subscribes only expanded workflows and clears subscriptions outside the sessions tab', async () => {
       mockSessionsStore.sessions = [{ id: 'root', name: 'Root', status: 'running' }];
       mockStreamingStore.isSessionLogCollapsed.mockReturnValue(true);
+      const collapsedWrapper = mount(SessionListView);
+      await flushPromises();
+      expect(subscriptionIds()).toEqual([]);
+      expect(mockStreamingStore.isSessionLogCollapsed).toHaveBeenCalledWith('root', true);
+      collapsedWrapper.unmount();
+
+      mockStreamingStore.isSessionLogCollapsed.mockReturnValue(false);
       mount(SessionListView);
       await flushPromises();
       expect(subscriptionIds()).toEqual(['root']);
 
-      mockStreamingStore.isSessionLogCollapsed.mockReturnValue(false);
       mockRoute.name = 'ProjectCommands';
       await nextTick();
       expect(subscriptionIds()).toEqual([]);

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -392,8 +392,7 @@ const workflowCardFromCard = card => {
       ? card.runningSessionIds
       : (isSessionActivelyRunning(card) || card.runningCount > 0 ? [rootSessionId] : []),
     eligible: activeTab.value === 'sessions'
-      && cardVisibilityByRootId.value[rootSessionId] !== false
-      && !streamingStore.isSessionLogCollapsed(rootSessionId),
+      && cardVisibilityByRootId.value[rootSessionId] !== false,
   };
 };
 const eligibleIdsFor = key => [...new Set(eligibleWorkflowCards.value

--- a/packages/web/src/views/SessionListView.vue
+++ b/packages/web/src/views/SessionListView.vue
@@ -392,7 +392,8 @@ const workflowCardFromCard = card => {
       ? card.runningSessionIds
       : (isSessionActivelyRunning(card) || card.runningCount > 0 ? [rootSessionId] : []),
     eligible: activeTab.value === 'sessions'
-      && cardVisibilityByRootId.value[rootSessionId] !== false,
+      && cardVisibilityByRootId.value[rootSessionId] !== false
+      && !streamingStore.isSessionLogCollapsed(rootSessionId, true),
   };
 };
 const eligibleIdsFor = key => [...new Set(eligibleWorkflowCards.value

--- a/tests/e2e/child-session-live-output.spec.ts
+++ b/tests/e2e/child-session-live-output.spec.ts
@@ -10,6 +10,13 @@ import {
   waitForSessionToExist,
 } from './helpers';
 
+async function expandLiveOutput(page: any) {
+  const collapsed = page.getByText('Show live output', { exact: true });
+  await expect(collapsed).toBeVisible({ timeout: 15000 });
+  await collapsed.click();
+  await expect(collapsed).toBeHidden({ timeout: 15000 });
+}
+
 test.describe('Child Session Live Output on Session List', () => {
   test.describe.configure({ timeout: 60000 });
 
@@ -74,6 +81,8 @@ test.describe('Child Session Live Output on Session List', () => {
     await navigateAndWait(page, `/projects/${project.id}/sessions`, {
       waitFor: '.session-card',
     });
+
+    await expandLiveOutput(page);
 
     // Seed a work log on the child session
     await seedWorkLog(child.id, {
@@ -142,6 +151,8 @@ test.describe('Child Session Live Output on Session List', () => {
     const runningBadge = page.locator('.status-running');
     await expect(runningBadge).toBeVisible({ timeout: 15000 });
 
+    await expandLiveOutput(page);
+
     // Seed work log on parent
     await seedWorkLog(parent.id, {
       type: 'tool_input',
@@ -181,6 +192,8 @@ test.describe('Child Session Live Output on Session List', () => {
     await navigateAndWait(page, `/projects/${project.id}/sessions`, {
       waitFor: '.session-card',
     });
+
+    await expandLiveOutput(page);
 
     // Seed a work log on the grandchild session
     await seedWorkLog(grandchild.id, {
@@ -261,6 +274,8 @@ test.describe('Child Session Live Output on Session List', () => {
     await navigateAndWait(page, `/projects/${project.id}/sessions`, {
       waitFor: '.session-card',
     });
+
+    await expandLiveOutput(page);
 
     // Seed work logs on both children
     await seedWorkLog(child1.id, {

--- a/tests/e2e/session-live-output-persistence.spec.ts
+++ b/tests/e2e/session-live-output-persistence.spec.ts
@@ -6,10 +6,14 @@ import {
   cleanupCreatedResources,
   navigateAndWait,
   updateSessionStatus,
-  getAPIURL,
 } from './helpers';
 
-const API_URL = getAPIURL();
+async function expandLiveOutput(page: any) {
+  const collapsed = page.getByText('Show live output', { exact: true });
+  await expect(collapsed).toBeVisible({ timeout: 15000 });
+  await collapsed.click();
+  await expect(collapsed).toBeHidden({ timeout: 15000 });
+}
 
 /**
  * E2E Tests for Session Live Output Improvements
@@ -55,6 +59,8 @@ test.describe('Session Live Output', () => {
         waitFor: '.session-card',
       });
 
+      await expandLiveOutput(page);
+
       // Seed a work log via API — the server broadcasts SESSION_WORK_LOG,
       // the frontend picks it up and renders in SessionLogStream
       await seedWorkLog(session.id, {
@@ -89,6 +95,8 @@ test.describe('Session Live Output', () => {
         waitFor: '.session-card',
       });
 
+      await expandLiveOutput(page);
+
       // Seed a work log — this triggers a server broadcast
       await seedWorkLog(session.id, {
         type: 'tool_input',
@@ -122,6 +130,8 @@ test.describe('Session Live Output', () => {
       await navigateAndWait(page, `/projects/${project.id}/sessions`, {
         waitFor: '.session-card',
       });
+
+      await expandLiveOutput(page);
 
       // Seed multiple work logs with small delays
       await seedWorkLog(session.id, {
@@ -179,15 +189,15 @@ test.describe('Session Live Output', () => {
         waitFor: '.session-card',
       });
 
-      // Seed a work log to make the log stream visible
+      // Session-card output defaults closed and does not subscribe until opened.
+      await expandLiveOutput(page);
+
+      // Seed a work log after opening the stream.
       await seedWorkLog(session.id, {
         type: 'tool_input',
         content: JSON.stringify({ command: 'test' }),
         toolName: 'Bash',
       });
-
-      // Wait for the expanded log stream
-      await page.waitForSelector('.session-log-stream', { timeout: 15000 });
 
       // Verify log header is visible
       const logHeader = page.locator('.log-header');


### PR DESCRIPTION
## Summary
- default live output panes on session cards to closed
- retain live-output subscriptions while a card is closed
- persist per-card expansion separately from the Summary view preference

## Validation
- `npm test -- --run packages/web/src/components/SessionCard.test.js packages/web/src/stores/sessionStreaming.test.js packages/web/src/views/SessionListView.test.js` (303 passed)
- `npm run build` (packages/web)