### PR TITLE
fix: reschedule retired lane workers on token-limit errors

### DIFF
--- a/packages/server/src/api/sessions.schedule.test.js
+++ b/packages/server/src/api/sessions.schedule.test.js
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import sessionsRouter from './sessions.js';
-import { projects, sessions, modelProviders, messages, conversations } from '../database.js';
+import { projects, sessions, modelProviders, messages, conversations, kanbanBoards, kanbanCards, kanbanLanes } from '../database.js';
+import {
+  attachRootSession, beginWorkflowTurn, createLaneRunForEntry,
+  finalizeOwnWorkCompletion, supersedeRunForCard,
+} from '../services/workflowSessionService.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as diffService from '../services/diffService.js';
@@ -573,5 +577,62 @@ describe('Sessions API - POST /:id/schedule', () => {
 
     expect(response.body.error).toMatch(/Unexpected field/i);
     expect(response.body.error).toContain('junkKey');
+  });
+
+  // ── Lane-run ownership fencing (retired vs superseded workers) ─────────────
+  //
+  // A worker retired from its lane run (own work closed successfully) keeps a
+  // historical lane_run_id pointer. Scheduling it is ordinary session work and
+  // must succeed; only genuinely displaced workers (superseded/cancelled) are
+  // fenced with 409.
+
+  function buildLaneRunWorker() {
+    const board = kanbanBoards.create(project.id);
+    const [source, target] = kanbanLanes.getByBoardId(board.id);
+    const workspace = sessions.create(project.id, 'Workspace', 'work');
+    const card = kanbanCards.create(source.id, workspace.id);
+    const worker = sessions.create(project.id, 'Lane worker', 'complete the lane', {
+      parentSessionId: workspace.id,
+    });
+    const run = createLaneRunForEntry({
+      projectId: project.id,
+      workspaceId: workspace.id,
+      cardId: card.id,
+      lane: { ...source, onEnterPrompt: 'complete the lane', completionTargetLaneId: target.id },
+    });
+    attachRootSession(run.id, worker.id);
+    return { source, target, workspace, card, worker, run };
+  }
+
+  it('schedules a retired (succeeded run) worker instead of 409ing', async () => {
+    const { worker } = buildLaneRunWorker();
+    finalizeOwnWorkCompletion(worker.id, beginWorkflowTurn(worker.id));
+    expect(sessions.getById(worker.id).ownWorkState).toBe('closed_successfully');
+
+    const response = await request(app)
+      .post(`/api/sessions/${worker.id}/schedule`)
+      .send({ prompt: 'Continue', scheduledAt: Date.now() + 3600000 })
+      .expect(200);
+
+    expect(response.body).toEqual(expect.objectContaining({
+      id: worker.id,
+      status: 'scheduled',
+      scheduledAt: expect.any(Number),
+    }));
+    expect(sessions.getById(worker.id).scheduledAt).toEqual(expect.any(Number));
+  });
+
+  it('still 409s a superseded (cancelled) worker', async () => {
+    const { worker, card } = buildLaneRunWorker();
+    supersedeRunForCard(card.id, 'manual_move');
+    expect(sessions.getById(worker.id).ownWorkState).toBe('cancelled');
+
+    const response = await request(app)
+      .post(`/api/sessions/${worker.id}/schedule`)
+      .send({ prompt: 'Continue', scheduledAt: Date.now() + 3600000 })
+      .expect(409);
+
+    expect(response.body.error).toBe('Session no longer owns an active lane run');
+    expect(sessions.getById(worker.id).scheduledAt).toBeNull();
   });
 });

--- a/packages/server/src/services/schedulerService.js
+++ b/packages/server/src/services/schedulerService.js
@@ -3,7 +3,7 @@ import { sessions, messages, conversations, projects, attachments } from '../dat
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
 import * as slashCommandService from './slashCommandService.js';
-import { claimWorkflowSessionStart, withActiveLaneRunOwnership, activeLaneRunOwnsSession, closeOwnWork } from './workflowSessionService.js';
+import { claimWorkflowSessionStart, withActiveLaneRunOwnership, laneRunFencesSystemWork, closeOwnWork } from './workflowSessionService.js';
 import { didSessionExecutionStart, rejectedSessionExecution, startedSessionExecution } from './sessionStartResult.js';
 import { broadcastSessionStatus } from './streamEventHandler.js';
 
@@ -389,8 +389,9 @@ class SchedulerService {
     }
 
     // Prompt resolution may yield to disk IO while a manual move supersedes
