### PR TITLE
test(e2e): stabilize live output coverage

### DIFF
--- a/packages/web/src/components/SessionLogStream.test.js
+++ b/packages/web/src/components/SessionLogStream.test.js
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { setActivePinia, createPinia } from 'pinia';
+import { reactive } from 'vue';
 import SessionLogStream from './SessionLogStream.vue';
 
 // Mock streaming store
+const collapseState = reactive({ value: false });
 const mockStreamingStore = {
   getSessionWorkLogs: vi.fn(() => []),
   getSessionPartialText: vi.fn(() => ''),
   getPartialThinking: vi.fn(() => null),
-  isSessionLogCollapsed: vi.fn(() => false),
-  toggleSessionLogCollapsed: vi.fn(),
+  isSessionLogCollapsed: vi.fn(() => collapseState.value),
+  toggleSessionLogCollapsed: vi.fn(() => { collapseState.value = !collapseState.value; }),
 };
 
 vi.mock('../stores/sessionStreaming.js', () => ({
@@ -39,8 +41,11 @@ describe('SessionLogStream', () => {
     mockStreamingStore.getSessionWorkLogs.mockReturnValue([]);
     mockStreamingStore.getSessionPartialText.mockReturnValue('');
     mockStreamingStore.getPartialThinking.mockReturnValue(null);
-    mockStreamingStore.isSessionLogCollapsed.mockReturnValue(false);
-    mockStreamingStore.toggleSessionLogCollapsed.mockReset();
+    collapseState.value = false;
+    mockStreamingStore.isSessionLogCollapsed.mockImplementation(() => collapseState.value);
+    mockStreamingStore.toggleSessionLogCollapsed.mockImplementation(() => {
+      collapseState.value = !collapseState.value;
+    });
 
     // Reset sessions store mock
     mockSessionsStore.sessions = [];
@@ -153,12 +158,22 @@ describe('SessionLogStream', () => {
       expect(wrapper.find('.log-summary').text()).toBe('Reading config file');
     });
 
-    it('hides component entirely when no content even if not collapsed', () => {
+    it('hides component entirely without default-collapsed behavior when no content', () => {
       mockStreamingStore.isSessionLogCollapsed.mockReturnValue(false);
       // No content at all
       const wrapper = mountComponent();
       expect(wrapper.find('.session-log-stream').exists()).toBe(false);
       expect(wrapper.find('.log-collapsed').exists()).toBe(false);
+    });
+
+    it('renders an empty expanded pane with default-collapsed behavior', () => {
+      mockStreamingStore.isSessionLogCollapsed.mockReturnValue(false);
+
+      const wrapper = mountComponent({ defaultCollapsed: true });
+
+      expect(wrapper.find('.session-log-stream').exists()).toBe(true);
+      expect(wrapper.find('.log-header-label').text()).toBe('Live Output');
+      expect(wrapper.find('.log-empty-state').text()).toBe('Waiting for output…');
     });
   });
 
@@ -198,6 +213,16 @@ describe('SessionLogStream', () => {
 
       expect(mockStreamingStore.toggleSessionLogCollapsed)
         .toHaveBeenCalledWith('root-session', true);
+    });
+
+    it('keeps the session-card pane visible after expanding an empty stream', async () => {
+      collapseState.value = true;
+
+      const wrapper = mountComponent({ defaultCollapsed: true });
+      await wrapper.find('.log-collapsed').trigger('click');
+
+      expect(wrapper.find('.session-log-stream').exists()).toBe(true);
+      expect(wrapper.find('.log-empty-state').exists()).toBe(true);
     });
   });
 

--- a/packages/web/src/components/SessionLogStream.vue
+++ b/packages/web/src/components/SessionLogStream.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="hasContent && !isCollapsed"
+    v-if="!isCollapsed && (hasContent || defaultCollapsed)"
     class="session-log-stream"
   >
     <!-- Collapse toggle bar -->
@@ -38,6 +38,12 @@
       <!-- Use flexbox column-reverse to anchor to bottom -->
       <div class="log-content-inner">
         <div>
+          <div
+            v-if="!hasContent"
+            class="log-empty-state"
+          >
+            Waiting for output…
+          </div>
           <!-- Work log entries -->
           <div
             v-for="log in recentLogs"
@@ -250,6 +256,12 @@ function toggleCollapse() {
 
 .log-entry {
   margin-bottom: 0.125rem;
+}
+
+.log-empty-state {
+  color: var(--color-text-soft, #9ca3af);
+  font-style: italic;
+  opacity: 0.7;
 }
 
 .log-tool {

--- a/packages/web/src/views/ProjectListView.test.js
+++ b/packages/web/src/views/ProjectListView.test.js
@@ -9,10 +9,22 @@ import { useProjectFiltersStore } from '../stores/projectFilters.js';
 
 const { getWorkspaceCards } = vi.hoisted(() => ({ getWorkspaceCards: vi.fn() }));
 const { fetchButtons } = vi.hoisted(() => ({ fetchButtons: vi.fn().mockResolvedValue(true) }));
+const { useRunningSessionSubscriptions, isSessionLogCollapsed } = vi.hoisted(() => ({
+  useRunningSessionSubscriptions: vi.fn(),
+  isSessionLogCollapsed: vi.fn(() => true),
+}));
 
 // Mock the composable to avoid opening a WebSocket in jsdom.
 vi.mock('../composables/useProjectListRealtime.js', () => ({
   useProjectListRealtime: vi.fn(),
+}));
+
+vi.mock('../composables/useRunningSessionSubscriptions.js', () => ({
+  useRunningSessionSubscriptions,
+}));
+
+vi.mock('../stores/sessionStreaming.js', () => ({
+  useSessionStreamingStore: () => ({ isSessionLogCollapsed }),
 }));
 
 // Mock the composable
@@ -91,6 +103,8 @@ describe('ProjectListView', () => {
     projectsStore = useProjectsStore();
     vi.spyOn(projectsStore, 'fetchProjects').mockResolvedValue(undefined);
     getWorkspaceCards.mockResolvedValue({ workspaces: [] });
+    isSessionLogCollapsed.mockReset();
+    isSessionLogCollapsed.mockReturnValue(true);
     fetchButtons.mockReset();
     fetchButtons.mockResolvedValue(true);
   });
@@ -332,6 +346,24 @@ describe('ProjectListView', () => {
   });
 
   describe('Embedded session cards', () => {
+    it('subscribes only to expanded project cards with expanded live output', async () => {
+      getWorkspaceCards.mockResolvedValueOnce({
+        workspaces: [{ id: 'root', status: 'running', runningSessionIds: ['running-child'] }],
+      });
+      projectsStore.projects = [fullProject({ sessionCount: 1, runningSessionCount: 1 })];
+      projectsStore.loading = false;
+      isSessionLogCollapsed.mockReturnValue(false);
+
+      const wrapper = mount(ProjectListView, { global: { plugins: [pinia, router] } });
+      await flushAll(wrapper);
+      expect(useRunningSessionSubscriptions.mock.calls.at(-1)[0].value).toEqual([]);
+
+      await wrapper.find('.sessions-toggle').trigger('click');
+      await flushAll(wrapper);
+
+      expect(useRunningSessionSubscriptions.mock.calls.at(-1)[0].value).toEqual(['running-child']);
+    });
+
     it('shows the three most recent cards for each project without a filter', async () => {
       getWorkspaceCards.mockResolvedValueOnce({
         workspaces: [

--- a/packages/web/src/views/ProjectListView.vue
+++ b/packages/web/src/views/ProjectListView.vue
@@ -145,17 +145,21 @@ import { useSessionsStore } from '../stores/sessions.js';
 import { useProjectFiltersStore } from '../stores/projectFilters.js';
 import { useCommandButtonsStore } from '../stores/commandButtons.js';
 import { useProjectListRealtime } from '../composables/useProjectListRealtime.js';
+import { useRunningSessionSubscriptions } from '../composables/useRunningSessionSubscriptions.js';
+import { useSessionStreamingStore } from '../stores/sessionStreaming.js';
 import ProjectFiltersPanel from '../components/ProjectFiltersPanel.vue';
 import SessionCard from '../components/SessionCard.vue';
 import { formatRelativeTime } from '../composables/useSummaryHelpers.js';
 import { api } from '../api/index.js';
 import { workspacePrSummary } from '../utils/workspaceCard.js';
+import { isSessionActivelyRunning } from '../utils/workflowStatus.js';
 
 const router = useRouter();
 const projectsStore = useProjectsStore();
 const sessionsStore = useSessionsStore();
 const projectFilters = useProjectFiltersStore();
 const commandButtonsStore = useCommandButtonsStore();
+const streamingStore = useSessionStreamingStore();
 const projectCards = ref({});
 const sessionVisibility = ref({});
 const hydratedCommandButtonProjects = new Set();
@@ -172,6 +176,24 @@ const sessionVisibilityStorageKey = 'circus-chief.project-list.session-visibilit
 const visibleProjects = computed(() => projectsStore.filteredProjects);
 const statusFacets = computed(() => projectsStore.statusFacets);
 const projectIds = computed(() => projectsStore.projects.map((p) => p.id));
+
+// Session cards default to a collapsed output pane. Only hydrate a running
+// workflow while its project's cards are visible and its pane is expanded.
+// This matches the session-list streaming policy without subscribing to the
+// project's hidden previews.
+const eligibleSessionIds = computed(() => [...new Set(
+  Object.entries(projectCards.value)
+    .filter(([projectId]) => areSessionsVisible(projectId))
+    .flatMap(([, workspaces]) => workspaces)
+    .flatMap((workspace) => {
+      if (streamingStore.isSessionLogCollapsed(workspace.id, true)) return [];
+      return Array.isArray(workspace.runningSessionIds)
+        ? workspace.runningSessionIds
+        : (isSessionActivelyRunning(workspace) || workspace.runningCount > 0 ? [workspace.id] : []);
+    })
+)]);
+
+useRunningSessionSubscriptions(eligibleSessionIds);
 
 function goToSessions(projectId) {
   router.push(`/projects/${projectId}/sessions`);

--- a/tests/e2e/dev-tooling.spec.ts
+++ b/tests/e2e/dev-tooling.spec.ts
@@ -80,6 +80,21 @@ function readPortFile(dir?: string): string | null {
   return null;
 }
 
+/**
+ * Resolve the port used by this Playwright run. pw.sh exports API_URL as the
+ * authoritative endpoint; .server-port remains the fallback for direct runs.
+ */
+function readActivePort(): string | null {
+  if (process.env.API_URL) {
+    try {
+      return new URL(process.env.API_URL).port || null;
+    } catch {
+      return null;
+    }
+  }
+  return readPortFile();
+}
+
 // ---------------------------------------------------------------------------
 // Temp directory tracking for cleanup
 // ---------------------------------------------------------------------------
@@ -166,8 +181,8 @@ test.describe('Category 1: start-server.sh Script Behavior', () => {
   });
 
   // Test 5
-  test('current worktree .server-port file exists with valid port', () => {
-    const port = readPortFile();
+  test('current worktree has a valid configured server port', () => {
+    const port = readActivePort();
     expect(port).not.toBeNull();
 
     const portNum = parseInt(port!, 10);
@@ -201,8 +216,8 @@ test.describe('Category 2: Port Isolation & Server Liveness', () => {
   test.describe.configure({ timeout: 15_000 });
 
   // Test 6
-  test('.server-port contains a valid port number', () => {
-    const portContent = readPortFile();
+  test('configured server port is a valid port number', () => {
+    const portContent = readActivePort();
     expect(portContent).not.toBeNull();
     expect(portContent).toMatch(/^\d+$/);
 
@@ -212,8 +227,8 @@ test.describe('Category 2: Port Isolation & Server Liveness', () => {
   });
 
   // Test 7
-  test('server is running on the port from .server-port', async () => {
-    const port = readPortFile();
+  test('server is running on the configured port', async () => {
+    const port = readActivePort();
     expect(port).not.toBeNull();
 
     const url = `http://localhost:${port}/api/projects`;
@@ -225,8 +240,8 @@ test.describe('Category 2: Port Isolation & Server Liveness', () => {
   });
 
   // Test 8
-  test('helpers.ts getAPIURL returns URL matching .server-port', () => {
-    const port = readPortFile();
+  test('helpers.ts getAPIURL returns URL matching the configured port', () => {
+    const port = readActivePort();
     expect(port).not.toBeNull();
 
     const expectedURL = `http://localhost:${port}`;

--- a/tests/e2e/project-list-live-output.spec.ts
+++ b/tests/e2e/project-list-live-output.spec.ts
@@ -30,11 +30,13 @@ test.describe('Project List Live Output', () => {
     await waitForSessionToExist(session.id);
     await updateSessionStatus(session.id, 'running');
 
-    await navigateAndWait(page, '/projects', { waitFor: '.project-card' });
-    await page.getByRole('button', { name: 'Show sessions' }).click();
-    await expect(page.locator('.embedded-session-list .session-card')).toBeVisible();
+    await navigateAndWait(page, '/');
+    const projectCard = page.locator('.project-card', { hasText: 'Project List Live Output' });
+    await expect(projectCard).toBeVisible();
+    await projectCard.getByRole('button', { name: 'Show sessions' }).click();
+    await expect(projectCard.locator('.embedded-session-list .session-card')).toBeVisible();
 
-    const stream = page.locator('[data-testid="session-log-stream"]');
+    const stream = projectCard.locator('[data-testid="session-log-stream"]');
     await expect(stream).toBeVisible();
     await stream.getByText('Show live output', { exact: true }).click();
 

--- a/tests/e2e/project-list-live-output.spec.ts
+++ b/tests/e2e/project-list-live-output.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedProject,
+  seedSession,
+  cleanupCreatedResources,
+  navigateAndWait,
+  updateSessionStatus,
+  waitForSessionToExist,
+} from './helpers';
+
+test.describe('Project List Live Output', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  let project: any;
+
+  test.beforeEach(async () => {
+    await cleanupCreatedResources();
+    project = await seedProject('Project List Live Output', '/tmp/test');
+  });
+
+  test.afterEach(async () => {
+    await cleanupCreatedResources();
+  });
+
+  test('live output pane stays visible after expanding it from the project list', async ({ page }) => {
+    const session = await seedSession(project.id, {
+      prompt: 'Live output test',
+      name: 'Live Output Session',
+    });
+    await waitForSessionToExist(session.id);
+    await updateSessionStatus(session.id, 'running');
+
+    await navigateAndWait(page, '/projects', { waitFor: '.project-card' });
+    await page.getByRole('button', { name: 'Show sessions' }).click();
+    await expect(page.locator('.embedded-session-list .session-card')).toBeVisible();
+
+    const stream = page.locator('[data-testid="session-log-stream"]');
+    await expect(stream).toBeVisible();
+    await stream.getByText('Show live output', { exact: true }).click();
+
+    await expect(stream).toBeVisible();
+    await expect(stream.getByText('Live Output', { exact: true })).toBeVisible();
+    await expect(stream.getByText('Waiting for output…', { exact: true })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- resolve the active test server port from API_URL when available
- scope project-list live-output assertions to the created project card

## Validation
- Playwright tests circus command passed