### PR TITLE
fix: wrap session filter buttons on narrow viewports

### DIFF
--- a/packages/web/src/components/SessionFiltersPanel.vue
+++ b/packages/web/src/components/SessionFiltersPanel.vue
@@ -120,6 +120,7 @@ const statusFilterCounts = computed(() => props.statusCounts || { running: 0, wa
 .status-filters {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 1rem;
 }

--- a/tests/e2e/filtering-navigation.spec.ts
+++ b/tests/e2e/filtering-navigation.spec.ts
@@ -51,6 +51,35 @@ test.describe('Status Filter', () => {
     await expect(idleBtn).toBeVisible();
   });
 
+  test('status filter row wraps instead of overflowing on mobile viewport', async ({ page }) => {
+    await seedSession(project.id, { prompt: 'Session', name: 'Session One', startImmediately: false });
+
+    await page.setViewportSize({ width: 375, height: 812 });
+    await navigateAndWait(page, `/projects/${project.id}/sessions`);
+
+    const statusFilters = page.locator('.status-filters');
+    await statusFilters.waitFor({ state: 'visible', timeout: 10000 });
+
+    // The filter row must wrap on narrow screens instead of clipping off the edges
+    const flexWrap = await statusFilters.evaluate(
+      (el) => window.getComputedStyle(el).flexWrap
+    );
+    expect(flexWrap).toBe('wrap');
+
+    // The row itself must not overflow its container
+    const overflow = await statusFilters.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+
+    // And the overflowing row must not push the whole page wider than the viewport
+    const pageOverflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(pageOverflows).toBe(false);
+  });
+
   test('clicking Running filter with no running sessions shows empty state', async ({ page }) => {
     await seedSession(project.id, { prompt: 'Idle 1', name: 'Idle One', startImmediately: false });
     await seedSession(project.id, { prompt: 'Idle 2', name: 'Idle Two', startImmediately: false });


### PR DESCRIPTION
## Problem

On small screens, the session status filter buttons (Running / Waiting / Idle / star / clock) did not wrap — the row was clipped off both edges of the viewport, and the overflow pushed the whole page wider, cutting off the header and other content as well (see the before screenshot in the linked issue discussion).

## Root cause

`.status-filters` in `SessionFiltersPanel.vue` used `display: flex` without `flex-wrap`, which defaults to `nowrap`. The sibling filter panels (`ProjectFiltersPanel.vue`, `AgentLogFilters.vue`) already set `flex-wrap: wrap` — this panel just missed it.

## Fix

One line: add `flex-wrap: wrap` to `.status-filters`, bringing it in line with the other filter panels. Buttons now wrap onto a second line when the row doesn't fit.

## Verification

- Screenshot at 375px: buttons wrap onto two lines, fully visible, no page overflow
- New E2E regression test (`filtering-navigation.spec.ts`): asserts `flex-wrap: wrap`, no row overflow, and no document-level horizontal overflow at mobile viewport
- Full filtering-navigation spec: 35/35 passed
- Unit tests (SessionListView + SessionFiltersPanel): 153 passed
- Lint: no warnings in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)