-    // this lane run. Fence the durable clear and provider handoff.
-    if (claimed.laneRunId && !activeLaneRunOwnsSession(claimed.id)) {
+    // this lane run. Fence the durable clear and provider handoff. Retired
+    // workers (own work closed successfully) are never fenced here.
+    if (laneRunFencesSystemWork(claimed.id)) {
       return { claimed: true, ...this.finishScheduledStart(claimed, rejectedSessionExecution(claimed.id, 'lane_run_ownership_lost')) };
     }
 

--- a/packages/server/src/services/schedulerService.test.js
+++ b/packages/server/src/services/schedulerService.test.js
@@ -32,8 +32,22 @@ vi.mock('../websocket.js', () => ({
   broadcastToProject: vi.fn(),
 }));
 
+// The workflow session service reads the sessions table directly through the
+// real SQLite database (databaseManager), which this suite replaces with the
+// mocked repository layer above — no rows exist there, and the missing-row
+// fail-closed policy would fence every launch. Stub the ownership boundary so
+// tests exercise scheduling logic; the fence itself is covered in
+// workflowSessionService.test.js and by the explicit fence test below.
+vi.mock('./workflowSessionService.js', () => ({
+  claimWorkflowSessionStart: vi.fn(() => true),
+  withActiveLaneRunOwnership: vi.fn((_sessionId, mutation) => mutation()),
+  laneRunFencesSystemWork: vi.fn(() => false),
+  closeOwnWork: vi.fn(),
+}));
+
 import { sessions, messages, conversations, projects, attachments } from '../database.js';
 import { broadcastToSession, broadcastToProject } from '../websocket.js';
+import { laneRunFencesSystemWork } from './workflowSessionService.js';
 
 describe('SchedulerService', () => {
   let scheduler;
@@ -709,6 +723,44 @@ describe('SchedulerService', () => {
 
       expect(mockSessionManager.continueSessionWithExistingMessage).toHaveBeenCalled();
       expect(mockSessionManager.runSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects the launch and clears the stale schedule when the lane-run fence trips', async () => {
+      scheduler.initialize(mockSessionManager);
+      const session = {
+        id: 'session-1', name: 'Test Session', projectId: 'project-1',
+        pendingPrompt: 'Hello', pendingModel: null,
+      };
+      stubSuccessfulClaim(session);
+
+      projects.getById.mockReturnValue({ id: 'project-1', workingDirectory: '/tmp' });
+      messages.getBySessionId.mockReturnValue([]);
+      conversations.getActiveBySessionId.mockReturnValue({ id: 'conv-1' });
+      messages.create.mockReturnValue({ id: 'msg-1', sessionId: 'session-1', role: 'user', content: 'Hello', conversationId: 'conv-1' });
+      attachments.getBySessionId.mockReturnValue([]);
+      laneRunFencesSystemWork.mockReturnValueOnce(true);
+
+      const result = await scheduler.startScheduledSession(session);
+
+      // Fenced launch keeps the claim but reports a rejected execution and
+      // never reaches the executor.
+      expect(result).toEqual({
+        claimed: true,
+        started: false,
+        sessionId: 'session-1',
+        reason: 'lane_run_ownership_lost',
+      });
+      expect(mockSessionManager.runSession).not.toHaveBeenCalled();
+      // The durable schedule fields are cleared alongside the stopped status
+      // so the stale schedule cannot re-fire on a later poll.
+      expect(sessions.update).toHaveBeenCalledWith('session-1', {
+        status: 'stopped',
+        scheduledAt: null,
+        pendingPrompt: null,
+        pendingModel: null,
+        pendingConversationId: null,
+      });
+      expect(broadcastToSession).toHaveBeenCalledWith('session-1', WS_MESSAGE_TYPES.SESSION_STATUS, { sessionId: 'session-1', status: 'stopped' });
     });
 
     describe('concurrency (manual/manual and manual/poller races)', () => {

--- a/packages/server/src/services/schedulerService.workflow.test.js
+++ b/packages/server/src/services/schedulerService.workflow.test.js
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { kanbanBoards, kanbanCards, kanbanLanes, projects, sessions } from '../database.js';
 import { SchedulerService } from './schedulerService.js';
-import { attachRootSession, createLaneRunForEntry, getRun } from './workflowSessionService.js';
+import { attachRootSession, beginWorkflowTurn, createLaneRunForEntry, finalizeOwnWorkCompletion, getRun } from './workflowSessionService.js';
 
 describe('SchedulerService scheduled launch budget workflow lifecycle', () => {
   it('fails and reconciles an automated lane worker instead of stranding its open run', async () => {
@@ -68,5 +68,62 @@ describe('SchedulerService scheduled launch budget workflow lifecycle', () => {
       laneId: source.id,
       activeLaneRunId: run.id,
     }));
+  });
+
+  // Regression: a retired worker (lane run already succeeded) that was
+  // auto-rescheduled — e.g. after a usage limit on a human follow-up turn —
+  // must still launch its scheduled retry. Previously both the start claim and
+  // the post-prompt-resolution fence rejected it as a stale worker, durably
+  // clearing the schedule.
+  it('launches a rescheduled retired worker instead of rejecting it as stale', async () => {
+    const project = projects.create('Retired launch project', '/tmp/retired-launch');
+    const board = kanbanBoards.create(project.id);
+    const [source, target] = kanbanLanes.getByBoardId(board.id);
+    const workspace = sessions.create(project.id, 'Workspace', 'work');
+    const card = kanbanCards.create(source.id, workspace.id);
+    const worker = sessions.create(project.id, 'Retired worker', 'complete the lane', {
+      parentSessionId: workspace.id,
+    });
+    const run = createLaneRunForEntry({
+      projectId: project.id,
+      workspaceId: workspace.id,
+      cardId: card.id,
+      lane: { ...source, onEnterPrompt: 'complete the lane', completionTargetLaneId: target.id },
+    });
+    attachRootSession(run.id, worker.id);
+    // Discharge the obligation: run succeeds, worker retires but keeps its
+    // historical lane_run_id pointer.
+    finalizeOwnWorkCompletion(worker.id, beginWorkflowTurn(worker.id));
+    expect(sessions.getById(worker.id).ownWorkState).toBe('closed_successfully');
+    expect(getRun(run.id).status).toBe('succeeded');
+
+    // The auto-reschedule after a usage limit on a follow-up turn.
+    sessions.update(worker.id, {
+      status: 'scheduled',
+      scheduledAt: Date.now(),
+      pendingPrompt: 'Continue',
+    });
+
+    const runSession = vi.fn().mockResolvedValue({ started: true, sessionId: worker.id });
+    const scheduler = new SchedulerService();
+    scheduler.initialize({ isSessionActive: () => false, runSession, continueSession: vi.fn() });
+
+    const result = await scheduler.startScheduledSession(sessions.getById(worker.id));
+
+    expect(result).toEqual(expect.objectContaining({
+      claimed: true,
+      started: true,
+      sessionId: worker.id,
+    }));
+    expect(runSession).toHaveBeenCalledTimes(1);
+    expect(runSession).toHaveBeenCalledWith(worker.id, expect.any(String), expect.any(String), expect.anything());
+
+    // The durable clear happened and the board is untouched.
+    expect(sessions.getById(worker.id)).toEqual(expect.objectContaining({
+      scheduledAt: null,
+      pendingPrompt: null,
+      ownWorkState: 'closed_successfully',
+    }));
+    expect(getRun(run.id).status).toBe('succeeded');
   });
 });

--- a/packages/server/src/services/sessionExecution.js
+++ b/packages/server/src/services/sessionExecution.js
@@ -20,7 +20,7 @@ import { buildConversationContextForModelSwitch, buildConversationContextForCont
 import { ensureWorktreeCommitAttributionHook } from './gitService.js';
 import { broadcastToSession } from '../websocket.js';
 import { WS_MESSAGE_TYPES } from '@circuschief/shared';
-import { beginWorkflowTurn, finalizeOwnWorkCompletion, finishWorkflowTurn, closeOwnWork, markExecutionState, markHeldForLimit, activeLaneRunOwnsSession } from './workflowSessionService.js';
+import { beginWorkflowTurn, finalizeOwnWorkCompletion, finishWorkflowTurn, closeOwnWork, markExecutionState, markHeldForLimit, laneRunFencesSystemWork } from './workflowSessionService.js';
 import { rejectedSessionExecution, startedSessionExecution } from './sessionStartResult.js';
 // W6: real cycle (kanbanService -> kanbanTriggers -> sessionManager ->
 // sessionExecution), safe because this is only called at runtime inside
@@ -98,7 +98,7 @@ export async function _executeSession({
 }) {
   const { handleTemplateTriggerIfNeeded, handleAutoSendIfNeeded } = callbacks; const workflowTurn = beginWorkflowTurn(sessionId);
   // Last ownership fence before the irreversible provider call.
-  if (!interactive && !workflowTurn && !activeLaneRunOwnsSession(sessionId)) {
+  if (!interactive && !workflowTurn && laneRunFencesSystemWork(sessionId)) {
     cleanupSessionState(sessionId, cleanupConversationId, controller);
     return rejectedSessionExecution(sessionId, 'lane_run_ownership_lost');
   }
@@ -377,7 +377,9 @@ export async function continueSessionCore(sessionId, content, workingDirectory, 
   }
   // A closed lane run only blocks system-owned work. Human follow-ups must
   // remain available after a workflow completes or a card is manually moved.
-  if (!interactive && session.laneRunId && !activeLaneRunOwnsSession(sessionId)) {
+  // Retired workers (own work closed successfully) are never fenced, so their
+  // scheduled continuations and reschedules run as ordinary system work.
+  if (!interactive && laneRunFencesSystemWork(sessionId)) {
     return rejectedSessionExecution(sessionId, 'lane_run_ownership_lost');
   }
 
@@ -445,7 +447,7 @@ export async function runSessionCore(sessionId, prompt, workingDirectory, config
   // Get session for settings
   let session = sessions.getById(sessionId);
   if (!session) throw new Error('Session not found');
-  if (!interactive && session.laneRunId && !activeLaneRunOwnsSession(sessionId)) {
+  if (!interactive && laneRunFencesSystemWork(sessionId)) {
     return rejectedSessionExecution(sessionId, 'lane_run_ownership_lost');
   }
   const controller = abortController || new AbortController();

--- a/packages/server/src/services/sessionExecution.workflowFailure.test.js
+++ b/packages/server/src/services/sessionExecution.workflowFailure.test.js
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-import { runSession } from './sessionManager.js';
+import { runSession, continueSession } from './sessionManager.js';
 import { agentGateway } from '../agents/AgentGateway.js';
 import { ProjectRepository } from '../db/ProjectRepository.js';
 import { SessionRepository } from '../db/SessionRepository.js';
@@ -97,6 +97,19 @@ describe('W4: failure/cancellation propagation through _executeSession', () => {
     return stubAgent;
   }
 
+  function stubSuccessAgent() {
+    const stubAgent = {
+      execute: vi.fn(async function* () {
+        yield { type: 'assistant', text: 'done' };
+        yield { type: 'result', success: true };
+      }),
+      supportsResume: () => false,
+      needsConversationContext: () => true,
+    };
+    createAgentSpy = vi.spyOn(agentGateway, 'createAgent').mockReturnValue(stubAgent);
+    return stubAgent;
+  }
+
   it('a permanent execution failure fails the run and does not move the card (AC-8)', async () => {
     stubThrowingAgent('boom: permanent failure');
 
@@ -142,6 +155,44 @@ describe('W4: failure/cancellation propagation through _executeSession', () => {
     expect(updated.executionState).toBe('retrying');
     expect(getRun(run.id).status).toBe('open');
     expect(cardRepo.getById(card.id).laneId).toBe(source.id);
+  });
+
+  // Regression for a production incident: a worker whose lane run had already
+  // succeeded received a human follow-up that hit the provider usage limit.
+  // The error matched the reschedule triggers, but the reschedule write was
+  // fenced off by the session's historical lane_run_id pointer and silently
+  // dropped — the session was left in 'error' with no retry.
+  it('a usage limit on a follow-up turn of a retired (succeeded run) worker is still rescheduled', async () => {
+    sessionRepo.update(root.id, {
+      autoRescheduleEnabled: true,
+      rescheduleOnTokenLimit: true,
+      rescheduleDelayMinutes: 15,
+    });
+
+    // Turn 1 succeeds: own work closes, run succeeds, card moves to target.
+    stubSuccessAgent();
+    await runSession(root.id, 'do work', tempDir);
+    expect(sessionRepo.getById(root.id).ownWorkState).toBe('closed_successfully');
+    expect(getRun(run.id).status).toBe('succeeded');
+    const targetLaneId = cardRepo.getById(card.id).laneId;
+    expect(targetLaneId).toBe(target.id);
+
+    // Turn 2: a human follow-up (interactive) hits the usage limit.
+    stubResultErrorAgent("You've hit your usage limit. Try again later.");
+    await continueSession(root.id, 'A human follow-up', tempDir, { interactive: true });
+
+    const updated = sessionRepo.getById(root.id);
+    expect(updated.status).toBe('scheduled');
+    expect(updated.scheduledAt).toEqual(expect.any(Number));
+    expect(updated.rescheduleCount).toBe(1);
+    expect(updated.pendingPrompt).toEqual(expect.any(String));
+    expect(updated.pendingPrompt.trim().length).toBeGreaterThan(0);
+
+    // The board is untouched by the follow-up and its reschedule: the
+    // obligation was already discharged; the retry is ordinary session work.
+    expect(updated.ownWorkState).toBe('closed_successfully');
+    expect(getRun(run.id).status).toBe('succeeded');
+    expect(cardRepo.getById(card.id).laneId).toBe(targetLaneId);
   });
 
   it('a non-retryable terminal result event fails rather than successfully completing the run', async () => {

--- a/packages/server/src/services/sessionExecution.workflowTransition.test.js
+++ b/packages/server/src/services/sessionExecution.workflowTransition.test.js
@@ -191,7 +191,7 @@ describe('W6: _executeSession triggers target-lane automation after a real succe
     expect(drainLaneEntryTriggerMock).toHaveBeenCalledTimes(1);
   });
 
-  it('runs an interactive turn after its lane run has succeeded, but rejects a system turn', async () => {
+  it('runs both interactive and system turns on a retired worker, without altering the board', async () => {
     const stubAgent = {
       execute: vi.fn(async function* () {
         yield { type: 'assistant', text: 'done' };
@@ -204,12 +204,27 @@ describe('W6: _executeSession triggers target-lane automation after a real succe
 
     await runSession(root.id, 'do work', tempDir);
     expect(getRun(run.id).status).toBe('succeeded');
+    expect(cardRepo.getById(card.id).laneId).toBe(target.id);
 
     await continueSession(root.id, 'A human follow-up', tempDir, { interactive: true });
     expect(stubAgent.execute).toHaveBeenCalledTimes(2);
 
-    await runSession(root.id, 'A stale system turn', tempDir);
-    expect(stubAgent.execute).toHaveBeenCalledTimes(2);
+    // A retired worker (own work closed successfully) keeps a historical
+    // lane_run_id pointer. Its scheduled continuations and reschedules are
+    // ordinary system work on its own row — the lane-run fence must not
+    // reject them (regression: a usage-limit reschedule used to be silently
+    // dropped here).
+    await runSession(root.id, 'A scheduled continuation', tempDir);
+    expect(stubAgent.execute).toHaveBeenCalledTimes(3);
+
+    // The board is untouched by post-retirement turns: the run stays
+    // succeeded, the card stays in its target lane, and no new target-lane
+    // automation is triggered.
+    const updated = sessionRepo.getById(root.id);
+    expect(updated.ownWorkState).toBe('closed_successfully');
+    expect(getRun(run.id).status).toBe('succeeded');
+    expect(cardRepo.getById(card.id).laneId).toBe(target.id);
+    expect(drainLaneEntryTriggerMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the provider when ownership is lost after admission but before execution', async () => {

--- a/packages/server/src/services/sessionManager.js
+++ b/packages/server/src/services/sessionManager.js
@@ -5,7 +5,7 @@ import * as summaryService from './summaryService.js';
 import { checkAndTriggerNextTemplate } from './templateTriggerService.js';
 import { resolveProviderFromModel, buildSessionEnv } from './sessionProvider.js';
 import { deriveAgentTypeUpdate } from './sessionAgentGuard.js';
-import { activeLaneRunOwnsSession, closeOwnWork } from './workflowSessionService.js';
+import { laneRunFencesSystemWork, closeOwnWork } from './workflowSessionService.js';
 import { rejectedSessionExecution, startedSessionExecution } from './sessionStartResult.js';
 import {
   shouldRescheduleOnError,
@@ -326,7 +326,7 @@ export async function continueSessionWithExistingMessage(sessionId, conversation
   let session = context.session;
   const { conversation, lastUserMessage } = context;
 
-  if (!interactive && session.laneRunId && !activeLaneRunOwnsSession(sessionId)) {
+  if (!interactive && laneRunFencesSystemWork(sessionId)) {
     return rejectedSessionExecution(sessionId, 'lane_run_ownership_lost');
   }
 

--- a/packages/server/src/services/workflowSessionService.js
+++ b/packages/server/src/services/workflowSessionService.js
@@ -37,6 +37,18 @@ function isParticipating(session) {
   return Boolean(session?.lane_run_id);
 }
 
+/** A session that discharged its obligation to a lane run which has since
+ * completed. It keeps its lane_run_id pointer for history but is board-inert:
+ * every own-work write is a no-op (each requires own_work_state='open').
+ * Scheduling fences exempt it — its token-limit reschedules, explicit
+ * schedules, and wakeups must not be silently dropped by that stale pointer.
+ * cancelled/closed_failed are deliberately NOT exempt: they were terminalized
+ * with their schedules cleared (clearExecutableMemberState) and FR-9 forbids
+ * reviving permanently-failed work. */
+function retiredFromLaneRun(session) {
+  return Boolean(session?.lane_run_id && session?.own_work_state === 'closed_successfully');
+}
+
 function activeRunOwnsSession(db, session) {
   if (!isParticipating(session)) return true;
   return Boolean(db.prepare(`SELECT 1 FROM kanban_lane_runs r
@@ -56,15 +68,40 @@ export function activeLaneRunOwnsSession(sessionId) {
   return Boolean(session?.own_work_state === 'open' && activeRunOwnsSession(db, session));
 }
 
+/** True when a lane-run fence must REJECT system-owned (non-interactive) work
+ * for this session. Identical to !activeLaneRunOwnsSession for participating
+ * sessions, with one deliberate exemption: a session retired from its lane run
+ * (own work closed successfully) is never fenced — its lane_run_id is a
+ * historical pointer, not an active obligation, so its scheduled continuations
+ * and reschedules run as ordinary system work on its own row. Non-participating
+ * sessions are never fenced. */
+export function laneRunFencesSystemWork(sessionId) {
+  const db = databaseManager.get();
+  const session = db.prepare(SELECT_SESSION_BY_ID).get(sessionId);
+  if (!isParticipating(session)) return false;
+  if (session.own_work_state === 'closed_successfully') return false;
+  return !(session.own_work_state === 'open' && activeRunOwnsSession(db, session));
+}
+
 /** Execute a synchronous write only while a lane worker still owns its run.
  * The predicate and write share one SQLite transaction, closing the gap
- * between an explicit schedule/reschedule request and a manual move. */
+ * between an explicit schedule/reschedule request and a manual move.
+ *
+ * A retired worker (own work closed successfully) is board-inert but still a
+ * live conversational session: it keeps a historical lane_run_id pointer, and
+ * its scheduling writes (error reschedules, explicit schedules, wakeups) go
+ * through unfenced so a follow-up turn's token-limit retry is never dropped. */
 export function withActiveLaneRunOwnership(sessionId, mutation) {
   return databaseManager.transaction(() => {
     const db = databaseManager.get();
     const session = db.prepare(SELECT_SESSION_BY_ID).get(sessionId);
     if (!session) return null;
-    if (session.lane_run_id && (session.own_work_state !== 'open' || !activeRunOwnsSession(db, session))) {
+    if (!retiredFromLaneRun(session) && session.lane_run_id
+      && (session.own_work_state !== 'open' || !activeRunOwnsSession(db, session))) {
+      console.warn(
+        `[workflowSessionService] withActiveLaneRunOwnership rejected write for session ${sessionId}: `
+        + `own_work_state=${session.own_work_state}, lane_run_id=${session.lane_run_id}`
+      );
       return null;
     }
     return mutation();
@@ -80,7 +117,9 @@ export function withActiveLaneRunOwnership(sessionId, mutation) {
  * withActiveLaneRunOwnership, releaseCardFromRun, claimWorkflowSessionStart)
  * prevent it from advancing the board once its own_work_state is 'cancelled'
  * here. `waiting` members are already idle and remain available for
- * follow-up messages.
+ * follow-up messages. These fences deliberately do NOT apply to members
+ * retired with own_work_state='closed_successfully' (see retiredFromLaneRun):
+ * their obligation is discharged, so scheduling is ordinary session work.
  */
 function clearExecutableMemberState(db, runId, reason, time) {
   return db.prepare(`UPDATE sessions SET own_work_state='cancelled', own_work_closed_at=?, workflow_reason=?,
@@ -104,6 +143,13 @@ export function claimWorkflowSessionStart(sessionId) {
     const db = databaseManager.get(); const session = db.prepare(SELECT_SESSION_BY_ID).get(sessionId);
     if (!session?.lane_run_id) return true;
     if (session.own_work_state === 'open' && activeRunOwnsSession(db, session)) {
+      audit(db, session.lane_run_id, 'scheduled_start_claimed', { sessionId });
+      return true;
+    }
+    // A retired worker's scheduled follow-ups (error reschedules, explicit
+    // schedules) are legitimate: claim them instead of clearing the schedule.
+    // Must precede the clearing branch below, which durably discards it.
+    if (session.own_work_state === 'closed_successfully') {
       audit(db, session.lane_run_id, 'scheduled_start_claimed', { sessionId });
       return true;
     }

--- a/packages/server/src/services/workflowSessionService.js
+++ b/packages/server/src/services/workflowSessionService.js
@@ -74,10 +74,13 @@ export function activeLaneRunOwnsSession(sessionId) {
  * (own work closed successfully) is never fenced — its lane_run_id is a
  * historical pointer, not an active obligation, so its scheduled continuations
  * and reschedules run as ordinary system work on its own row. Non-participating
- * sessions are never fenced. */
+ * sessions are never fenced. A missing session is fenced so callers using this
+ * as a final pre-provider race check fail closed if the row was deleted during
+ * asynchronous launch preparation. */
 export function laneRunFencesSystemWork(sessionId) {
   const db = databaseManager.get();
   const session = db.prepare(SELECT_SESSION_BY_ID).get(sessionId);
+  if (!session) return true;
   if (!isParticipating(session)) return false;
   if (session.own_work_state === 'closed_successfully') return false;
   return !(session.own_work_state === 'open' && activeRunOwnsSession(db, session));

--- a/packages/server/src/services/workflowSessionService.test.js
+++ b/packages/server/src/services/workflowSessionService.test.js
@@ -7,6 +7,7 @@ import {
   getRun, attachRootSession, reconcileLaneRun,
   supersedeRunForCard, closeOwnWork, markExecutionState, markHeldForLimit,
   computeSubtreeOutcome, recomputeSubtreeOutcomes, attemptLaneRunTransition,
+  withActiveLaneRunOwnership, claimWorkflowSessionStart, laneRunFencesSystemWork,
 } from './workflowSessionService.js';
 import { auditKanbanInvariants, reconcileKanbanOwnership } from './kanbanRecoveryService.js';
 import { kanbanRoutingMetrics } from './kanbanRoutingObservability.js';
@@ -703,5 +704,146 @@ describe('workflowSessionService', () => {
 
       expect(() => sessions.create(project.id, 'Child', 'on time', { parentSessionId: worker.id })).not.toThrow();
     });
+  });
+});
+
+describe('retired (closed_successfully) sessions keep scheduling fences open', () => {
+  let project; let source; let target; let root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    project = projects.create('Retired worker project', '/tmp/retired-worker');
+    const board = kanbanBoards.create(project.id);
+    [source, target] = kanbanLanes.getByBoardId(board.id);
+    root = sessions.create(project.id, 'Root', 'work');
+  });
+
+  function structuredLane() {
+    return { ...kanbanLanes.getById(source.id), onEnterPrompt: 'Perform lane work', completionTargetLaneId: target.id };
+  }
+
+  let cardSeq = 0;
+
+  /** Each scenario needs its own card (a card is keyed to one workspace
+   * session, and can be owned by only one run at a time), so pair every fresh
+   * card with its own workspace session. Returns { card, workspace }. */
+  function freshCard() {
+    cardSeq += 1;
+    const workspace = sessions.create(project.id, `Workspace ${cardSeq}`, 'work');
+    return { card: kanbanCards.create(source.id, workspace.id), workspace };
+  }
+
+  /** Build a worker attached to an owning run on a fresh card.
+   * @param {{ closeViaFinalize?: boolean }} options - true (default) closes
+   *   own work through finalizeOwnWorkCompletion (run succeeds); false marks
+   *   own work closed directly while the run stays open (e.g. waiting on
+   *   descendants). */
+  function retiredWorker({ closeViaFinalize = true } = {}) {
+    const { card, workspace } = freshCard();
+    const worker = sessions.create(project.id, 'Worker', 'lane work', { parentSessionId: workspace.id });
+    const run = createLaneRunForEntry({ projectId: project.id, workspaceId: workspace.id, cardId: card.id, lane: structuredLane() });
+    attachRootSession(run.id, worker.id);
+    if (closeViaFinalize) {
+      finalizeOwnWorkCompletion(worker.id, beginWorkflowTurn(worker.id)); // run succeeds
+    } else {
+      databaseManager.get().prepare("UPDATE sessions SET own_work_state='closed_successfully' WHERE id=?").run(worker.id);
+    }
+    return { worker, run, card };
+  }
+
+  /** Build a worker attached to an owning run on a fresh card, in the given
+   * terminal/displaced state. */
+  function workerOnFreshCard({ supersede = false, failOwnWork = false } = {}) {
+    const { card, workspace } = freshCard();
+    const worker = sessions.create(project.id, 'Worker', 'lane work', { parentSessionId: workspace.id });
+    const run = createLaneRunForEntry({ projectId: project.id, workspaceId: workspace.id, cardId: card.id, lane: structuredLane() });
+    attachRootSession(run.id, worker.id);
+    if (supersede) supersedeRunForCard(card.id, 'manual_move');
+    if (failOwnWork) {
+      databaseManager.get().prepare("UPDATE sessions SET own_work_state='closed_failed' WHERE id=?").run(worker.id);
+    }
+    return { worker, run, card };
+  }
+
+  it('withActiveLaneRunOwnership runs the mutation for a retired worker on a succeeded run', () => {
+    const { worker } = retiredWorker();
+    expect(sessions.getById(worker.id).ownWorkState).toBe('closed_successfully');
+    expect(withActiveLaneRunOwnership(worker.id, () => 'ran')).toBe('ran');
+  });
+
+  it('withActiveLaneRunOwnership runs the mutation for closed_successfully on a still-open run', () => {
+    const { worker, run } = retiredWorker({ closeViaFinalize: false });
+    expect(getRun(run.id).status).toBe('open');
+    expect(sessions.getById(worker.id).ownWorkState).toBe('closed_successfully');
+    expect(withActiveLaneRunOwnership(worker.id, () => 'ran')).toBe('ran');
+  });
+
+  it('withActiveLaneRunOwnership still rejects a superseded (cancelled) member, and warns', () => {
+    const { worker } = workerOnFreshCard({ supersede: true });
+    expect(sessions.getById(worker.id).ownWorkState).toBe('cancelled');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(withActiveLaneRunOwnership(worker.id, () => 'ran')).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(worker.id));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('claimWorkflowSessionStart claims a retired worker and preserves its schedule', () => {
+    const { worker, run } = retiredWorker();
+    sessions.update(worker.id, { scheduledAt: Date.now() + 60_000, pendingPrompt: 'Continue' });
+
+    expect(claimWorkflowSessionStart(worker.id)).toBe(true);
+
+    const after = sessions.getById(worker.id);
+    expect(after.scheduledAt).toEqual(expect.any(Number));
+    expect(after.pendingPrompt).toBe('Continue');
+    expect(after.ownWorkState).toBe('closed_successfully');
+    const auditRow = databaseManager.get()
+      .prepare("SELECT session_id FROM kanban_lane_run_audit_events WHERE lane_run_id=? AND event_type='scheduled_start_claimed' AND session_id=?")
+      .get(run.id, worker.id);
+    expect(auditRow).toBeTruthy();
+  });
+
+  it('claimWorkflowSessionStart still rejects and clears a superseded member', () => {
+    const { worker, run } = workerOnFreshCard({ supersede: true });
+    sessions.update(worker.id, { scheduledAt: Date.now() + 60_000, pendingPrompt: 'Continue' });
+
+    expect(claimWorkflowSessionStart(worker.id)).toBe(false);
+
+    const after = sessions.getById(worker.id);
+    expect(after.scheduledAt).toBeNull();
+    expect(after.pendingPrompt).toBeNull();
+    const auditRow = databaseManager.get()
+      .prepare("SELECT session_id FROM kanban_lane_run_audit_events WHERE lane_run_id=? AND event_type='stale_start_rejected' AND session_id=?")
+      .get(run.id, worker.id);
+    expect(auditRow).toBeTruthy();
+  });
+
+  it('laneRunFencesSystemWork exempts retired and non-participating sessions only', () => {
+    // Non-participating: never fenced.
+    expect(laneRunFencesSystemWork(root.id)).toBe(false);
+
+    // Open worker on an actively owning run: not fenced.
+    const { worker: openWorker } = workerOnFreshCard();
+    expect(laneRunFencesSystemWork(openWorker.id)).toBe(false);
+
+    // Retired worker on a succeeded run: not fenced (the fix).
+    const { worker: retired } = retiredWorker();
+    expect(laneRunFencesSystemWork(retired.id)).toBe(false);
+
+    // closed_successfully while the run is still open: not fenced.
+    const { worker: closedEarly } = retiredWorker({ closeViaFinalize: false });
+    expect(laneRunFencesSystemWork(closedEarly.id)).toBe(false);
+
+    // Superseded (cancelled) member: fenced.
+    const { worker: cancelledWorker } = workerOnFreshCard({ supersede: true });
+    expect(laneRunFencesSystemWork(cancelledWorker.id)).toBe(true);
+
+    // closed_failed member: fenced (FR-9 — permanent failures stay dead).
+    const { worker: failedWorker } = workerOnFreshCard({ failOwnWork: true });
+    expect(laneRunFencesSystemWork(failedWorker.id)).toBe(true);
   });
 });

--- a/packages/server/src/services/workflowSessionService.test.js
+++ b/packages/server/src/services/workflowSessionService.test.js
@@ -823,6 +823,10 @@ describe('retired (closed_successfully) sessions keep scheduling fences open', (
   });
 
   it('laneRunFencesSystemWork exempts retired and non-participating sessions only', () => {
+    // Missing row: fenced so the final pre-provider check fails closed if a
+    // session is deleted during asynchronous launch preparation.
+    expect(laneRunFencesSystemWork('deleted-session')).toBe(true);
+
     // Non-participating: never fenced.
     expect(laneRunFencesSystemWork(root.id)).toBe(false);
 


### PR DESCRIPTION
## Summary

Fixes an incident where a session configured to auto-reschedule on token limits failed to reschedule and had to be scheduled manually.

**Root cause:** when a kanban lane run succeeds, member sessions keep their `lane_run_id` pointer forever (historical, by design). If a human follow-up turn on such a *retired* session then hits a provider usage limit, the auto-reschedule machinery matched the error correctly — but the scheduling write was routed through the lane-run ownership fence, which requires `own_work_state='open'`. The write was rejected and **silently dropped** (no log, no audit). Two further fences would have killed the retry even if the write had landed.

**Fix:** exempt retired workers (`own_work_state='closed_successfully'`) from the three fence layers:

| Fence | Change |
|---|---|
| `withActiveLaneRunOwnership` (5 write sites) | Skips the fence for retired workers; **now `console.warn`s on genuine rejections** — the silent drop was what made the incident invisible |
| `claimWorkflowSessionStart` | Claims a retired worker's scheduled launch instead of durably clearing it |
| Execution gates (5 sites) | New `laneRunFencesSystemWork()` predicate replaces `activeLaneRunOwnsSession()` checks |

`cancelled` and `closed_failed` members remain fenced — FR-9 forbids reviving permanently-failed work.

## Why this is safe

- **No new board-write power**: every own-work write (`beginWorkflowTurn`, `finalizeOwnWorkCompletion`, `closeOwnWork`, `markHeldForLimit`) still requires `own_work_state='open'`. The succeeded run, card position, and any successor run are untouched — verified by test assertions in each scenario.
- **Children created during follow-ups** inherit `lane_run_id = NULL` (existing behavior).
- **Boot recovery** only cancels scheduled members of `superseded/failed/cancelled` runs — `'succeeded'` is not in its list.
- **Races unchanged**: the claim CAS and `isSessionActive` guard behave identically.

## Behavior change (intentional)

A non-interactive/system turn on a retired session was previously rejected as `lane_run_ownership_lost`; it now runs as ordinary system work. The previous behavior is what silently swallowed the reschedule. Genuinely displaced workers (superseded runs) are still rejected — covered by the existing test at `sessionExecution.workflowTransition.test.js:215` and new tests.

## Test plan

- [x] New unit truth table: `withActiveLaneRunOwnership` (retired passes, superseded rejects + warns), `claimWorkflowSessionStart` (retired claims + preserves schedule, superseded clears), `laneRunFencesSystemWork` (6 states)
- [x] End-to-end incident repro: successful run → interactive follow-up hits usage limit → `status='scheduled'`, `rescheduleCount=1`, board untouched
- [x] Scheduler launch of a rescheduled retired worker (claim + dispatch + durable clear, run stays `succeeded`)
- [x] REST: `POST /:id/schedule` → 200 on retired worker (was 409), still 409 on superseded worker (previously untested branch)
- [x] Updated `workflowTransition` behavior test; full server suite (5272) and web suite (4915) green; `yarn lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)