### PR TITLE
Fix scheduling modal datetime local minimum

### DIFF
--- a/packages/web/src/components/ScheduleSessionModal.vue
+++ b/packages/web/src/components/ScheduleSessionModal.vue
@@ -69,6 +69,7 @@ import { ref, reactive, computed, watch, nextTick } from 'vue';
 import { api } from '../composables/useApi.js';
 import { useUiStore } from '../stores/ui.js';
 import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
+import { formatDateTimeLocal } from '../utils/formatters.js';
 
 const props = defineProps({
   isOpen: { type: Boolean, default: false },
@@ -92,7 +93,7 @@ const form = reactive({
 const minDateTime = computed(() => {
   const now = new Date();
   now.setMinutes(now.getMinutes() + 1);
-  return now.toISOString().slice(0, 16);
+  return formatDateTimeLocal(now);
 });
 
 // Single source of truth for which prompt will be submitted.

--- a/packages/web/src/components/SchedulingEditModal.vue
+++ b/packages/web/src/components/SchedulingEditModal.vue
@@ -237,6 +237,7 @@ import { ref, reactive, computed, watch } from 'vue';
 import { useInjectedSessionsStore } from '../composables/useOverlayStore.js';
 import { useUiStore } from '../stores/ui.js';
 import { DEFAULT_RESCHEDULE_DELAY_MINUTES } from '@circuschief/shared';
+import { formatDateTimeLocal } from '../utils/formatters.js';
 import ModelSelector from './ModelSelector.vue';
 import ModeSelector from './ModeSelector.vue';
 import TemplateSelector from './TemplateSelector.vue';
@@ -275,7 +276,7 @@ const form = reactive({
 const minDateTime = computed(() => {
   const now = new Date();
   now.setMinutes(now.getMinutes() + 1);
-  return now.toISOString().slice(0, 16);
+  return formatDateTimeLocal(now);
 });
 
 const modalTitle = computed(() => {
@@ -295,13 +296,7 @@ function handleTemplateChange(templateId) {
 
 function convertToLocalDatetime(timestamp) {
   if (!timestamp) return '';
-  const date = new Date(timestamp);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
+  return formatDateTimeLocal(new Date(timestamp));
 }
 
 async function handleSave() {

--- a/packages/web/src/utils/formatters.js
+++ b/packages/web/src/utils/formatters.js
@@ -12,3 +12,19 @@ export function formatDate(timestamp) {
     minute: '2-digit',
   });
 }
+
+/**
+ * Format a Date for a datetime-local input using the user's local timezone.
+ * datetime-local values do not include a timezone, so UTC ISO strings must not
+ * be used here.
+ * @param {Date} date - Date to format
+ * @returns {string} Local datetime in YYYY-MM-DDTHH:mm format
+ */
+export function formatDateTimeLocal(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}

--- a/packages/web/src/utils/formatters.test.js
+++ b/packages/web/src/utils/formatters.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate } from './formatters.js';
+import { formatDate, formatDateTimeLocal } from './formatters.js';
 
 describe('formatters', () => {
   describe('formatDate', () => {
@@ -30,6 +30,23 @@ describe('formatters', () => {
       const result = formatDate('2024-01-15T10:30:00Z');
       // The exact time format depends on locale, but should include hours and minutes
       expect(result).toMatch(/\d{1,2}:\d{2}/);
+    });
+  });
+
+  describe('formatDateTimeLocal', () => {
+    it('uses local date fields instead of a UTC ISO string', () => {
+      const date = {
+        getFullYear: () => 2025,
+        getMonth: () => 0,
+        getDate: () => 15,
+        getHours: () => 6,
+        getMinutes: () => 34,
+        toISOString: () => {
+          throw new Error('datetime-local formatting must not use UTC');
+        },
+      };
+
+      expect(formatDateTimeLocal(date)).toBe('2025-01-15T06:34');
     });
   });
 });


### PR DESCRIPTION
## Summary
- prevent selecting a past local datetime in the scheduling modal

## Testing
- ./scripts/pw.sh test